### PR TITLE
CP-1775: Address book: Using saved BTC address

### DIFF
--- a/app/components/addressBook/AddressBookLists.tsx
+++ b/app/components/addressBook/AddressBookLists.tsx
@@ -13,10 +13,12 @@ import { selectAccounts } from 'store/account'
 export type AddressBookListsProps = {
   onContactSelected: (item: Contact | Account, type: AddrBookItemType) => void
   navigateToAddressBook: () => void
+  onlyBtc?: boolean
 }
 export default function AddressBookLists({
   onContactSelected,
-  navigateToAddressBook
+  navigateToAddressBook,
+  onlyBtc = false
 }: AddressBookListsProps) {
   const { theme } = useApplicationContext()
   const { recentContacts, addressBook } =
@@ -24,27 +26,37 @@ export default function AddressBookLists({
   const accounts = useSelector(selectAccounts)
 
   const addressBookContacts = useMemo(
-    () => [...addressBook.values()],
-    [addressBook]
+    () =>
+      [...addressBook.values()].filter(
+        value => (onlyBtc && value.addressBtc) || !onlyBtc
+      ),
+    [addressBook, onlyBtc]
   )
 
   const recentAddresses = useMemo(
     () =>
-      recentContacts.map(contact => {
-        switch (contact.type) {
-          case 'account':
-            return {
-              item: accounts[contact.id as AccountId]!,
-              type: contact.type
-            }
-          case 'contact':
-            return {
-              item: addressBook.get(contact.id as UID)!,
-              type: contact.type
-            }
-        }
-      }),
-    [addressBook, recentContacts, accounts]
+      recentContacts
+        .map(contact => {
+          switch (contact.type) {
+            case 'account':
+              return {
+                item: accounts[contact.id as AccountId]!,
+                type: contact.type
+              }
+            case 'contact':
+              return {
+                item: addressBook.get(contact.id as UID)!,
+                type: contact.type
+              }
+          }
+        })
+        .filter(
+          value =>
+            (onlyBtc && value.type === 'contact' && value.item.addressBtc) ||
+            (onlyBtc && value.type === 'account') ||
+            !onlyBtc
+        ),
+    [recentContacts, accounts, addressBook, onlyBtc]
   )
 
   const renderCustomLabel = (title: string, selected: boolean) => {

--- a/app/screens/send/SendToken.tsx
+++ b/app/screens/send/SendToken.tsx
@@ -17,6 +17,9 @@ import { useAddressBookLists } from 'components/addressBook/useAddressBookLists'
 import QrScannerAva from 'components/QrScannerAva'
 import QRScanSVG from 'components/svg/QRScanSVG'
 import { TokenWithBalance } from 'store/balance'
+import { useSelector } from 'react-redux'
+import { selectActiveNetwork } from 'store/network'
+import { NetworkVMType } from '@avalabs/chains-sdk'
 
 type Props = {
   onNext: () => void
@@ -46,7 +49,12 @@ const SendToken: FC<Props> = ({
     canSubmit,
     sdkError
   } = useSendTokenContext()
+  const activeNetwork = useSelector(selectActiveNetwork)
   const [showQrCamera, setShowQrCamera] = useState(false)
+  const placeholder =
+    activeNetwork.vmName === NetworkVMType.EVM
+      ? 'Enter 0x Address'
+      : 'Enter Bitcoin Address'
 
   const {
     showAddressBook,
@@ -83,7 +91,17 @@ const SendToken: FC<Props> = ({
     item: Contact | Account,
     type: AddrBookItemType
   ) => {
-    setAddress({ address: item.address, title: item.title })
+    switch (activeNetwork.vmName) {
+      case NetworkVMType.EVM:
+        setAddress({ address: item.address, title: item.title })
+        break
+      case NetworkVMType.BITCOIN:
+        setAddress({
+          address: item.addressBtc,
+          title: item.title
+        })
+        break
+    }
     selectContact(item, type)
   }
 
@@ -104,7 +122,7 @@ const SendToken: FC<Props> = ({
       <Space y={4} />
       <View style={[{ flex: 0, paddingStart: 4, paddingEnd: 4 }]}>
         <InputText
-          placeholder="Enter 0x Address"
+          placeholder={placeholder}
           multiline={true}
           onChangeText={text => {
             toAccount.setTitle?.('Address')
@@ -144,6 +162,7 @@ const SendToken: FC<Props> = ({
       <Space y={24} />
       {showAddressBook ? (
         <AddressBookLists
+          onlyBtc={activeNetwork.vmName === NetworkVMType.BITCOIN}
           onContactSelected={onContactSelected}
           navigateToAddressBook={onOpenAddressBook}
         />


### PR DESCRIPTION
- when the Bitcoin network is selected the send to box displays “Enter Bitcoin Address”
- when the Bitcoin network is selected the Recents/Address Book/My Accounts sections display only entries with Bitcoin addresses associated with them (i.e. if an address book contact does not have a BTC address do not display)
