### PR TITLE
fix: remove so glacier requests work in the release app

### DIFF
--- a/app/utils/glacierUtils.ts
+++ b/app/utils/glacierUtils.ts
@@ -15,7 +15,6 @@ if (!GLACIER_URL) Logger.error('GLACIER URL ENV is missing')
  */
 export function addGlacierAPIKeyIfNeeded(url: string): string {
   if (
-    __DEV__ &&
     Config.GLACIER_API_KEY &&
     (url.startsWith(Config.GLACIER_DEV_URL) ||
       url.startsWith(Config.GLACIER_PROD_URL))


### PR DESCRIPTION
### What does this PR accomplish?

https://ava-labs.atlassian.net/browse/CP-3017

ETH / BTC balances were not updating because of an unneeded `__DEV__` condition which caused the requested to fail with 403 unauthorized response. With this change the `token` query string key will be correctly added so glacier auth will succeed. 