### PR TITLE
CP-2933 make paste option easier to trigger

### DIFF
--- a/app/components/TextArea.tsx
+++ b/app/components/TextArea.tsx
@@ -76,7 +76,7 @@ export default function TextArea(props: Props | Readonly<Props>): JSX.Element {
           }}
           style={[
             {
-              flexShrink: 1,
+              flexGrow: 1,
               textAlignVertical: 'top',
               color: theme.colorText1,
               fontSize: 16,


### PR DESCRIPTION
### What does this PR accomplish?

https://ava-labs.atlassian.net/browse/CP-2933

This makes the whole textarea interactive so the `Paste` option comes up no matter where the user taps. Before it only worked when tapping on the placeholder text.

I verified with Mike that on his phone he can tap on the placeholder text to bring up the `Paste` option so I feel confident that this will fix the issue.