### PR TITLE
CP-2863 fix ethereum bridging

### DIFF
--- a/app/hooks/networkProviderHooks.ts
+++ b/app/hooks/networkProviderHooks.ts
@@ -12,7 +12,7 @@ export function useEthereumProvider() {
   const network = useSelector(selectActiveNetwork)
 
   return useMemo(
-    () => getEthereumProvider(Object.values(networks), network.isTestnet),
+    () => getEthereumProvider(networks, network.isTestnet),
     [networks, network]
   )
 }
@@ -28,7 +28,7 @@ export function useAvalancheProvider() {
   const network = useSelector(selectActiveNetwork)
 
   return useMemo(
-    () => getAvalancheProvider(Object.values(networks), network.isTestnet),
+    () => getAvalancheProvider(networks, network.isTestnet),
     [networks, network]
   )
 }

--- a/app/services/network/utils/providerUtils.ts
+++ b/app/services/network/utils/providerUtils.ts
@@ -8,6 +8,7 @@ import {
 import { BlockCypherProvider, JsonRpcBatchInternal } from '@avalabs/wallets-sdk'
 import Config from 'react-native-config'
 import { PollingConfig } from 'store/balance'
+import { Networks } from 'store/network'
 import { addGlacierAPIKeyIfNeeded, GLACIER_URL } from 'utils/glacierUtils'
 
 const BLOCKCYPHER_PROXY_URL = `${GLACIER_URL}/proxy/blockcypher`
@@ -41,7 +42,7 @@ export function getEvmProvider(network: Network) {
 }
 
 export function getAvalancheProvider(
-  networks: Network[],
+  networks: Networks,
   isTest: boolean | undefined
 ): JsonRpcBatchInternal | undefined {
   const network = getAvalancheNetwork(networks, isTest)
@@ -50,7 +51,7 @@ export function getAvalancheProvider(
 }
 
 export function getEthereumProvider(
-  networks: Network[],
+  networks: Networks,
   isTest: boolean | undefined
 ): JsonRpcBatchInternal | undefined {
   const network = getEthereumNetwork(networks, isTest)
@@ -59,7 +60,7 @@ export function getEthereumProvider(
 }
 
 export function getAvalancheNetwork(
-  networks: Network[],
+  networks: Networks,
   isTest: boolean | undefined
 ): Network | undefined {
   const network = isTest
@@ -75,7 +76,7 @@ export function getBitcoinNetwork(
 }
 
 export function getEthereumNetwork(
-  networks: Network[],
+  networks: Networks,
   isTest: boolean | undefined
 ): Network | undefined {
   const network = isTest

--- a/app/store/network/types.ts
+++ b/app/store/network/types.ts
@@ -2,9 +2,11 @@ import { Network } from '@avalabs/chains-sdk'
 
 export type ChainID = number
 
+export type Networks = { [chainId: ChainID]: Network }
+
 export type NetworkState = {
-  networks: Record<ChainID, Network>
-  customNetworks: Record<ChainID, Network>
+  networks: Networks
+  customNetworks: Networks
   favorites: ChainID[]
   active: ChainID
 }


### PR DESCRIPTION
### What does this PR accomplish?

Ethereum bridging was broken because it was using the wrong provider.

Part of https://ava-labs.atlassian.net/browse/CP-2863
