### PR TITLE
fix: use es6-promise so the allSettled polyfill is consistent

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 
 import 'react-native-get-random-values'
 import 'react-native-url-polyfill/auto'
+import 'es6-promise/auto'
 import { AppRegistry } from 'react-native'
 import ContextApp from './app/ContextApp'
 import { name as appName } from './app.json'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -392,7 +392,7 @@ PODS:
     - React-Core
   - RNGestureHandler (1.10.3):
     - React-Core
-  - RNInAppBrowser (3.6.3):
+  - RNInAppBrowser (3.7.0):
     - React-Core
   - RNKeychain (8.1.1):
     - React-Core
@@ -727,7 +727,7 @@ SPEC CHECKSUMS:
   RNFlashList: adcc3a39aa72012852681bc439ccb4108c8c4448
   RNFS: fc610f78fdf8bfc89a9e5cc2f898519f4dba1002
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
-  RNInAppBrowser: 3ff3a3b8f458aaf25aaee879d057352862edf357
+  RNInAppBrowser: e36d6935517101ccba0e875bac8ad7b0cb655364
   RNKeychain: ff836453cba46938e0e9e4c22e43d43fa2c90333
   RNOS: 6f2f9a70895bbbfbdad7196abd952e7b01d45027
   RNPermissions: de7b7c3fe1680d974ac7a85e3e97aa539c0e68ea

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "bn.js": "5.2.0",
     "crypto-js": "4.1.1",
     "date-fns": "2.28.0",
+    "es6-promise": "4.2.8",
     "ethers": "5.6.8",
     "events": "1.1.1",
     "hdkey": "2.0.1",
@@ -158,6 +159,7 @@
     "web3": "1.7.1"
   },
   "resolutions": {
+    "es6-promise": "4.2.8",
     "minimist": "1.2.6",
     "hermes-engine": "0.10.0",
     "simple-plist": "1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9688,7 +9688,7 @@ es6-object-assign@^1.1.0:
   resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
   integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
 
-es6-promise@^4.2.8:
+es6-promise@4.2.8, es6-promise@^4.2.8:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==


### PR DESCRIPTION
### What does this PR accomplish?

A fix for the following error which is caused by the coingecko-api using es6-promise (via paraswap) which overwrites the `promise.allsetted` polyfill.

```
Promise.allSettled is not a function
```
