### PR TITLE
fix: inappbrowser crashes in the release build

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -19,3 +19,10 @@
 
 # https://github.com/oblador/react-native-keychain#proguard-rules
 -keep class com.facebook.crypto.** { *; }
+
+# https://github.com/proyecto26/react-native-inappbrowser#android
+-keepattributes *Annotation*
+-keepclassmembers class ** {
+  @org.greenrobot.eventbus.Subscribe <methods>;
+}
+-keep enum org.greenrobot.eventbus.ThreadMode { *; }


### PR DESCRIPTION
### What does this PR accomplish?

https://ava-labs.atlassian.net/browse/CP-3276

[Someone in this issue](https://github.com/proyecto26/react-native-inappbrowser/issues/174#issuecomment-663763687) said adding proguard rules for `react-native-inappbrowser-reborn` will fix the crash.

I verified that this fix works by installing [this build](https://app.bitrise.io/build/38c8730c-222d-4536-a993-2689e11479c0).
