### PR TITLE
CP-3553 Make Dependabot PRs testable

### DIFF
--- a/.github/workflows/mobile-pr.yml
+++ b/.github/workflows/mobile-pr.yml
@@ -21,13 +21,12 @@ jobs:
 
       - name: Eslint
         run: yarn lint:ci
-
-      - name: Annotate Eslint Results
-        uses: ataylorme/eslint-annotate-action@1.2.0
-        if: always()
+        continue-on-error: true
+      - name: "Eslint: Annotate Results"
+        uses: ataylorme/eslint-annotate-action@v2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           report-json: 'eslint_report.json'
-          
+
       - name: Typescript
         run: yarn tsc


### PR DESCRIPTION
### What does this PR accomplish?

This reverts commit 3f43d70a3a05d723a31354538ee9d7395b65a2df.

https://ava-labs.atlassian.net/browse/CP-3553
Make Dependabot PRs testable.

There's probably more to do for this story but removing the conditions from `.github/workflows/mobile-pr.yml` is the first step.

It turns out the [ataylorme/eslint-annotate-action](https://github.com/ataylorme/eslint-annotate-action) action was not setup correctly and never reported errors or warnings because of the `--quiet` flag on the `lint:ci` script. I fixed that bug and also upgraded it to the latest version.

---

Here's an example run with some testing code where it reports on an error: 

https://github.com/ava-labs/avalanche-wallet-apps/actions/runs/3130999824/jobs/5081873067#step:4:14

And here's what the diff looks like with errors/warnings:

<img width="725" alt="image" src="https://user-images.githubusercontent.com/4348/192379440-278d4e9c-439f-4bbd-b643-5147f9a18850.png">
