### PR TITLE
chore: Give Dependabot permission to write Eslint annotation results

### DIFF
--- a/.github/workflows/mobile-pr.yml
+++ b/.github/workflows/mobile-pr.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - 'development'
 
+permissions:
+  contents: read
+  # The following give Dependabot permission to write Eslint annotation results
+  checks: write
+  pull-requests: write
+
 jobs:
   test:
     name: Test
@@ -21,6 +27,7 @@ jobs:
 
       - name: Eslint
         run: yarn lint:ci
+        # Continue to Annotate step which will fail if there are errors
         continue-on-error: true
       - name: "Eslint: Annotate Results"
         uses: ataylorme/eslint-annotate-action@v2


### PR DESCRIPTION
### What does this PR accomplish?

https://ava-labs.atlassian.net/browse/CP-3553
Give Dependabot permission to write Eslint annotation results.

Hopefully this fixes the Dependabot PR CI errors, here's an example https://github.com/ava-labs/avalanche-wallet-apps/actions/runs/3137037901/jobs/5094703237
