### PR TITLE
CP-3473 always show chart price cursor

### DIFF
--- a/app/components/SparklineChart.tsx
+++ b/app/components/SparklineChart.tsx
@@ -15,6 +15,7 @@ interface Props {
   xRange: [number, number]
   negative?: boolean
   interactive?: boolean
+  onPress?: () => void
 }
 
 const SparklineChart: FC<Props> = ({
@@ -25,7 +26,8 @@ const SparklineChart: FC<Props> = ({
   yRange,
   xRange,
   negative = false,
-  interactive = false
+  interactive = false,
+  onPress
 }) => {
   const theme = useApplicationContext().theme
   const { currencyFormatter } = useApplicationContext().appHook
@@ -66,6 +68,7 @@ const SparklineChart: FC<Props> = ({
         cursorColor: theme.alternateBackground,
         cursorBorderColor: theme.alternateBackground
       }}
+      onPress={onPress}
       toolTipProps={{
         displayToolTip: interactive,
         borderRadius: 20,

--- a/app/screens/watchlist/components/WatchListItem.tsx
+++ b/app/screens/watchlist/components/WatchListItem.tsx
@@ -54,6 +54,7 @@ const WatchListItem: FC<Props> = ({
           chartDays={chartDays}
           value={value}
           filterBy={filterBy}
+          onPress={onPress}
         />
       }
       onPress={onPress}
@@ -92,6 +93,7 @@ type RightComponentProps = {
   chartDays: number
   value?: string
   filterBy: WatchlistFilter
+  onPress?: () => void
 }
 
 type ChartData = { x: number; y: number }[]
@@ -120,7 +122,8 @@ const RightComponent = ({
   token,
   chartDays,
   value,
-  filterBy
+  filterBy,
+  onPress
 }: RightComponentProps) => {
   const lastItemId = useRef(token.id)
   const { theme, appHook } = useApplicationContext()
@@ -185,6 +188,7 @@ const RightComponent = ({
         chartData={chartData}
         ranges={ranges}
         isLoadingChartData={isLoadingChartData}
+        onPress={onPress}
       />
       <View
         style={{
@@ -216,12 +220,14 @@ type MiddleComponentProps = {
   chartData: ChartData
   ranges: Ranges
   isLoadingChartData: boolean
+  onPress?: () => void
 }
 
 const MiddleComponent = ({
   chartData,
   ranges,
-  isLoadingChartData
+  isLoadingChartData,
+  onPress
 }: MiddleComponentProps) => {
   return (
     <View
@@ -237,6 +243,7 @@ const MiddleComponent = ({
           height={80}
           animated={false}
           data={chartData}
+          onPress={onPress}
           yRange={[ranges.minPrice, ranges.maxPrice]}
           xRange={[ranges.minDate, ranges.maxDate]}
           negative={ranges.diffValue < 0}


### PR DESCRIPTION
### What does this PR accomplish?

https://ava-labs.atlassian.net/browse/CP-3473
Always show chart price cursor to match Gemini mobile app. The cursor position starts in the middle of the chart, I couldn't find a way to change the initial cursor position but I think the middle is probably fine.

I also noticed and fixed a bug where I couldn't press on the mini chart in the list view.

### Screenshots/Videos


https://user-images.githubusercontent.com/4348/192894424-26bcca3f-a7c8-4529-a33d-a8c328481e22.mov

