### PR TITLE
CP-3467 ignore bridged tokens in watchlist

### DIFF
--- a/app/store/watchlist/listeners.ts
+++ b/app/store/watchlist/listeners.ts
@@ -2,7 +2,7 @@ import { AppStartListening } from 'store/middleware/listener'
 import { onRehydrationComplete } from 'store/app'
 import { AppListenerEffectAPI } from 'store/index'
 import watchlistService from 'services/watchlist/WatchlistService'
-import { selectActiveNetwork, selectNetworks, setActive } from 'store/network'
+import { selectNetworks, setActive } from 'store/network'
 import {
   selectSelectedCurrency,
   setSelectedCurrency
@@ -17,11 +17,9 @@ async function fetchWatchlist(
   const dispatch = listenerApi.dispatch
   const state = listenerApi.getState()
   const allNetworks = Object.values(selectNetworks(state) ?? [])
-  const network = selectActiveNetwork(state)
   const currency = selectSelectedCurrency(state)
 
   const watchlistTokens = await watchlistService.getMarketData(
-    network,
     currency.toLowerCase(),
     allNetworks
   )


### PR DESCRIPTION
### What does this PR accomplish?

https://ava-labs.atlassian.net/browse/CP-3467
Some tokens don't show a chart or price.

I found that many of the tokens that don't show a chart are bridged tokens (i.e. the token ends in ".e" or ".b").
My suggestion is to not show bridged tokens.

The others don't show up because Coingecko doesn't have data for the token address.

### Screenshots/Videos

Before

<img width="409" alt="Screen Shot 2022-10-03 at 4 53 30 PM" src="https://user-images.githubusercontent.com/4348/193700550-2a0c48a8-e288-4308-8c07-b0e421cd8559.png">

After

<img width="404" alt="Screen Shot 2022-10-03 at 4 53 48 PM" src="https://user-images.githubusercontent.com/4348/193700571-d775a083-2f93-442c-b4b7-0de5cbf0314e.png">
