### PR TITLE
fix: CP-4021 kill all walletconnect sessions on logout

### DIFF
--- a/app/store/app/listeners.ts
+++ b/app/store/app/listeners.ts
@@ -123,8 +123,9 @@ const clearData = async (action: any, listenerApi: AppListenerEffectAPI) => {
   const { dispatch } = listenerApi
   dispatch(setWalletState(WalletState.NONEXISTENT))
   await BiometricsSDK.clearWalletKey()
-  await AsyncStorage.clear()
+  // do before clearing AsyncStorage since it writes it
   await WalletConnectService.killAllSessions()
+  await AsyncStorage.clear()
 }
 
 export const addAppListeners = (startListening: AppStartListening) => {


### PR DESCRIPTION
### What does this PR accomplish?
Kill all active walletconnect sessions when the user logs out from the wallet.


