### PR TITLE
CP-4142: Fix instant custom rpcs not working

### DIFF
--- a/app/services/walletconnect/WalletConnectService.ts
+++ b/app/services/walletconnect/WalletConnectService.ts
@@ -94,8 +94,9 @@ class WalletConnectService {
       isExisting: boolean
     ) => {
       Logger.info('received dapp session request', error ?? payload)
+
       if (error) {
-        console.error(error)
+        throw error
       }
 
       try {
@@ -270,9 +271,6 @@ class WalletConnectService {
   // Call request emitters
   callRequests = (data: TypedJsonRpcRequest<string, unknown>) =>
     new Promise((resolve, reject) => {
-      Logger.info('dapp emitting CALL request')
-      emitter.emit(WalletConnectRequest.CALL, data)
-
       emitter.on(WalletConnectRequest.CALL_APPROVED, args => {
         const { id, result } = args
         if (data.id === id) {
@@ -288,6 +286,9 @@ class WalletConnectService {
           reject(error)
         }
       })
+
+      Logger.info('dapp emitting CALL request')
+      emitter.emit(WalletConnectRequest.CALL, data)
     })
 
   startSession = async (existing: boolean) => {

--- a/app/store/rpc/handlers/index.ts
+++ b/app/store/rpc/handlers/index.ts
@@ -1,10 +1,12 @@
 import { avalancheGetAccountsHandler } from './avalanche_getAccounts'
 import { avalancheGetContactsHandler } from './avalanche_getContacts'
+import { avalancheUpdateContactHandler } from './avalanche_updateContact'
 import { ethSendTransactionHandler } from './eth_sendTransaction'
 import { ethSignHandler } from './eth_sign'
 import { sessionRequestHandler } from './session_request'
 
 const handlerMap = [
+  avalancheUpdateContactHandler,
   avalancheGetAccountsHandler,
   avalancheGetContactsHandler,
   ethSendTransactionHandler,


### PR DESCRIPTION
### What does this PR accomplish?
There is a race condition issue where the app couldn't register event listeners fast enough for instant custom rpcs (avalanche_getAccounts, avalanche_getContant). The fix is to simply make sure we emit events after event listeners have been established.

Also make sure updateContact handler is registered.

