### PR TITLE
CP-4681: Fixed customSpendLimit for SignTransactions component

### DIFF
--- a/app/screens/rpc/hooks/useExplainTransactionShared.ts
+++ b/app/screens/rpc/hooks/useExplainTransactionShared.ts
@@ -164,6 +164,7 @@ export const useExplainTransactionShared = (args: Args) => {
    * Load transaction information
    *****************************************************************************/
   useEffect(() => {
+    // TODO: determine why loadTx render multiple times on Token Spend Approval
     async function loadTx() {
       if (!network) throw Error('Invalid network')
 
@@ -284,6 +285,7 @@ export const useExplainTransactionShared = (args: Args) => {
     loadTx().catch(err => {
       onError(err?.error || err.message)
     })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     network,
     avaxToken,

--- a/app/screens/rpc/util/getTransactionInfo.ts
+++ b/app/screens/rpc/util/getTransactionInfo.ts
@@ -73,8 +73,18 @@ export async function getTxInfo(
     return { error: 'Contract source code not verified' }
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const isJson = (str: any) => {
+    try {
+      JSON.parse(str)
+    } catch (e) {
+      return false
+    }
+    return true
+  }
+
   const abi = result || contractSource?.ABI
-  if (!abi) return { error: 'unable to get abi' }
+  if (!abi || !isJson(abi)) return { error: 'unable to get abi' }
   return parseDataWithABI(data, value, new Interface(abi))
 }
 


### PR DESCRIPTION
### What does this PR accomplish?
- Fixed Spend limit not appearing on token spend approval screen

### Is there anything in particular you want feedback on?
- Added function to check if abi is a json
- Added Todo for `loadTx` re-renders

### Screenshots/Videos

![ScreenShot 2023-02-16 at 17 28 50](https://user-images.githubusercontent.com/33738404/219512326-f5312ccf-7aec-48ae-acf3-5825e383faf8.png)
