### PR TITLE
CP-5312: Fix iOS wrong FPS calculation

### DIFF
--- a/docs/patches.md
+++ b/docs/patches.md
@@ -2,4 +2,12 @@
 
 ### react-native-flipper-performance-plugin+0.4.0.patch
 
-this patch is needed to make this plugin work with release builds on Android
+Android:
+- adjust gradle to make it work with release builds
+
+iOS:
+- change collect interval to 1s to fix FPS wrong calculation.
+
+- there are also changes on the flipper side https://github.com/ava-labs/react-native-flipper-performance-monitor/pull/1
+
+

--- a/patches/react-native-flipper-performance-plugin+0.4.0.patch
+++ b/patches/react-native-flipper-performance-plugin+0.4.0.patch
@@ -19,3 +19,16 @@ diff --git a/node_modules/react-native-flipper-performance-plugin/android/src/de
 similarity index 100%
 rename from node_modules/react-native-flipper-performance-plugin/android/src/debug/java/tech/bam/rnperformance/flipper/RNPerfMonitorPlugin.java
 rename to node_modules/react-native-flipper-performance-plugin/android/src/main/java/tech/bam/rnperformance/flipper/RNPerfMonitorPlugin.java
+diff --git a/node_modules/react-native-flipper-performance-plugin/ios/FlipperPerformancePlugin.m b/node_modules/react-native-flipper-performance-plugin/ios/FlipperPerformancePlugin.m
+index 6c4716e..355144d 100644
+--- a/node_modules/react-native-flipper-performance-plugin/ios/FlipperPerformancePlugin.m
++++ b/node_modules/react-native-flipper-performance-plugin/ios/FlipperPerformancePlugin.m
+@@ -113,7 +113,7 @@ - (void)onFrameTick:(CADisplayLink *)displayLink frameCountHolder:(FrameCountHol
+   [frameCountHolder incrementFrameCount];
+   if ([frameCountHolder previousTime] == -1) {
+     [frameCountHolder setPreviousTime:frameTimestamp];
+-  } else if (frameTimestamp - [frameCountHolder previousTime] >= 0.5) {
++  } else if (frameTimestamp - [frameCountHolder previousTime] >= 1) {
+     [_connection send:@"addRecord" withParams:@{
+       @"frameCount" : [NSNumber numberWithLong:[frameCountHolder frameCount]],
+       @"time": [NSNumber numberWithLong:(frameTimestamp - [frameCountHolder previousTime]) * 1000],


### PR DESCRIPTION
## Description

On iOS, patching [iOS](https://github.com/bamlab/react-native-flipper-performance-monitor) to increase collect interval to 1 second. This helps fixing the wrong FPS calculation issue. There are also other changes needed on the Flipper side https://github.com/ava-labs/react-native-flipper-performance-monitor/pull/1 

## Checklist for the author
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added necessary unit tests 
