### PR TITLE
fix: module resolution for cryptoassets

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -9,6 +9,20 @@ module.exports = {
   resolver: {
     extraNodeModules: {
       crypto: require.resolve('react-native-quick-crypto')
+    },
+    resolveRequest: (context, moduleName, platform) => {
+      if (moduleName.startsWith('@ledgerhq/cryptoassets')) {
+        return context.resolveRequest(
+          context,
+          moduleName.replace(
+            '@ledgerhq/cryptoassets',
+            '@ledgerhq/cryptoassets/lib-es'
+          ),
+          platform
+        )
+      }
+      // Optionally, chain to the standard Metro resolver.
+      return context.resolveRequest(context, moduleName, platform)
     }
   },
   transformer: {


### PR DESCRIPTION
## Description

Due to the lack of the export field support in the metro bundler, the build was failing when attempting to resolve a deep import from the module `@ledgerhq/cryptoassets`

Issue report: https://github.com/facebook/metro/issues/670
There is an RFC but it’s not fully working yet. In RN 0.72.0 it’s behind a feature flag: unstable_enablePackageExports. It will be released in 0.73.0 hopefully
https://github.com/react-native-community/discussions-and-proposals/pull/534

## Screenshots/Videos


## Testing


## Checklist for the author
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added necessary unit tests 
