### PR TITLE
CP-5106: migrate bitcoin chain ids

### DIFF
--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -29,6 +29,8 @@ import { WatchlistBlacklistTransform } from './transforms/WatchlistBlacklistTran
 import { WalletConnectBlacklistTransform } from './transforms/WalletConnectBlacklistTransform'
 import { AppBlacklistTransform } from './transforms/AppBlacklistTransform'
 
+const VERSION = 5
+
 // list of reducers that don't need to be persisted
 // for nested/partial blacklist, please use transform
 const blacklist = [
@@ -105,7 +107,7 @@ export function configureEncryptedStore(secretKey: string) {
       EncryptionTransform // last!
     ],
     migrate: createMigrate(migrations, { debug: __DEV__ }),
-    version: 4
+    version: VERSION
   }
 
   const persistedReducer = persistReducer(persistConfig, rootReducer)

--- a/app/store/migrations.ts
+++ b/app/store/migrations.ts
@@ -1,3 +1,4 @@
+import { ChainId } from '@avalabs/chains-sdk'
 import { initialState as watchlistInitialState } from './watchlist'
 import { initialState as posthogInitialState } from './posthog'
 
@@ -35,6 +36,37 @@ export const migrations = {
       posthog: {
         distinctID: posthogInitialState.distinctID,
         userID: state.posthog.userID
+      }
+    }
+  },
+  5: (state: any) => {
+    // migrate BTC and BTC testnet chainIds
+    const updatedFavorites = state.network.favorites.map((chainId: number) => {
+      if (chainId === -1) {
+        return ChainId.BITCOIN
+      }
+
+      if (chainId === -2) {
+        return ChainId.BITCOIN_TESTNET
+      }
+
+      return chainId
+    })
+
+    let updatedActive = state.network.active
+
+    if (updatedActive === -1) {
+      updatedActive = ChainId.BITCOIN
+    } else if (updatedActive === -2) {
+      updatedActive = ChainId.BITCOIN_TESTNET
+    }
+
+    return {
+      ...state,
+      network: {
+        ...state.network,
+        favorites: updatedFavorites,
+        active: updatedActive
       }
     }
   }

--- a/app/store/network/slice.ts
+++ b/app/store/network/slice.ts
@@ -1,5 +1,9 @@
 import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit'
-import { BITCOIN_NETWORK, Network } from '@avalabs/chains-sdk'
+import {
+  BITCOIN_NETWORK,
+  ChainId as ChainsSDKChainId,
+  Network
+} from '@avalabs/chains-sdk'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { selectAllCustomTokens } from 'store/customToken'
 import { LocalTokenWithBalance } from 'store/balance'
@@ -13,14 +17,22 @@ export const defaultNetwork = BITCOIN_NETWORK
 
 export const noActiveNetwork = 0
 
-export const alwaysFavoriteNetworks = [43114, 43113] //Avalanche mainnet, testnet
+export const alwaysFavoriteNetworks = [
+  ChainsSDKChainId.AVALANCHE_MAINNET_ID,
+  ChainsSDKChainId.AVALANCHE_TESTNET_ID
+]
 
 const reducerName = 'network'
 
 const initialState: NetworkState = {
   networks: {},
   customNetworks: {},
-  favorites: [...alwaysFavoriteNetworks, -1, -2, 1], //BTC, BTC testnet, ETH
+  favorites: [
+    ...alwaysFavoriteNetworks,
+    ChainsSDKChainId.BITCOIN,
+    ChainsSDKChainId.BITCOIN_TESTNET,
+    ChainsSDKChainId.ETHEREUM_HOMESTEAD
+  ],
   active: noActiveNetwork
 }
 


### PR DESCRIPTION
## Description
This pr removes all hard coded references of bitcoin chain ids and replaces them with the ChainId enum from the sdk. Also adds a migration to convert outdated bitcoin chain ids to the new ones.

## Checklist for the author
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added necessary unit tests 
