### PR TITLE
CP-5507: Stop connecting evm wallet to provider

### DIFF
--- a/app/services/wallet/WalletService.tsx
+++ b/app/services/wallet/WalletService.tsx
@@ -21,11 +21,11 @@ import {
   signTypedData,
   SignTypedDataVersion
 } from '@metamask/eth-sig-util'
-import { getEvmProvider } from 'services/network/utils/providerUtils'
 import SentryWrapper from 'services/sentry/SentryWrapper'
 import { Transaction } from '@sentry/types'
 import { Account } from 'store/account'
 import { RpcMethod } from 'store/walletConnectV2/types'
+import Logger from 'utils/Logger'
 
 class WalletService {
   private mnemonic?: string
@@ -67,13 +67,13 @@ class WalletService {
     }
     const provider = networkService.getProviderForNetwork(network)
 
-    log('btcWallet', now())
+    Logger.info('btcWallet', now())
     const btcWallet = await BitcoinWallet.fromMnemonic(
       this.mnemonic,
       accountIndex,
       provider as BitcoinProviderAbstract
     )
-    log('btcWallet end', now())
+    Logger.info('btcWallet end', now())
     return btcWallet
   }
 
@@ -85,18 +85,16 @@ class WalletService {
       throw new Error('Only EVM networks supported')
     }
     const start = now()
-    log('evmWallet', now() - start)
-    const walletFromMnemonic = getWalletFromMnemonic(
+
+    const wallet = getWalletFromMnemonic(
       this.mnemonic,
       accountIndex,
       DerivationPath.BIP44
     )
 
-    log('evmWallet getWalletFromMnemonic', now() - start)
-    const connectedWallet = walletFromMnemonic.connect(getEvmProvider(network))
-    log('evmWallet end', now() - start)
+    Logger.info('evmWallet getWalletFromMnemonic', now() - start)
 
-    return connectedWallet
+    return wallet
   }
 
   async sign(
@@ -305,9 +303,3 @@ class WalletService {
 }
 
 export default new WalletService()
-
-function log(message?: unknown, ...optionalParams: unknown[]) {
-  if (__DEV__) {
-    console.log(message, ...optionalParams)
-  }
-}


### PR DESCRIPTION
## Description

Currently, every time we create an evm wallet (when signing), we connect the wallet to the evm provider. This is unnecessary as we don't use the wallet to fetch blockchain data or send transactions. This pr removes this extra step. This saves 1/3 of the time it takes to generate an evm wallet. See videos below for more details.

References: https://docs.ethers.org/v4/api-wallet.html

## Screenshots/Videos

Before: on iphone SE, it takes about 600 ms to get the evm wallet instance
https://user-images.githubusercontent.com/8824551/191975047-c3e8ac49-690c-4a59-a160-6a2e29b92f79.MP4

After: on iphone SE, it takes about 400 ms to get the evm wallet instance
https://github.com/ava-labs/avalanche-wallet-apps/assets/8824551/003cca10-f166-42d7-bd83-ad7c394ac45f

## Checklist for the author
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added necessary unit tests 
