### PR TITLE
bitrise androidE2e fix

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -149,7 +149,7 @@ workflows:
                     # on ubuntu, yarn setup command will fail
                     # as patch-package doesn't have write access to the node_modules folder
                     # thus, we need to set write permission manually and rerun yarn
-
+                    # Bitrise issue link https://support.bitrise.io/hc/en-us/requests/39436?page=1
                     sudo chown root .
 
                     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash


### PR DESCRIPTION
## Description

- Added a custom build script to install NVM on the Ubuntu stack
- Proof that yarn commands now work [correctly](https://app.bitrise.io/build/e8e297b6-1597-4179-932a-97f29ae2d5d0)
- Bunch of other stuff is broken in regards to detox tests but that's for another day/fix

## Checklist for the author
- [x] I have performed a self-review of my code
- [x] I have verified the code works
