### PR TITLE
bitrise ios yarn setup fix

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -143,13 +143,7 @@ workflows:
                 set -o pipefail
                 # debug log
                 set -x
-                # trap 'catch $?' EXIT
-                # catch() {
-                #   echo 'This must be an ios build'
-                #   echo 'error $1 occurred'
-                #   yarn setup:ci
-                #   exit 0
-                # }
+
                 if ! cat /etc/issue 2>/dev/null
                 then
                 yarn setup:ci
@@ -173,8 +167,6 @@ workflows:
                     nvm install 18.14.1
                      
                     yarn setup:ci
-                else
-                  yarn setup:ci
                 fi
       - save-npm-cache@1: {}
       - script@1:


### PR DESCRIPTION
## Description

- Bitrise doesn't like the `stack=$( cat /etc/issue )` command in our bash script so i put in a conditional to check to see of the file/folder exists 

