### PR TITLE
CP-5658 Tapping settings burger menu opens the networks dropdown 

### DIFF
--- a/app/components/Dropdown.tsx
+++ b/app/components/Dropdown.tsx
@@ -208,7 +208,6 @@ function DropDown<ItemT>({
         style
       ]}
       wrapperStyle={{
-        width: width,
         overflow: 'visible'
       }}
       caret={false}

--- a/app/screens/bridge/Bridge.tsx
+++ b/app/screens/bridge/Bridge.tsx
@@ -340,8 +340,7 @@ const Bridge: FC = () => {
           paddingVertical: 8,
           paddingLeft: 16,
           alignItems: 'center',
-          justifyContent: 'flex-end',
-          flex: 1
+          justifyContent: 'flex-end'
         }}>
         {renderBlockchain(blockchain, 'large')}
       </Row>
@@ -392,21 +391,23 @@ const Bridge: FC = () => {
           title={'From'}
           rightComponentMaxWidth="auto"
           rightComponent={
-            <DropDown
-              width={dropdownWith}
-              data={availableBlockchains}
-              selectedIndex={availableBlockchains.indexOf(currentBlockchain)}
-              onItemSelected={setCurrentBlockchain}
-              optionsRenderItem={item =>
-                renderDropdownItem(item.item, currentBlockchain)
-              }
-              selectionRenderItem={() =>
-                renderFromBlockchain(currentBlockchain)
-              }
-              style={{
-                top: 22
-              }}
-            />
+            <View>
+              <DropDown
+                width={dropdownWith}
+                data={availableBlockchains}
+                selectedIndex={availableBlockchains.indexOf(currentBlockchain)}
+                onItemSelected={setCurrentBlockchain}
+                optionsRenderItem={item =>
+                  renderDropdownItem(item.item, currentBlockchain)
+                }
+                selectionRenderItem={() =>
+                  renderFromBlockchain(currentBlockchain)
+                }
+                style={{
+                  top: 22
+                }}
+              />
+            </View>
           }
         />
       </>


### PR DESCRIPTION
## Description
This PR removes setting width style property in Dropdown > Popable > wrapper which caused Dropdown to have much larger hit area than needed. 
Screenshots of all Dropdown instances are provided to prove nothing else is broken by this change.

## Screenshots/Videos

Hit area (red) much larger
<img width="372" alt="Hit area (red) much larger" src="https://github.com/ava-labs/avalanche-wallet-apps/assets/6573904/0a6c6fe8-50e9-4746-8648-89d65940a5c5">
<br>
Hit area after the fix
<img width="384" alt="Hit area after the fix" src="https://github.com/ava-labs/avalanche-wallet-apps/assets/6573904/35b5e8af-6576-4539-a130-c70aa7b1d66f">
<br>
Network dropdown
<img width="300" alt="Network dropdown" src="https://github.com/ava-labs/avalanche-wallet-apps/assets/6573904/9c4f0dff-8074-416c-ad46-ef2afcdfe071">
<br>
Watchlist dropdown
<img width="167" alt="Watchlist dropdown" src="https://github.com/ava-labs/avalanche-wallet-apps/assets/6573904/1d92f3d5-9b89-4ece-9099-ad6f5d32ca84">
<br>
Activity dropdown
<img width="326" alt="Activity dropdown" src="https://github.com/ava-labs/avalanche-wallet-apps/assets/6573904/15e14516-d709-4dc3-98e9-4b903b8fd9ca">
<br>
Bridge dropdown
<img width="332" alt="Bridge dropdown" src="https://github.com/ava-labs/avalanche-wallet-apps/assets/6573904/f2a11a80-4ddb-47b0-a0c0-818cca674d22">
<br>


## Checklist for the author
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added necessary unit tests 
