### PR TITLE
add true string

### DIFF
--- a/e2e/sendResults.ts
+++ b/e2e/sendResults.ts
@@ -111,7 +111,7 @@ export default async function sendResults() {
   const testCasesToSend = preparedFinalResults.testCasesToSend
   const resultsToSendToTestrail = preparedFinalResults.resultsToSendToTestrail
 
-  if (process.env.POST_TO_TESTRAIL) {
+  if (process.env.POST_TO_TESTRAIL === 'true') {
     if (await isResultPresent('android')) {
       await generatePlatformResults(
         testCasesToSend,


### PR DESCRIPTION
## Description

- Environment variable for posting results to testrail is returned as a string and not a bool.  This change takes care of the issue with locally run tests posting to testrail.

