### PR TITLE
cp-6000: fix weird UI state on stake dashboard

### DIFF
--- a/app/screens/earn/components/CircularProgress.tsx
+++ b/app/screens/earn/components/CircularProgress.tsx
@@ -39,12 +39,14 @@ export const CircularProgress: FC<CircularProgressProps> = ({ data }) => {
           const amountPercent = item.amount / total
 
           // This will calculate the start and end of each section of the the circular path
-          end = end + Number(amountPercent.toFixed(2))
-
           if (index !== 0) {
             const startPercent = (data[index - 1]?.amount || 0) / total
             start = start + Number(startPercent.toFixed(2))
           }
+          end = end + Number(amountPercent.toFixed(2))
+
+          const startPath = isNaN(start) ? 0 : start
+          const endPath = isNaN(end) ? 0 : end
 
           return (
             <Path
@@ -55,8 +57,8 @@ export const CircularProgress: FC<CircularProgressProps> = ({ data }) => {
               strokeJoin="round"
               strokeWidth={strokeWidth}
               strokeCap="round"
-              start={index === 0 ? 0 : start}
-              end={end}>
+              start={index === 0 ? 0 : startPath}
+              end={endPath}>
               <Shadow
                 dx={-1}
                 dy={-1}


### PR DESCRIPTION
## Description
- in a case where there is no avax to calculate the start point and end point of the circular progress, we get NaN, which Skia doens't like it.

## Screenshots/Videos

https://github.com/ava-labs/avalanche-wallet-apps/assets/137183702/4c25b4bc-79b5-4ab0-981b-754510b6f670

## Testing
manual

## Checklist for the author
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added necessary unit tests 
