### PR TITLE
Fixed stake setup screens showing bottom tab

### DIFF
--- a/app/navigation/AppNavigation.ts
+++ b/app/navigation/AppNavigation.ts
@@ -55,7 +55,8 @@ enum WalletScreens {
   ActivityDetail = 'WalletScreens.ActivityDetail',
   Bridge = 'WalletScreens.Bridge',
   QRCode = 'WalletScreens.QRCode',
-  Earn = 'WalletScreens.Earn'
+  Earn = 'WalletScreens.Earn',
+  StakeSetup = 'WalletScreens.StakeSetup'
 }
 
 enum NoWalletScreens {

--- a/app/navigation/WalletScreenStack/WalletScreenStack.tsx
+++ b/app/navigation/WalletScreenStack/WalletScreenStack.tsx
@@ -66,6 +66,9 @@ import { ChainID } from 'store/network'
 import EarnScreenStack, {
   EarnStackParamList
 } from 'navigation/wallet/EarnScreenStack'
+import StakeSetupScreenStack, {
+  StakeSetupStackParamList
+} from 'navigation/wallet/StakeSetupScreenStack'
 import { BridgeStackParamList } from '../wallet/BridgeScreenStack'
 import {
   AddEthereumChainParams,
@@ -133,11 +136,11 @@ export type WalletScreenStackParams = {
   [AppNavigation.Wallet.Earn]:
     | NavigatorScreenParams<EarnStackParamList>
     | undefined
+  [AppNavigation.Wallet.StakeSetup]:
+    | NavigatorScreenParams<StakeSetupStackParamList>
+    | undefined
   [AppNavigation.Wallet.NFTDetails]: NavigatorScreenParams<NFTStackParamList>
   [AppNavigation.Wallet.NFTManage]: undefined
-  [AppNavigation.Wallet.Earn]:
-    | NavigatorScreenParams<EarnStackParamList>
-    | undefined
   [AppNavigation.Wallet.AddressBook]:
     | NavigatorScreenParams<AddressBookStackParamList>
     | undefined
@@ -298,6 +301,13 @@ function WalletScreenStack(props: Props | Readonly<Props>) {
           }}
           name={AppNavigation.Wallet.Earn}
           component={EarnScreenStack}
+        />
+        <WalletScreenS.Screen
+          options={{
+            headerShown: false
+          }}
+          name={AppNavigation.Wallet.StakeSetup}
+          component={StakeSetupScreenStack}
         />
         <WalletScreenS.Screen
           options={{

--- a/app/navigation/wallet/EarnScreenStack.tsx
+++ b/app/navigation/wallet/EarnScreenStack.tsx
@@ -1,18 +1,12 @@
 import React from 'react'
 import AppNavigation from 'navigation/AppNavigation'
 import { createStackNavigator } from '@react-navigation/stack'
-import { NavigatorScreenParams } from '@react-navigation/native'
 import StakeDetails from 'screens/earn/StakeDetails'
 import { StakeDashboard } from 'screens/earn/StakeDashboard'
 import TopNavigationHeader from 'navigation/TopNavigationHeader'
-import StakeSetupScreenStack, {
-  StakeSetupStackParamList
-} from './StakeSetupScreenStack'
 
 export type EarnStackParamList = {
   [AppNavigation.Earn.StakeDashboard]: undefined
-  [AppNavigation.Earn
-    .StakeSetup]: NavigatorScreenParams<StakeSetupStackParamList>
   [AppNavigation.Earn.StakeDetails]: {
     txHash: string
     stakeTitle: string
@@ -35,11 +29,6 @@ function EarnScreenStack() {
           header: NavigationHeader
         }}
         component={StakeDashboard}
-      />
-      <EarnStack.Screen
-        name={AppNavigation.Earn.StakeSetup}
-        options={{ headerShown: false }}
-        component={StakeSetupScreenStack}
       />
       <EarnStack.Screen
         name={AppNavigation.Earn.StakeDetails}

--- a/app/screens/earn/components/Balance.tsx
+++ b/app/screens/earn/components/Balance.tsx
@@ -63,7 +63,7 @@ export const Balance: React.FC<BalanceProps> = ({ stakingData }) => {
   const renderStakeButton = () => (
     <AvaButton.PrimaryLarge
       onPress={() =>
-        navigate(AppNavigation.Earn.StakeSetup, {
+        navigate(AppNavigation.Wallet.StakeSetup, {
           screen: AppNavigation.StakeSetup.StakingAmount
         })
       }>
@@ -80,7 +80,7 @@ export const Balance: React.FC<BalanceProps> = ({ stakingData }) => {
       <AvaButton.SecondaryLarge
         style={{ flex: 1 }}
         onPress={() =>
-          navigate(AppNavigation.Earn.StakeSetup, {
+          navigate(AppNavigation.Wallet.StakeSetup, {
             screen: AppNavigation.StakeSetup.StakingAmount
           })
         }>
@@ -90,7 +90,7 @@ export const Balance: React.FC<BalanceProps> = ({ stakingData }) => {
       <AvaButton.SecondaryLarge
         style={{ flex: 1 }}
         onPress={() =>
-          navigate(AppNavigation.Earn.StakeSetup, {
+          navigate(AppNavigation.Wallet.StakeSetup, {
             screen: AppNavigation.StakeSetup.StakingAmount
           })
         }>


### PR DESCRIPTION
## Description
StakeSetup stack was added within Earn tab, which when we navigate, it is still navigate within the tab navigator.   we should move StakeSetup one level up to WalletStack (*authenticated root stack), to avoid showing bottom tab in those screens.

## Screenshots/Videos

https://github.com/ava-labs/avalanche-wallet-apps/assets/137183702/ff679c10-c0ac-4a63-877a-0bc463171636



## Testing
-manual

## Checklist for the author
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added necessary unit tests 
