### PR TITLE
CP-6029: Fix auto refresh animation on Stake screen

### DIFF
--- a/app/hooks/earn/useActiveStakes.ts
+++ b/app/hooks/earn/useActiveStakes.ts
@@ -2,11 +2,12 @@ import { isOnGoing } from 'utils/earn/status'
 import { useStakes } from './useStakes'
 
 export const useActiveStakes = () => {
-  const { data, isFetching, refetch, isRefetching, isLoading } = useStakes()
+  const { data, isFetching, pullToRefresh, isRefreshing, isLoading } =
+    useStakes()
 
   const now = new Date()
 
   const stakes = data?.filter(transaction => isOnGoing(transaction, now)) ?? []
 
-  return { stakes, isFetching, refetch, isRefetching, isLoading }
+  return { stakes, isFetching, pullToRefresh, isRefreshing, isLoading }
 }

--- a/app/hooks/earn/usePastStakes.ts
+++ b/app/hooks/earn/usePastStakes.ts
@@ -2,12 +2,13 @@ import { isCompleted } from 'utils/earn/status'
 import { useStakes } from './useStakes'
 
 export const usePastStakes = () => {
-  const { data, isFetching, refetch, isRefetching, isLoading } = useStakes()
+  const { data, isFetching, pullToRefresh, isRefreshing, isLoading } =
+    useStakes()
 
   const now = new Date()
 
   const stakes =
     data?.filter(transaction => isCompleted(transaction, now)) ?? []
 
-  return { stakes, isFetching, refetch, isRefetching, isLoading }
+  return { stakes, isFetching, pullToRefresh, isRefreshing, isLoading }
 }

--- a/app/hooks/earn/useStakes.ts
+++ b/app/hooks/earn/useStakes.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query'
 import { refetchIntervals } from 'consts/earn'
+import { useRefreshableQuery } from 'hooks/query/useRefreshableQuery'
 import { useSelector } from 'react-redux'
 import EarnService from 'services/earn/EarnService'
 import { selectActiveAccount } from 'store/account'
@@ -10,7 +10,7 @@ export const useStakes = () => {
   const account = useSelector(selectActiveAccount)
   const pAddress = account?.addressPVM ?? ''
 
-  return useQuery({
+  return useRefreshableQuery({
     refetchInterval: refetchIntervals.stakes,
     enabled: Boolean(pAddress),
     queryKey: ['stakes', isDeveloperMode, pAddress],

--- a/app/hooks/query/useRefreshableQuery.ts
+++ b/app/hooks/query/useRefreshableQuery.ts
@@ -1,0 +1,44 @@
+import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { useEffect, useRef } from 'react'
+
+/**
+ * This hook is same as useQuery. The only difference is
+ * it supports pullToRefresh and isRefreshing.
+ * These 2 props are needed to show refreshing state with list components.
+ *
+ * More details here:
+ * - pull to refresh solution: https://github.com/TanStack/query/discussions/2842
+ * - wrapper typing: https://twitter.com/TkDodo/status/1491451513264574501
+ */
+export const useRefreshableQuery = <
+  TQueryKey extends (string | Record<string, unknown> | boolean)[],
+  TQueryFnData,
+  TError,
+  TData = TQueryFnData
+>(
+  options: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    'initialData'
+  > & {
+    initialData?: undefined
+  }
+) => {
+  const isRefreshing = useRef(false)
+  const query = useQuery(options)
+
+  useEffect(() => {
+    if (!query.isRefetching) isRefreshing.current = false
+  }, [query.isRefetching])
+
+  const pullToRefresh = () => {
+    isRefreshing.current = true
+    query.refetch()
+  }
+
+  return Object.assign({}, query, {
+    pullToRefresh,
+    get isRefreshing() {
+      return query.isRefetching && isRefreshing.current
+    }
+  })
+}

--- a/app/screens/earn/components/ActiveStakes.tsx
+++ b/app/screens/earn/components/ActiveStakes.tsx
@@ -10,7 +10,7 @@ import { NoActiveStakes } from './ZeroState'
 import { StakeListLoader } from './StakeListLoader'
 
 export const ActiveStakes = () => {
-  const { stakes, refetch, isRefetching, isLoading } = useActiveStakes()
+  const { stakes, pullToRefresh, isRefreshing, isLoading } = useActiveStakes()
 
   if (isLoading) {
     return <StakeListLoader />
@@ -45,8 +45,8 @@ export const ActiveStakes = () => {
       data={stakes}
       renderItem={renderItem}
       ListEmptyComponent={NoActiveStakes}
-      refreshing={isRefetching}
-      onRefresh={refetch}
+      refreshing={isRefreshing}
+      onRefresh={pullToRefresh}
       keyExtractor={keyExtractor}
       estimatedItemSize={201}
       contentContainerStyle={styles.cardContainer}

--- a/app/screens/earn/components/PastStakes.tsx
+++ b/app/screens/earn/components/PastStakes.tsx
@@ -10,7 +10,7 @@ import { NoPastStakes } from './ZeroState'
 import { StakeListLoader } from './StakeListLoader'
 
 export const PastStakes = () => {
-  const { stakes, refetch, isRefetching, isLoading } = usePastStakes()
+  const { stakes, pullToRefresh, isRefreshing, isLoading } = usePastStakes()
 
   if (isLoading) {
     return <StakeListLoader />
@@ -48,8 +48,8 @@ export const PastStakes = () => {
       data={stakes}
       renderItem={renderItem}
       ListEmptyComponent={NoPastStakes}
-      refreshing={isRefetching}
-      onRefresh={refetch}
+      refreshing={isRefreshing}
+      onRefresh={pullToRefresh}
       keyExtractor={keyExtractor}
       estimatedItemSize={233}
       contentContainerStyle={styles.cardContainer}


### PR DESCRIPTION
## Description
There is no way to differentiate between a background refetch vs manual refetch out of the box from React Query. We have to manually track the process. This pr adds `useRefreshableQuery` that does just that. 


## Checklist for the author
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added necessary unit tests 
