### PR TITLE
CP-6725: use posthog test feature flags key for internal builds

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -194,13 +194,20 @@ workflows:
 
                 # Check if the value is not empty (found in .env.development)
                 if [ -n "$feature_flags_key" ]; then
-                    # Update the value of POSTHOG_FEATURE_FLAGS_KEY in the .env file
-                    sed -i "s/^POSTHOG_FEATURE_FLAGS_KEY=.*/POSTHOG_FEATURE_FLAGS_KEY=$feature_flags_key/" .env
+                    # Create a temporary file for the in-place edit
+                    temp_file=$(mktemp)
+
+                    # Replace the value of POSTHOG_FEATURE_FLAGS_KEY in the .env file and save it in the temporary file
+                    sed "s/^POSTHOG_FEATURE_FLAGS_KEY=.*/POSTHOG_FEATURE_FLAGS_KEY=$feature_flags_key/" .env > "$temp_file"
+
+                    # Replace the original .env file with the modified temporary file
+                    mv "$temp_file" .env
+
                     echo "Updated POSTHOG_FEATURE_FLAGS_KEY in .env"
                 else
                     echo "POSTHOG_FEATURE_FLAGS_KEY not found in .env.development or is empty."
                 fi
-
+                
             fi
   _send-notification-slack:
     steps:


### PR DESCRIPTION
## Description

- when USE_TEST_FEATURE_FLAGS env var is true, the build will use posthog test feature flags key. 
- all internal builds have this set to true.

## Checklist for the author
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added necessary unit tests 
