### PR TITLE
CP-6914: Don't auto sign transactions when estimating fees

### DIFF
--- a/app/hooks/earn/useClaimFees.ts
+++ b/app/hooks/earn/useClaimFees.ts
@@ -4,13 +4,11 @@ import {
   calculateCChainFee,
   calculatePChainFee
 } from 'services/earn/calculateCrossChainFees'
-import { UnsignedTx } from '@avalabs/avalanchejs-v2'
 import { useSelector } from 'react-redux'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import NetworkService from 'services/network/NetworkService'
 import { selectActiveAccount } from 'store/account'
 import WalletService from 'services/wallet/WalletService'
-import { AvalancheTransactionRequest } from 'services/wallet/types'
 import Logger from 'utils/Logger'
 import { useCChainBaseFee } from 'hooks/useCChainBaseFee'
 
@@ -55,19 +53,7 @@ export const useClaimFees = () => {
         shouldValidateBurnedAmount: false
       })
 
-      const signedTxJson = await WalletService.sign(
-        { tx: unsignedTx } as AvalancheTransactionRequest,
-        activeAccount.index,
-        avaxXPNetwork
-      )
-
-      const signedTx = UnsignedTx.fromJSON(signedTxJson).getSignedTx()
-
-      const importCFee = calculateCChainFee(
-        instantBaseFee,
-        unsignedTx,
-        signedTx
-      )
+      const importCFee = calculateCChainFee(instantBaseFee, unsignedTx)
 
       Logger.info('importCFee', importCFee.toDisplay())
       Logger.info('exportPFee', exportPFee.toDisplay())

--- a/app/hooks/earn/useEstimateStakingFees.ts
+++ b/app/hooks/earn/useEstimateStakingFees.ts
@@ -5,13 +5,11 @@ import {
   calculateCChainFee,
   calculatePChainFee
 } from 'services/earn/calculateCrossChainFees'
-import { UnsignedTx } from '@avalabs/avalanchejs-v2'
 import { useSelector } from 'react-redux'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import NetworkService from 'services/network/NetworkService'
 import { selectActiveAccount } from 'store/account'
 import WalletService from 'services/wallet/WalletService'
-import { AvalancheTransactionRequest } from 'services/wallet/types'
 import Logger from 'utils/Logger'
 import { useCChainBaseFee } from 'hooks/useCChainBaseFee'
 
@@ -77,13 +75,7 @@ export const useEstimateStakingFees = (
         shouldValidateBurnedAmount: false
       })
 
-      const signedTxJson = await WalletService.sign(
-        { tx: unsignedTx } as AvalancheTransactionRequest,
-        activeAccount.index,
-        avaxXPNetwork
-      )
-      const signedTx = UnsignedTx.fromJSON(signedTxJson).getSignedTx()
-      const exportFee = calculateCChainFee(instantBaseFee, unsignedTx, signedTx)
+      const exportFee = calculateCChainFee(instantBaseFee, unsignedTx)
       setEstimatedStakingFee(exportFee.add(importFee))
     }
     calculateEstimatedStakingFee().catch(reason => Logger.error(reason))

--- a/app/services/earn/calculateCChainFee.test.ts
+++ b/app/services/earn/calculateCChainFee.test.ts
@@ -17,20 +17,12 @@ describe('earn/calculateCChainFee', () => {
     } as unknown as UnsignedTx
 
     it('should result 0.00033003 for single byte with base fee 30nAvax', async () => {
-      const result = calculateCChainFee(
-        Avax.fromNanoAvax(30),
-        unsignedTxMock,
-        unsignedTxMock.getSignedTx()
-      )
+      const result = calculateCChainFee(Avax.fromNanoAvax(30), unsignedTxMock)
       expect(result.toString()).toBe('0.00033003')
     })
 
     it('should result 0.000495045 for single byte with base fee 45nAvax', async () => {
-      const result = calculateCChainFee(
-        Avax.fromNanoAvax(45),
-        unsignedTxMock,
-        unsignedTxMock.getSignedTx()
-      )
+      const result = calculateCChainFee(Avax.fromNanoAvax(45), unsignedTxMock)
       expect(result.toString()).toBe('0.000495045')
     })
   })

--- a/app/services/earn/calculateCrossChainFees.ts
+++ b/app/services/earn/calculateCrossChainFees.ts
@@ -1,17 +1,20 @@
-import { avaxSerial, UnsignedTx } from '@avalabs/avalanchejs-v2'
+import { UnsignedTx } from '@avalabs/avalanchejs-v2'
 import { Avax } from 'types/Avax'
 
 /**
- * https://docs.avax.network/quickstart/transaction-fees#atomic-transaction-fees
+ * Calculate the fee needed to perform C-Chain atomic transactions (imports + exports from/to other chains)
+ * @param baseFee
+ * @param unsignedTx a dummy unsigned transaction object
+ *
+ * More details: https://docs.avax.network/quickstart/transaction-fees#atomic-transaction-fees
  */
 export function calculateCChainFee(
   baseFee: Avax,
-  unsignedTx: UnsignedTx,
-  signedTx: avaxSerial.SignedTx
+  unsignedTx: UnsignedTx
 ): Avax {
   const usedGas =
     BigInt(unsignedTx.toBytes().length) +
-    BigInt(1000 * signedTx.getAllSignatures().length) +
+    BigInt(1000 * unsignedTx.getSignedTx().getAllSignatures().length) +
     10000n
   return baseFee.mul(usedGas)
 }


### PR DESCRIPTION
## Description

We no longer auto sign transactions when estimating fees for stake setup and claim rewards flows. Only the dummy unsigned transaction object is used.

## Checklist for the author
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have added necessary unit tests 
