### PR TITLE
CP-6946 Change timer on node search screen

### DIFF
--- a/app/screens/earn/NodeSearch.tsx
+++ b/app/screens/earn/NodeSearch.tsx
@@ -20,12 +20,12 @@ export const NodeSearch = () => {
     stakingEndTime,
     validators: data?.validators
   })
-  const [isShowtime, setIsShowTime] = useState(true)
+  const [isShowSearching, setIsShowSearching] = useState(true)
   setTimeout(() => {
-    setIsShowTime(false)
+    setIsShowSearching(false)
   }, 3000)
 
-  if (isShowtime || isFetching) return <Searching />
+  if (isShowSearching || isFetching) return <Searching />
   if (error || useSearchNodeError || !validator) return <NoMatchFound />
   return <MatchFound validator={validator} />
 }


### PR DESCRIPTION
## Description

- The api call for node search is very fast and didn't allow the copy on the `Searching` screen to show so timer was implemented to force the screen to be displayed for 4 seconds
- 4 seconds seems optimal to allow the user to read the text before the they're taken to the confirmation screen. App still feels fast and responsive.

## Screenshots/Videos

https://github.com/ava-labs/avalanche-wallet-apps/assets/17894098/434dc14a-d3ec-42d0-9c3b-43366a5180f6

## Checklist for the author
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added necessary unit tests 
