### PR TITLE
QA tyler - update test case name parsing

### DIFF
--- a/e2e/getResultsFromLogs.ts
+++ b/e2e/getResultsFromLogs.ts
@@ -114,7 +114,6 @@ async function splitTestResult(testItem: string | undefined) {
     return { sectionName: trimmedSectionName, testCase }
   }
 }
-splitTestResult('✓ Activity Tab should display incoming transaction details(3)')
 
 function removeTestSectionExtraChars(testSection: string | undefined) {
   if (testSection) {


### PR DESCRIPTION
## Description

- Detox retries is causing multiple test cases to be create due to multiple result logs being generated with `(#)` iterator.  The function we use to parse the logs has been updated to remove the iterator.
- Need to check to make sure results are still being reported correctly


## Checklist for the author
- [x] I have performed a self-review of my code
- [x] I have verified the code works
