### PR TITLE
CP-6941: add backdrop opacity

### DIFF
--- a/app/components/BottomSheet.tsx
+++ b/app/components/BottomSheet.tsx
@@ -32,7 +32,7 @@ export const BottomSheet: FC<BottomSheetProps> = ({
   children
 }) => {
   const { goBack } = useNavigation()
-  const defaultSnapPoints = ['95%']
+  const defaultSnapPoints = ['94%']
 
   const renderBottomSheetBackdrop = useCallback(props => {
     return (


### PR DESCRIPTION
## Description

- add opacity of 0.6 based on Figma to bottom-sheet backdrop component

## Screenshots/Videos

<img width="762" alt="Screenshot 2023-08-18 at 9 40 31 AM" src="https://github.com/ava-labs/avalanche-wallet-apps/assets/137183702/cd42e9f2-4434-4124-963d-7dd1a81eeebb">

https://github.com/ava-labs/avalanche-wallet-apps/assets/137183702/9fa86050-c2ff-4bad-bb26-353be58e5167

## Testing
- manual

## Checklist for the author
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added necessary unit tests 
