### PR TITLE
QA tyler fix change network test

### DIFF
--- a/e2e/tests/network/changeNetwork.e2e.smoke.ts
+++ b/e2e/tests/network/changeNetwork.e2e.smoke.ts
@@ -67,7 +67,6 @@ describe('Change Network', () => {
   it('should remove BTC network from favorites', async () => {
     await PortfolioPage.tapNetworksDropdown()
     await PortfolioPage.tapManageNetworks()
-    await NetworksManagePage.tapNetworksTab()
     await NetworksManagePage.addBtcNetwork()
     await NetworksManagePage.tapHeaderBack()
     await PortfolioPage.tapNetworksDropdown()


### PR DESCRIPTION
## Description

- Fix for change network test.  The Beam subnet was added to the networks screen so detox was tapping the wrong favorites icon.  
- No need to tap on manage networks tab since btc is already on the favorites by default


