### PR TITLE
QA fix section name parse

### DIFF
--- a/e2e/getResultsFromLogs.ts
+++ b/e2e/getResultsFromLogs.ts
@@ -107,14 +107,15 @@ async function splitTestResult(testItem: string | undefined) {
       const splitTestCase = testCase.split('(')
       const rejoinedString = splitTestCase[0]
       const trimmedTestCase = rejoinedString?.trim()
-      return { sectionName: rawSectionName, testCase: trimmedTestCase }
+      const sectionName = removeTestSectionExtraChars(rawSectionName)
+      const trimmedSectionName = sectionName?.trim()
+      return { sectionName: trimmedSectionName, testCase: trimmedTestCase }
     }
     const sectionName = removeTestSectionExtraChars(rawSectionName)
     const trimmedSectionName = sectionName?.trim()
     return { sectionName: trimmedSectionName, testCase }
   }
 }
-splitTestResult('✓ Activity Tab should display incoming transaction details(3)')
 
 function removeTestSectionExtraChars(testSection: string | undefined) {
   if (testSection) {


### PR DESCRIPTION
## Description

- Section name was not being parsed correctly on retry
