### PR TITLE
QA tyler fix test report timeout

### DIFF
--- a/e2e/generateTestrailObjects.ts
+++ b/e2e/generateTestrailObjects.ts
@@ -418,9 +418,29 @@ async function getTestCasesBySection(section_id: number) {
     // console.log(tCtitle)
     tcArray.push({ testCaseTitle, sectionID })
   })
-  // console.log(tcArray)
   return tcArray
 }
+
+//getTestCasesBySection(518)
+
+export async function deleteEmptyTestSections() {
+  const sections = await api.getSections(projectId)
+  sections.forEach(async function (section: { name: any; id: any }) {
+    const sectionName = section.name
+    const sectionID = section.id
+    try {
+      const cases = await getTestCasesBySection(sectionID)
+      if (cases.length === 0) {
+        console.log(sectionName + ' is empty and will be deleted!!!')
+        await api.deleteSection(sectionID)
+      }
+    } catch (error) {
+      console.log(error)
+    }
+  })
+}
+// only run this if a mistake was made and emtpy sections were created
+// deleteEmptyTestSections()
 
 export async function getTestRunCases(testRunId: any) {
   const cases = await api.getTests(testRunId)

--- a/e2e/sendResults.ts
+++ b/e2e/sendResults.ts
@@ -212,7 +212,7 @@ async function generatePlatformResults(
           if (failScreenshot) {
             const failedPayload = {
               name: 'failed.png',
-              value: fs.createReadStream(failScreenshot)
+              value: await fs.createReadStream(failScreenshot)
             }
             // Attaches the screenshot to the corressponding case in the test run
             const attachmentID = await api.addAttachmentToResult(


### PR DESCRIPTION
## Description

- We were missing an important `await` and i also created a function to delete empty test sections in case another parsing error occurs in the future
