### PR TITLE
CP-7056: Fix App stuck on "Send" collectibles

### DIFF
--- a/app/contexts/SendNFTContext.tsx
+++ b/app/contexts/SendNFTContext.tsx
@@ -27,6 +27,7 @@ import BN from 'bn.js'
 import { InteractionManager } from 'react-native'
 import SentryWrapper from 'services/sentry/SentryWrapper'
 import { usePostCapture } from 'hooks/usePosthogCapture'
+import { RootState } from 'store'
 
 export interface SendNFTContextState {
   sendToken: NFTItemData
@@ -57,8 +58,9 @@ export const SendNFTContextProvider = ({
   const activeAccount = useSelector(selectActiveAccount)
   const activeNetwork = useSelector(selectActiveNetwork)
   const selectedCurrency = useSelector(selectSelectedCurrency)
-  const nativeTokenBalance = useSelector(
+  const nativeTokenBalance = useSelector((state: RootState) =>
     selectNativeTokenBalanceForNetworkAndAccount(
+      state,
       activeNetwork.chainId,
       activeAccount?.index
     )
@@ -205,6 +207,7 @@ export const SendNFTContextProvider = ({
       setCanSubmit(false)
       return
     }
+
     sendService
       .validateStateAndCalculateFees(
         {

--- a/app/store/balance/slice.ts
+++ b/app/store/balance/slice.ts
@@ -1,4 +1,9 @@
-import { createAction, createSlice, PayloadAction } from '@reduxjs/toolkit'
+import {
+  createAction,
+  createSelector,
+  createSlice,
+  PayloadAction
+} from '@reduxjs/toolkit'
 import { RootState } from 'store'
 import { selectActiveAccount } from 'store/account'
 import { selectActiveNetwork, selectIsTestnet } from 'store/network'
@@ -186,12 +191,24 @@ export const selectBalanceTotalInCurrencyForNetworkAndAccount =
     return totalInCurrency
   }
 
-export const selectNativeTokenBalanceForNetworkAndAccount =
-  (chainId: number, accountIndex: number | undefined) => (state: RootState) => {
-    if (accountIndex === undefined) return undefined
+const _selectAllBalances = (state: RootState) => state.balance.balances
 
-    const key = getKey(chainId, accountIndex)
-    const balanceForNetworkAndAccount = state.balance.balances[key]
+const _selectBalanceKeyForNetworkAndAccount = (
+  _state: RootState,
+  chainId: number,
+  accountIndex: number | undefined
+) => {
+  if (accountIndex === undefined) return undefined
+
+  return getKey(chainId, accountIndex)
+}
+
+export const selectNativeTokenBalanceForNetworkAndAccount = createSelector(
+  [_selectAllBalances, _selectBalanceKeyForNetworkAndAccount],
+  (allBalances, key) => {
+    if (key === undefined) return undefined
+
+    const balanceForNetworkAndAccount = allBalances[key]
 
     const nativeToken = Object.values(
       balanceForNetworkAndAccount?.tokens ?? []
@@ -199,6 +216,7 @@ export const selectNativeTokenBalanceForNetworkAndAccount =
 
     return Avax.fromWei(nativeToken?.balance ?? 0)
   }
+)
 
 export const selectBalanceTotalForNetwork =
   (chainId: number) => (state: RootState) => {


### PR DESCRIPTION
## Description

Problem: 
- selectNativeTokenBalanceForNetworkAndAccount return a new Avax object on every call
- the Avax object is used in a useEffect's dep array in SendNftContext

Solution: memoize the returned value of selectNativeTokenBalanceForNetworkAndAccount and only rerun whenever balances change

## Checklist for the author
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added necessary unit tests 
