### PR TITLE
CP-6959: Make value param optional for eth_sendTransaction

### DIFF
--- a/app/screens/rpc/hooks/useExplainTransactionShared.ts
+++ b/app/screens/rpc/hooks/useExplainTransactionShared.ts
@@ -192,13 +192,13 @@ export const useExplainTransactionShared = (args: Args) => {
         try {
           gasLimit = await (txParams.gas
             ? BigNumber.from(txParams.gas).toNumber()
-            : networkFeeService.estimateGasLimit(
-                txParams.from,
-                txParams.to,
-                txParams.data ?? '',
-                txParams.value,
+            : networkFeeService.estimateGasLimit({
+                from: txParams.from,
+                to: txParams.to,
+                data: txParams.data,
+                value: txParams.value,
                 network
-              ))
+              }))
         } catch (e) {
           Logger.error('failed to calculate gas limit', e)
           throw Error('Unable to calculate gas limit')

--- a/app/services/networkFee/NetworkFeeService.ts
+++ b/app/services/networkFee/NetworkFeeService.ts
@@ -44,13 +44,19 @@ class NetworkFeeService {
     return null
   }
 
-  async estimateGasLimit(
-    from: string,
-    to: string,
-    data: string,
-    value: BigNumberish,
+  async estimateGasLimit({
+    from,
+    to,
+    data,
+    value,
+    network
+  }: {
+    from: string
+    to: string
+    data?: string
+    value?: BigNumberish
     network: Network
-  ): Promise<number | null> {
+  }): Promise<number | null> {
     if (network.vmName !== NetworkVMType.EVM) return null
 
     const provider = getEvmProvider(network)

--- a/app/store/walletConnectV2/handlers/eth_sendTransaction/eth_sendTransaction.test.ts
+++ b/app/store/walletConnectV2/handlers/eth_sendTransaction/eth_sendTransaction.test.ts
@@ -156,8 +156,7 @@ describe('eth_sendTransaction handler', () => {
         [null],
         [
           {
-            from: '0xcA0E993876152ccA6053eeDFC753092c8cE712D0',
-            to: '0xC7E5ffBd7843EdB88cCB2ebaECAa07EC55c65318'
+            from: '0xcA0E993876152ccA6053eeDFC753092c8cE712D0'
           }
         ],
         [
@@ -202,8 +201,7 @@ describe('eth_sendTransaction handler', () => {
         {},
         {
           txParams: {
-            from: '0xcA0E993876152ccA6053eeDFC753092c8cE712D0',
-            to: '0xC7E5ffBd7843EdB88cCB2ebaECAa07EC55c65318'
+            from: '0xcA0E993876152ccA6053eeDFC753092c8cE712D0'
           }
         }
       ]

--- a/app/store/walletConnectV2/handlers/eth_sendTransaction/utils.ts
+++ b/app/store/walletConnectV2/handlers/eth_sendTransaction/utils.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 const transactionSchema = z.object({
   from: z.string(),
   to: z.string(),
-  value: z.string(),
+  value: z.string().optional(),
   data: z.string().optional(),
   gas: z.string().or(z.number()).optional(),
   gasPrice: z.string().optional()
@@ -26,7 +26,7 @@ export const parseApproveData = (data: unknown) => {
 export type TransactionParams = {
   from: string
   to: string
-  value: string
+  value?: string
   data?: string
   gas?: string | number
   gasPrice?: string


### PR DESCRIPTION
## Description
Tickets: [CP-6959]

We currently require the value param to be present for eth_sendTransaction request. However, this param can be optional and this pr fixes that.

## Screenshots/Videos
Before

https://github.com/ava-labs/avalanche-wallet-apps/assets/8824551/d89ebf71-1f40-4245-a13e-6a1a6a4d15fe

After

https://github.com/ava-labs/avalanche-wallet-apps/assets/8824551/1024943a-ed85-4726-afe8-dde659e97ce7

## Testing
Go to https://snowtrace.io/token/0xd586e7f844cea2f87f50152665bcbc2c279d8d70#writeContract, connect wallet and try to execute approve.

## Checklist for the author
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have added necessary unit tests 


[CP-6959]: https://ava-labs.atlassian.net/browse/CP-6959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ