### PR TITLE
CP-7245: use PixelRatio to get proper image size in png

### DIFF
--- a/app/utils/Contentful.test.ts
+++ b/app/utils/Contentful.test.ts
@@ -12,10 +12,22 @@ describe('formatUriImageToPng function', () => {
   it('Uri is a svg image should return updated url that has png and resize params in uri', () => {
     const result = formatUriImageToPng(
       'https://images.ctfassets.net/logo.svg',
-      25
+      25,
+      1
     )
     expect(result).toBe(
       'https://images.ctfassets.net/logo.svg?fm=png&w=25&h=25'
+    )
+  })
+
+  it('Uri is a svg image with pixel ratio should return updated url that has png and resize params with the pixel ratio in uri', () => {
+    const result = formatUriImageToPng(
+      'https://images.ctfassets.net/logo.svg',
+      25,
+      2
+    )
+    expect(result).toBe(
+      'https://images.ctfassets.net/logo.svg?fm=png&w=50&h=50'
     )
   })
 })

--- a/app/utils/Contentful.ts
+++ b/app/utils/Contentful.ts
@@ -1,9 +1,13 @@
 import { PixelRatio } from 'react-native'
 
-export const formatUriImageToPng = (uri: string, size: number) => {
+export const formatUriImageToPng = (
+  uri: string,
+  size: number,
+  pixelRatio: number = PixelRatio.get()
+) => {
   const allowedUrl = 'https://images.ctfassets.net'
   if (uri.startsWith(allowedUrl)) {
-    const sizeInPixel = size * PixelRatio.get()
+    const sizeInPixel = size * pixelRatio
 
     return uri?.endsWith('.svg')
       ? `${uri}?fm=png&w=${sizeInPixel}&h=${sizeInPixel}`


### PR DESCRIPTION
## Description

**Ticket: [CP-7245]** 

* use react-native's `PixelRatio` to calculate image's size for different devices
* modern devices usually use 3 for PixelRatio(for super retina display), so we need to use 3 times bigger images in pixel for proper quality

## Screenshots/Videos
| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/c1010c71-698c-4220-abdf-7a05cb0effc8"  width="320" />  |  <img src="https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/01c8621c-e9b8-4512-b2d8-aa9178c0bc80" width="320" /> |

## Checklist
- [x] I have performed a self-review of my code
- [x] I have verified the code works

[CP-7245]: https://ava-labs.atlassian.net/browse/CP-7245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ