### PR TITLE
Fix failing tests + improving logic for Watchlist, Send, Bridge

### DIFF
--- a/e2e/locators/portfolio.loc.ts
+++ b/e2e/locators/portfolio.loc.ts
@@ -12,6 +12,7 @@ export default {
   btcNetwork: 'Bitcoin',
   collectiblesTab: 'Collectibles',
   ethNetwork: 'Ethereum',
+  ethGoerlyNetwork: 'Ethereum Goerli',
   favoritesHeader: 'Favorites',
   manageNetworks: 'Manage networks',
   manageTokens: 'Manage',

--- a/e2e/pages/bridgeTab.page.ts
+++ b/e2e/pages/bridgeTab.page.ts
@@ -203,7 +203,7 @@ class BridgeTabPage {
   }
 
   async switchToNetwork(network: string) {
-    await PortfolioPage.tapActivityTab()
+    await PortfolioPage.tapAvaxNetwork()
     await BottomTabsPage.tapPlusIcon()
     await PlusMenuPage.tapBridgeButton()
     await this.tapNetworkDropdown()
@@ -244,6 +244,7 @@ class BridgeTabPage {
     await Assert.isVisible(completedStatusOutgoingNetwork)
 
     await this.tapClose()
+    await PortfolioPage.tapAvaxNetwork()
     await PortfolioPage.tapActivityTab()
     await Assert.isVisible(successfullBridgeTransaction)
   }

--- a/e2e/pages/networksManage.page.ts
+++ b/e2e/pages/networksManage.page.ts
@@ -1,6 +1,7 @@
 import Action from '../helpers/actions'
 import networksManage from '../locators/networksManage.loc'
 import { Platform } from '../helpers/constants'
+import PortfolioPage from './portfolio.page'
 
 const platformIndex = Action.platform() === Platform.iOS ? 1 : 0
 
@@ -188,6 +189,22 @@ class NetworksPage {
 
   async swipeUp() {
     await Action.swipeUp(this.nativeTokenSymbol, 'fast', 0.5, 0)
+  }
+
+  async switchToEthereumGoerliNetwork() {
+    await PortfolioPage.tapNetworksDropdown()
+    if (
+      (await Action.isVisible(PortfolioPage.manageNetworks, platformIndex)) ===
+      false
+    ) {
+      await PortfolioPage.tapNetworksDropdown()
+    }
+    await PortfolioPage.tapManageNetworks()
+    await this.tapNetworksTab()
+    if ((await Action.isVisible(this.ethereumGoerlyNetwork, 0)) === false) {
+      await Action.swipeUp(this.bitcoinTestnet, 'slow', 0.5, 0)
+    }
+    await this.tapEthereumGoerliNetwork()
   }
 }
 

--- a/e2e/pages/portfolio.page.ts
+++ b/e2e/pages/portfolio.page.ts
@@ -50,6 +50,10 @@ class PortfolioPage {
     return by.text(portfolio.ethNetwork)
   }
 
+  get ethGoerlyNetwork() {
+    return by.text(portfolio.ethGoerlyNetwork)
+  }
+
   get assetsTab() {
     return by.text(portfolio.assetsTab)
   }
@@ -128,6 +132,14 @@ class PortfolioPage {
 
   async tapBtcFavoriteToken() {
     await Action.tapElementAtIndex(this.btcTokenItem, 0)
+  }
+
+  async tapEthNetwork() {
+    await Action.tapElementAtIndex(this.ethNetwork, 1)
+  }
+
+  async tapEthGoerlyNetwork() {
+    await Action.tapElementAtIndex(this.ethGoerlyNetwork, 1)
   }
 
   async tapManageTokens() {

--- a/e2e/tests/activityTab/activityTab.e2e.smoke.ts
+++ b/e2e/tests/activityTab/activityTab.e2e.smoke.ts
@@ -14,6 +14,7 @@ describe('Activity Tab', () => {
   })
 
   it('should show contract call only in activity list', async () => {
+    await PortfolioPage.tapAvaxNetwork()
     await PortfolioPage.tapActivityTab()
     const startTime = new Date().getTime()
     await actions.waitForElement(ActivityTabPage.arrowSVG, 10000, 1)
@@ -106,8 +107,11 @@ describe('Activity Tab', () => {
       ActivityTabPage.selectFilterDropdown,
       'Display: Outgoing'
     )
-    await ActivityTabPage.tapArrowIcon(0)
-    await Assert.isVisible(TransactionDetailsPage.status)
-    await Assert.isVisible(TransactionDetailsPage.transactionType)
+
+    if ((await actions.isVisible(ActivityTabPage.linkSVG, 0)) === false) {
+      await ActivityTabPage.tapArrowIcon(0)
+      await Assert.isVisible(TransactionDetailsPage.status)
+      await Assert.isVisible(TransactionDetailsPage.transactionType)
+    }
   })
 })

--- a/e2e/tests/plusIcon/send.e2e.ts
+++ b/e2e/tests/plusIcon/send.e2e.ts
@@ -28,6 +28,7 @@ describe('Send AVAX', () => {
 
   it('should successfully navigate to send and review screen', async () => {
     const secondAccountAddress = await AccountManagePage.createSecondAccount()
+    await PortfolioPage.tapAvaxNetwork()
     await PortfolioPage.tapActivityTab()
     await SendPage.sendTokenTo2ndAccount(
       sendLoc.avaxToken,

--- a/e2e/tests/send/sendAvaxTo2ndAccount.e2e.smoke.ts
+++ b/e2e/tests/send/sendAvaxTo2ndAccount.e2e.smoke.ts
@@ -16,6 +16,7 @@ describe('Send Avax to another account', () => {
 
   it('Should send AVAX to second account', async () => {
     const secondAccountAddress = await AccountManagePage.createSecondAccount()
+    await PortfolioPage.tapAvaxNetwork()
     await PortfolioPage.tapActivityTab()
     await SendPage.sendTokenTo2ndAccount(
       sendLoc.avaxToken,

--- a/e2e/tests/send/sendEthTo2ndAccount.e2e.ts
+++ b/e2e/tests/send/sendEthTo2ndAccount.e2e.ts
@@ -19,6 +19,7 @@ describe('Send Eth to another account', () => {
     await PortfolioPage.tapNetworksDropdownETH()
 
     const secondAccountAddress = await AccountManagePage.createSecondAccount()
+    await PortfolioPage.tapEthNetwork()
     await PortfolioPage.tapActivityTab()
     await SendPage.sendTokenTo2ndAccount(
       sendLoc.ethToken,

--- a/e2e/tests/send/sendGoerlyEthTo2ndAccount.e2e.ts
+++ b/e2e/tests/send/sendGoerlyEthTo2ndAccount.e2e.ts
@@ -1,5 +1,4 @@
 /* eslint-disable jest/expect-expect */
-import actions from '../../helpers/actions'
 import AccountManagePage from '../../pages/accountManage.page'
 import ActivityTabPage from '../../pages/activityTab.page'
 import ActivityTabLoc from '../../locators/activityTab.loc'
@@ -9,10 +8,7 @@ import PortfolioPage from '../../pages/portfolio.page'
 import SendPage from '../../pages/send.page'
 import sendLoc from '../../locators/send.loc'
 import { warmup } from '../../helpers/warmup'
-import { Platform } from '../../helpers/constants'
 import AdvancedPage from '../../pages/burgerMenu/advanced.page'
-
-const platformIndex = actions.platform() === Platform.iOS ? 1 : 0
 
 describe('Send Goerly Eth to another account', () => {
   beforeAll(async () => {
@@ -22,30 +18,20 @@ describe('Send Goerly Eth to another account', () => {
 
   it('Should send Goerly Eth to second account', async () => {
     await AdvancedPage.switchToTestnet()
-    await PortfolioPage.tapNetworksDropdown()
-    if (
-      (await actions.isVisible(PortfolioPage.manageNetworks, platformIndex)) ===
-      false
-    ) {
-      await PortfolioPage.tapNetworksDropdown()
-    }
-    await PortfolioPage.tapManageNetworks()
-    await NetworksManagePage.tapNetworksTab()
-    await NetworksManagePage.tapEthereumGoerliNetwork()
-
+    await NetworksManagePage.switchToEthereumGoerliNetwork()
     const secondAccountAddress = await AccountManagePage.createSecondAccount()
-
+    await PortfolioPage.tapEthGoerlyNetwork()
     await PortfolioPage.tapActivityTab()
     await SendPage.sendTokenTo2ndAccount(
       sendLoc.ethToken,
       sendLoc.sendingAmount
     )
     await ActivityTabPage.verifyOutgoingTransaction(
-      40000,
+      60000,
       secondAccountAddress,
       ActivityTabLoc.ethOutgoingTransactionDetail
     )
-  }, 90000)
+  }, 120000)
 
   it('Should receive Goerly Eth on second account', async () => {
     await ActivityTabPage.tapHeaderBack()

--- a/e2e/tests/send/sendUsdcTo2ndAccount.e2e.ts
+++ b/e2e/tests/send/sendUsdcTo2ndAccount.e2e.ts
@@ -16,6 +16,7 @@ describe('Send USDC to another account', () => {
 
   it('Should send USDC to second account', async () => {
     const secondAccountAddress = await AccountManagePage.createSecondAccount()
+    await PortfolioPage.tapAvaxNetwork()
     await PortfolioPage.tapActivityTab()
     await SendPage.sendTokenTo2ndAccount(
       sendLoc.usdcToken,

--- a/e2e/tests/send/sendWethTo2ndAccount.e2e.ts
+++ b/e2e/tests/send/sendWethTo2ndAccount.e2e.ts
@@ -16,6 +16,7 @@ describe('Send WETH to another account', () => {
 
   it('Should send WETH to second account', async () => {
     const secondAccountAddress = await AccountManagePage.createSecondAccount()
+    await PortfolioPage.tapAvaxNetwork()
     await PortfolioPage.tapActivityTab()
     await SendPage.sendTokenTo2ndAccount(
       sendLoc.wethToken,


### PR DESCRIPTION
The changes in the Activity Tab's location are causing tests to fail. There is a PR that fixes this:

Fixed tests:
1. Send (Avax, Usdc, Eth, Weth, GoerlyEth)
2. Bridge (Testnet & Mainnet)
3. ActivityTab

Improved logic for Networks Manage function,  ActivityTab test.