### PR TITLE
CP-7285: Update cached bridge tx properly

### DIFF
--- a/app/contexts/BridgeContext.tsx
+++ b/app/contexts/BridgeContext.tsx
@@ -122,6 +122,10 @@ function LocalBridgeProvider({ children }: { children: ReactNode }) {
           const subscription = trackBridgeTransaction({
             bridgeTransaction: trackedTransaction,
             onBridgeTransactionUpdate: (tx: BridgeTransaction) => {
+              // Update the transaction, even if it's complete
+              // (we want to keep the tx up to date, because some Component(i.e. BridgeTransactionStatus) has local state that depends on it)
+              dispatch(addBridgeTransaction(tx))
+
               if (tx.complete) {
                 dispatch(popBridgeTransaction(tx.sourceTxHash))
                 capture('BridgeTransferRequestSucceeded')
@@ -143,8 +147,6 @@ function LocalBridgeProvider({ children }: { children: ReactNode }) {
                     }
                   })
                 }
-              } else {
-                dispatch(addBridgeTransaction(tx))
               }
             },
             config,

--- a/app/screens/bridge/components/BridgeConfirmations.tsx
+++ b/app/screens/bridge/components/BridgeConfirmations.tsx
@@ -13,7 +13,6 @@ interface Props {
   paddingHorizontal?: number
   confirmationCount: number
   requiredConfirmationCount: number
-  complete: boolean
   startTime?: number
   endTime?: number
   started: boolean

--- a/app/screens/shared/BridgeTransactionStatus.tsx
+++ b/app/screens/shared/BridgeTransactionStatus.tsx
@@ -208,7 +208,6 @@ const BridgeTransactionStatus: FC<Props> = ({ txHash, showHideButton }) => {
             requiredConfirmationCount={
               bridgeTransaction.requiredConfirmationCount
             }
-            complete={bridgeTransaction.complete}
             startTime={bridgeTransaction.sourceStartedAt}
             endTime={bridgeTransaction.targetStartedAt}
             confirmationCount={bridgeTransaction.confirmationCount}
@@ -235,7 +234,6 @@ const BridgeTransactionStatus: FC<Props> = ({ txHash, showHideButton }) => {
             requiredConfirmationCount={
               1 // On avalanche, we just need 1 confirmation
             }
-            complete={bridgeTransaction.complete}
             confirmationCount={bridgeTransaction.complete ? 1 : 0}
           />
         )}


### PR DESCRIPTION
## Description

**Ticket: [CP-7285]** 

* call `dispatch(addBridgeTransaction(tx))` always(even if tx is complete) `onBridgeTransactionUpdate` observer, since some Component(i.e. `BridgeTransactionStatus`) should to render updated tx info
* remove `complete` prop from `BridgeConfirmations` since no longer used

## Screenshots/Videos
https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/61f13d4f-6e6e-4198-8dd9-b5ee21da4a92



## Checklist
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-7285]: https://ava-labs.atlassian.net/browse/CP-7285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ