### PR TITLE
CP-7132: Dismiss QR code scanner after scan is complete

### DIFF
--- a/app/screens/tokenManagement/AddCustomToken.tsx
+++ b/app/screens/tokenManagement/AddCustomToken.tsx
@@ -14,7 +14,7 @@ import { ShowSnackBar } from 'components/Snackbar'
 
 const AddCustomToken: FC = () => {
   const theme = useApplicationContext().theme
-  const [showQrCamera, setShowQrCamera] = useState(false)
+  const [showQrScanner, setShowQrScanner] = useState(false)
   const { goBack } = useNavigation()
 
   const showSuccess = useCallback(() => {
@@ -27,6 +27,11 @@ const AddCustomToken: FC = () => {
 
   // only enable button if we have token and no error message
   const disabled = !!(errorMessage || !token)
+
+  const handleQrCodeScanSuccess = (data: string): void => {
+    setTokenAddress(data)
+    setShowQrScanner(false)
+  }
 
   return (
     <View
@@ -53,7 +58,7 @@ const AddCustomToken: FC = () => {
                 right: 24,
                 top: 40
               }}>
-              <AvaButton.Icon onPress={() => setShowQrCamera(true)}>
+              <AvaButton.Icon onPress={() => setShowQrScanner(true)}>
                 <QRCode />
               </AvaButton.Icon>
             </View>
@@ -80,11 +85,11 @@ const AddCustomToken: FC = () => {
       <Modal
         animationType="slide"
         transparent={true}
-        onRequestClose={() => setShowQrCamera(false)}
-        visible={showQrCamera}>
+        onRequestClose={() => setShowQrScanner(false)}
+        visible={showQrScanner}>
         <QrScannerAva
-          onSuccess={setTokenAddress}
-          onCancel={() => setShowQrCamera(false)}
+          onSuccess={handleQrCodeScanSuccess}
+          onCancel={() => setShowQrScanner(false)}
         />
       </Modal>
     </View>


### PR DESCRIPTION
## Description

**Ticket: [CP-7132]** 

* dismiss QR code scanner after scan is complete 
* show token info when user adds existing token
* refactoring: rename variables, error handlers, explicit function return types

## Screenshots/Videos
| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/5e1684b0-fb58-43b2-a08b-75ee53e51c36"  width="320" />  |  <img src="https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/f98b0b6c-70eb-4da9-b4d7-f4d0332fb935" width="320" /> |

https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/bcedb392-78a3-4bc3-9e98-3a15a4789658


## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-7132]: https://ava-labs.atlassian.net/browse/CP-7132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ