### PR TITLE
QA-81: Insufficient balance for fee

### DIFF
--- a/e2e/locators/collectibles.loc.ts
+++ b/e2e/locators/collectibles.loc.ts
@@ -4,6 +4,8 @@ export default {
   addressInput: 'input_text',
   addressBook: 'address_book',
   cancelButton: 'btnSecondary',
+  customFeeButton: 'Custom',
+  customFeeInput: 'input_text',
   myAccounts: 'My Accounts',
   nextButton: 'btnPrimary',
   nftTokenId: 'NftTokenID',
@@ -20,5 +22,7 @@ export default {
   networkFeeText: 'Network Fee',
   sendTitle: 'Send',
   collectibleText: 'Collectible',
-  nftlogo: 'avatar__logo_avatar'
+  nftlogo: 'avatar__logo_avatar',
+  warningAddressRequired: 'Address required',
+  warningInsufficientFee: 'Insufficient balance for fee.'
 }

--- a/e2e/pages/collectibles.page.ts
+++ b/e2e/pages/collectibles.page.ts
@@ -44,6 +44,14 @@ class CollectiblesPage {
     return by.text(Collectibles.collectibleText)
   }
 
+  get customFeeButton() {
+    return by.text(Collectibles.customFeeButton)
+  }
+
+  get customFeeInput() {
+    return by.id(Collectibles.customFeeInput)
+  }
+
   get nftlogo() {
     return by.id(Collectibles.nftlogo)
   }
@@ -100,8 +108,20 @@ class CollectiblesPage {
     return by.text(Collectibles.propertiesTitle)
   }
 
+  get warningAddressRequired() {
+    return by.text(Collectibles.warningAddressRequired)
+  }
+
+  get warningInsufficientFee() {
+    return by.text(Collectibles.warningInsufficientFee)
+  }
+
   async tapAddressBook() {
     await Action.tapElementAtIndex(this.addressBook, 0)
+  }
+
+  async tapCustomFeeButton() {
+    await Action.tapElementAtIndex(this.customFeeButton, 0)
   }
 
   async tapGridItem() {
@@ -192,6 +212,11 @@ class CollectiblesPage {
     await this.verifySendNftItems()
     await this.tapSendNowButton()
     return result
+  }
+
+  async inputCustomFee() {
+    await Action.setInputText(this.customFeeInput, '25000000', 1)
+    await Action.tap(this.sendTitle)
   }
 }
 

--- a/e2e/tests/nft/insufficientAmountNft.e2e.ts
+++ b/e2e/tests/nft/insufficientAmountNft.e2e.ts
@@ -1,0 +1,32 @@
+/* eslint-disable jest/expect-expect */
+import LoginRecoverWallet from '../../helpers/loginRecoverWallet'
+import AccountManagePage from '../../pages/accountManage.page'
+import Actions from '../../helpers/actions'
+import Assert from '../../helpers/assertions'
+import PortfolioPage from '../../pages/portfolio.page'
+import CollectiblesPage from '../../pages/collectibles.page'
+import { warmup } from '../../helpers/warmup'
+
+describe('Send Avax to another account', () => {
+  beforeAll(async () => {
+    await warmup()
+    await LoginRecoverWallet.recoverWalletLogin()
+  })
+
+  it('Should verify Address Required warning', async () => {
+    await PortfolioPage.tapCollectiblesTab()
+    await Actions.waitForElement(CollectiblesPage.gridItem, 5000)
+    await CollectiblesPage.tapGridItem()
+    await CollectiblesPage.tapSendButton()
+    await Assert.isVisible(CollectiblesPage.warningAddressRequired)
+  })
+
+  it('Should verify Insufficient balance for fee warning', async () => {
+    await CollectiblesPage.tapAddressBook()
+    await CollectiblesPage.tapMyAccounts()
+    await AccountManagePage.tapFirstAccount()
+    await CollectiblesPage.tapCustomFeeButton()
+    await CollectiblesPage.inputCustomFee()
+    await Assert.isVisible(CollectiblesPage.warningInsufficientFee)
+  })
+})

--- a/e2e/tests/nft/sendNft.e2e.ts
+++ b/e2e/tests/nft/sendNft.e2e.ts
@@ -7,8 +7,6 @@ import CollectiblesPage from '../../pages/collectibles.page'
 import { warmup } from '../../helpers/warmup'
 import { Platform } from '../../helpers/constants'
 
-//Add InsufficientFeeAmountTest
-
 describe('Send Avax to another account', () => {
   beforeAll(async () => {
     await warmup()


### PR DESCRIPTION
New automation tests added for NFT Send warning messages verification:

1. Should verify Address Required warning
2. Should verify Insufficient balance for fee warning