### PR TITLE
CP-7644: Missing url scheme for InfoRelease.plist

### DIFF
--- a/packages/core-mobile/ios/AvaxWallet/InfoRelease.plist
+++ b/packages/core-mobile/ios/AvaxWallet/InfoRelease.plist
@@ -39,7 +39,7 @@
       <array>
         <string>com.googleusercontent.apps.1023766203719-ngiu0g65qaspe3qoad2sv3hodlhsj9br</string>
       </array>
-		</dict>
+    </dict>
   </array>
   <key>CFBundleVersion</key>
   <string>$(CURRENT_PROJECT_VERSION)</string>


### PR DESCRIPTION
## Description

**Ticket: [CP-7644]** 
* add url scheme for google signin to InfoRelease.plist as well

## Checklist
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-7644]: https://ava-labs.atlassian.net/browse/CP-7644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ