### PR TITLE
Fix: hide navigation header in verify code screen

### DIFF
--- a/packages/core-mobile/app/navigation/onboarding/RecoveryMethodsStack.tsx
+++ b/packages/core-mobile/app/navigation/onboarding/RecoveryMethodsStack.tsx
@@ -20,7 +20,6 @@ import { PasskeySetupScreen } from 'seedless/screens/PasskeySetupScreen'
 import { FIDONameInputScreen } from 'seedless/screens/FIDONameInputScreen'
 import { useNavigation } from '@react-navigation/native'
 import { RecoveryMethodsScreenProps } from 'navigation/types'
-import { BackButton } from 'components/BackButton'
 
 export type RecoveryMethodsStackParamList = {
   [AppNavigation.RecoveryMethods.AddRecoveryMethods]: undefined
@@ -125,9 +124,7 @@ function VerifyCodeScreen(): JSX.Element {
 
   useLayoutEffect(() => {
     setOptions({
-      headerTitle: '',
-      // eslint-disable-next-line react/no-unstable-nested-components
-      headerLeft: () => <BackButton />
+      headerShown: false
     })
   }, [setOptions])
 


### PR DESCRIPTION
## Description

* hide navigation header in verify code screen

## Screenshots/Videos
| before | after |
| ------------- | ------------- |
| <img src="https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/7556293b-db3d-45a0-ac7d-ac635a35b2d5" width="320" /> | <img src="https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/21e5f348-c0db-4433-9995-886a99eb266e" width="320" /> |

