### PR TITLE
add agreeAndContinueBtn

### DIFF
--- a/packages/core-mobile/e2e/helpers/loginRecoverWallet.ts
+++ b/packages/core-mobile/e2e/helpers/loginRecoverWallet.ts
@@ -18,7 +18,7 @@ class LoginRecoverWallet {
     await nameWalletPage.enterWalletName('testWallet1\n')
     await CreatePinPage.tapNumpadZero()
     await CreatePinPage.tapNumpadZero()
-    await CreatePinPage.tapNextBtn()
+    await CreatePinPage.tapAgreeAndContinueBtn()
     await commonElsPage.tapGetStartedButton()
     await PortfolioPage.verifyPorfolioScreen()
   }

--- a/packages/core-mobile/e2e/locators/createPin.loc.ts
+++ b/packages/core-mobile/e2e/locators/createPin.loc.ts
@@ -1,7 +1,7 @@
 export default {
   numPadZero: `0`,
   numpadOne: '1',
-  emptyCheckBox: `checkbox_empty_svg`,
+  agreeAndContinueBtn: `Agree and Continue`,
   nextBtn: `Next`,
   enterYourPinHeader: 'Enter your pin',
   setNewPinHeader: 'Set new pin',

--- a/packages/core-mobile/e2e/pages/createPin.page.ts
+++ b/packages/core-mobile/e2e/pages/createPin.page.ts
@@ -10,8 +10,8 @@ class CreatePinPage {
     return by.id(createPinLoc.numpadOne)
   }
 
-  get emptyCheckBox() {
-    return by.id(createPinLoc.emptyCheckBox)
+  get agreeAndContinueBtn() {
+    return by.text(createPinLoc.agreeAndContinueBtn)
   }
 
   get nextBtn() {
@@ -46,9 +46,8 @@ class CreatePinPage {
     await Action.tap(this.nextBtn)
   }
 
-  async tapEmptyCheckbox() {
-    await Action.tapElementAtIndex(this.emptyCheckBox, 0)
-    await Action.tapElementAtIndex(this.emptyCheckBox, 0)
+  async tapAgreeAndContinueBtn() {
+    await Action.tapElementAtIndex(this.agreeAndContinueBtn, 0)
   }
 
   async tapNumpadZero6Times() {

--- a/packages/core-mobile/e2e/pages/existingRecoveryPhrase.page.ts
+++ b/packages/core-mobile/e2e/pages/existingRecoveryPhrase.page.ts
@@ -90,7 +90,7 @@ class ExistingRecoveryPhrasePage {
     await Action.waitForElement(CreatePinPage.numpadOne)
     await CreatePinPage.tapNumpadZero()
     await CreatePinPage.tapNumpadZero()
-    await CreatePinPage.tapNextBtn()
+    await CreatePinPage.tapAgreeAndContinueBtn()
     await commonElsPage.tapGetStartedButton()
     await Action.waitForElement(PortfolioPage.colectiblesTab)
     await PortfolioPage.verifyPorfolioScreen()

--- a/packages/core-mobile/e2e/tests/login/createNewWallet.e2e.smoke.ts
+++ b/packages/core-mobile/e2e/tests/login/createNewWallet.e2e.smoke.ts
@@ -50,7 +50,7 @@ describe('Create new wallet', () => {
   it('should successfully create a new wallet', async () => {
     await nameWalletPage.enterWalletName('tester1\n')
     await CreatePinPage.createPin()
-    await CreatePinPage.tapNextBtn()
+    await CreatePinPage.tapAgreeAndContinueBtn()
     await commonElsPage.tapGetStartedButton()
     await PortfolioPage.verifyPorfolioScreen()
     await BottomTabsPage.verifyBottomTabs()


### PR DESCRIPTION
## Description

- We have a 'Agree and Continue' button after the pin screen.  This adds this element to the tests.

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
