### PR TITLE
Sign out google when user deletes wallet

### DIFF
--- a/packages/core-mobile/app/seedless/store/listeners.ts
+++ b/packages/core-mobile/app/seedless/store/listeners.ts
@@ -2,6 +2,7 @@ import { AppStartListening } from 'store/middleware/listener'
 import {
   immediateAppLock,
   onAppUnlocked,
+  onLogOut,
   onRehydrationComplete,
   selectWalletState,
   WalletState
@@ -214,6 +215,10 @@ async function startRefreshSeedlessTokenFlow(): Promise<
   }
 }
 
+const signOutSocial = async (_: Action): Promise<void> => {
+  await GoogleSigninService.signOut()
+}
+
 export const addSeedlessListeners = (
   startListening: AppStartListening
 ): void => {
@@ -228,5 +233,9 @@ export const addSeedlessListeners = (
   startListening({
     actionCreator: onRehydrationComplete,
     effect: registerTokenExpireHandler
+  })
+  startListening({
+    actionCreator: onLogOut,
+    effect: signOutSocial
   })
 }

--- a/packages/core-mobile/app/services/socialSignIn/google/GoogleSigninService.ts
+++ b/packages/core-mobile/app/services/socialSignIn/google/GoogleSigninService.ts
@@ -41,6 +41,10 @@ class GoogleSigninService {
       throw new Error('Google sign in error')
     }
   }
+
+  async signOut(): Promise<null> {
+    return GoogleSignin.signOut()
+  }
 }
 
 export default new GoogleSigninService()


### PR DESCRIPTION
## Description

This will prompt user to select one of the registered google accounts to proceed.

## Testing
- have more than 1 google account registered on device
- sign in with one google account
- delete wallet
- try to sign in with Google
=> should see prompt to select account

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
