### PR TITLE
Fix seedless signer to use maxFeePerGas for gasPrice field

### DIFF
--- a/packages/core-mobile/app/seedless/services/wallet/SeedlessWallet.ts
+++ b/packages/core-mobile/app/seedless/services/wallet/SeedlessWallet.ts
@@ -253,7 +253,13 @@ export default class SeedlessWallet implements Wallet {
       { provider }
     )
 
-    return signer.signTransaction(transaction)
+    // seedless signer expects maxFeePerGas instead of gasPrice for EVM transactions
+    const nomalizedTx = { ...transaction }
+    if (transaction.gasPrice && !transaction.maxFeePerGas) {
+      nomalizedTx.maxFeePerGas = transaction.gasPrice
+    }
+
+    return signer.signTransaction(nomalizedTx)
   }
 
   public async getPublicKey(): Promise<PubKeyType> {


### PR DESCRIPTION
## Description

* Fix seedless signer to use maxFeePerGas for gasPrice field
* https://avalancheavax.slack.com/archives/C046YF16REU/p1702318451696059
* https://avalancheavax.slack.com/archives/C046YF16REU/p1702321323379779

## Checklist
Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
