### PR TITLE
Set type 0 for legacy transaction

### DIFF
--- a/packages/core-mobile/app/screens/rpc/util/txToCustomEvmTx.ts
+++ b/packages/core-mobile/app/screens/rpc/util/txToCustomEvmTx.ts
@@ -10,7 +10,7 @@ export async function txToCustomEvmTx(
   from: string
   to: string
   value: BigNumberish | undefined
-  maxFeePerGas: bigint
+  gasPrice: bigint
 }> {
   if (!txParams) {
     throw new Error('params is malformed')
@@ -31,7 +31,7 @@ export async function txToCustomEvmTx(
   const gasLimit = Number(gas)
 
   return {
-    maxFeePerGas: sureGasPrice,
+    gasPrice: sureGasPrice,
     gasLimit: gasLimit,
     to,
     from,

--- a/packages/core-mobile/app/seedless/services/wallet/SeedlessWallet.ts
+++ b/packages/core-mobile/app/seedless/services/wallet/SeedlessWallet.ts
@@ -253,13 +253,13 @@ export default class SeedlessWallet implements Wallet {
       { provider }
     )
 
-    // seedless signer expects maxFeePerGas instead of gasPrice for EVM transactions
-    const nomalizedTx = { ...transaction }
-    if (transaction.gasPrice && !transaction.maxFeePerGas) {
-      nomalizedTx.maxFeePerGas = transaction.gasPrice
+    // set type 0 to indicate legacy transaction, since mobile doesn't support EIP-1559 yet
+    const legacyTx = {
+      ...transaction,
+      type: 0
     }
 
-    return signer.signTransaction(nomalizedTx)
+    return signer.signTransaction(legacyTx)
   }
 
   public async getPublicKey(): Promise<PubKeyType> {

--- a/packages/core-mobile/app/services/send/SendServiceEVM.ts
+++ b/packages/core-mobile/app/services/send/SendServiceEVM.ts
@@ -132,7 +132,7 @@ export class SendServiceEVM implements SendServiceHelper {
           ...unsignedTx,
           chainId,
           gasLimit,
-          maxFeePerGas: sendState.gasPrice,
+          gasPrice: sendState.gasPrice,
           nonce
         }
       })

--- a/packages/core-mobile/app/store/walletConnectV2/handlers/eth_sendTransaction/eth_sendTransaction.test.ts
+++ b/packages/core-mobile/app/store/walletConnectV2/handlers/eth_sendTransaction/eth_sendTransaction.test.ts
@@ -267,7 +267,7 @@ describe('eth_sendTransaction handler', () => {
           chainId: mockNetwork.chainId,
           data: '0x10000',
           gasLimit: 256,
-          maxFeePerGas: BigInt(testData.txParams.gasPrice),
+          gasPrice: BigInt(testData.txParams.gasPrice),
           to: testData.txParams.to,
           value: testData.txParams.value
         },
@@ -313,7 +313,7 @@ describe('eth_sendTransaction handler', () => {
           chainId: mockNetwork.chainId,
           data: '0x10000',
           gasLimit: 256,
-          maxFeePerGas: BigInt(testData.txParams.gasPrice),
+          gasPrice: BigInt(testData.txParams.gasPrice),
           to: testData.txParams.to,
           value: testData.txParams.value
         },

--- a/packages/core-mobile/app/store/walletConnectV2/handlers/eth_sendTransaction/eth_sendTransaction.ts
+++ b/packages/core-mobile/app/store/walletConnectV2/handlers/eth_sendTransaction/eth_sendTransaction.ts
@@ -137,7 +137,7 @@ class EthSendTransactionHandler
         {
           nonce,
           chainId: network.chainId,
-          maxFeePerGas: evmParams.maxFeePerGas,
+          gasPrice: evmParams.gasPrice,
           gasLimit: evmParams.gasLimit,
           data: evmParams.data,
           to: params.to,


### PR DESCRIPTION
## Description

* since mobile doesn't support EIP-1559 yet, set type 0 for transaction request before signing with cubesigner
* tested sending avax, sending/receiving nfts, and bridge from Etheruem to Avalanche network