### PR TITLE
Fix Auth UI issues for Seedless

### DIFF
--- a/packages/core-mobile/app/hooks/useWallet.ts
+++ b/packages/core-mobile/app/hooks/useWallet.ts
@@ -72,13 +72,12 @@ export function useWallet(): UseWallet {
     walletType: WalletType
   ): Promise<void> => {
     try {
-      if (walletType) {
-        dispatch(setWalletType(walletType))
-      }
+      dispatch(setWalletType(walletType))
+
       await initWalletServiceAndUnlock({
         dispatch,
         mnemonic,
-        walletType: cachedWalletType,
+        walletType,
         isLoggingIn: true
       })
 

--- a/packages/core-mobile/app/seedless/screens/VerifyCode.tsx
+++ b/packages/core-mobile/app/seedless/screens/VerifyCode.tsx
@@ -45,20 +45,23 @@ export const VerifyCode = ({
 
     setIsVerifying(true)
 
-    const result = await SeedlessService.verifyCode(
-      oidcToken,
-      mfaId,
-      changedText
-    )
-    if (result.success === false) {
+    try {
+      const result = await SeedlessService.verifyCode(
+        oidcToken,
+        mfaId,
+        changedText
+      )
+      if (result.success === false) {
+        throw new Error(result.error.message)
+      }
+      setIsVerifying(false)
+      onVerifySuccess()
+      capture('TotpValidationSuccess')
+    } catch (error) {
       setShowError(true)
       setIsVerifying(false)
-      capture('TotpValidationFailed', { error: result.error.name })
-      return
+      capture('TotpValidationFailed', { error: error as string })
     }
-    setIsVerifying(false)
-    onVerifySuccess()
-    capture('TotpValidationSuccess')
   }
 
   const textInputStyle = showError

--- a/packages/core-mobile/app/seedless/store/listeners.ts
+++ b/packages/core-mobile/app/seedless/store/listeners.ts
@@ -61,12 +61,6 @@ const handleTokenExpired = async (
   Navigation.navigate({
     name: AppNavigation.Root.RefreshToken,
     params: {
-      screen: AppNavigation.RefreshToken.OwlLoader
-    }
-  })
-  Navigation.navigate({
-    name: AppNavigation.Root.RefreshToken,
-    params: {
       screen: AppNavigation.RefreshToken.SessionTimeout,
       params: {
         onRetry: () => handleRetry(listenerApi)
@@ -79,6 +73,13 @@ function handleRetry(listenerApi: AppListenerEffectAPI): void {
   const { dispatch } = listenerApi
   //dismiss previous modal screen
   Navigation.goBack()
+
+  Navigation.navigate({
+    name: AppNavigation.Root.RefreshToken,
+    params: {
+      screen: AppNavigation.RefreshToken.OwlLoader
+    }
+  })
   startRefreshSeedlessTokenFlow()
     .then(result => {
       if (result.success) {


### PR DESCRIPTION
## Description

- in fresh token flow, the owl loader was not showing in the background during social login and MFA verify screen.  move the logic to navigate to owlLoader right after the session time out screen is dismissed.
- fixed the issue wallet type is UNSET on initial login
- catch the error when verify code throw when entering non-numerical value

## Screenshots/Videos


https://github.com/ava-labs/avalanche-wallet-apps/assets/137183702/63e3ce73-cc31-400c-8913-3a2bbb8a5a56



## Testing
- manual

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
