### PR TITLE
CP-7962: Use message field in content for sharing in android

### DIFF
--- a/packages/core-mobile/app/screens/browser/components/DockMenu.tsx
+++ b/packages/core-mobile/app/screens/browser/components/DockMenu.tsx
@@ -35,9 +35,19 @@ export const DockMenu: FC<Props> = ({
   const activeHistory = useSelector(selectActiveHistory)
 
   const onShare = async (): Promise<void> => {
-    await ShareApi.share({
-      url: activeHistory?.url ?? ''
-    })
+    const linkToShare = activeHistory?.url
+    if (linkToShare) {
+      const content =
+        Platform.OS === 'ios'
+          ? {
+              url: linkToShare
+            }
+          : {
+              message: linkToShare
+            }
+
+      await ShareApi.share(content)
+    }
   }
 
   const favoriteIcon = isFavorited


### PR DESCRIPTION
## Description

**Ticket: [CP-7962]** 

* `url` is not supported for sharing in android(https://reactnative.dev/docs/share#share), so use message field instead.

## Screenshots/Videos'
<img src="https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/c4d2876f-d72f-4a53-a95d-a122b1360710" width="320" />

[CP-7962]: https://ava-labs.atlassian.net/browse/CP-7962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ