### PR TITLE
CP-7960 Fix testing if url is valid http url

### DIFF
--- a/packages/core-mobile/app/screens/browser/utils.test.ts
+++ b/packages/core-mobile/app/screens/browser/utils.test.ts
@@ -51,8 +51,16 @@ describe('normalizeUrlWithHttps', () => {
   })
 
   it('should return same input if result is not valid url', () => {
-    const url = 'core app'
-    const result = normalizeUrlWithHttps(url)
+    let url = 'core app'
+    let result = normalizeUrlWithHttps(url)
+    expect(result).toEqual(url)
+
+    url = 'coreapp'
+    result = normalizeUrlWithHttps(url)
+    expect(result).toEqual(url)
+
+    url = 'http://coreapp'
+    result = normalizeUrlWithHttps(url)
     expect(result).toEqual(url)
   })
 

--- a/packages/core-mobile/app/screens/browser/utils.ts
+++ b/packages/core-mobile/app/screens/browser/utils.ts
@@ -29,6 +29,10 @@ export function isValidUrl(url: string): boolean {
 }
 
 export function isValidHttpUrl(url: string): boolean {
+  //urls such as http://core we will discard, it must have at least one dot
+  const basicHttpUrlRegex = new RegExp('[^ ]*[.][^ ]*', 'i')
+  if (!basicHttpUrlRegex.test(url)) return false
+
   let urlObj
   try {
     urlObj = new URL(url)


### PR DESCRIPTION
## Description

**Ticket: [CP-7960]** 

This PR will discard urls that doesn't contain any dot in it, such as https://asdf/ since `new URL("https://asdf/")` is valid.

## Testing
- when in non-empty tab, enter "asdf" in url input and press submit. Google search should open with that string as search item.

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-7960]: https://ava-labs.atlassian.net/browse/CP-7960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ