### PR TITLE
Fix - remove warnings when loading snapshots that are not existed

### DIFF
--- a/packages/core-mobile/app/screens/browser/TabsListScreen.tsx
+++ b/packages/core-mobile/app/screens/browser/TabsListScreen.tsx
@@ -121,6 +121,7 @@ function TabsListScreen(): JSX.Element {
         <TabListItem
           title={activeHistory?.url ? removeProtocol(activeHistory.url) : ''}
           imagePath={imagePath}
+          onVerifyImagePath={SnapshotService.exists}
           onPress={() => handlePressTab(item)}
           onClose={() => handleCloseTab(item)}
         />

--- a/packages/core-mobile/app/screens/browser/components/TabListItem.tsx
+++ b/packages/core-mobile/app/screens/browser/components/TabListItem.tsx
@@ -7,12 +7,13 @@ import {
   View,
   useTheme
 } from '@avalabs/k2-mobile'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { LayoutChangeEvent } from 'react-native'
 
 type Props = {
   title?: string
   imagePath: string
+  onVerifyImagePath: (imagePath: string) => Promise<boolean>
   onPress: () => void
   onClose: () => void
 }
@@ -20,6 +21,7 @@ type Props = {
 function TabListItem({
   title,
   imagePath,
+  onVerifyImagePath,
   onPress,
   onClose
 }: Props): JSX.Element {
@@ -27,10 +29,23 @@ function TabListItem({
     theme: { colors }
   } = useTheme()
   const [width, setWidth] = useState(0)
+  const [verifiedImageSource, setVerifiedImageSource] = useState<string>()
 
   function handleLayout({ nativeEvent }: LayoutChangeEvent): void {
     setWidth(nativeEvent.layout.width)
   }
+
+  useEffect(() => {
+    onVerifyImagePath(imagePath)
+      .then(isVerified => {
+        if (isVerified) {
+          setVerifiedImageSource(imagePath)
+        }
+      })
+      .catch(() => {
+        // do nothing
+      })
+  }, [imagePath, onVerifyImagePath])
 
   return (
     <TouchableOpacity onPress={onPress}>
@@ -62,7 +77,7 @@ function TabListItem({
           </Pressable>
         </View>
         <Image
-          source={{ uri: imagePath }}
+          source={{ uri: verifiedImageSource }}
           style={{ height: width * IMAGE_RATIO }}
         />
       </View>

--- a/packages/core-mobile/app/services/snapshot/SnapshotService.ts
+++ b/packages/core-mobile/app/services/snapshot/SnapshotService.ts
@@ -42,6 +42,13 @@ class SnapshotService {
       await RNFS.unlink(this.folderPath)
     }
   }
+
+  async exists(path: string): Promise<boolean> {
+    const url = new URL(path)
+    url.search = '' // remove query params, i.e. ?timestamp=1234567890
+
+    return await RNFS.exists(url.href)
+  }
 }
 
 export default new SnapshotService()


### PR DESCRIPTION
## Description
* let `TabListItem` use verified image source only, to avoid warning in `React Native`

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
