### PR TITLE
CP-8031: set more menu to dark theme

### DIFF
--- a/packages/core-mobile/app/screens/browser/components/MoreMenu.tsx
+++ b/packages/core-mobile/app/screens/browser/components/MoreMenu.tsx
@@ -61,8 +61,7 @@ export const MoreMenu: FC<Props> = ({
       ? { ios: 'star.fill', android: 'star_fill_24px' }
       : { ios: 'star', android: 'star_24px' }
 
-    const menuActionColor =
-      Platform.OS === 'android' ? colors.$white : colors.$black
+    const menuActionColor = colors.$white
 
     const historyAction = {
       id: MenuId.History,
@@ -195,6 +194,7 @@ export const MoreMenu: FC<Props> = ({
           }
         }
       }}
+      themeVariant="dark"
       actions={menuActions}
       shouldOpenOnLongPress={false}>
       {children}


### PR DESCRIPTION
## Description

**Ticket: [CP-8031]** 

set more menu to dark theme so it's consistent with the rest of the app

## Screenshots/Videos
<img src="https://github.com/ava-labs/avalanche-wallet-apps/assets/8824551/96bb24fa-440b-46fb-acf6-96bf6471c2dc" width=300/>


## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-8031]: https://ava-labs.atlassian.net/browse/CP-8031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ