### PR TITLE
CP-5262: add 'max-params' rule to eslint config

### DIFF
--- a/packages/eslint-mobile/src/configs.js
+++ b/packages/eslint-mobile/src/configs.js
@@ -60,7 +60,8 @@ const recommended = {
         ]
       }
     ],
-    'sonarjs/no-duplicate-string': 0
+    'sonarjs/no-duplicate-string': 0,
+    'max-params': ['warn', 3]
   },
   overrides: [
     {


### PR DESCRIPTION
## Description

**Ticket: [CP-5262]** 

* A new rule `'max-params': ['warn', 3]` has been added to the ESLint config. This rule is set to generate a warning if a function is defined with more than 3 parameters.

## Screenshots/Videos
![Screenshot 2024-01-18 at 10 54 01 AM](https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/01fa85e5-90ca-4f67-a949-b60dec97938b)

[CP-5262]: https://ava-labs.atlassian.net/browse/CP-5262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ