### PR TITLE
CP-8035: added a feature flag for cctp feature

### DIFF
--- a/packages/core-mobile/app/services/posthog/types.ts
+++ b/packages/core-mobile/app/services/posthog/types.ts
@@ -21,7 +21,8 @@ export enum FeatureGates {
   SEEDLESS_MFA_YUBIKEY = 'seedless-mfa-yubikey',
   SEEDLESS_MFA_PASSKEY = 'seedless-mfa-passkey',
   SEEDLESS_MFA_AUTHENTICATOR = 'seedless-mfa-authenticator',
-  SEEDLESS_SIGNING = 'seedless-signing'
+  SEEDLESS_SIGNING = 'seedless-signing',
+  UNIFIED_BRIDGE_CCTP = 'unified-bridge-cctp'
 }
 
 export enum FeatureVars {

--- a/packages/core-mobile/app/store/posthog/slice.ts
+++ b/packages/core-mobile/app/store/posthog/slice.ts
@@ -292,6 +292,14 @@ export const selectIsSeedlessMfaYubikeyBlocked = (
   )
 }
 
+export const selectIsUnifiedBridgeCCTPBlocked = (state: RootState): boolean => {
+  const { featureFlags } = state.posthog
+  return (
+    !featureFlags[FeatureGates.UNIFIED_BRIDGE_CCTP] ||
+    !featureFlags[FeatureGates.EVERYTHING]
+  )
+}
+
 // actions
 export const { regenerateUserId, toggleAnalytics, setFeatureFlags } =
   posthogSlice.actions


### PR DESCRIPTION
## Description

**Ticket: [CP-8035]** 

* a feature flag `unified-bridge-cctp` added to both prod and test environment (set disabled for prod now)
* `selectIsUnifiedBridgeCCTPBlocked` selector added

[CP-8035]: https://ava-labs.atlassian.net/browse/CP-8035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ