### PR TITLE
CP-8221: gas widget UI improvement

### DIFF
--- a/packages/core-mobile/app/components/EditFees.tsx
+++ b/packages/core-mobile/app/components/EditFees.tsx
@@ -29,7 +29,7 @@ type EditFeesProps<T extends TokenBaseUnit<T>> = {
   lowMaxFeePerGas: NetworkTokenUnit
   isGasLimitEditable?: boolean
   isBtcNetwork?: boolean
-  customGasLimitError?: string
+  noGasLimitError?: string
 } & Eip1559Fees<T>
 
 const maxBaseFeeInfoMessage =
@@ -59,9 +59,9 @@ const EditFees = ({
   onClose,
   isGasLimitEditable,
   isBtcNetwork,
-  customGasLimitError
+  noGasLimitError
 }: EditFeesProps<NetworkTokenUnit>): JSX.Element => {
-  const _gasLimitError = customGasLimitError ?? 'Please enter a valid gas limit'
+  const _gasLimitError = noGasLimitError ?? 'Please enter a valid gas limit'
   const {
     theme: { colors }
   } = useTheme()

--- a/packages/core-mobile/app/components/NetworkFeeSelector.tsx
+++ b/packages/core-mobile/app/components/NetworkFeeSelector.tsx
@@ -42,14 +42,14 @@ const NetworkFeeSelector = ({
   onFeesChange,
   maxNetworkFee,
   isGasLimitEditable = true,
-  customGasLimitError
+  noGasLimitError
 }: {
   chainId?: number
   gasLimit: number
   onFeesChange?(fees: Eip1559Fees<NetworkTokenUnit>, feePreset: FeePreset): void
   maxNetworkFee?: NetworkTokenUnit
   isGasLimitEditable?: boolean
-  customGasLimitError?: string
+  noGasLimitError?: string
 }): JSX.Element => {
   const {
     appHook: { currencyFormatter }
@@ -157,7 +157,7 @@ const NetworkFeeSelector = ({
       gasLimit,
       isGasLimitEditable,
       isBtcNetwork,
-      customGasLimitError
+      noGasLimitError
     })
   }
 

--- a/packages/core-mobile/app/navigation/WalletScreenStack/createModals.tsx
+++ b/packages/core-mobile/app/navigation/WalletScreenStack/createModals.tsx
@@ -243,7 +243,7 @@ const EditGasLimit = (): JSX.Element => {
       lowMaxFeePerGas={params.lowMaxFeePerGas}
       isGasLimitEditable={params.isGasLimitEditable}
       isBtcNetwork={params.isBtcNetwork}
-      customGasLimitError={params.customGasLimitError}
+      noGasLimitError={params.noGasLimitError}
     />
   )
 }

--- a/packages/core-mobile/app/navigation/types.ts
+++ b/packages/core-mobile/app/navigation/types.ts
@@ -74,7 +74,7 @@ export type EditGasLimitParams = {
   lowMaxFeePerGas: NetworkTokenUnit
   isGasLimitEditable?: boolean
   isBtcNetwork?: boolean
-  customGasLimitError?: string
+  noGasLimitError?: string
 } & Eip1559Fees<NetworkTokenUnit>
 
 export type SessionProposalV2Params = {

--- a/packages/core-mobile/app/screens/bridge/Bridge.tsx
+++ b/packages/core-mobile/app/screens/bridge/Bridge.tsx
@@ -794,7 +794,7 @@ const Bridge: FC = () => {
           gasLimit={eip1559Fees.gasLimit}
           onFeesChange={handleFeesChange}
           isGasLimitEditable={false}
-          customGasLimitError={
+          noGasLimitError={
             provider === BridgeProvider.UNIFIED
               ? 'Please select a token and enter a transfer amount'
               : 'Please select a token'

--- a/packages/core-mobile/app/screens/shared/EditGasLimitBottomSheet.tsx
+++ b/packages/core-mobile/app/screens/shared/EditGasLimitBottomSheet.tsx
@@ -14,7 +14,7 @@ type Props<T extends TokenBaseUnit<T>> = {
   lowMaxFeePerGas: NetworkTokenUnit
   isGasLimitEditable?: boolean
   isBtcNetwork?: boolean
-  customGasLimitError?: string
+  noGasLimitError?: string
 } & Eip1559Fees<T>
 
 const EditGasLimitBottomSheet = ({
@@ -27,7 +27,7 @@ const EditGasLimitBottomSheet = ({
   lowMaxFeePerGas,
   isGasLimitEditable,
   isBtcNetwork,
-  customGasLimitError
+  noGasLimitError
 }: Props<NetworkTokenUnit>): JSX.Element => {
   return (
     <Sheet onClose={onClose || noop}>
@@ -43,7 +43,7 @@ const EditGasLimitBottomSheet = ({
         lowMaxFeePerGas={lowMaxFeePerGas}
         isGasLimitEditable={isGasLimitEditable}
         isBtcNetwork={isBtcNetwork}
-        customGasLimitError={customGasLimitError}
+        noGasLimitError={noGasLimitError}
       />
     </Sheet>
   )


### PR DESCRIPTION
## Description

**Ticket: [CP-8221 & CP-8222]** 

- show a custom gas limit error message for Bridge to ask user to select a token and amount first
- fix iOS keyboard hiding the save button in edit fee screen.

## Screenshots/Videos

https://github.com/ava-labs/avalanche-wallet-apps/assets/137183702/65a3945e-0b9a-4a4e-b469-78195184b43c

## Testing
- manual

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
