### PR TITLE
CP-8181: ignore invalid pairing link error

### DIFF
--- a/packages/core-mobile/app/services/walletconnectv2/WalletConnectService.ts
+++ b/packages/core-mobile/app/services/walletconnectv2/WalletConnectService.ts
@@ -91,9 +91,7 @@ class WalletConnectService {
           .toLowerCase()
           .includes('missing or invalid. pair() uri#relay-protocol')
       ) {
-        Logger.info(
-          'pairing already exists, ignore this wallet connect v1 pairing error'
-        )
+        Logger.info('ignore invalid link')
         return
       }
 


### PR DESCRIPTION
## Description

**Ticket: [CP-8181]** 

- when dapp sends a session approval request in browser, it triggers pairing with invalid uri (happens only in Android) which is missing the relayer protocol.  we should just ignore this.

## Screenshots/Videos

https://github.com/ava-labs/avalanche-wallet-apps/assets/137183702/d7a114a5-19db-4429-867c-4ded0dd0e252

## Testing
- manual

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-8181]: https://ava-labs.atlassian.net/browse/CP-8181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ