### PR TITLE
Add Copy Gemfile script step to build ios simulator

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -160,6 +160,18 @@ workflows:
   _build-ios-simulator:
     steps:
     - restore-cocoapods-cache@1: {}
+    - script@1:
+        title: Copy Gemfile to iOS folder
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
+            set -o pipefail
+            # we need to do this to make sure the cocoapods install step consider our Gemfile
+            cp Gemfile ios
+            cp Gemfile.lock ios
     - cocoapods-install@2:
         inputs:
         - verbose: "true"


### PR DESCRIPTION
## Description

- Installing cocoapods for `_build-for-ios-simulator` workflow was failing and this fixes it
- Copied script step from `_build-for-ios` workflow




## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
