### PR TITLE
CP-8268: Do not allow to verify with the mfa when deleting it

### DIFF
--- a/packages/core-mobile/app/seedless/hooks/useSeedlessManageMFA.ts
+++ b/packages/core-mobile/app/seedless/hooks/useSeedlessManageMFA.ts
@@ -95,7 +95,7 @@ function useSeedlessManageMFA(): {
       verifyMFA({
         response: fidoDeleteResponse,
         onVerifySuccess: handleVerifySuccess,
-        excludeMfaId: fidoId
+        excludeFidoMfaId: fidoId
       })
     } else {
       throw new Error('fidoDelete requires MFA')

--- a/packages/core-mobile/app/seedless/hooks/useVerifyMFA.ts
+++ b/packages/core-mobile/app/seedless/hooks/useVerifyMFA.ts
@@ -50,17 +50,17 @@ function useVerifyMFA(sessionManager: SeedlessSessionManager): {
   const verifyMFA: VerifyMFAFunction = async <T>({
     response,
     onVerifySuccess,
-    excludeMfaId
+    excludeFidoMfaId
   }: {
     response: CubeSignerResponse<T>
     onVerifySuccess: (response: T) => void
-    excludeMfaId?: string
+    excludeFidoMfaId?: string
   }) => {
     let mfaMethods = await sessionManager.userMfa()
 
-    if (excludeMfaId) {
+    if (excludeFidoMfaId) {
       mfaMethods = mfaMethods.filter(
-        mfa => mfa.type === 'totp' || mfa.id !== excludeMfaId
+        mfa => mfa.type === 'totp' || mfa.id !== excludeFidoMfaId
       )
     }
 
@@ -132,11 +132,11 @@ function useVerifyMFA(sessionManager: SeedlessSessionManager): {
 type VerifyMFAFunction = <T>({
   response,
   onVerifySuccess,
-  excludeMfaId
+  excludeFidoMfaId
 }: {
   response: CubeSignerResponse<T>
   onVerifySuccess: (response: T) => void
-  excludeMfaId?: string
+  excludeFidoMfaId?: string
 }) => Promise<void>
 
 type VerifyTotpFunction = <T>({


### PR DESCRIPTION
## Description

**Ticket: [CP-8268]** 

* Cubist sdk doesn't allow to use the mfa for verification when deleting it, so exclude it from the options during the deletion process.

[CP-8268]: https://ava-labs.atlassian.net/browse/CP-8268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ