### PR TITLE
CP-8197: Do not reload url when the browser is already on the url

### DIFF
--- a/packages/core-mobile/app/screens/browser/Browser.tsx
+++ b/packages/core-mobile/app/screens/browser/Browser.tsx
@@ -84,8 +84,10 @@ export default function Browser({ tabId }: { tabId: string }): JSX.Element {
   }
 
   useEffect(() => {
-    activeHistory?.url && setUrlToLoad(activeHistory.url)
-  }, [activeHistory?.url])
+    if (activeHistory?.url && urlEntry !== activeHistory.url) {
+      setUrlToLoad(activeHistory.url)
+    }
+  }, [activeHistory?.url, urlEntry])
 
   useEffect(() => {
     //initiate deep link if user copies WC link to clipboard


### PR DESCRIPTION
## Description

**Ticket: [CP-8197]** 

* Do not reload with `activeHistory.url` when the browser instance is already on the url

## Screenshots/Videos

### iOS
https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/2dab9aa4-c221-4902-afa1-8096835719fd

### Android
https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/737e9cd5-8851-42db-bbbf-26416fb714c8

[CP-8197]: https://ava-labs.atlassian.net/browse/CP-8197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ