### PR TITLE
dismiss owl before onAccountVerified is called

### DIFF
--- a/packages/core-mobile/app/components/GlobalOwlLoader.tsx
+++ b/packages/core-mobile/app/components/GlobalOwlLoader.tsx
@@ -11,7 +11,10 @@ let rootNode: RootSiblingsManager | null = null
 const showModal = (element: JSX.Element): void => {
   // if there is already a modal shown, hide it first
   if (rootNode !== null) {
-    Logger.warn('there is already a modal shown, you should hide it first')
+    Logger.warn(
+      'duplicate owl modal',
+      'there is already a modal shown, you should hide it first'
+    )
   }
   rootNode = new RootSiblingsManager(element)
 }

--- a/packages/core-mobile/app/utils/Logger.ts
+++ b/packages/core-mobile/app/utils/Logger.ts
@@ -46,22 +46,22 @@ class Logger {
   trace = (message: string, value?: any): void => {
     if (this.shouldLog(LogLevel.TRACE)) {
       console.groupCollapsed(...formatMessage(message, 'grey'))
-      console.trace(message, value ?? '')
+      value && console.trace(value)
       console.groupEnd()
     }
   }
 
   info = (message: string, value?: any): void => {
     if (this.shouldLog(LogLevel.INFO)) {
-      console.info(...formatMessage(message))
-      console.info(message, value ?? '')
+      message && console.info(...formatMessage(message))
+      value && console.info(value)
     }
   }
 
   warn = (message: string, value?: any): void => {
     if (this.shouldLog(LogLevel.WARN)) {
       console.groupCollapsed(...formatMessage(message, 'yellow'))
-      console.warn(message, value ?? '')
+      value && console.warn(value)
       console.groupEnd()
     }
   }
@@ -69,7 +69,7 @@ class Logger {
   error = (message: string, value?: any): void => {
     if (this.shouldLog(LogLevel.ERROR)) {
       console.groupCollapsed(...formatMessage(message, 'red'))
-      console.error(message, value ?? '')
+      value && console.error(value)
       console.groupEnd()
 
       if (this.shouldLogErrorToSentry) {


### PR DESCRIPTION
## Description

- for Fido, we show/hide Owl when verifying mfa, and show/hide is also called while waiting for seedless account name, and the order was like `showOwl (mfa) -> showOwl (fetch account name) -> hideOwl (accountName) -> navigation -> hideOwl (mfa)`.  
- the problem is when we show two owls, the rootNode is set to the latest element, so when we call hideOwl twice, they are both trying to destroy the latest element.  
- update the logic to hide owl right before we call `onAccountVerified`.

## Screenshots/Videos

https://github.com/ava-labs/avalanche-wallet-apps/assets/137183702/ae86c576-1df0-4241-a3ec-1f05b43428fd

![Simulator Screenshot - iPhone 14 - 2024-03-14 at 15 14 44](https://github.com/ava-labs/avalanche-wallet-apps/assets/137183702/ca509393-ba0e-4e8d-8871-73d983e4ebcf)


## Testing
- manual

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
