### PR TITLE
use Avalanche.SimpleSigner to sign transactions

### DIFF
--- a/packages/core-mobile/app/services/wallet/MnemonicWallet.test.ts
+++ b/packages/core-mobile/app/services/wallet/MnemonicWallet.test.ts
@@ -65,6 +65,10 @@ describe('MnemonicWallet', () => {
       const wallet = MnemonicWallet.getAvaSigner(0, {})
       expect(wallet).toBeInstanceOf(Avalanche.StaticSigner)
     })
+    it('should have returned Avalanche.SimpleSigner', () => {
+      const wallet = MnemonicWallet.getAvaSigner(0)
+      expect(wallet).toBeInstanceOf(Avalanche.SimpleSigner)
+    })
     it('should have called getEvmSigner for EVM network', async () => {
       await MnemonicWallet.getSigner({
         accountIndex: 0,
@@ -230,6 +234,15 @@ describe('MnemonicWallet', () => {
     jest.spyOn(BitcoinWallet.prototype, 'signTx').mockImplementation(() => {
       return { toHex: () => 'signedTx' }
     })
+    jest
+      .spyOn(Avalanche.SimpleSigner.prototype, 'signTx')
+      .mockImplementation(() => {
+        return {
+          toJSON: () => {
+            return { signedTx: 'signedTx' }
+          }
+        }
+      })
     jest
       .spyOn(Avalanche.StaticSigner.prototype, 'signTx')
       .mockImplementation(() => {


### PR DESCRIPTION
## Description

**Ticket: [MISSING_TICKET]** 

- replace avalanche staticSigner with simpleSigner to sign transaction, simplerSigner has simpler interface to sign xp/c transactions without having to explicitly provide the xp/c addresses.

## Screenshots/Videos

https://github.com/ava-labs/avalanche-wallet-apps/assets/137183702/759b13d6-d07f-44cf-a49b-6e1d056d62c5

## Testing
- manual
- unit test

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [X] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
