### PR TITLE
CP-8436: Fix running off content in ApproveTransaction

### DIFF
--- a/packages/core-mobile/.storybook/storybook.requires.js
+++ b/packages/core-mobile/.storybook/storybook.requires.js
@@ -48,6 +48,7 @@ try {
 
 const getStories = () => {
   return {
+    "./storybook/stories/ApproveTransactionView.stories.tsx": require("../storybook/stories/ApproveTransactionView.stories.tsx"),
     "./storybook/stories/AvaListItem.stories.tsx": require("../storybook/stories/AvaListItem.stories.tsx"),
     "./storybook/stories/AvaText.stories.tsx": require("../storybook/stories/AvaText.stories.tsx"),
     "./storybook/stories/BottomSheet.stories.tsx": require("../storybook/stories/BottomSheet.stories.tsx"),
@@ -69,14 +70,14 @@ const getStories = () => {
     "./storybook/stories/earn/StakeProgress.stories.tsx": require("../storybook/stories/earn/StakeProgress.stories.tsx"),
     "./storybook/stories/earn/StatusChip.stories.tsx": require("../storybook/stories/earn/StatusChip.stories.tsx"),
     "./storybook/stories/earn/ZeroState.stories.tsx": require("../storybook/stories/earn/ZeroState.stories.tsx"),
-    "./storybook/stories/seedless/SessionTimeout.stories.tsx": require("../storybook/stories/seedless/SessionTimeout.stories.tsx"),
-    "./storybook/stories/seedless/WrongSocialAccount.stories.tsx": require("../storybook/stories/seedless/WrongSocialAccount.stories.tsx"),
     "./storybook/stories/FeeSelector.stories.tsx": require("../storybook/stories/FeeSelector.stories.tsx"),
     "./storybook/stories/IntroModal.stories.tsx": require("../storybook/stories/IntroModal.stories.tsx"),
     "./storybook/stories/JailbrokenWarning.stories.tsx": require("../storybook/stories/JailbrokenWarning.stories.tsx"),
     "./storybook/stories/Login.stories.tsx": require("../storybook/stories/Login.stories.tsx"),
     "./storybook/stories/Lotties.stories.tsx": require("../storybook/stories/Lotties.stories.tsx"),
     "./storybook/stories/RadioButton.stories.tsx": require("../storybook/stories/RadioButton.stories.tsx"),
+    "./storybook/stories/seedless/SessionTimeout.stories.tsx": require("../storybook/stories/seedless/SessionTimeout.stories.tsx"),
+    "./storybook/stories/seedless/WrongSocialAccount.stories.tsx": require("../storybook/stories/seedless/WrongSocialAccount.stories.tsx"),
     "./storybook/stories/StackedImages.stories.tsx": require("../storybook/stories/StackedImages.stories.tsx"),
     "./storybook/stories/SVGs.stories.tsx": require("../storybook/stories/SVGs.stories.tsx"),
     "./storybook/stories/Tooltip.stories.tsx": require("../storybook/stories/Tooltip.stories.tsx"),

--- a/packages/core-mobile/app/screens/rpc/components/shared/signTransaction/ApproveTransaction.tsx
+++ b/packages/core-mobile/app/screens/rpc/components/shared/signTransaction/ApproveTransaction.tsx
@@ -35,7 +35,6 @@ export function ApproveTransaction({
   setShowCustomSpendLimit?: Dispatch<boolean>
   customSpendLimit: SpendLimit
 }): JSX.Element {
-  const theme = useApplicationContext().theme
   const account = useSelector(selectAccountByAddress(rest.fromAddress))
   const selectedCurrency = useSelector(selectSelectedCurrency)
 
@@ -59,6 +58,55 @@ export function ApproveTransaction({
       })
 
   return (
+    <ApproveTransactionView
+      title={account?.title}
+      toAddress={rest.toAddress}
+      url={site?.url}
+      editButton={
+        hideEdit ? null : (
+          <AvaButton.Base
+            onPress={() => {
+              setShowCustomSpendLimit?.(true)
+            }}>
+            <AvaText.TextLink>Edit</AvaText.TextLink>
+          </AvaButton.Base>
+        )
+      }
+      tokenName={tokenToBeApproved.name}
+      tokenLogoUri={tokenToBeApproved.logoUri}
+      tokenSymbol={tokenToBeApproved.symbol}
+      tokenValue={tokenValue}
+      fiatValue={fiatValue}
+    />
+  )
+}
+
+type ApproveTransactionViewProps = {
+  title?: string
+  toAddress?: string
+  url?: string
+  editButton: JSX.Element | null
+  tokenName: string
+  tokenLogoUri?: string
+  tokenSymbol: string
+  tokenValue: string
+  fiatValue: string
+}
+
+export const ApproveTransactionView = ({
+  title,
+  toAddress,
+  url,
+  editButton,
+  tokenName,
+  tokenLogoUri,
+  tokenSymbol,
+  tokenValue,
+  fiatValue
+}: ApproveTransactionViewProps): JSX.Element => {
+  const theme = useApplicationContext().theme
+
+  return (
     <>
       <View
         style={[
@@ -70,34 +118,29 @@ export function ApproveTransaction({
         <Row style={{ justifyContent: 'space-between' }}>
           <AvaText.Body2>Account</AvaText.Body2>
           <AvaText.ButtonMedium color={theme.colorText1}>
-            {account?.title}
+            {title}
           </AvaText.ButtonMedium>
         </Row>
         <Space y={8} />
-        {rest.toAddress && (
+        {toAddress && (
           <Row style={{ justifyContent: 'space-between' }}>
             <AvaText.Body2>Contract</AvaText.Body2>
-            <TokenAddress address={rest.toAddress} />
+            <TokenAddress address={toAddress} />
           </Row>
         )}
         <Space y={8} />
         <Row style={{ justifyContent: 'space-between' }}>
           <AvaText.Body2>Website</AvaText.Body2>
-          <AvaText.ButtonMedium color={theme.colorText1}>
-            {site?.url}
+          <AvaText.ButtonMedium
+            textStyle={{ flexShrink: 1, marginLeft: 16 }}
+            color={theme.colorText1}>
+            {url}
           </AvaText.ButtonMedium>
         </Row>
       </View>
       <Row style={{ justifyContent: 'space-between' }}>
         <AvaText.Body2>Spend Limit</AvaText.Body2>
-        {hideEdit || (
-          <AvaButton.Base
-            onPress={() => {
-              setShowCustomSpendLimit?.(true)
-            }}>
-            <AvaText.TextLink>Edit</AvaText.TextLink>
-          </AvaButton.Base>
-        )}
+        {editButton}
       </Row>
       <View
         style={[
@@ -111,26 +154,20 @@ export function ApproveTransaction({
         ]}>
         <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
           <Row style={{ alignItems: 'center' }}>
-            {tokenToBeApproved && (
-              <Avatar.Custom
-                name={tokenToBeApproved.name}
-                logoUri={tokenToBeApproved?.logoUri}
-              />
-            )}
+            <Avatar.Custom name={tokenName} logoUri={tokenLogoUri} />
             <Space x={10} />
-            <AvaText.Body1>{tokenToBeApproved?.symbol}</AvaText.Body1>
+            <AvaText.Body1>{tokenSymbol}</AvaText.Body1>
           </Row>
-          {customSpendLimit && (
-            <View
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'flex-end'
-              }}>
-              <AvaText.Body1>{tokenValue}</AvaText.Body1>
-              <AvaText.Body2>{fiatValue}</AvaText.Body2>
-            </View>
-          )}
+          <View
+            style={{
+              flexDirection: 'column',
+              alignItems: 'flex-end',
+              marginLeft: 16,
+              flexShrink: 1
+            }}>
+            <AvaText.Body1>{tokenValue}</AvaText.Body1>
+            <AvaText.Body2>{fiatValue}</AvaText.Body2>
+          </View>
         </Row>
       </View>
     </>

--- a/packages/core-mobile/app/store/account/slice.ts
+++ b/packages/core-mobile/app/store/account/slice.ts
@@ -46,10 +46,15 @@ export const selectAccounts = (state: RootState): AccountCollection =>
   state.account.accounts
 
 export const selectAccountByAddress =
-  (address?: string) => (state: RootState) =>
-    Object.values(state.account.accounts).find(
+  (address?: string) =>
+  (state: RootState): Account | undefined => {
+    const accounts: Account[] = Object.values(state.account.accounts)
+
+    return accounts.find(
       acc => acc.address.toLowerCase() === address?.toLowerCase()
     )
+  }
+
 export const selectActiveAccount = (state: RootState): Account | undefined =>
   state.account.accounts[state.account.activeAccountIndex]
 

--- a/packages/core-mobile/storybook/stories/ApproveTransactionView.stories.tsx
+++ b/packages/core-mobile/storybook/stories/ApproveTransactionView.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import type { Meta } from '@storybook/react-native'
+import { ApproveTransactionView } from 'screens/rpc/components/shared/signTransaction/ApproveTransaction'
+import { K2ThemeProvider, View } from '@avalabs/k2-mobile'
+import AvaButton from 'components/AvaButton'
+import AvaText from 'components/AvaText'
+
+export default {
+  title: 'ApproveTransactionView'
+} as Meta
+
+export const Default = (): JSX.Element => {
+  return (
+    <K2ThemeProvider>
+      <View sx={{ padding: 16 }}>
+        <ApproveTransactionView
+          title="Shitcoins"
+          toAddress="0xC775C0C30840Cb9F51e21061B054ebf1A00aCC29"
+          url="https://traderjoexyz.com/avalanche/stek/0xC775C0C30840Cb9F51e21061B054ebf1A00aCC29"
+          editButton={
+            <AvaButton.Base>
+              <AvaText.TextLink>Edit</AvaText.TextLink>
+            </AvaButton.Base>
+          }
+          tokenName="KONG"
+          tokenSymbol="KONG"
+          tokenValue="455,759,587.222151641394909179 l12345"
+          fiatValue=""
+        />
+      </View>
+    </K2ThemeProvider>
+  )
+}


### PR DESCRIPTION
## Description

**Ticket: [CP-8436]** 

* refactor `ApproveTransaction` with `ApproveTransactionView` component
* add `ApproveTransactionView.stories.tsx` to storybook
* fix running off ui in storybook
* type `selectAccountByAddress` selector properly

## Screenshots/Videos
| before | after |
| --- | --- |
| <img src="https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/a6dbfdb7-f809-44e3-85fd-f57765bc9a07" width=320 /> | <img src="https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/e1f6c8c7-6e7f-4d97-8ba5-edac2aee718f" width=320 /> |

[CP-8436]: https://ava-labs.atlassian.net/browse/CP-8436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ