### PR TITLE
CP-8495 Fix stake estimation alignment

### DIFF
--- a/packages/core-mobile/app/screens/earn/durationScreen/DurationScreen.tsx
+++ b/packages/core-mobile/app/screens/earn/durationScreen/DurationScreen.tsx
@@ -162,22 +162,24 @@ export const StakingDuration = (): JSX.Element => {
 
   const renderFooter = (): JSX.Element => (
     <View>
-      <Tooltip
-        content={renderPopoverInfoText()}
-        style={{ width: 246 }}
-        isLabelPopable>
-        <AvaText.Caption
-          textStyle={{
-            color: theme.neutral400,
-            textAlign: 'center',
-            lineHeight: 20,
-            marginHorizontal: 40
-          }}>
-          Estimates are provided for informational purposes only...
-          <Space x={8} />
-          <InfoSVG size={13.33} />
-        </AvaText.Caption>
-      </Tooltip>
+      <View style={{ alignItems: 'center' }}>
+        <Tooltip
+          content={renderPopoverInfoText()}
+          style={{ width: 246 }}
+          isLabelPopable>
+          <AvaText.Caption
+            textStyle={{
+              color: theme.neutral400,
+              textAlign: 'center',
+              lineHeight: 20,
+              marginHorizontal: 40
+            }}>
+            Estimates are provided for informational purposes only...
+            <Space x={8} />
+            <InfoSVG size={13.33} />
+          </AvaText.Caption>
+        </Tooltip>
+      </View>
       <Space y={12} />
       <AvaButton.PrimaryLarge
         disabled={isNextDisabled}


### PR DESCRIPTION
## Description

**Ticket: [https://ava-labs.atlassian.net/browse/CP-8495]** 

- Nested the estimation warning in a separate view and set it to center alignment

## Screenshots/Videos
Before
![image-20240416-191608](https://github.com/ava-labs/avalanche-wallet-apps/assets/17894098/78390d03-7c31-4af7-99a2-d67633ee6ae3)

After
![Simulator Screenshot - iPhone 15 Pro - 2024-04-17 at 09 40 45](https://github.com/ava-labs/avalanche-wallet-apps/assets/17894098/f83f93d6-83c7-4d92-9de6-a1b17ee570a8)


## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
