### PR TITLE
CP-8441: Support P-chain BaseTx

### DIFF
--- a/packages/core-mobile/app/screens/rpc/components/shared/AvalancheSendTransaction/BaseTxView.tsx
+++ b/packages/core-mobile/app/screens/rpc/components/shared/AvalancheSendTransaction/BaseTxView.tsx
@@ -11,6 +11,7 @@ import { Avalanche } from '@avalabs/wallets-sdk'
 import { AvalancheChainStrings } from 'store/rpc/handlers/types'
 import { GetAssetDescriptionResponse } from '@avalabs/avalanchejs/dist/vms/common'
 import { Avax } from 'types'
+import { PVM } from '@avalabs/avalanchejs'
 import { TxFee } from './components/TxFee'
 
 const BaseTxView = ({ tx }: { tx: Avalanche.BaseTx }): JSX.Element => {
@@ -84,11 +85,15 @@ const BaseTxView = ({ tx }: { tx: Avalanche.BaseTx }): JSX.Element => {
       <Space y={16} />
       <TxFee txFee={txFee} />
       <Space y={16} />
-      <AvaText.Body2 color={theme.colorText1}>Memo</AvaText.Body2>
-      <Space y={8} />
-      <Card style={styles.cardContainer}>
-        <AvaText.Caption color={theme.colorText2}>{memo}</AvaText.Caption>
-      </Card>
+      {chain !== PVM && (
+        <>
+          <AvaText.Body2 color={theme.colorText1}>Memo</AvaText.Body2>
+          <Space y={8} />
+          <Card style={styles.cardContainer}>
+            <AvaText.Caption color={theme.colorText2}>{memo}</AvaText.Caption>
+          </Card>
+        </>
+      )}
     </ScrollView>
   )
 }


### PR DESCRIPTION
## Description

**Ticket: [CP-8441]** 

## Changes
* `getAssetDescription` is not supported on P-chain, so we need to hardcode the default decimal to display the amount properly. it seems there is [an ongoing work to improve this](https://ava-labs.atlassian.net/browse/CP-8461).
* P-chain baseTx does not allow memo, so remove memo section when the tx is on p-chain. 

## Testing
1. Visit [playground](https://ava-labs.github.io/extension-avalanche-playground/avalanche-transactions)
2. Connect to core mobile via wallet connect
3. Avalanche Transactions -> PVM BaseTx
4. Please make sure that PVM BaseTx is working.(Currently It is set to send 0.1AVAX when signing this tx.)

## Screenshots/Videos
https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/ab8abc8d-8f07-4f43-8d23-be24eb01fc12

## References
* Pr for extension: https://github.com/ava-labs/extension-avalanche/pull/1386

[CP-8441]: https://ava-labs.atlassian.net/browse/CP-8441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ