### PR TITLE
CP-8582: Fix Biometric Authentication Failure for Sign in

### DIFF
--- a/packages/core-mobile/app/screens/login/PinOrBiometryLoginViewModel.ts
+++ b/packages/core-mobile/app/screens/login/PinOrBiometryLoginViewModel.ts
@@ -180,7 +180,7 @@ export function usePinOrBiometryLogin(): {
     (): Observable<WalletLoadingResults> => {
       return timer(0, asyncScheduler).pipe(
         //timer is here to give UI opportunity to draw everything
-        concatMap(() => BiometricsSDK.getAccessType()),
+        concatMap(() => of(BiometricsSDK.getAccessType())),
         concatMap((value: string | null) => {
           if (value && value === 'BIO') {
             return BiometricsSDK.loadWalletKey({


### PR DESCRIPTION
## Description

**Ticket: [CP-8582]** 

* Updated `react-native-keychain` to 8.2.0
* Wrapped `BiometricsSDK.getAccessType()` return value in `of()` to properly integrate it as an `Observable` in our `RxJS` flow. This ensures the string `BIO` is processed as a whole, maintaining consistent behavior across the authentication process.



[CP-8582]: https://ava-labs.atlassian.net/browse/CP-8582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ