### PR TITLE
Fix: show zero state properly in favorite tab in watchlist

### DIFF
--- a/packages/core-mobile/app/screens/watchlist/FavoriteWatchlistView.tsx
+++ b/packages/core-mobile/app/screens/watchlist/FavoriteWatchlistView.tsx
@@ -10,9 +10,9 @@ interface Props {
 }
 
 const FavoriteWatchlistView: React.FC<Props> = ({ onTabIndexChanged }) => {
-  const { favorites, prices, charts } = useWatchlist()
+  const { favorites, prices, charts, tokens } = useWatchlist()
 
-  const isFetchingTokens = favorites.length === 0
+  const isFetchingTokens = tokens.length === 0
 
   return (
     <>


### PR DESCRIPTION
## Description

* fix to show zero state instead of loading state in favorite tab when user has no favorite tokens. 

## Screenshots/Videos
| before | after |
| --- | --- |
| <img src='https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/4ac4cf00-e7d3-4ce7-a69b-7746f570e656' width=320 /> | <img src='https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/5233bbca-1c09-4b27-9812-a8709eee9506' width=320 /> |