### PR TITLE
CP-8584: fix pin screen lags

### DIFF
--- a/packages/core-mobile/app/navigation/RootScreenStack.tsx
+++ b/packages/core-mobile/app/navigation/RootScreenStack.tsx
@@ -129,8 +129,9 @@ const WalletScreenStackWithContext: FC = () => {
   // we only render the wallet stack once user has unlocked the wallet
   return (
     <>
-      <WalletScreenStack onExit={doExit} />
-
+      {walletState === WalletState.ACTIVE && (
+        <WalletScreenStack onExit={doExit} />
+      )}
       {walletState === WalletState.INACTIVE && <LoginWithPinOrBiometryScreen />}
       {/* This protects from leaking last screen in "recent apps" list.                                 */}
       {/* For Android it is additionally implemented natively in MainActivity.java because react-native */}


### PR DESCRIPTION
## Description

**Ticket: [CP-8584]** 

- set detachInactiveScreens to false to keep the drawer and tabs navigators in the view hierarchy.  Technically we did not remove these navigators, they should still be in memory, but somehow setting detachInactiveScreens to falsely fix the lags and running the performance monitor, there are many differences in Ram usage.

## Screenshots/Videos

https://github.com/ava-labs/avalanche-wallet-apps/assets/137183702/caf483b6-aa14-498c-9fd0-e6def13a2fd5

performance monitor:

before: 
<img width="1360" alt="Screenshot 2024-05-08 at 1 17 13 PM" src="https://github.com/ava-labs/avalanche-wallet-apps/assets/137183702/9a23ea26-1875-4460-9c4b-68b5a3356d67">


after: 
<img width="1344" alt="Screenshot 2024-05-08 at 1 15 20 PM" src="https://github.com/ava-labs/avalanche-wallet-apps/assets/137183702/528932aa-125e-414e-8e4f-25c8e8e4ac90">


## Testing
- manual

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-8584]: https://ava-labs.atlassian.net/browse/CP-8584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ