### PR TITLE
CP-8626: Balance shows 0 when logging into existing or new seedless wallets

### DIFF
--- a/packages/core-mobile/app/screens/portfolio/home/Portfolio.tsx
+++ b/packages/core-mobile/app/screens/portfolio/home/Portfolio.tsx
@@ -21,7 +21,7 @@ import { DeFiProtocolList } from 'screens/defi/DeFiProtocolList'
 import AnalyticsService from 'services/analytics/AnalyticsService'
 import { fetchWatchlist } from 'store/watchlist'
 import { useNetworks } from 'hooks/networks/useNetworks'
-import { selectIsLoadingBalances } from 'store/balance'
+import { selectIsBalanceLoadedForNetworks } from 'store/balance/slice'
 import InactiveNetworkCard from './components/Cards/InactiveNetworkCard'
 import PortfolioHeader from './components/PortfolioHeader'
 import { PortfolioInactiveNetworksLoader } from './components/Loaders/PortfolioInactiveNetworksLoader'
@@ -85,13 +85,18 @@ const TokensTab = (): JSX.Element => {
   const { inactiveNetworks } = useNetworks()
   const { isRefetching, refetch } = useSearchableTokenList()
   const dispatch = useDispatch()
-  const isLoadingBalances = useSelector(selectIsLoadingBalances)
+
+  const isBalanceLoadedForInactiveNetworks = useSelector(
+    selectIsBalanceLoadedForNetworks(
+      inactiveNetworks.map(network => network.chainId)
+    )
+  )
 
   // set item to render to the first inactive network as dummy single value array
   // in order to show the loader while the balances are still loading
   // * the loader consist of 4 content reactangle loaders
   const itemsToRender =
-    isLoadingBalances && inactiveNetworks.length > 0
+    !isBalanceLoadedForInactiveNetworks && inactiveNetworks.length > 0
       ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         [inactiveNetworks[0]!]
       : inactiveNetworks
@@ -135,7 +140,7 @@ const TokensTab = (): JSX.Element => {
         numColumns={2}
         data={itemsToRender}
         renderItem={
-          isLoadingBalances
+          !isBalanceLoadedForInactiveNetworks
             ? renderInactiveNetworkLoader
             : renderInactiveNetwork
         }

--- a/packages/core-mobile/app/store/account/listeners.ts
+++ b/packages/core-mobile/app/store/account/listeners.ts
@@ -16,7 +16,6 @@ import {
   selectAccounts,
   selectActiveAccount,
   selectWalletName,
-  setAccount,
   setAccounts
 } from './slice'
 
@@ -52,9 +51,7 @@ const initAccounts = async (
 
       const title = await SeedlessService.getAccountName(i)
       const accountTitle = title ?? acc.name
-      listenerApi.dispatch(setAccount({ ...acc, name: accountTitle }))
-
-      accounts.push(acc)
+      accounts.push({ ...acc, name: accountTitle })
     }
   } else if (walletType === WalletType.MNEMONIC) {
     // only add the first account for mnemonic wallet
@@ -67,10 +64,10 @@ const initAccounts = async (
 
     const accountTitle =
       walletName && walletName.length > 0 ? walletName : acc.name
-    listenerApi.dispatch(setAccount({ ...acc, name: accountTitle }))
-
-    accounts.push(acc)
+    accounts.push({ ...acc, name: accountTitle })
   }
+
+  listenerApi.dispatch(setAccounts(accounts))
 
   if (isDeveloperMode === false) {
     AnalyticsService.captureWithEncryption('AccountAddressesUpdated', {

--- a/packages/core-mobile/app/store/balance/slice.ts
+++ b/packages/core-mobile/app/store/balance/slice.ts
@@ -76,6 +76,18 @@ export const selectIsBalanceLoadedForActiveNetwork = (
   ]
 }
 
+export const selectIsBalanceLoadedForNetworks =
+  (chainIds: number[]) =>
+  (state: RootState): boolean => {
+    const activeAccount = selectActiveAccount(state)
+
+    if (!activeAccount) return false
+
+    return chainIds.every(chainId => {
+      return !!state.balance.balances[getKey(chainId, activeAccount.index)]
+    })
+  }
+
 export const selectIsLoadingBalances = (state: RootState): boolean =>
   state.balance.status === QueryStatus.LOADING
 


### PR DESCRIPTION
## Description

**Ticket: [CP-8626]** 

There are a few things that together cause the issue:

1/ for seedless, it takes a few seconds to fetch addresses after first logging in. this makes all attempts to fetch balances fail
**solution**: we trigger a balance refetch when addresses are loaded. 

2/ we aren't updating the balance status correctly when fetching active network's balance. the status never goes to IDLE, thus, the forever loading
**solution**: make sure we set status to IDLE correctly

3/ for the first login, the inactive network cards will always show up with 0 balance even though we haven't fetched them yet. this is because we are just relying on balance !== IDLE status to render them
**solution**: make sure the `state.balance.balances` object contains each of the inactive networks's balance before rendering them

## Screenshots/Videos
https://github.com/ava-labs/avalanche-wallet-apps/assets/8824551/4c1408bb-f8be-4f77-b09a-8d4427440aa9


## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-8626]: https://ava-labs.atlassian.net/browse/CP-8626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ