### PR TITLE
CP-8636 CP-8638 CP-8639 Fix info about X and P chains

### DIFF
--- a/packages/core-mobile/app/screens/network/NetworkDetails.tsx
+++ b/packages/core-mobile/app/screens/network/NetworkDetails.tsx
@@ -12,6 +12,7 @@ import { Network } from '@avalabs/chains-sdk'
 import { showSnackBarCustom } from 'components/Snackbar'
 import GeneralToast from 'components/toast/GeneralToast'
 import { useNetworks } from 'hooks/networks/useNetworks'
+import { absoluteChain } from 'utils/network/isAvalancheNetwork'
 import { NetworkLogo } from './NetworkLogo'
 
 export type NetworkDetailsProps = {
@@ -58,7 +59,10 @@ export default function NetworkDetails({
           <Space y={40} />
           <DetailItem title={'Network RPC URL'} value={network.rpcUrl} />
           <Space y={24} />
-          <DetailItem title={'Chain ID'} value={chainId.toString()} />
+          <DetailItem
+            title={'Chain ID'}
+            value={absoluteChain(chainId).toString()}
+          />
           <Space y={24} />
           <DetailItem
             title={'Network Token Symbol'}

--- a/packages/core-mobile/app/services/network/NetworkService.ts
+++ b/packages/core-mobile/app/services/network/NetworkService.ts
@@ -120,28 +120,30 @@ class NetworkService {
       chainId: -AVALANCHE_XP_NETWORK.chainId,
       isTestnet: false,
       vmName: NetworkVMType.PVM,
-      chainName: 'Avalanche (P-chain)',
+      chainName: 'Avalanche (P-Chain)',
       logoUri:
         'https://images.ctfassets.net/gcj8jwzm6086/42aMwoCLblHOklt6Msi6tm/1e64aa637a8cead39b2db96fe3225c18/pchain-square.svg',
       networkToken: {
         ...AVALANCHE_XP_NETWORK.networkToken,
         logoUri:
           'https://glacier-api.avax.network/proxy/chain-assets/cb14a1f/chains/43114/token-logo.png'
-      }
+      },
+      explorerUrl: 'https://subnets.avax.network/p-chain'
     } as Network
     const pChainTest = {
       ...AVALANCHE_XP_TEST_NETWORK,
       chainId: -AVALANCHE_XP_TEST_NETWORK.chainId,
       isTestnet: true,
       vmName: NetworkVMType.PVM,
-      chainName: 'Avalanche (P-chain)',
+      chainName: 'Avalanche (P-Chain)',
       logoUri:
         'https://images.ctfassets.net/gcj8jwzm6086/42aMwoCLblHOklt6Msi6tm/1e64aa637a8cead39b2db96fe3225c18/pchain-square.svg',
       networkToken: {
         ...AVALANCHE_XP_TEST_NETWORK.networkToken,
         logoUri:
           'https://glacier-api.avax.network/proxy/chain-assets/cb14a1f/chains/43114/token-logo.png'
-      }
+      },
+      explorerUrl: 'https://subnets-test.avax.network/p-chain'
     } as Network
     return isDeveloperMode ? pChainTest : pChain
   }
@@ -152,15 +154,17 @@ class NetworkService {
   getAvalancheNetworkX(isDeveloperMode: boolean): Network {
     const xChain = {
       ...AVALANCHE_XP_NETWORK,
-      chainName: 'Avalanche (X-chain)',
+      chainName: 'Avalanche (X-Chain)',
       logoUri:
-        'https://images.ctfassets.net/gcj8jwzm6086/5xiGm7IBR6G44eeVlaWrxi/1b253c4744a3ad21a278091e3119feba/xchain-square.svg'
+        'https://images.ctfassets.net/gcj8jwzm6086/5xiGm7IBR6G44eeVlaWrxi/1b253c4744a3ad21a278091e3119feba/xchain-square.svg',
+      explorerUrl: 'https://subnets.avax.network/x-chain'
     } as Network
     const xChainTest = {
       ...AVALANCHE_XP_TEST_NETWORK,
-      chainName: 'Avalanche (X-chain)',
+      chainName: 'Avalanche (X-Chain)',
       logoUri:
-        'https://images.ctfassets.net/gcj8jwzm6086/5xiGm7IBR6G44eeVlaWrxi/1b253c4744a3ad21a278091e3119feba/xchain-square.svg'
+        'https://images.ctfassets.net/gcj8jwzm6086/5xiGm7IBR6G44eeVlaWrxi/1b253c4744a3ad21a278091e3119feba/xchain-square.svg',
+      explorerUrl: 'https://subnets-test.avax.network/x-chain'
     } as Network
     return isDeveloperMode ? xChainTest : xChain
   }


### PR DESCRIPTION
## Description

**Ticket: [CP-8636] [CP-8638] [CP-8639]** 

This fixes information on network details for X and P chain

## Screenshots/Videos
![xChain Testnet](https://github.com/ava-labs/avalanche-wallet-apps/assets/6573904/3962ee77-91eb-41ff-ae43-1a73354e62c5)
![pChain Testnet](https://github.com/ava-labs/avalanche-wallet-apps/assets/6573904/e7f5b93d-7c28-46bf-8713-92e2b86eca88)
![xChain Mainnet](https://github.com/ava-labs/avalanche-wallet-apps/assets/6573904/5b66cdb6-5f2c-4252-b3d8-e0c0d98944b0)
![pChain Mainnet](https://github.com/ava-labs/avalanche-wallet-apps/assets/6573904/37769ef2-a164-428e-92c2-f3a2f06b4211)


## Testing
- From Network Manager select info icon of P and X Chain networks and observe details
- switch to testnet

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-8636]: https://ava-labs.atlassian.net/browse/CP-8636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-8638]: https://ava-labs.atlassian.net/browse/CP-8638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-8639]: https://ava-labs.atlassian.net/browse/CP-8639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ