### PR TITLE
CP-8641 Clicking MAX with small balance results in negative values

### DIFF
--- a/packages/core-mobile/app/services/send/SendServiceAVM.ts
+++ b/packages/core-mobile/app/services/send/SendServiceAVM.ts
@@ -37,10 +37,8 @@ export class SendServiceAVM {
           ? new BN(gasLimit).mul(new BN(defaultMaxFeePerGas.toString()))
           : undefined
         let maxAmount = token.balance.sub(sendFee || new BN(0))
+        maxAmount = BN.max(maxAmount, new BN(0))
 
-        if (maxAmount.lt(new BN(0))) {
-          maxAmount = new BN(0)
-        }
         const newState: SendState = {
           ...sendState,
           canSubmit: true,

--- a/packages/core-mobile/app/services/send/SendServiceEVM.ts
+++ b/packages/core-mobile/app/services/send/SendServiceEVM.ts
@@ -48,10 +48,12 @@ export class SendServiceEVM implements SendServiceHelper {
         const sendFee = defaultMaxFeePerGas
           ? new BN(gasLimit).mul(new BN(defaultMaxFeePerGas.toString()))
           : undefined
-        const maxAmount =
+        let maxAmount =
           token.type === TokenType.NATIVE
             ? token.balance.sub(sendFee || new BN(0))
             : token.balance
+
+        maxAmount = BN.max(maxAmount, new BN(0))
 
         const newState: SendState = {
           ...sendState,

--- a/packages/core-mobile/app/services/send/SendServicePVM.ts
+++ b/packages/core-mobile/app/services/send/SendServicePVM.ts
@@ -37,10 +37,7 @@ export class SendServicePVM {
           ? new BN(gasLimit).mul(new BN(defaultMaxFeePerGas.toString()))
           : undefined
         let maxAmount = token.balance.sub(sendFee || new BN(0))
-
-        if (maxAmount.lt(new BN(0))) {
-          maxAmount = new BN(0)
-        }
+        maxAmount = BN.max(maxAmount, new BN(0))
 
         const newState: SendState = {
           ...sendState,


### PR DESCRIPTION
## Description

**Ticket: [CP-8641]** 

This PR fixes negative values to send when pressing MAX button in case where balance is less than total fees.

## Screenshots/Videos

https://github.com/ava-labs/avalanche-wallet-apps/assets/6573904/41a58a91-b6a4-45ac-9fd2-ada0c181faa1


## Testing
- select X or P chain network
- select account with 0.0009 or less AVAX
- go to Send screen and press MAX amount to send
-> it should be set to zero instead of negative number

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-8641]: https://ava-labs.atlassian.net/browse/CP-8641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ