### PR TITLE
CP-8556: fix button text alignment in NetworkFeeSelector

### DIFF
--- a/packages/core-mobile/app/components/NetworkFeeSelector.tsx
+++ b/packages/core-mobile/app/components/NetworkFeeSelector.tsx
@@ -20,7 +20,14 @@ import { calculateGasAndFees, Eip1559Fees, GasAndFees } from 'utils/Utils'
 import { useNetworkFee } from 'hooks/useNetworkFee'
 import { useNativeTokenPriceForNetwork } from 'hooks/networks/useNativeTokenPriceForNetwork'
 import { NetworkTokenUnit } from 'types'
-import { alpha, Button, Text, useTheme, View } from '@avalabs/k2-mobile'
+import {
+  alpha,
+  Button,
+  Text,
+  TouchableOpacity,
+  useTheme,
+  View
+} from '@avalabs/k2-mobile'
 import { useApplicationContext } from 'contexts/ApplicationContext'
 import { NetworkFee } from 'services/networkFee/types'
 import { useBridgeSDK } from '@avalabs/bridge-sdk'
@@ -391,9 +398,7 @@ export const FeeSelector: FC<{
       />
     </ButtonWrapper>
   ) : (
-    <Button
-      type="tertiary"
-      size="small"
+    <TouchableOpacity
       style={{
         paddingLeft: 0,
         paddingHorizontal: 0,
@@ -414,7 +419,7 @@ export const FeeSelector: FC<{
         <ButtonText selected={selected}>{label}</ButtonText>
         <ButtonText selected={selected}>{value}</ButtonText>
       </View>
-    </Button>
+    </TouchableOpacity>
   )
 }
 


### PR DESCRIPTION
## Description

**Ticket: [CP-8556]** 

* use `TouchableOpacity` for custom buttons instead of k2 `Button`(the k2 button is only for buttons that are predefined in k2 with specific sizes and types) 

## Screenshots/Videos
| before | after |
| --- | --- |
| <img src="https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/d3b65b71-4c43-410e-b0ee-42c92c5fe3f0" width=320 /> | <img src="https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/dc5c3092-4dfa-48aa-8ac9-a48cc6fd1df3" width=320 /> |

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-8556]: https://ava-labs.atlassian.net/browse/CP-8556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ