### PR TITLE
CP-8729: Set adjustsFontSizeToFit to true for k2 button texts

### DIFF
--- a/packages/k2-mobile/src/components/Button/Button.tsx
+++ b/packages/k2-mobile/src/components/Button/Button.tsx
@@ -155,6 +155,7 @@ export const Button: FC<ButtonProps & PropsWithChildren> = ({
             <Text
               numberOfLines={1}
               variant={textVariant}
+              adjustsFontSizeToFit={true}
               style={{
                 color: color,
                 flexShrink: 1


### PR DESCRIPTION
## Description

**Ticket: [CP-8729]** 

* Set adjustsFontSizeToFit to true for k2 button texts to prevent truncated texts

## Screenshots/Videos
| before | after |
| --- | --- |
| <img src="https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/c1930ac2-5d3e-4fc8-92b1-f9e1bd7e109e" width=320 /> | <img src="https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/509e85ca-47cd-4d83-bf69-bc16b664a272" width=320 />

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation

[CP-8729]: https://ava-labs.atlassian.net/browse/CP-8729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ