### PR TITLE
Enable corepack to fix iOS build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "engines": {
     "node": ">=18.14.1",
-    "yarn": ">=1.22.10"
-  }
+    "yarn": ">=3.6.4"
+  },
+  "packageManager": "yarn@3.6.4"
 }

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -246,7 +246,7 @@
   },
   "engines": {
     "node": ">=18.14.1",
-    "yarn": ">=1.22.10"
+    "yarn": ">=3.6.4"
   },
   "lavamoat": {
     "allowScripts": {

--- a/scripts/bitrise/yarnSetup.sh
+++ b/scripts/bitrise/yarnSetup.sh
@@ -5,6 +5,9 @@ set -e
 
 set -o pipefail
 
+# enable corepack
+corepack enable
+
 if ! cat /etc/issue 2>/dev/null
 then
 yarn install --immutable && yarn setup


### PR DESCRIPTION
Not exactly sure what's wrong with building iOS on Bitrise. For some reason, Bitrise kept using yarn classic instead of our yarn version (v3). This pr just enables corepack on Bitrise. This seems to fix the build issue.