### PR TITLE
CP-8680: Show bridge button in detail screen for bitcoin on bitcoin network

### DIFF
--- a/packages/core-mobile/app/screens/bridge/Bridge.tsx
+++ b/packages/core-mobile/app/screens/bridge/Bridge.tsx
@@ -223,15 +223,15 @@ const Bridge: FC = () => {
   )
 
   useEffect(() => {
-    if (params?.initialTokenSymbol) {
+    if (params?.initialTokenSymbol && !selectedAsset) {
       const token = assetsWithBalances?.find(
-        tk => tk.symbolOnNetwork === params.initialTokenSymbol
+        tk => (tk.symbolOnNetwork ?? tk.symbol) === params.initialTokenSymbol
       )
       if (token) {
         handleSelect(token)
       }
     }
-  }, [params, assetsWithBalances, handleSelect])
+  }, [params, assetsWithBalances, handleSelect, selectedAsset])
 
   // Remove chains turned off by the feature flags
   const filterChains = useCallback(

--- a/packages/core-mobile/app/screens/portfolio/ownedTokenDetail/OwnedTokenDetail.tsx
+++ b/packages/core-mobile/app/screens/portfolio/ownedTokenDetail/OwnedTokenDetail.tsx
@@ -42,7 +42,9 @@ const OwnedTokenDetail: FC = () => {
   const { assetsWithBalances } = useBridge()
   const isTokenBridgable = Boolean(
     assetsWithBalances &&
-      assetsWithBalances.some(asset => asset.symbolOnNetwork === token?.symbol)
+      assetsWithBalances.some(
+        asset => (asset.symbolOnNetwork ?? asset.symbol) === token?.symbol
+      )
   )
 
   useEffect(loadToken, [filteredTokenList, token, tokenId])


### PR DESCRIPTION
## Description

**Ticket: [CP-8680]** 

* Bitcoin on Bitcoin network is actually available to bridge, so show the bridge button in the detail screen.

## Screenshots/Videos
| before | after |
| --- | --- |
| <img src=https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/698bc1be-58d9-4e75-8b27-29dbf117129f width=320 /> | <img src=https://github.com/ava-labs/avalanche-wallet-apps/assets/1456312/dca58ff5-0bcd-45ff-8653-97ed8f6976de width=320 /> |

## Testing
* Please verify that you can see the additional Bridge button in the detail screen for Bitcoin, and tapping the button should navigate to Bridge screen with Bitcoin selected.

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation

[CP-8680]: https://ava-labs.atlassian.net/browse/CP-8680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ