### PR TITLE
CP-8680: OwnedTokenDetail shouldn't be accessible if the active network is changed while on it

### DIFF
--- a/packages/core-mobile/app/navigation/WalletScreenStack/WalletScreenStack.tsx
+++ b/packages/core-mobile/app/navigation/WalletScreenStack/WalletScreenStack.tsx
@@ -131,7 +131,7 @@ export type WalletScreenStackParams = {
     | undefined
   [AppNavigation.Wallet.AddCustomToken]: undefined
   [AppNavigation.Wallet.TokenDetail]: { tokenId: string }
-  [AppNavigation.Wallet.OwnedTokenDetail]: { tokenId: string }
+  [AppNavigation.Wallet.OwnedTokenDetail]: { chainId: number; tokenId: string }
   [AppNavigation.Wallet.ActivityDetail]: {
     tx?: Transaction
   }

--- a/packages/core-mobile/app/screens/portfolio/network/NetworkTokens.tsx
+++ b/packages/core-mobile/app/screens/portfolio/network/NetworkTokens.tsx
@@ -63,6 +63,7 @@ const NetworkTokens = (): JSX.Element => {
 
   const selectToken = (token: LocalTokenWithBalance): void => {
     navigate(AppNavigation.Wallet.OwnedTokenDetail, {
+      chainId: activeNetwork.chainId,
       tokenId: token.localId
     })
 

--- a/packages/core-mobile/app/screens/portfolio/ownedTokenDetail/OwnedTokenDetail.tsx
+++ b/packages/core-mobile/app/screens/portfolio/ownedTokenDetail/OwnedTokenDetail.tsx
@@ -2,7 +2,11 @@ import { Space } from 'components/Space'
 import React, { FC, useEffect, useState } from 'react'
 import AvaListItem from 'components/AvaListItem'
 import Avatar from 'components/Avatar'
-import { useNavigation, useRoute } from '@react-navigation/native'
+import {
+  useFocusEffect,
+  useNavigation,
+  useRoute
+} from '@react-navigation/native'
 import { useSearchableTokenList } from 'screens/portfolio/useSearchableTokenList'
 import { Row } from 'components/Row'
 import AppNavigation from 'navigation/AppNavigation'
@@ -30,8 +34,8 @@ type ScreenProps = WalletScreenProps<
 
 const OwnedTokenDetail: FC = () => {
   const { activeNetwork } = useNetworks()
-  const { tokenId } = useRoute<ScreenProps['route']>().params
-  const { navigate } = useNavigation<ScreenProps['navigation']>()
+  const { chainId, tokenId } = useRoute<ScreenProps['route']>().params
+  const { navigate, pop } = useNavigation<ScreenProps['navigation']>()
   const { filteredTokenList } = useSearchableTokenList()
   const [token, setToken] = useState<TokenWithBalance>()
   const {
@@ -48,6 +52,13 @@ const OwnedTokenDetail: FC = () => {
   )
 
   useEffect(loadToken, [filteredTokenList, token, tokenId])
+
+  useFocusEffect(() => {
+    // This screen shouldn't be accessible if the active network is changed while on it
+    if (activeNetwork.chainId !== chainId) {
+      pop()
+    }
+  })
 
   const openTransactionDetails = (item: Transaction): void => {
     navigate(AppNavigation.Wallet.ActivityDetail, {


### PR DESCRIPTION
## Description

**Ticket: [CP-8680]** 

* `OwnedTokenDetail` shouldn't be accessible if the active network is changed while on it.
* The `OwnedTokenDetail` screen should only be displayed when the token is on the active network. If the active network changes (e.g., modifying the from/to network in a bridge), it can cause state inconsistencies and various bugs. To prevent this, `OwnedTokenDetail` should detect changes in the active network and pop the screen if the network no longer matches. 

[CP-8680]: https://ava-labs.atlassian.net/browse/CP-8680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ