### PR TITLE
CP-8749: show pending when networkFee is unavailable

### DIFF
--- a/packages/core-mobile/app/screens/shared/BridgeTransactionStatus.tsx
+++ b/packages/core-mobile/app/screens/shared/BridgeTransactionStatus.tsx
@@ -63,11 +63,6 @@ const BridgeTransactionStatus: FC<Props> = ({ txHash, showHideButton }) => {
 
   const { amount, sourceNetworkFee } = useBridgeAmounts(bridgeTransaction)
 
-  const formattedNetworkPrice =
-    networkPrice && sourceNetworkFee
-      ? currencyFormatter(networkPrice.mul(sourceNetworkFee).toNumber())
-      : '-'
-
   const {
     isComplete,
     sourceCurrentConfirmations,
@@ -147,6 +142,28 @@ const BridgeTransactionStatus: FC<Props> = ({ txHash, showHideButton }) => {
     </View>
   )
 
+  const renderNetworkFeeRightComponent = (): React.JSX.Element => {
+    if (sourceNetworkFee === undefined) {
+      return <AvaText.Heading3>Pending</AvaText.Heading3>
+    }
+
+    return (
+      <View style={{ alignItems: 'flex-end' }}>
+        <Row>
+          <AvaText.Heading3>
+            {sourceNetworkFee?.toNumber().toFixed(6)}{' '}
+            {getNativeTokenSymbol(
+              bridgeTransaction?.sourceChain ?? Blockchain.UNKNOWN
+            )}
+          </AvaText.Heading3>
+        </Row>
+        <AvaText.Body3 color={theme.colorText1}>
+          {currencyFormatter(networkPrice.mul(sourceNetworkFee).toNumber())}
+        </AvaText.Body3>
+      </View>
+    )
+  }
+
   return (
     <View style={{ flex: 1 }}>
       <View style={[styles.infoContainer, { backgroundColor: theme.colorBg2 }]}>
@@ -195,21 +212,7 @@ const BridgeTransactionStatus: FC<Props> = ({ txHash, showHideButton }) => {
         <AvaListItem.Base
           title={<AvaText.Body2>Network Fee</AvaText.Body2>}
           titleAlignment="flex-start"
-          rightComponent={
-            <View style={{ alignItems: 'flex-end' }}>
-              <Row>
-                <AvaText.Heading3>
-                  {sourceNetworkFee?.toNumber().toFixed(6)}{' '}
-                  {getNativeTokenSymbol(
-                    bridgeTransaction?.sourceChain ?? Blockchain.UNKNOWN
-                  )}
-                </AvaText.Heading3>
-              </Row>
-              <AvaText.Body3 currency color={theme.colorText1}>
-                ~{formattedNetworkPrice}
-              </AvaText.Body3>
-            </View>
-          }
+          rightComponent={renderNetworkFeeRightComponent()}
         />
         <Separator color={theme.colorBg3} inset={16} />
         {bridgeTransaction && (


### PR DESCRIPTION
## Description

**Ticket: [CP-8749]** 

***network fee will be returned once we receive a confirmation.

- show `Pending` when networkFee is not available for bitcoin bridge transaction
- remove leading `~` in networkFee amount



## Screenshots/Videos

https://github.com/ava-labs/avalanche-wallet-apps/assets/137183702/a69199bd-a06f-4a6a-a1f7-c78f8cd7ad59

<img width="374" alt="Screenshot 2024-06-25 at 1 19 15 PM" src="https://github.com/ava-labs/avalanche-wallet-apps/assets/137183702/1b273708-f4d6-4edc-b730-eaf4edf74ea0">

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-8749]: https://ava-labs.atlassian.net/browse/CP-8749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ