### PR TITLE
CP-8859 Harden isContentfulImageUri function

### DIFF
--- a/packages/core-mobile/app/utils/Contentful.ts
+++ b/packages/core-mobile/app/utils/Contentful.ts
@@ -18,7 +18,6 @@ export const formatUriImageToPng = (
 
 export const isContentfulImageUri = (uri: string): boolean => {
   const allowedHosts = ['images.ctfassets.net']
-  const allowedUrl = 'https://images.ctfassets.net'
   const host = url.parse(uri, false).host
-  return !!host && allowedHosts.includes(host) && uri.startsWith(allowedUrl)
+  return !!host && allowedHosts.includes(host)
 }


### PR DESCRIPTION
## Description

**Ticket: [CP-8859]** 

Github's [code scanning](https://github.com/ava-labs/avalanche-wallet-apps/security/code-scanning/14) found issue with `isContentfulImageUri` so this PR fixes that by parsing url and checking if host is in allowed list of hosts.

## Screenshots/Videos
![Simulator Screenshot - iPhone 15 - 2024-07-17 at 18 35 46](https://github.com/user-attachments/assets/90404c2d-f5ae-4eec-a90a-8722b7dfea9a)


## Testing
- make sure contentful content is loaded in app, such as token icons and NFTs

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-8859]: https://ava-labs.atlassian.net/browse/CP-8859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ