### PR TITLE
CP-8968 Cannot access staking dashboard on seedless wallet

### DIFF
--- a/packages/core-mobile/app/hooks/earn/useEstimateStakingFees.ts
+++ b/packages/core-mobile/app/hooks/earn/useEstimateStakingFees.ts
@@ -25,7 +25,10 @@ export const useEstimateStakingFees = (
   stakingAmount: Avax
 ): Avax | undefined => {
   const isDevMode = useSelector(selectIsDeveloperMode)
-  const avaxXPNetwork = NetworkService.getAvalancheNetworkP(isDevMode)
+  const avaxXPNetwork = useMemo(
+    () => NetworkService.getAvalancheNetworkP(isDevMode),
+    [isDevMode]
+  )
   const activeAccount = useSelector(selectActiveAccount)
   const amountForCrossChainTransfer =
     useGetAmountForCrossChainTransfer(stakingAmount)
@@ -42,7 +45,7 @@ export const useEstimateStakingFees = (
   )
 
   useEffect(() => {
-    const calculateEstimatedStakingFee = async () => {
+    const calculateEstimatedStakingFee = async (): Promise<void> => {
       if (amountForCrossChainTransfer === undefined) {
         setEstimatedStakingFee(undefined)
         return

--- a/packages/core-mobile/app/hooks/earn/useIsEarnDashboardEnabled.ts
+++ b/packages/core-mobile/app/hooks/earn/useIsEarnDashboardEnabled.ts
@@ -4,15 +4,14 @@ import { useStakes } from './useStakes'
 // a hook to determine whether the Earn Dashboard should be displayed
 // when there are stakes (either active or completed), we display the Dashboard
 // when there are no stakes, we direct users to Stake Setup flow
-export const useIsEarnDashboardEnabled = () => {
+export const useIsEarnDashboardEnabled = (): {
+  isEarnDashboardEnabled: boolean
+} => {
   const { data: stakes } = useStakes()
   const [isEarnDashboardEnabled, setIsEarnDashboardEnabled] = useState(true)
 
   useEffect(() => {
-    if (!stakes) return
-
-    const hasStakes = stakes.length > 0
-    setIsEarnDashboardEnabled(hasStakes ? true : false)
+    setIsEarnDashboardEnabled(!stakes || stakes.length > 0)
   }, [stakes])
 
   return { isEarnDashboardEnabled }


### PR DESCRIPTION
## Description

**Ticket: [CP-8968]** 

Sometimes it can happen that when user presses `Earn` tab they would land on `StakeSetup` screen instead of `StakeDashboard` because `useIsEarnDashboardEnabled` would return stale data.
This PR fixes that.

Also it fixes bug with infinite render.

## Testing
- i couldn't reproduce it reliably 

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-8968]: https://ava-labs.atlassian.net/browse/CP-8968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ