### PR TITLE
Update avax and bip122 namespace accounts based on isTestnet

### DIFF
--- a/packages/core-mobile/app/store/rpc/handlers/wc_sessionRequest/namespaces.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/wc_sessionRequest/namespaces.ts
@@ -18,18 +18,41 @@ export const NON_EVM_OPTIONAL_NAMESPACES: ProposalTypes.OptionalNamespaces = {
   [BlockchainNamespace.AVAX]: {
     chains: [
       AvalancheCaip2ChainId.C,
-      AvalancheCaip2ChainId.C_TESTNET,
       AvalancheCaip2ChainId.P,
-      AvalancheCaip2ChainId.P_TESTNET,
-      AvalancheCaip2ChainId.X,
-      AvalancheCaip2ChainId.X_TESTNET
+      AvalancheCaip2ChainId.X
     ],
     methods: CORE_AVAX_METHODS,
     events: COMMON_EVENTS
   },
   [BlockchainNamespace.BIP122]: {
-    chains: [BitcoinCaip2ChainId.MAINNET, BitcoinCaip2ChainId.TESTNET],
+    chains: [BitcoinCaip2ChainId.MAINNET],
     methods: CORE_BTC_METHODS,
     events: COMMON_EVENTS
   }
+}
+
+export const NON_EVM_TEST_NET_OPTIONAL_NAMESPACES: ProposalTypes.OptionalNamespaces =
+  {
+    [BlockchainNamespace.AVAX]: {
+      chains: [
+        AvalancheCaip2ChainId.C_TESTNET,
+        AvalancheCaip2ChainId.P_TESTNET,
+        AvalancheCaip2ChainId.X_TESTNET
+      ],
+      methods: CORE_AVAX_METHODS,
+      events: COMMON_EVENTS
+    },
+    [BlockchainNamespace.BIP122]: {
+      chains: [BitcoinCaip2ChainId.TESTNET],
+      methods: CORE_BTC_METHODS,
+      events: COMMON_EVENTS
+    }
+  }
+
+export const getNonEvmOptionalNamespaces = (
+  isTestnet?: boolean
+): ProposalTypes.OptionalNamespaces => {
+  return isTestnet
+    ? NON_EVM_TEST_NET_OPTIONAL_NAMESPACES
+    : NON_EVM_OPTIONAL_NAMESPACES
 }

--- a/packages/core-mobile/app/store/rpc/handlers/wc_sessionRequest/wc_sessionRequest.test.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/wc_sessionRequest/wc_sessionRequest.test.ts
@@ -12,6 +12,15 @@ import { AlertType } from '@avalabs/vm-module-types'
 import { AvalancheCaip2ChainId } from '@avalabs/core-chains-sdk'
 import { wcSessionRequestHandler as handler } from './wc_sessionRequest'
 
+const mockIsDeveloperMode = true
+jest.mock('store/settings/advanced/slice', () => {
+  const actual = jest.requireActual('store/settings/advanced/slice')
+  return {
+    ...actual,
+    selectIsDeveloperMode: () => mockIsDeveloperMode
+  }
+})
+
 jest.mock('store/network/slice', () => {
   const actual = jest.requireActual('store/network/slice')
   return {
@@ -88,11 +97,8 @@ const testNamespacesToApprove = {
 const testNonEVMNamespacesToApprove = {
   avax: {
     chains: [
-      AvalancheCaip2ChainId.C,
       AvalancheCaip2ChainId.C_TESTNET,
-      AvalancheCaip2ChainId.P,
       AvalancheCaip2ChainId.P_TESTNET,
-      AvalancheCaip2ChainId.X,
       AvalancheCaip2ChainId.X_TESTNET
     ],
     methods: [
@@ -109,10 +115,7 @@ const testNonEVMNamespacesToApprove = {
     ]
   },
   bip122: {
-    chains: [
-      'bip122:000000000019d6689c085ae165831e93',
-      'bip122:000000000933ea01ad0ee984209779ba'
-    ],
+    chains: ['bip122:000000000933ea01ad0ee984209779ba'],
     methods: [RpcMethod.BITCOIN_SEND_TRANSACTION],
     events: [
       'chainChanged',
@@ -588,25 +591,16 @@ describe('session_request handler', () => {
         },
         avax: {
           accounts: [
-            'avax:8aDU0Kqh-5d23op-B-r-4YbQFRbsgF9a:0xcA0E993876152ccA6053eeDFC753092c8cE712D0',
-            'avax:8aDU0Kqh-5d23op-B-r-4YbQFRbsgF9a:0xC7E5ffBd7843EdB88cCB2ebaECAa07EC55c65318',
             'avax:YRLfeDBJpfEqUWe2FYR1OpXsnDDZeKWd:0xcA0E993876152ccA6053eeDFC753092c8cE712D0',
             'avax:YRLfeDBJpfEqUWe2FYR1OpXsnDDZeKWd:0xC7E5ffBd7843EdB88cCB2ebaECAa07EC55c65318',
-            'avax:Rr9hnPVPxuUvrdCul-vjEsU1zmqKqRDo:pvmAddress1',
-            'avax:Rr9hnPVPxuUvrdCul-vjEsU1zmqKqRDo:pvmAddress2',
             'avax:Sj7NVE3jXTbJvwFAiu7OEUo_8g8ctXMG:pvmAddress1',
             'avax:Sj7NVE3jXTbJvwFAiu7OEUo_8g8ctXMG:pvmAddress2',
-            'avax:imji8papUf2EhV3le337w1vgFauqkJg-:avmAddress1',
-            'avax:imji8papUf2EhV3le337w1vgFauqkJg-:avmAddress2',
             'avax:8AJTpRj3SAqv1e80Mtl9em08LhvKEbkl:avmAddress1',
             'avax:8AJTpRj3SAqv1e80Mtl9em08LhvKEbkl:avmAddress2'
           ],
           chains: [
-            'avax:8aDU0Kqh-5d23op-B-r-4YbQFRbsgF9a',
             'avax:YRLfeDBJpfEqUWe2FYR1OpXsnDDZeKWd',
-            'avax:Rr9hnPVPxuUvrdCul-vjEsU1zmqKqRDo',
             'avax:Sj7NVE3jXTbJvwFAiu7OEUo_8g8ctXMG',
-            'avax:imji8papUf2EhV3le337w1vgFauqkJg-',
             'avax:8AJTpRj3SAqv1e80Mtl9em08LhvKEbkl'
           ],
           events: [
@@ -624,15 +618,10 @@ describe('session_request handler', () => {
         },
         bip122: {
           accounts: [
-            'bip122:000000000019d6689c085ae165831e93:btcAddress1',
-            'bip122:000000000019d6689c085ae165831e93:btcAddress2',
             'bip122:000000000933ea01ad0ee984209779ba:btcAddress1',
             'bip122:000000000933ea01ad0ee984209779ba:btcAddress2'
           ],
-          chains: [
-            'bip122:000000000019d6689c085ae165831e93',
-            'bip122:000000000933ea01ad0ee984209779ba'
-          ],
+          chains: ['bip122:000000000933ea01ad0ee984209779ba'],
           events: [
             'chainChanged',
             'accountsChanged',

--- a/packages/core-mobile/app/store/rpc/handlers/wc_sessionRequest/wc_sessionRequest.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/wc_sessionRequest/wc_sessionRequest.ts
@@ -15,6 +15,7 @@ import { getChainIdFromCaip2 } from 'temp/caip2ChainIds'
 import mergeWith from 'lodash/mergeWith'
 import isArray from 'lodash/isArray'
 import union from 'lodash/union'
+import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { RpcMethod, CORE_EVM_METHODS } from '../../types'
 import {
   RpcRequestHandler,
@@ -33,7 +34,7 @@ import {
   parseApproveData,
   scanAndSessionProposal
 } from './utils'
-import { NON_EVM_OPTIONAL_NAMESPACES, COMMON_EVENTS } from './namespaces'
+import { COMMON_EVENTS, getNonEvmOptionalNamespaces } from './namespaces'
 
 const supportedMethods = [
   RpcMethod.ETH_SEND_TRANSACTION,
@@ -198,6 +199,7 @@ class WCSessionRequestHandler implements RpcRequestHandler<WCSessionProposal> {
     listenerApi: AppListenerEffectAPI
   ): HandleResponse => {
     const state = listenerApi.getState()
+    const isDeveloperMode = selectIsDeveloperMode(state)
     const { params } = request.data
     const { proposer, requiredNamespaces, optionalNamespaces } = params
     const dappUrl = proposer.metadata.url
@@ -210,7 +212,10 @@ class WCSessionRequestHandler implements RpcRequestHandler<WCSessionProposal> {
       // it throws an error when we add these non-EVM namespaces in the dapp.
       // This is a temporary fix until core web supports these namespaces
       isCoreApp
-        ? { ...optionalNamespaces, ...NON_EVM_OPTIONAL_NAMESPACES }
+        ? {
+            ...optionalNamespaces,
+            ...getNonEvmOptionalNamespaces(isDeveloperMode)
+          }
         : optionalNamespaces
     )
 

--- a/packages/core-mobile/app/store/walletConnectV2/listeners/index.ts
+++ b/packages/core-mobile/app/store/walletConnectV2/listeners/index.ts
@@ -2,12 +2,13 @@ import { isAnyOf } from '@reduxjs/toolkit'
 import { onLogIn, onLogOut, onRehydrationComplete } from 'store/app/slice'
 import { AppStartListening } from 'store/middleware/listener'
 import { setActive } from 'store/network/slice'
-import { setActiveAccountIndex } from 'store/account/slice'
+import { setAccounts, setActiveAccountIndex } from 'store/account/slice'
 import { killSessions, newSession, onDisconnect } from '../slice'
 import {
   handleAccountChange,
   handleDisconnect,
   handleNetworkChange,
+  handleNonEvmAccountsChange,
   initWalletConnect,
   killAllSessions,
   killSomeSessions,
@@ -48,5 +49,10 @@ export const addWCListeners = (startListening: AppStartListening): void => {
   startListening({
     actionCreator: setActiveAccountIndex,
     effect: handleAccountChange
+  })
+
+  startListening({
+    actionCreator: setAccounts,
+    effect: handleNonEvmAccountsChange
   })
 }


### PR DESCRIPTION
## Description

- the AddressWithCaip2ChainId construction is incorrect (see screenshot below), testnet and mainnet addresses are both used in mainnet and testnet namespace
- the chainList and accounts in session namespace should only contain the chains and accounts that is either in testnet or mainnet.

## Screenshots/Videos

- before

<img width="733" alt="Screenshot 2024-08-22 at 5 22 36 PM" src="https://github.com/user-attachments/assets/359b170d-1921-49c3-9158-b6aced8a3fed">

- after

https://github.com/user-attachments/assets/cb468eb5-4d84-45fe-a140-eb1abe83b6a8

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [X] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
