### PR TITLE
Fix iOS workflow not getting triggered on Bitrise

### DIFF
--- a/packages/core-mobile/scripts/bitrise/triggerIosInternalBuild.sh
+++ b/packages/core-mobile/scripts/bitrise/triggerIosInternalBuild.sh
@@ -2,18 +2,18 @@ PIPELINE=$(
   curl -X 'POST' \
   "https://api.bitrise.io/v0.1/apps/$BITRISE_APP_SLUG/builds" \
   -H 'accept: application/json' \
-  -H "Authorization: $BITRISE_ACCESS_TOKEN"\
+  -H "Authorization: $BITRISE_ACCESS_TOKEN" \
   -H 'Content-Type: application/json' \
-  -d '{
-  "build_params": {
-    "branch": $BITRISE_GIT_BRANCH,
-    "pipeline_id": "build-ios-apps-internal-triggered-e2e",
-    "commit_message": $GIT_CLONE_COMMIT_MESSAGE_SUBJECT,
+  -d "{
+  \"build_params\": {
+    \"branch\": \"$BITRISE_GIT_BRANCH\",
+    \"pipeline_id\": \"build-ios-apps-internal-triggered-e2e\",
+    \"commit_message\": \"$GIT_CLONE_COMMIT_MESSAGE_SUBJECT\"
   },
-  "hook_info": {
-    "type": "bitrise"
+  \"hook_info\": {
+    \"type\": \"bitrise\"
   }
-}'
+}"
 )
 
-echo $PIPELINE
+echo "$PIPELINE"


### PR DESCRIPTION
## Description

triggerIosInternalBuild.sh didn't parse the variables correctly. thus, the iOS workflow never got triggered

