### PR TITLE
Add mainnet and testnet chainids

### DIFF
--- a/packages/core-mobile/app/store/rpc/handlers/wc_sessionRequest/namespaces.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/wc_sessionRequest/namespaces.ts
@@ -18,41 +18,18 @@ export const NON_EVM_OPTIONAL_NAMESPACES: ProposalTypes.OptionalNamespaces = {
   [BlockchainNamespace.AVAX]: {
     chains: [
       AvalancheCaip2ChainId.C,
+      AvalancheCaip2ChainId.C_TESTNET,
       AvalancheCaip2ChainId.P,
-      AvalancheCaip2ChainId.X
+      AvalancheCaip2ChainId.P_TESTNET,
+      AvalancheCaip2ChainId.X,
+      AvalancheCaip2ChainId.X_TESTNET
     ],
     methods: CORE_AVAX_METHODS,
     events: COMMON_EVENTS
   },
   [BlockchainNamespace.BIP122]: {
-    chains: [BitcoinCaip2ChainId.MAINNET],
+    chains: [BitcoinCaip2ChainId.MAINNET, BitcoinCaip2ChainId.TESTNET],
     methods: CORE_BTC_METHODS,
     events: COMMON_EVENTS
   }
-}
-
-export const NON_EVM_TEST_NET_OPTIONAL_NAMESPACES: ProposalTypes.OptionalNamespaces =
-  {
-    [BlockchainNamespace.AVAX]: {
-      chains: [
-        AvalancheCaip2ChainId.C_TESTNET,
-        AvalancheCaip2ChainId.P_TESTNET,
-        AvalancheCaip2ChainId.X_TESTNET
-      ],
-      methods: CORE_AVAX_METHODS,
-      events: COMMON_EVENTS
-    },
-    [BlockchainNamespace.BIP122]: {
-      chains: [BitcoinCaip2ChainId.TESTNET],
-      methods: CORE_BTC_METHODS,
-      events: COMMON_EVENTS
-    }
-  }
-
-export const getNonEvmOptionalNamespaces = (
-  isTestnet?: boolean
-): ProposalTypes.OptionalNamespaces => {
-  return isTestnet
-    ? NON_EVM_TEST_NET_OPTIONAL_NAMESPACES
-    : NON_EVM_OPTIONAL_NAMESPACES
 }

--- a/packages/core-mobile/app/store/rpc/handlers/wc_sessionRequest/wc_sessionRequest.test.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/wc_sessionRequest/wc_sessionRequest.test.ts
@@ -12,15 +12,6 @@ import { AlertType } from '@avalabs/vm-module-types'
 import { AvalancheCaip2ChainId } from '@avalabs/core-chains-sdk'
 import { wcSessionRequestHandler as handler } from './wc_sessionRequest'
 
-const mockIsDeveloperMode = true
-jest.mock('store/settings/advanced/slice', () => {
-  const actual = jest.requireActual('store/settings/advanced/slice')
-  return {
-    ...actual,
-    selectIsDeveloperMode: () => mockIsDeveloperMode
-  }
-})
-
 jest.mock('store/network/slice', () => {
   const actual = jest.requireActual('store/network/slice')
   return {
@@ -97,8 +88,11 @@ const testNamespacesToApprove = {
 const testNonEVMNamespacesToApprove = {
   avax: {
     chains: [
+      AvalancheCaip2ChainId.C,
       AvalancheCaip2ChainId.C_TESTNET,
+      AvalancheCaip2ChainId.P,
       AvalancheCaip2ChainId.P_TESTNET,
+      AvalancheCaip2ChainId.X,
       AvalancheCaip2ChainId.X_TESTNET
     ],
     methods: [
@@ -115,7 +109,10 @@ const testNonEVMNamespacesToApprove = {
     ]
   },
   bip122: {
-    chains: ['bip122:000000000933ea01ad0ee984209779ba'],
+    chains: [
+      'bip122:000000000019d6689c085ae165831e93',
+      'bip122:000000000933ea01ad0ee984209779ba'
+    ],
     methods: [RpcMethod.BITCOIN_SEND_TRANSACTION],
     events: [
       'chainChanged',
@@ -591,16 +588,25 @@ describe('session_request handler', () => {
         },
         avax: {
           accounts: [
+            'avax:8aDU0Kqh-5d23op-B-r-4YbQFRbsgF9a:0xcA0E993876152ccA6053eeDFC753092c8cE712D0',
+            'avax:8aDU0Kqh-5d23op-B-r-4YbQFRbsgF9a:0xC7E5ffBd7843EdB88cCB2ebaECAa07EC55c65318',
             'avax:YRLfeDBJpfEqUWe2FYR1OpXsnDDZeKWd:0xcA0E993876152ccA6053eeDFC753092c8cE712D0',
             'avax:YRLfeDBJpfEqUWe2FYR1OpXsnDDZeKWd:0xC7E5ffBd7843EdB88cCB2ebaECAa07EC55c65318',
+            'avax:Rr9hnPVPxuUvrdCul-vjEsU1zmqKqRDo:pvmAddress1',
+            'avax:Rr9hnPVPxuUvrdCul-vjEsU1zmqKqRDo:pvmAddress2',
             'avax:Sj7NVE3jXTbJvwFAiu7OEUo_8g8ctXMG:pvmAddress1',
             'avax:Sj7NVE3jXTbJvwFAiu7OEUo_8g8ctXMG:pvmAddress2',
+            'avax:imji8papUf2EhV3le337w1vgFauqkJg-:avmAddress1',
+            'avax:imji8papUf2EhV3le337w1vgFauqkJg-:avmAddress2',
             'avax:8AJTpRj3SAqv1e80Mtl9em08LhvKEbkl:avmAddress1',
             'avax:8AJTpRj3SAqv1e80Mtl9em08LhvKEbkl:avmAddress2'
           ],
           chains: [
+            'avax:8aDU0Kqh-5d23op-B-r-4YbQFRbsgF9a',
             'avax:YRLfeDBJpfEqUWe2FYR1OpXsnDDZeKWd',
+            'avax:Rr9hnPVPxuUvrdCul-vjEsU1zmqKqRDo',
             'avax:Sj7NVE3jXTbJvwFAiu7OEUo_8g8ctXMG',
+            'avax:imji8papUf2EhV3le337w1vgFauqkJg-',
             'avax:8AJTpRj3SAqv1e80Mtl9em08LhvKEbkl'
           ],
           events: [
@@ -618,10 +624,15 @@ describe('session_request handler', () => {
         },
         bip122: {
           accounts: [
+            'bip122:000000000019d6689c085ae165831e93:btcAddress1',
+            'bip122:000000000019d6689c085ae165831e93:btcAddress2',
             'bip122:000000000933ea01ad0ee984209779ba:btcAddress1',
             'bip122:000000000933ea01ad0ee984209779ba:btcAddress2'
           ],
-          chains: ['bip122:000000000933ea01ad0ee984209779ba'],
+          chains: [
+            'bip122:000000000019d6689c085ae165831e93',
+            'bip122:000000000933ea01ad0ee984209779ba'
+          ],
           events: [
             'chainChanged',
             'accountsChanged',

--- a/packages/core-mobile/app/store/rpc/handlers/wc_sessionRequest/wc_sessionRequest.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/wc_sessionRequest/wc_sessionRequest.ts
@@ -15,7 +15,6 @@ import { getChainIdFromCaip2 } from 'temp/caip2ChainIds'
 import mergeWith from 'lodash/mergeWith'
 import isArray from 'lodash/isArray'
 import union from 'lodash/union'
-import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { RpcMethod, CORE_EVM_METHODS } from '../../types'
 import {
   RpcRequestHandler,
@@ -34,7 +33,7 @@ import {
   parseApproveData,
   scanAndSessionProposal
 } from './utils'
-import { COMMON_EVENTS, getNonEvmOptionalNamespaces } from './namespaces'
+import { COMMON_EVENTS, NON_EVM_OPTIONAL_NAMESPACES } from './namespaces'
 
 const supportedMethods = [
   RpcMethod.ETH_SEND_TRANSACTION,
@@ -199,7 +198,6 @@ class WCSessionRequestHandler implements RpcRequestHandler<WCSessionProposal> {
     listenerApi: AppListenerEffectAPI
   ): HandleResponse => {
     const state = listenerApi.getState()
-    const isDeveloperMode = selectIsDeveloperMode(state)
     const { params } = request.data
     const { proposer, requiredNamespaces, optionalNamespaces } = params
     const dappUrl = proposer.metadata.url
@@ -214,7 +212,7 @@ class WCSessionRequestHandler implements RpcRequestHandler<WCSessionProposal> {
       isCoreApp
         ? {
             ...optionalNamespaces,
-            ...getNonEvmOptionalNamespaces(isDeveloperMode)
+            ...NON_EVM_OPTIONAL_NAMESPACES
           }
         : optionalNamespaces
     )


### PR DESCRIPTION
## Description

- it seems adding only mainnet or testnet chainIds depend on the current developer mode for avax and btc in wc namespace will throw error `invalid chainId...` error.  we should instead include all of them in the initial session proposal.

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
