### PR TITLE
CP-9171: Fix bug causing NFT send failure

### DIFF
--- a/packages/core-mobile/app/contexts/SendNFTContext.tsx
+++ b/packages/core-mobile/app/contexts/SendNFTContext.tsx
@@ -110,7 +110,8 @@ export const SendNFTContextProvider = ({
       address: sendToAddress,
       defaultMaxFeePerGas: defaultMaxFeePerGas.toSubUnit(),
       gasLimit,
-      token: sendService.mapTokenFromNFT(sendToken)
+      token: sendService.mapTokenFromNFT(sendToken),
+      canSubmit
     } as SendState
 
     InteractionManager.runAfterInteractions(() => {

--- a/packages/core-mobile/app/contexts/SendTokenContext.tsx
+++ b/packages/core-mobile/app/contexts/SendTokenContext.tsx
@@ -173,7 +173,7 @@ export const SendTokenContextProvider = ({
       defaultMaxFeePerGas: defaultMaxFeePerGas.toSubUnit(),
       gasLimit,
       token: sendToken,
-      canSubmit: true
+      canSubmit
     }
 
     InteractionManager.runAfterInteractions(() => {


### PR DESCRIPTION
## Description

**Ticket: [CP-9171]** 

* In the [previous PR](https://github.com/ava-labs/core-mobile/pull/1566) aimed at speeding up BTC send, the state validation logic was moved, and the `canSubmit: true` setting was left out of the sendState. Since we already manage the `canSubmit` state within the hook, we can pass it directly to the sendState.

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9171]: https://ava-labs.atlassian.net/browse/CP-9171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ