### PR TITLE
CP-8964: add avalanche_renameAccount rpc method

### DIFF
--- a/packages/core-mobile/app/store/rpc/handlers/account/avalanche_renameAccount/avalanche_renameAccount.test.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/account/avalanche_renameAccount/avalanche_renameAccount.test.ts
@@ -1,0 +1,117 @@
+import { rpcErrors } from '@metamask/rpc-errors'
+import { RpcMethod, RpcProvider, RpcRequest } from 'store/rpc/types'
+import mockSession from 'tests/fixtures/walletConnect/session.json'
+import mockAccounts from 'tests/fixtures/accounts.json'
+import * as Navigation from 'utils/Navigation'
+import { avalancheRenameAccountHandler as handler } from './avalanche_renameAccount'
+
+jest.mock('store/account/slice', () => {
+  const actual = jest.requireActual('store/account/slice')
+  return {
+    ...actual,
+    selectAccounts: () => mockAccounts
+  }
+})
+
+const mockNavigate = jest.fn()
+jest.spyOn(Navigation, 'navigate').mockImplementation(mockNavigate)
+
+const mockDispatch = jest.fn()
+const mockListenerApi = {
+  getState: jest.fn(),
+  dispatch: mockDispatch
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any
+
+const createRequest = (
+  params: unknown
+): RpcRequest<RpcMethod.AVALANCHE_RENAME_ACCOUNT> => {
+  return {
+    provider: RpcProvider.WALLET_CONNECT,
+    method: RpcMethod.AVALANCHE_RENAME_ACCOUNT,
+    data: {
+      id: 1677366383831712,
+      topic: '3a094bf511357e0f48ff266f0b8d5b846fd3f7de4bd0824d976fdf4c5279b261',
+      params: {
+        request: {
+          method: RpcMethod.AVALANCHE_RENAME_ACCOUNT,
+          params
+        },
+        chainId: 'eip155:43113'
+      }
+    },
+    peerMeta: mockSession.peer.metadata
+  }
+}
+
+const testHandleInvalidParams = async (params: unknown) => {
+  const testRequest = createRequest(params)
+
+  const result = await handler.handle(testRequest, mockListenerApi)
+
+  expect(result).toEqual({
+    success: false,
+    error: rpcErrors.invalidParams('Account id is invalid')
+  })
+}
+
+describe('avalanche_renameAccount handler', () => {
+  it('should contain correct methods', () => {
+    expect(handler.methods).toEqual(['avalanche_renameAccount'])
+  })
+
+  describe('handle', () => {
+    it('should return error when params are invalid', async () => {
+      const invalidParamsScenarios = [null, [], [null], [1234, 'title']]
+
+      for (const scenario of invalidParamsScenarios) {
+        await testHandleInvalidParams(scenario)
+      }
+    })
+
+    it('should return success when requested account is already active', async () => {
+      const testRequest = createRequest(['0', 'new title'])
+
+      const result = await handler.handle(testRequest, mockListenerApi)
+
+      expect(result).toEqual({ success: true, value: [] })
+    })
+
+    it('should return error when requested account does not exist', async () => {
+      const testRequest = createRequest(['2', 'new title'])
+
+      const result = await handler.handle(testRequest, mockListenerApi)
+
+      expect(result).toEqual({
+        success: false,
+        error: rpcErrors.resourceNotFound('Requested account does not exist')
+      })
+    })
+
+    it('should return error when new account name is an empty string', async () => {
+      const testRequest = createRequest(['2', ''])
+
+      const result = await handler.handle(testRequest, mockListenerApi)
+
+      expect(result).toEqual({
+        success: false,
+        error: rpcErrors.invalidParams('Invalid new name')
+      })
+    })
+
+    it('should return error when renaming account fails', async () => {
+      mockDispatch.mockImplementationOnce(() => {
+        throw new Error('some error')
+      })
+
+      const testRequest = createRequest(['0', 'new title'])
+
+      const result = await handler.handle(testRequest, mockListenerApi)
+
+      expect(result).toEqual({
+        success: false,
+        error: rpcErrors.internal('Account renaming failed')
+      })
+    })
+  })
+})

--- a/packages/core-mobile/app/store/rpc/handlers/account/avalanche_renameAccount/avalanche_renameAccount.test.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/account/avalanche_renameAccount/avalanche_renameAccount.test.ts
@@ -2,7 +2,6 @@ import { rpcErrors } from '@metamask/rpc-errors'
 import { RpcMethod, RpcProvider, RpcRequest } from 'store/rpc/types'
 import mockSession from 'tests/fixtures/walletConnect/session.json'
 import mockAccounts from 'tests/fixtures/accounts.json'
-import * as Navigation from 'utils/Navigation'
 import { avalancheRenameAccountHandler as handler } from './avalanche_renameAccount'
 
 jest.mock('store/account/slice', () => {
@@ -12,9 +11,6 @@ jest.mock('store/account/slice', () => {
     selectAccounts: () => mockAccounts
   }
 })
-
-const mockNavigate = jest.fn()
-jest.spyOn(Navigation, 'navigate').mockImplementation(mockNavigate)
 
 const mockDispatch = jest.fn()
 const mockListenerApi = {

--- a/packages/core-mobile/app/store/rpc/handlers/account/avalanche_renameAccount/avalanche_renameAccount.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/account/avalanche_renameAccount/avalanche_renameAccount.ts
@@ -1,0 +1,92 @@
+import { AppListenerEffectAPI } from 'store'
+import { rpcErrors } from '@metamask/rpc-errors'
+import { selectAccounts, setAccountTitle } from 'store/account/slice'
+import Logger from 'utils/Logger'
+import { WalletType as AvalabsWalletType } from '@avalabs/types'
+import { WalletType } from 'services/wallet/types'
+import { RpcMethod, RpcRequest } from '../../../types'
+import { HandleResponse, RpcRequestHandler } from '../../types'
+import { parseRequestParams } from './utils'
+
+type AvalancheRenameAccountRequest =
+  RpcRequest<RpcMethod.AVALANCHE_RENAME_ACCOUNT>
+
+class AvalancheRenameAccountHandler
+  implements RpcRequestHandler<AvalancheRenameAccountRequest>
+{
+  methods = [RpcMethod.AVALANCHE_RENAME_ACCOUNT]
+
+  handle = async (
+    request: AvalancheRenameAccountRequest,
+    listenerApi: AppListenerEffectAPI
+  ): HandleResponse => {
+    const { getState, dispatch } = listenerApi
+    const { params } = request.data.params.request
+
+    const result = parseRequestParams(params)
+
+    if (!result.success) {
+      Logger.error('invalid params', result.error)
+      return {
+        success: false,
+        error: rpcErrors.invalidParams('Account id is invalid')
+      }
+    }
+
+    const accountId = result.data[0]
+    const title = result.data[1]
+
+    const accounts = selectAccounts(getState())
+    const requestedAccount = Object.values(accounts).find(
+      account => account.id === accountId
+    )
+
+    if (title.trim().length === 0) {
+      return {
+        success: false,
+        error: rpcErrors.invalidParams('Invalid new name')
+      }
+    }
+
+    if (requestedAccount === undefined) {
+      return {
+        success: false,
+        error: rpcErrors.resourceNotFound('Requested account does not exist')
+      }
+    }
+
+    let walletType: WalletType
+    if (requestedAccount.walletType === AvalabsWalletType.Mnemonic) {
+      walletType = WalletType.MNEMONIC
+    } else if (requestedAccount.walletType === AvalabsWalletType.Seedless) {
+      walletType = WalletType.SEEDLESS
+    } else {
+      return {
+        success: false,
+        error: rpcErrors.internal(
+          'Wallet type not supported: ' + requestedAccount.walletType
+        )
+      }
+    }
+
+    try {
+      dispatch(
+        setAccountTitle({
+          accountIndex: requestedAccount.index,
+          title,
+          walletType
+        })
+      )
+    } catch (error) {
+      Logger.error('Account renaming failed', error)
+      return {
+        success: false,
+        error: rpcErrors.internal('Account renaming failed')
+      }
+    }
+
+    return { success: true, value: [] }
+  }
+}
+
+export const avalancheRenameAccountHandler = new AvalancheRenameAccountHandler()

--- a/packages/core-mobile/app/store/rpc/handlers/account/avalanche_renameAccount/utils.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/account/avalanche_renameAccount/utils.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+const paramsSchema = z.tuple([z.string(), z.string()])
+
+export const parseRequestParams = (
+  params: unknown
+): z.SafeParseReturnType<[string, string], [string, string]> => {
+  return paramsSchema.safeParse(params)
+}

--- a/packages/core-mobile/app/store/rpc/handlers/index.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/index.ts
@@ -13,6 +13,7 @@ import { avalancheGetAccountPubKeyHandler } from './avalanche_getAccountPubKey/a
 import { avalancheSetDeveloperModeHandler } from './avalanche_setDeveloperMode/avalanche_setDeveloperMode'
 import { walletGetEthereumChainHandler } from './chain/wallet_getEthereumChain/wallet_getEthereumChain'
 import { avalancheGetAddressesInRangeHandler } from './avalanche_getAddressesInRange/avalanche_getAddressesInRange'
+import { avalancheRenameAccountHandler } from './account/avalanche_renameAccount/avalanche_renameAccount'
 
 const handlerMap = [
   avalancheSelectAccountHandler,
@@ -28,7 +29,8 @@ const handlerMap = [
   walletGetEthereumChainHandler,
   avalancheGetAccountPubKeyHandler,
   avalancheSetDeveloperModeHandler,
-  avalancheGetAddressesInRangeHandler
+  avalancheGetAddressesInRangeHandler,
+  avalancheRenameAccountHandler
 ].reduce((acc, current) => {
   if (current?.methods === undefined) return acc
 

--- a/packages/core-mobile/app/store/rpc/handlers/wc_sessionRequest/wc_sessionRequest.test.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/wc_sessionRequest/wc_sessionRequest.test.ts
@@ -581,7 +581,8 @@ describe('session_request handler', () => {
             'avalanche_selectAccount',
             'avalanche_setDeveloperMode',
             'avalanche_updateContact',
-            'avalanche_getAddressesInRange'
+            'avalanche_getAddressesInRange',
+            'avalanche_renameAccount'
           ],
           // all requested events
           events: validRequiredNamespaces.eip155.events

--- a/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.ts
+++ b/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.ts
@@ -25,7 +25,8 @@ const chainAgnosticMethods = [
   RpcMethod.WALLET_ADD_ETHEREUM_CHAIN,
   RpcMethod.WALLET_SWITCH_ETHEREUM_CHAIN,
   RpcMethod.AVALANCHE_GET_ACCOUNT_PUB_KEY,
-  RpcMethod.AVALANCHE_SET_DEVELOPER_MODE
+  RpcMethod.AVALANCHE_SET_DEVELOPER_MODE,
+  RpcMethod.AVALANCHE_RENAME_ACCOUNT
 ]
 
 class WalletConnectProvider implements AgnosticRpcProvider {

--- a/packages/core-mobile/app/store/rpc/types.ts
+++ b/packages/core-mobile/app/store/rpc/types.ts
@@ -62,6 +62,7 @@ export enum RpcMethod {
   AVALANCHE_GET_ADDRESSES_IN_RANGE = 'avalanche_getAddressesInRange',
   BITCOIN_SEND_TRANSACTION = 'bitcoin_sendTransaction',
   AVALANCHE_SIGN_MESSAGE = 'avalanche_signMessage',
+  AVALANCHE_RENAME_ACCOUNT = 'avalanche_renameAccount',
 
   /* custom methods that only apply to Wallet Connect*/
   WC_SESSION_REQUEST = 'wc_sessionRequest'
@@ -78,7 +79,8 @@ export const CORE_EVM_METHODS = [
   RpcMethod.AVALANCHE_SELECT_ACCOUNT,
   RpcMethod.AVALANCHE_SET_DEVELOPER_MODE,
   RpcMethod.AVALANCHE_UPDATE_CONTACT,
-  RpcMethod.AVALANCHE_GET_ADDRESSES_IN_RANGE
+  RpcMethod.AVALANCHE_GET_ADDRESSES_IN_RANGE,
+  RpcMethod.AVALANCHE_RENAME_ACCOUNT
 ]
 
 export const CORE_AVAX_METHODS = [


### PR DESCRIPTION
## Description

**Ticket: [CP-8964]** 

* Add `avalanche_renameAccount` rpc method
* Related PR: https://github.com/ava-labs/extension-avalanche-playground/pull/50

## Screenshots/Videos
https://github.com/user-attachments/assets/2437c092-4a06-467e-b7dc-cd71478e4168

## Testing
* Use playground to rename the account (see PR link above)

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-8964]: https://ava-labs.atlassian.net/browse/CP-8964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ