### PR TITLE
CP-9194: Fix 0 balance on fresh install

### DIFF
--- a/packages/core-mobile/app/store/balance/slice.ts
+++ b/packages/core-mobile/app/store/balance/slice.ts
@@ -187,9 +187,9 @@ export const selectBalanceTotalInCurrencyForAccount =
     }, 0)
   }
 export const selectBalanceForAccountIsAccurate =
-  (accountIndex: number | undefined) => (state: RootState) => {
-    if (accountIndex === undefined) return true
-
+  (accountIndex: number) => (state: RootState) => {
+    const tokens = selectTokensWithBalanceForAccount(accountIndex)(state)
+    if (tokens.length === 0) return false
     return !Object.values(state.balance.balances).some(
       balance => !balance.dataAccurate
     )


### PR DESCRIPTION
## Description

**Ticket: [CP-9194]** 

- set data is inaccurate when tokens are not yet in redux.

## Screenshots/Videos

https://github.com/user-attachments/assets/7af60369-b35d-448d-b67c-243455a7f1df

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9194]: https://ava-labs.atlassian.net/browse/CP-9194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ