### PR TITLE
Use custom user agent on Android

### DIFF
--- a/packages/core-mobile/android/app/src/main/java/com/avaxwallet/CoreOkHttpClientFactory.kt
+++ b/packages/core-mobile/android/app/src/main/java/com/avaxwallet/CoreOkHttpClientFactory.kt
@@ -1,0 +1,21 @@
+package com.avaxwallet
+
+import com.facebook.react.modules.network.OkHttpClientFactory
+import com.facebook.react.modules.network.ReactCookieJarContainer
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit;
+
+
+class CoreOkHttpClientFactory(private val userAgent: String) : OkHttpClientFactory {
+    override fun createNewNetworkModuleClient(): OkHttpClient {
+        // No timeouts by default
+        return OkHttpClient.Builder()
+            .cookieJar(ReactCookieJarContainer())
+            .addInterceptor(UserAgentInterceptor(userAgent))
+            .connectTimeout(0, TimeUnit.MILLISECONDS)
+            .readTimeout(0, TimeUnit.MILLISECONDS)
+            .writeTimeout(0, TimeUnit.MILLISECONDS)
+            .build()
+    }
+}
+

--- a/packages/core-mobile/android/app/src/main/java/com/avaxwallet/MainApplication.kt
+++ b/packages/core-mobile/android/app/src/main/java/com/avaxwallet/MainApplication.kt
@@ -1,20 +1,19 @@
 package com.avaxwallet;
 
 import android.app.Application
-import android.content.Context
 import android.database.CursorWindow
+import android.webkit.WebSettings
 import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
-import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
+import com.facebook.react.modules.network.OkHttpClientProvider
 import com.facebook.soloader.SoLoader
 import java.lang.reflect.Field
-import java.util.ArrayList
 
 class MainApplication : Application(), ReactApplication {
 
@@ -39,6 +38,22 @@ class MainApplication : Application(), ReactApplication {
     override fun onCreate() {
         super.onCreate()
 
+        increaseWindowCursorSize()
+
+        // Manually set user agent to our format. This helps avoid getting identified as a bot and rate limited by cloudflare
+        // the default format is usually okhttp/x.x.x
+        // while our format is
+        // avaxwallet/0.14.15.1532 Mozilla/5.0 (Linux; Android 13; Pixel 7 Build/TQ1A.221205.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/128.0.6613.127 Mobile Safari/537.36
+        OkHttpClientProvider.setOkHttpClientFactory(CoreOkHttpClientFactory(getUserAgent()))
+
+        SoLoader.init(this, false)
+        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+            // If you opted-in for the New Architecture, we load the native entry point for this app.
+            load()
+        }
+    }
+
+    private fun increaseWindowCursorSize() {
         // Temp workaround for data not getting persisted on Android
         // https://github.com/rt2zz/redux-persist/issues/199
         // https://github.com/rt2zz/redux-persist/issues/960
@@ -53,11 +68,18 @@ class MainApplication : Application(), ReactApplication {
         } catch (e: Exception) {
             e.printStackTrace()
         }
+    }
 
-        SoLoader.init(this, false)
-        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-            // If you opted-in for the New Architecture, we load the native entry point for this app.
-            load()
+    private fun getUserAgent(): String {
+        try {
+            val shortPackageName = packageName.substring(packageName.lastIndexOf(".") + 1)
+            val appVersion = BuildConfig.VERSION_NAME
+            val buildNumber = BuildConfig.VERSION_CODE
+            val systemUserAgent = WebSettings.getDefaultUserAgent(this.applicationContext)
+            return "$shortPackageName/$appVersion.$buildNumber $systemUserAgent"
+        } catch (e: java.lang.Exception) {
+            e.printStackTrace()
+            return ""
         }
     }
 }

--- a/packages/core-mobile/android/app/src/main/java/com/avaxwallet/UserAgentInterceptor.kt
+++ b/packages/core-mobile/android/app/src/main/java/com/avaxwallet/UserAgentInterceptor.kt
@@ -1,0 +1,24 @@
+package com.avaxwallet
+
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+
+
+class UserAgentInterceptor(private val userAgent: String) : Interceptor {
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest: Request = chain.request()
+
+        if (userAgent.isNotEmpty()) {
+            val updatedRequest = originalRequest.newBuilder()
+                .removeHeader("User-Agent")
+                .addHeader("User-Agent", userAgent)
+                .build()
+            return chain.proceed(updatedRequest)
+        } else {
+            return chain.proceed(originalRequest)
+        }
+    }
+}


### PR DESCRIPTION
this is another attempt to avoid getting rate limited by cloudflare. looks like people have reported this kind of issue before https://community.cloudflare.com/t/bot-traffic-control/320928/2. basically the default user agent that our app uses is usually just `okhttp/x.x.x` and cloudflare may consider that a bot. this pr manually sets the user agent for all requests to a standard format as specified here https://www.scientiamobile.com/correctly-form-user-agents-for-mobile-apps/

for example: 
default user agent:  **okhttp/4.11.0**

new user agent:
**avaxwallet/0.0.0.1 Mozilla/5.0 (Linux; Android 13; Pixel 7 Build/TQ1A.221205.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/128.0.6613.127 Mobile Safari/537.36**