### PR TITLE
Revert react-native-aes-crypto

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,4 @@ updates:
       - dependency-name: "bitcoinjs-lib" # we should be using bitcoinjs-lib 5.2.0 (please refer to dependencies_resolutions.md)
       - dependency-name: "bip39" # we should be using patched version of bip39 3.0.4 (please refer to /patches/bip39+3.0.4.patch) 
       - dependency-name: "@shopify/react-native-skia" # the latest version is not compatible with react-native-graph 1.1.0.
+      - dependency-name: "react-native-aes-crypto" # the latest version crashes on Android

--- a/packages/core-mobile/ios/Podfile.lock
+++ b/packages/core-mobile/ios/Podfile.lock
@@ -918,6 +918,8 @@ PODS:
   - React-Mapbuffer (0.73.7):
     - glog
     - React-debug
+  - react-native-aes (1.3.10):
+    - React-Core
   - react-native-blur (3.6.1):
     - React
   - react-native-camera (4.2.1):
@@ -1262,6 +1264,7 @@ DEPENDENCIES:
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector-modern`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
+  - react-native-aes (from `../node_modules/react-native-aes-crypto`)
   - "react-native-blur (from `../node_modules/@react-native-community/blur`)"
   - react-native-camera (from `../node_modules/react-native-camera`)
   - "react-native-compat (from `../node_modules/@walletconnect/react-native-compat`)"
@@ -1416,6 +1419,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/logger"
   React-Mapbuffer:
     :path: "../node_modules/react-native/ReactCommon"
+  react-native-aes:
+    :path: "../node_modules/react-native-aes-crypto"
   react-native-blur:
     :path: "../node_modules/@react-native-community/blur"
   react-native-camera:
@@ -1598,6 +1603,7 @@ SPEC CHECKSUMS:
   React-jsinspector: f356e49aa086380d3a4892708ca173ad31ac69c1
   React-logger: 7b19bdfb254772a0332d6cd4d66eceb0678b6730
   React-Mapbuffer: 6f392912435adb8fbf4c3eee0e79a0a0b4e4b717
+  react-native-aes: c6e4e3ffcff410535e31e161fca95d50e608d4ee
   react-native-blur: 4568dd93d1d82748c180df8beb2d929c97b13b47
   react-native-camera: 3eae183c1d111103963f3dd913b65d01aef8110f
   react-native-compat: 5a5b7a043bec932a7814dc35f0649712bc10324e

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -114,6 +114,7 @@
     "react-content-loader": "6.2.0",
     "react-hook-form": "7.45.1",
     "react-native": "0.73.7",
+    "react-native-aes-crypto": "1.3.10",
     "react-native-argon2": "2.0.1",
     "react-native-big-list": "1.6.1",
     "react-native-bootsplash": "6.1.3",

--- a/packages/core-mobile/patches/react-native-aes-crypto+1.3.10.patch
+++ b/packages/core-mobile/patches/react-native-aes-crypto+1.3.10.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native-aes-crypto/android/build.gradle b/node_modules/react-native-aes-crypto/android/build.gradle
+index a68c5b7..19ad67c 100644
+--- a/node_modules/react-native-aes-crypto/android/build.gradle
++++ b/node_modules/react-native-aes-crypto/android/build.gradle
+@@ -20,7 +20,7 @@ buildscript {
+ }
+ 
+ apply plugin: 'com.android.library'
+-apply plugin: 'maven'
++apply plugin: 'maven-publish'
+ 
+ // Matches values in recent template from React Native 0.59 / 0.60
+ // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9

--- a/yarn.lock
+++ b/yarn.lock
@@ -297,6 +297,7 @@ __metadata:
     react-dom: 18.2.0
     react-hook-form: 7.45.1
     react-native: 0.73.7
+    react-native-aes-crypto: 1.3.10
     react-native-argon2: 2.0.1
     react-native-big-list: 1.6.1
     react-native-bootsplash: 6.1.3
@@ -23364,6 +23365,13 @@ __metadata:
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: e20fe84c86ff172fc8d898251b7cc2c43645d108bf96d0b8edf39b98f9a2cae97b40520ee7ed8ee0085ccc94736c4886294456033304151c3f94978cec03df21
+  languageName: node
+  linkType: hard
+
+"react-native-aes-crypto@npm:1.3.10":
+  version: 1.3.10
+  resolution: "react-native-aes-crypto@npm:1.3.10"
+  checksum: 84682c2900a843b102efa22baa6584713b6a3ba4b063c53358ac8991184e5c160820a707ea7d17a3637cf19edc0a3abd64958a326898c491880872f19d908531
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: [CP-9109]** 

* revert `react-native-aes-crypto`
* ignore `react-native-aes-crypto` from dependabot since the latest version crashes on android

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9109]: https://ava-labs.atlassian.net/browse/CP-9109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ