### PR TITLE
fix: Hide splash screen immediately after storyboook app launching

### DIFF
--- a/packages/core-mobile/index.js
+++ b/packages/core-mobile/index.js
@@ -5,6 +5,7 @@ import { Text, TextInput } from 'react-native'
 import './polyfills'
 import { AppRegistry } from 'react-native'
 import Big from 'big.js'
+import Bootsplash from 'react-native-bootsplash'
 import ContextApp from './app/ContextApp'
 import { name as appName } from './app.json'
 import DevDebuggingConfig from './app/utils/debugging/DevDebuggingConfig'
@@ -31,6 +32,7 @@ TextInput.defaultProps.allowFontScaling = false
 let AppEntryPoint = ContextApp
 
 if (DevDebuggingConfig.STORYBOOK_ENABLED) {
+  Bootsplash.hide()
   AppEntryPoint = require('./storybook').default
 }
 


### PR DESCRIPTION
## Description
* Hide splash screen immediately for storyboook app launching

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
