### PR TITLE
CP-9279: revert react-native-keychain version to 8.1.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,4 +37,5 @@ updates:
       - dependency-name: "@shopify/react-native-skia" # the latest version is not compatible with react-native-graph 1.1.0.
       - dependency-name: "react-native-aes-crypto" # the latest version crashes on Android
       - dependency-name: "react-native-quick-crypto" # the latest version has conflicts with @wallet-connect/react-native-compat. consider to update @walletconnect/* first
-      - dependency-name: "react-native-haptic-feedback" # the latest version is only compatible with new architecture of react-native  
+      - dependency-name: "react-native-haptic-feedback" # the latest version is only compatible with new architecture of react-native
+      - dependency-name: "react-native-keychain" # the latest version slows down android app launch time. https://github.com/oblador/react-native-keychain/issues/630 please update after this issue is resolved

--- a/packages/core-mobile/ios/Podfile.lock
+++ b/packages/core-mobile/ios/Podfile.lock
@@ -1272,7 +1272,7 @@ PODS:
     - React-Core
   - RNInAppBrowser (3.7.0):
     - React-Core
-  - RNKeychain (8.2.0):
+  - RNKeychain (8.1.1):
     - React-Core
   - RNLocalize (3.2.1):
     - React-Core
@@ -1785,7 +1785,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 75e2ebf4e8ac521f2b3c9afdc048fcbc2e2c9ea4
   RNGoogleSignin: a6a612cce56a45ab701c5c5c6e36f5390522d100
   RNInAppBrowser: e36d6935517101ccba0e875bac8ad7b0cb655364
-  RNKeychain: bfe3d12bf4620fe488771c414530bf16e88f3678
+  RNKeychain: ff836453cba46938e0e9e4c22e43d43fa2c90333
   RNLocalize: 4f22418187ecd5ca693231093ff1d912d1b3c9bc
   RNNotifee: 2b7df6e32a9cc24b9af6b410fa7db1cd2f411d6d
   RNOS: 6f2f9a70895bbbfbdad7196abd952e7b01d45027

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -134,7 +134,7 @@
     "react-native-graph": "1.1.0",
     "react-native-haptic-feedback": "2.0.3",
     "react-native-inappbrowser-reborn": "3.7.0",
-    "react-native-keychain": "8.2.0",
+    "react-native-keychain": "8.1.1",
     "react-native-level-fs": "3.0.1",
     "react-native-localize": "3.2.1",
     "react-native-mmkv": "2.12.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -314,7 +314,7 @@ __metadata:
     react-native-graph: 1.1.0
     react-native-haptic-feedback: 2.0.3
     react-native-inappbrowser-reborn: 3.7.0
-    react-native-keychain: 8.2.0
+    react-native-keychain: 8.1.1
     react-native-level-fs: 3.0.1
     react-native-localize: 3.2.1
     react-native-mmkv: 2.12.2
@@ -24463,10 +24463,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-keychain@npm:8.2.0":
-  version: 8.2.0
-  resolution: "react-native-keychain@npm:8.2.0"
-  checksum: 4c4d5331013b8ab17c21120a2388e1e82aa30586738c0a34ed9dcffb6ce12454125ddb690951cad5563c9290b060eb68ccffa9477650cc3a5ddc347696b5d4ef
+"react-native-keychain@npm:8.1.1":
+  version: 8.1.1
+  resolution: "react-native-keychain@npm:8.1.1"
+  checksum: fce8319ef8f793516982f96b86080d0a85281d35e91585f1490c41751df4703dcb52b0f22523d2e5f1b87ca7e037daf7d412c7098712cdd3913e6baf239cb673
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: [CP-9279]** 

* `react-native-keychain` version 8.2.0 is slowing down the Android app’s launch time, as mentioned in this [open issue](https://github.com/oblador/react-native-keychain/issues/630). Let’s revert to the previous version we were using.

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9279]: https://ava-labs.atlassian.net/browse/CP-9279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ