### PR TITLE
AppCheck clean up

### DIFF
--- a/packages/core-mobile/app/services/fcm/AppCheckService.ts
+++ b/packages/core-mobile/app/services/fcm/AppCheckService.ts
@@ -51,4 +51,5 @@ class AppCheckService {
     return await firebase.appCheck().getToken(false)
   }
 }
+
 export default new AppCheckService()

--- a/packages/core-mobile/app/services/notifications/balanceChange/registerDeviceToNotificationSender.ts
+++ b/packages/core-mobile/app/services/notifications/balanceChange/registerDeviceToNotificationSender.ts
@@ -18,7 +18,7 @@ export async function registerDeviceToNotificationSender(
     throw error
   })
   if (response.ok) {
-    return response.json()
+    return await response.json()
   } else {
     throw new Error(`${response.status}:${response.statusText}`)
   }

--- a/packages/core-mobile/app/services/notifications/balanceChange/subscribeForBalanceChange.ts
+++ b/packages/core-mobile/app/services/notifications/balanceChange/subscribeForBalanceChange.ts
@@ -23,7 +23,7 @@ export async function subscribeForBalanceChange({
     throw new Error(error)
   })
   if (response.ok) {
-    return response.json()
+    return await response.json()
   } else {
     throw new Error(`${response.status}:${response.statusText}`)
   }

--- a/packages/core-mobile/app/store/notifications/listeners/subscribeBalanceChangeNotifications.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/subscribeBalanceChangeNotifications.ts
@@ -8,16 +8,26 @@ import { subscribeForBalanceChange } from 'services/notifications/balanceChange/
 import Logger from 'utils/Logger'
 import { ChannelId } from 'services/notifications/channels'
 import NotificationsService from 'services/notifications/NotificationsService'
+import { selectHasPromptedForBalanceChange } from '../slice'
 
 export async function subscribeBalanceChangeNotifications(
   listenerApi: AppListenerEffectAPI
 ): Promise<void> {
   const { getState } = listenerApi
-  const accounts = selectAccounts(getState())
+
+  const state = getState()
+  const hasPromptedForBalanceChange = selectHasPromptedForBalanceChange(state)
+
+  if (!hasPromptedForBalanceChange) {
+    // skip if user has not been prompted for balance change notifications
+    return
+  }
+
+  const accounts = selectAccounts(state)
   const addresses = Object.values(accounts).map(account => account.addressC)
 
   if (addresses.length === 0) {
-    //skip if no addresses, means wallet is not yet created
+    // skip if no addresses, means wallet is not yet created
     return
   }
 

--- a/packages/core-mobile/app/utils/httpClient.ts
+++ b/packages/core-mobile/app/utils/httpClient.ts
@@ -13,5 +13,6 @@ export default async function fetchWithAppCheck(
     },
     body: bodyJson
   }
+
   return fetch(url, options)
 }


### PR DESCRIPTION
this pr makes the balance change notifications code a bit more efficient by:
- not calling subscribe/unsubscribe logic unless the feature flag has been updated
- not calling subscribe logic if user has not been prompted for balance change notifications before