### PR TITLE
QA - handle notification modal 

### DIFF
--- a/packages/core-mobile/e2e/helpers/loginRecoverWallet.ts
+++ b/packages/core-mobile/e2e/helpers/loginRecoverWallet.ts
@@ -20,12 +20,12 @@ class LoginRecoverWallet {
     await CreatePinPage.tapNumpadZero()
     await CreatePinPage.tapNumpadZero()
     await CreatePinPage.tapAgreeAndContinueBtn()
+    await commonElsPage.tapGetStartedButton()
     try {
       await commonElsPage.tapNotNow()
     } catch (e) {
       console.log('The Not Now Button is not displayed')
     }
-    await commonElsPage.tapGetStartedButton()
     await PortfolioPage.verifyPorfolioScreen()
   }
 


### PR DESCRIPTION
## Description

- The new build displays the notification setup modal after dismissing the get started modal. It's a quick fix to handle that. 

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
