### PR TITLE
CP-9278: Fix app crash on portfolio tab

### DIFF
--- a/packages/core-mobile/app/components/TabView.tsx
+++ b/packages/core-mobile/app/components/TabView.tsx
@@ -6,11 +6,13 @@ import {
 import React from 'react'
 import { useTheme, View } from '@avalabs/k2-mobile'
 import { Dimensions } from 'react-native'
-import { PortfolioTabs } from 'consts/portfolio'
 
 export const Tab = createMaterialTopTabNavigator()
 
-export type TabScreens = { name: PortfolioTabs; component: React.FC }[]
+export type TabScreens = {
+  name: string
+  component: React.FC
+}[]
 
 export const TabView = ({
   currenTabName,
@@ -24,9 +26,9 @@ export const TabView = ({
   lazy?: boolean
   testID?: string
   hideSingleTab?: boolean
-  currenTabName?: PortfolioTabs
+  currenTabName?: string
   tabScreens: TabScreens
-  onPress?: (name: PortfolioTabs) => void
+  onPress?: (name: string) => void
   renderCustomLabel?: (props: {
     focused: boolean
     color: string

--- a/packages/core-mobile/app/components/TabView.tsx
+++ b/packages/core-mobile/app/components/TabView.tsx
@@ -1,0 +1,95 @@
+import {
+  createMaterialTopTabNavigator,
+  MaterialTopTabBar,
+  MaterialTopTabBarProps
+} from '@react-navigation/material-top-tabs'
+import React from 'react'
+import { useTheme, View } from '@avalabs/k2-mobile'
+import { Dimensions } from 'react-native'
+import { PortfolioTabs } from 'consts/portfolio'
+
+export const Tab = createMaterialTopTabNavigator()
+
+export type TabScreens = { name: PortfolioTabs; component: React.FC }[]
+
+export const TabView = ({
+  currenTabName,
+  tabScreens,
+  onPress,
+  renderCustomLabel,
+  hideSingleTab = true,
+  testID,
+  lazy
+}: {
+  lazy?: boolean
+  testID?: string
+  hideSingleTab?: boolean
+  currenTabName?: PortfolioTabs
+  tabScreens: TabScreens
+  onPress?: (name: PortfolioTabs) => void
+  renderCustomLabel?: (props: {
+    focused: boolean
+    color: string
+    children: string
+  }) => React.ReactNode
+}): React.JSX.Element => {
+  const {
+    theme: { colors }
+  } = useTheme()
+
+  return (
+    <Tab.Navigator
+      tabBar={renderCustomMaterialTopTabBar}
+      testID={testID}
+      initialRouteName={currenTabName}
+      initialLayout={{ width: Dimensions.get('window').width }}
+      screenOptions={{
+        tabBarActiveTintColor: colors.$white,
+        tabBarInactiveTintColor: colors.$white,
+        tabBarIndicatorStyle: {
+          backgroundColor: colors.$blueMain,
+          height: 2,
+          marginBottom: 1
+        },
+        tabBarStyle: {
+          display: tabScreens.length <= 1 && hideSingleTab ? 'none' : 'flex',
+          elevation: 0,
+          shadowOpacity: 0,
+          backgroundColor: colors.$transparent,
+          marginHorizontal: 16
+        },
+        tabBarLabel: renderCustomLabel,
+        lazy
+      }}>
+      {tabScreens.map(screen => {
+        return (
+          <Tab.Screen
+            key={screen.name.toLowerCase()}
+            name={screen.name}
+            component={screen.component}
+            listeners={({ route }) => ({
+              swipeEnd: () => onPress?.(route.name),
+              tabPress: () => onPress?.(route.name)
+            })}
+          />
+        )
+      })}
+    </Tab.Navigator>
+  )
+}
+
+const renderCustomMaterialTopTabBar = (
+  props: MaterialTopTabBarProps
+): React.JSX.Element => {
+  return (
+    <>
+      <MaterialTopTabBar {...props} />
+      <View
+        sx={{
+          borderBottomColor: '$neutral800',
+          borderBottomWidth: 1
+        }}
+      />
+    </>
+  )
+}

--- a/packages/core-mobile/app/consts/portfolio.ts
+++ b/packages/core-mobile/app/consts/portfolio.ts
@@ -1,5 +1,5 @@
 export enum PortfolioTabs {
-  Tokens,
-  NFT,
-  DeFi
+  Assets = 'Assets',
+  Collectibles = 'Collectibles',
+  DeFi = 'DeFi'
 }

--- a/packages/core-mobile/app/navigation/wallet/PortfolioScreenStack.tsx
+++ b/packages/core-mobile/app/navigation/wallet/PortfolioScreenStack.tsx
@@ -8,7 +8,7 @@ import { createStackNavigator } from '@react-navigation/stack'
 import { PortfolioTabs } from 'consts/portfolio'
 
 export type PortfolioStackParamList = {
-  [AppNavigation.Portfolio.Portfolio]: { tabIndex?: PortfolioTabs }
+  [AppNavigation.Portfolio.Portfolio]: { tabName?: PortfolioTabs }
   [AppNavigation.Portfolio.NetworkTokens]:
     | { tabIndex?: NetworkTokensTabs }
     | undefined

--- a/packages/core-mobile/app/screens/earn/StakeTabs.tsx
+++ b/packages/core-mobile/app/screens/earn/StakeTabs.tsx
@@ -1,22 +1,24 @@
 import React from 'react'
 import AvaText from 'components/AvaText'
-import TabViewAva from 'components/TabViewAva'
+import { TabView } from 'components/TabView'
 import { ActiveStakes } from './components/ActiveStakes'
 import { PastStakes } from './components/PastStakes'
 
-const renderCustomLabel = (title: string, selected: boolean, color: string) => {
-  return <AvaText.Subtitle1 textStyle={{ color }}>{title}</AvaText.Subtitle1>
+const renderCustomLabel = ({
+  children,
+  color
+}: {
+  children: string
+  color: string
+}): React.JSX.Element => {
+  return <AvaText.Subtitle1 textStyle={{ color }}>{children}</AvaText.Subtitle1>
 }
 
-export const StakeTabs = () => {
-  return (
-    <TabViewAva renderCustomLabel={renderCustomLabel}>
-      <TabViewAva.Item title={'Active'}>
-        <ActiveStakes />
-      </TabViewAva.Item>
-      <TabViewAva.Item title={'History'}>
-        <PastStakes />
-      </TabViewAva.Item>
-    </TabViewAva>
-  )
-}
+const tabScreens = [
+  { name: 'Active', component: ActiveStakes },
+  { name: 'History', component: PastStakes }
+]
+
+export const StakeTabs = (): React.JSX.Element => (
+  <TabView tabScreens={tabScreens} renderCustomLabel={renderCustomLabel} />
+)

--- a/packages/core-mobile/app/screens/portfolio/home/Portfolio.tsx
+++ b/packages/core-mobile/app/screens/portfolio/home/Portfolio.tsx
@@ -74,8 +74,8 @@ const Portfolio = (): JSX.Element => {
       <TabView
         currenTabName={params?.tabName}
         tabScreens={tabScreens}
-        onPress={(name: PortfolioTabs) => {
-          setParams({ tabName: name })
+        onPress={(name: string) => {
+          setParams({ tabName: name as PortfolioTabs })
           captureAnalyticsEvents(name)
         }}
         renderCustomLabel={renderCustomLabel}

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -67,6 +67,7 @@
     "@react-navigation/bottom-tabs": "6.6.1",
     "@react-navigation/drawer": "6.7.2",
     "@react-navigation/elements": "1.3.31",
+    "@react-navigation/material-top-tabs": "6.6.14",
     "@react-navigation/native": "6.1.18",
     "@react-navigation/native-stack": "6.11.0",
     "@react-navigation/stack": "6.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -212,6 +212,7 @@ __metadata:
     "@react-navigation/bottom-tabs": 6.6.1
     "@react-navigation/drawer": 6.7.2
     "@react-navigation/elements": 1.3.31
+    "@react-navigation/material-top-tabs": 6.6.14
     "@react-navigation/native": 6.1.18
     "@react-navigation/native-stack": 6.11.0
     "@react-navigation/stack": 6.4.1
@@ -8039,6 +8040,22 @@ __metadata:
     react-native: "*"
     react-native-safe-area-context: ">= 3.0.0"
   checksum: 1e4a65ccd9fab757d01bf41f605aafd6ca8301ae25ad7d3f1769320793418cca9fe2f25ac9337578ce1e0a1560bbbc3a88f18b899867aacd4d31de7a789e417e
+  languageName: node
+  linkType: hard
+
+"@react-navigation/material-top-tabs@npm:6.6.14":
+  version: 6.6.14
+  resolution: "@react-navigation/material-top-tabs@npm:6.6.14"
+  dependencies:
+    color: ^4.2.3
+    warn-once: ^0.1.0
+  peerDependencies:
+    "@react-navigation/native": ^6.0.0
+    react: "*"
+    react-native: "*"
+    react-native-pager-view: ">= 4.0.0"
+    react-native-tab-view: ">= 3.0.0"
+  checksum: 565919b1a9a948ab30d6448dd2d59035cb05f1d87d559f3710072a0795b344fdcc543f2eeb8884b5d699a965cac7db5d88641ba87ec7544e23245404ffb860ec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: [CP-9278]** 

- add @react-navigation/top-material-tab to reset tabs when tabs are dynamically loaded
- created TabView to render tabs
- replace TabViewAva with TabView for following components 
    - Portfolio
    - StakeTabs
    - NetworkManager

## Screenshots/Videos

NetworkManager

https://github.com/user-attachments/assets/098520f7-7004-4bd2-9157-82b3e8a4f38c

StakeTabs

https://github.com/user-attachments/assets/a1aa6cc3-c16d-45d5-9d91-7b67536ced18

Portfolio


## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9278]: https://ava-labs.atlassian.net/browse/CP-9278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ