### PR TITLE
CP-9266: use forked react-native-webview package

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,6 +6,8 @@ nmHoistingLimits: workspaces
 
 nmSelfReferences: false
 
+checksumBehavior: update
+
 nodeLinker: node-modules
 
 plugins:

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -162,7 +162,7 @@
     "react-native-toast-notifications": "3.3.0",
     "react-native-url-polyfill": "2.0.0",
     "react-native-view-shot": "3.8.0",
-    "react-native-webview": "https://github.com/ava-labs/react-native-webview#5b6767d0b502f3f24cb21a6393037ca764cfaf17",
+    "react-native-webview": "ava-labs/react-native-webview#5b6767d0b502f3f24cb21a6393037ca764cfaf17",
     "react-native-webview-crypto": "0.0.26",
     "react-redux": "8.0.1",
     "react-timer-hook": "3.0.7",

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -162,7 +162,7 @@
     "react-native-toast-notifications": "3.3.0",
     "react-native-url-polyfill": "2.0.0",
     "react-native-view-shot": "3.8.0",
-    "react-native-webview": "https://github.com/ava-labs/react-native-webview#cp-9266",
+    "react-native-webview": "https://github.com/ava-labs/react-native-webview#5b6767d0b502f3f24cb21a6393037ca764cfaf17",
     "react-native-webview-crypto": "0.0.26",
     "react-redux": "8.0.1",
     "react-timer-hook": "3.0.7",

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -162,7 +162,7 @@
     "react-native-toast-notifications": "3.3.0",
     "react-native-url-polyfill": "2.0.0",
     "react-native-view-shot": "3.8.0",
-    "react-native-webview": "ava-labs/react-native-webview#5b6767d0b502f3f24cb21a6393037ca764cfaf17",
+    "react-native-webview": "ava-labs/react-native-webview#cp-9266",
     "react-native-webview-crypto": "0.0.26",
     "react-redux": "8.0.1",
     "react-timer-hook": "3.0.7",

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -162,7 +162,7 @@
     "react-native-toast-notifications": "3.3.0",
     "react-native-url-polyfill": "2.0.0",
     "react-native-view-shot": "3.8.0",
-    "react-native-webview": "13.12.2",
+    "react-native-webview": "https://github.com/ava-labs/react-native-webview#cp-9266",
     "react-native-webview-crypto": "0.0.26",
     "react-redux": "8.0.1",
     "react-timer-hook": "3.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,7 +343,7 @@ __metadata:
     react-native-toast-notifications: 3.3.0
     react-native-url-polyfill: 2.0.0
     react-native-view-shot: 3.8.0
-    react-native-webview: "ava-labs/react-native-webview#5b6767d0b502f3f24cb21a6393037ca764cfaf17"
+    react-native-webview: "ava-labs/react-native-webview#cp-9266"
     react-native-webview-crypto: 0.0.26
     react-redux: 8.0.1
     react-test-renderer: 18.3.1
@@ -24873,16 +24873,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-webview@ava-labs/react-native-webview#5b6767d0b502f3f24cb21a6393037ca764cfaf17":
+"react-native-webview@ava-labs/react-native-webview#cp-9266":
   version: 13.12.2
-  resolution: "react-native-webview@https://github.com/ava-labs/react-native-webview.git#commit=5b6767d0b502f3f24cb21a6393037ca764cfaf17"
+  resolution: "react-native-webview@https://github.com/ava-labs/react-native-webview.git#commit=8f099fedbc1cc84865472840e8586645aee8c310"
   dependencies:
     escape-string-regexp: ^4.0.0
     invariant: 2.2.4
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 3cc7c9c2cd3d5a38a8a15b05e4fb3bf55ba38c59e2fdc68dd7c98fe67f5b17fd58100496c1d7b465be1072b6ecc0eb1f3cac85321520965d48201d73fb2d73b5
+  checksum: 336439b4d5cd9c8ffd7713faf5584e93fdd2cd42e6e57850fb235a3eb0d6311a49c18b6faf5633e08a6c277a3b1ef69fd9784605e2a1e6a214a10947f301d7bc
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,7 +343,7 @@ __metadata:
     react-native-toast-notifications: 3.3.0
     react-native-url-polyfill: 2.0.0
     react-native-view-shot: 3.8.0
-    react-native-webview: "https://github.com/ava-labs/react-native-webview#cp-9266"
+    react-native-webview: "https://github.com/ava-labs/react-native-webview#5b6767d0b502f3f24cb21a6393037ca764cfaf17"
     react-native-webview-crypto: 0.0.26
     react-redux: 8.0.1
     react-test-renderer: 18.3.1
@@ -24873,7 +24873,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-webview@https://github.com/ava-labs/react-native-webview#cp-9266":
+"react-native-webview@https://github.com/ava-labs/react-native-webview#5b6767d0b502f3f24cb21a6393037ca764cfaf17":
   version: 13.12.2
   resolution: "react-native-webview@https://github.com/ava-labs/react-native-webview.git#commit=5b6767d0b502f3f24cb21a6393037ca764cfaf17"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,7 +343,7 @@ __metadata:
     react-native-toast-notifications: 3.3.0
     react-native-url-polyfill: 2.0.0
     react-native-view-shot: 3.8.0
-    react-native-webview: 13.12.2
+    react-native-webview: "https://github.com/ava-labs/react-native-webview#cp-9266"
     react-native-webview-crypto: 0.0.26
     react-redux: 8.0.1
     react-test-renderer: 18.3.1
@@ -24873,16 +24873,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-webview@npm:13.12.2":
+"react-native-webview@https://github.com/ava-labs/react-native-webview#cp-9266":
   version: 13.12.2
-  resolution: "react-native-webview@npm:13.12.2"
+  resolution: "react-native-webview@https://github.com/ava-labs/react-native-webview.git#commit=5b6767d0b502f3f24cb21a6393037ca764cfaf17"
   dependencies:
     escape-string-regexp: ^4.0.0
     invariant: 2.2.4
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: d84b2e2e75dc484eb40f8e285607b9686693f2d31e95802e2b358dc0820bcc294b438a77174eba157c31d95675c962c61c94885629af999416ad1355e9618fe0
+  checksum: 3cc7c9c2cd3d5a38a8a15b05e4fb3bf55ba38c59e2fdc68dd7c98fe67f5b17fd58100496c1d7b465be1072b6ecc0eb1f3cac85321520965d48201d73fb2d73b5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,7 +343,7 @@ __metadata:
     react-native-toast-notifications: 3.3.0
     react-native-url-polyfill: 2.0.0
     react-native-view-shot: 3.8.0
-    react-native-webview: "https://github.com/ava-labs/react-native-webview#5b6767d0b502f3f24cb21a6393037ca764cfaf17"
+    react-native-webview: "ava-labs/react-native-webview#5b6767d0b502f3f24cb21a6393037ca764cfaf17"
     react-native-webview-crypto: 0.0.26
     react-redux: 8.0.1
     react-test-renderer: 18.3.1
@@ -24873,7 +24873,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-webview@https://github.com/ava-labs/react-native-webview#5b6767d0b502f3f24cb21a6393037ca764cfaf17":
+"react-native-webview@ava-labs/react-native-webview#5b6767d0b502f3f24cb21a6393037ca764cfaf17":
   version: 13.12.2
   resolution: "react-native-webview@https://github.com/ava-labs/react-native-webview.git#commit=5b6767d0b502f3f24cb21a6393037ca764cfaf17"
   dependencies:


### PR DESCRIPTION
## Description

**Ticket: [CP-9266]** 

- always prompt permission dialog when a website is requesting camera and file download permission
- custom permission prompt is displayed before the system permission prompt

## ava-labs/react-native-webview branch
https://github.com/ava-labs/react-native-webview/tree/cp-9266

## Screenshots/Videos

camera permission request

https://github.com/user-attachments/assets/87c0635e-cb36-4aec-9521-9af0b64b0fab

file download permission request

https://github.com/user-attachments/assets/066a0b50-e01c-48a4-90d2-f5d36fa946e4



## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9266]: https://ava-labs.atlassian.net/browse/CP-9266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ