### PR TITLE
Fix ff balance notificaitons

### DIFF
--- a/packages/core-mobile/app/store/notifications/listeners/handleMaybePromptBalanceNotification.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/handleMaybePromptBalanceNotification.ts
@@ -6,6 +6,7 @@ import NotificationsService from 'services/notifications/NotificationsService'
 import { AnyAction } from '@reduxjs/toolkit'
 import { selectHasBeenViewedOnce, setViewOnce } from 'store/viewOnce/slice'
 import { ViewOnceKey } from 'store/viewOnce/types'
+import { selectIsBalanceChangeNotificationsBlocked } from 'store/posthog'
 import {
   selectHasPromptedForBalanceChange,
   selectNotificationSubscription,
@@ -18,13 +19,16 @@ export const handleMaybePromptBalanceNotification = async (
   _: AnyAction,
   listenerApi: AppListenerEffectAPI
 ): Promise<void> => {
+  const state = listenerApi.getState()
+  const isBalanceChangeNotificationsBlocked =
+    selectIsBalanceChangeNotificationsBlocked(state)
+  if (isBalanceChangeNotificationsBlocked) return
   if (isWaitingForIntroMux) return //if already waiting ignore this handler
   await waitIfIntroScreenIsYetNotDismissed(listenerApi)
   isWaitingForIntroMux = false
 
   const blockedNotifications =
     await NotificationsService.getBlockedNotifications()
-  const state = listenerApi.getState()
   const isSubscribedToBalanceChanges = selectNotificationSubscription(
     ChannelId.BALANCE_CHANGES
   )(state)

--- a/packages/core-mobile/app/store/notifications/listeners/listeners.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/listeners.ts
@@ -115,8 +115,8 @@ export const addNotificationsListeners = (
           listenerApi.getOriginalState().posthog.featureFlags[
             FeatureGates.BALANCE_CHANGE_NOTIFICATIONS
           ]
-        // avoid unsubscribing when previous flag is already false
-        if (previousFlag === false) return
+        // avoid unsubscribing when previous flag is already falsy
+        if (!previousFlag) return
       }
 
       await unsubscribeBalanceChangeNotifications().catch(reason => {


### PR DESCRIPTION
## Description

This PR uses `selectIsBalanceChangeNotificationsBlocked` to block notification feature if disabled.

## Testing
- should not see notification switch in Notifications settings
- should stop receiving notifications
- should not see "enable notifications" prompt on wallet first open

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
