### PR TITLE
QA - Handle pixel6 correctly for bitrise smoke run 

### DIFF
--- a/packages/core-mobile/scripts/bitrise/detox/androidInternalE2ENoReuseAppState.sh
+++ b/packages/core-mobile/scripts/bitrise/detox/androidInternalE2ENoReuseAppState.sh
@@ -25,10 +25,14 @@ if [ "$IS_REGRESSION_RUN" = true ]; then
     test_result=$?
   fi
 else
-  echo "The test list above will be reduced by the android smoke config ignoreTestList"
-  echo "Running smoke run..."
-  QT_QPA_PLATFORM=xcb ./node_modules/.bin/detox test --configuration android.internal.release.smoke.ci --headless
-  test_result=$?
+  if [ "$PARAMETERIZED_TESTS" = true ]; then
+    exit 0  # we don't run parameterized tests on smoke run
+  else
+    echo "The test list above will be reduced by the android smoke config ignoreTestList"
+    echo "Running smoke run..."
+    QT_QPA_PLATFORM=xcb ./node_modules/.bin/detox test --configuration android.internal.release.smoke.ci --headless
+    test_result=$?
+  fi
 fi
 
 npx ts-node ./e2e/attachLogsSendResultsToTestrail.ts


### PR DESCRIPTION
## Description
- Pixel6 is only for parameterized tests on regression. I found out pixel6 not correctly handled on smoke run. It should bypass the parameterized tests on smoke run correctly 

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
