### PR TITLE
QA - New: Notification setting tests and getting ready for notification service testing

### DIFF
--- a/packages/core-mobile/app/screens/drawer/notifications/Notifications.tsx
+++ b/packages/core-mobile/app/screens/drawer/notifications/Notifications.tsx
@@ -120,7 +120,17 @@ function NotificationToggle({
       title={channel.title}
       subtitle={channel.subtitle}
       background={theme.background}
-      rightComponent={<Switch value={checked} onValueChange={onChange} />}
+      rightComponent={
+        <Switch
+          testID={
+            checked
+              ? `${channel.title}_enabled_switch`
+              : `${channel.title}_disabled_switch`
+          }
+          value={checked}
+          onValueChange={onChange}
+        />
+      }
     />
   )
 }

--- a/packages/core-mobile/e2e/config.json
+++ b/packages/core-mobile/e2e/config.json
@@ -24,6 +24,7 @@
     ]
   },
   "testPathIgnorePatterns": [
-    "./e2e/tests/plusIcon/send/sendBitcoin.e2e.ts"
+    "./e2e/tests/plusIcon/send/sendBitcoin.e2e.ts",
+    "./e2e/tests/notification/sendNotification.e2e.ts"
   ]
 }

--- a/packages/core-mobile/e2e/configs/regressionConfig.json
+++ b/packages/core-mobile/e2e/configs/regressionConfig.json
@@ -24,6 +24,7 @@
     ]
   },
   "testPathIgnorePatterns": [
-    "<rootDir>/tests/plusIcon/send/sendBitcoin.e2e.ts"
+    "<rootDir>/tests/plusIcon/send/sendBitcoin.e2e.ts",
+    "<rootDir>/tests/notification/sendNotification.e2e.ts"
   ]
 }

--- a/packages/core-mobile/e2e/configs/reuseStateConfig.json
+++ b/packages/core-mobile/e2e/configs/reuseStateConfig.json
@@ -28,6 +28,7 @@
     "./e2e/tests/settings/showRecoveryPhrase.e2e.smoke.ts",
     "./e2e/tests/login/recoverMetaMaskWallet.e2e.smoke.ts",
     "./e2e/tests/login/unlockWithRecoveryPhrase.e2e.ts",
-    "./e2e/tests/plusIcon/send/sendBitcoin.e2e.ts"
+    "./e2e/tests/plusIcon/send/sendBitcoin.e2e.ts",
+    "./e2e/tests/notification/sendNotification.e2e.ts"
   ]
 }

--- a/packages/core-mobile/e2e/helpers/loginRecoverWallet.ts
+++ b/packages/core-mobile/e2e/helpers/loginRecoverWallet.ts
@@ -9,7 +9,7 @@ import existingRecoveryPhrasePage from '../pages/existingRecoveryPhrase.page'
 import Actions from '../helpers/actions'
 
 class LoginRecoverWallet {
-  async recoverMnemonicWallet() {
+  async recoverMnemonicWallet(isBalanceNotificationOn = false) {
     const recoveryPhrase: string = process.env.E2E_MNEMONIC as string
     await ExistingRecoveryPhrasePage.tapAccessExistingWallet()
     await ExistingRecoveryPhrasePage.tapRecoveryPhraseBtn()
@@ -21,7 +21,11 @@ class LoginRecoverWallet {
     await CreatePinPage.tapNumpadZero()
     await CreatePinPage.tapAgreeAndContinueBtn()
     await commonElsPage.tapGetStartedButton()
-    await commonElsPage.tapNotNow()
+    if (isBalanceNotificationOn) {
+      await commonElsPage.tapTurnOnNotifications()
+    } else {
+      await commonElsPage.tapNotNow()
+    }
     await PortfolioPage.verifyPorfolioScreen()
   }
 
@@ -30,7 +34,7 @@ class LoginRecoverWallet {
     await commonElsPage.checkIfMainnet()
   }
 
-  async recoverWalletLogin() {
+  async recoverWalletLogin(isBalanceNotificationOn = false) {
     const isVisibleNo = await Actions.expectToBeVisible(
       existingRecoveryPhrasePage.forgotPinBtn
     )
@@ -39,7 +43,7 @@ class LoginRecoverWallet {
       await this.enterPin()
       await accountManagePage.switchToFirstAccount()
     } else {
-      await this.recoverMnemonicWallet()
+      await this.recoverMnemonicWallet(isBalanceNotificationOn)
     }
   }
 }

--- a/packages/core-mobile/e2e/helpers/warmup.ts
+++ b/packages/core-mobile/e2e/helpers/warmup.ts
@@ -6,7 +6,10 @@ import Action from './actions'
 import { Platform } from './constants'
 import loginRecoverWallet from './loginRecoverWallet'
 
-export const warmup = async (newInstance = false) => {
+export const warmup = async (
+  newInstance = false,
+  isBalanceNotificationOn = false
+) => {
   const permissions: DevicePermissions = { notifications: 'YES', camera: 'YES' }
   const initialArgs: DeviceLaunchAppConfig = {
     permissions: permissions,
@@ -31,7 +34,7 @@ export const warmup = async (newInstance = false) => {
     console.log('Jailbroken warning handled!!!')
   }
   try {
-    await loginRecoverWallet.recoverWalletLogin()
+    await loginRecoverWallet.recoverWalletLogin(isBalanceNotificationOn)
   } catch (e) {
     console.log('Skipped login process...')
   }

--- a/packages/core-mobile/e2e/locators/burgerMenu/bugerMenu.loc.ts
+++ b/packages/core-mobile/e2e/locators/burgerMenu/bugerMenu.loc.ts
@@ -8,5 +8,8 @@ export default {
   saveButton: 'Save',
   securityAndPrivacy: 'Security & Privacy',
   showRecoveryPhrase: 'Show recovery phrase',
-  carrotSvg: 'carrot_svg'
+  carrotSvg: 'carrot_svg',
+  notifications: 'Notifications',
+  deleteWalletBtn: 'Delete Wallet',
+  iUnderstand: 'I understand, continue'
 }

--- a/packages/core-mobile/e2e/locators/commonEls.loc.ts
+++ b/packages/core-mobile/e2e/locators/commonEls.loc.ts
@@ -7,5 +7,6 @@ export default {
   getStartedBtn: 'Get Started',
   retryBtn: 'Retry',
   testnetBanner: 'testnet_banner',
-  notNow: 'Not Now'
+  notNow: 'Not Now',
+  turnOnNotifications: 'Turn on Notifications'
 }

--- a/packages/core-mobile/e2e/pages/burgerMenu/burgerMenu.page.ts
+++ b/packages/core-mobile/e2e/pages/burgerMenu/burgerMenu.page.ts
@@ -30,6 +30,18 @@ class BurgerMenuPage {
     return by.text(burgerMenu.securityAndPrivacy)
   }
 
+  get notifications() {
+    return by.text(burgerMenu.notifications)
+  }
+
+  get deleteWalletBtn() {
+    return by.text(burgerMenu.deleteWalletBtn)
+  }
+
+  get iUnderstand() {
+    return by.text(burgerMenu.iUnderstand)
+  }
+
   async swipeLeft() {
     await Actions.swipeLeft(
       by.id(burgerMenu.carrotSvg),
@@ -52,6 +64,9 @@ class BurgerMenuPage {
     await Actions.tapElementAtIndex(this.burgerMenuButton, 0)
   }
 
+  async tapNotifications() {
+    await Actions.tapElementAtIndex(this.notifications, 0)
+  }
   async tapCurrency() {
     await Actions.tapElementAtIndex(this.currency, 0)
   }
@@ -71,6 +86,11 @@ class BurgerMenuPage {
   async exitBurgerMenu() {
     await this.tapBackbutton()
     await this.dismissBurgerMenu()
+  }
+
+  async deleteWallet() {
+    await Actions.tapElementAtIndex(this.deleteWalletBtn, 0)
+    await Actions.tapElementAtIndex(this.iUnderstand, 0)
   }
 }
 

--- a/packages/core-mobile/e2e/pages/burgerMenu/notifications.page.ts
+++ b/packages/core-mobile/e2e/pages/burgerMenu/notifications.page.ts
@@ -1,0 +1,83 @@
+import actions from '../../helpers/actions'
+import commonElsPage from '../commonEls.page'
+import burgerMenuPage from './burgerMenu.page'
+
+class Notifications {
+  get stakeEnabledSwitch() {
+    return by.id('Stake_enabled_switch')
+  }
+
+  get stakeDisabledSwitch() {
+    return by.id('Stake_disabled_switch')
+  }
+
+  get balanceEnabledSwitch() {
+    return by.id('Balance_enabled_switch')
+  }
+
+  get balanceDisabledSwitch() {
+    return by.id('Balance_disabled_switch')
+  }
+
+  async tapStakeSwitch(on = true) {
+    if (on) {
+      await actions.tap(this.stakeDisabledSwitch)
+    } else {
+      await actions.tap(this.stakeEnabledSwitch)
+    }
+  }
+
+  async tapBalanceSwitch(on = true) {
+    if (on) {
+      await actions.tap(this.balanceDisabledSwitch)
+    } else {
+      await actions.tap(this.balanceEnabledSwitch)
+    }
+  }
+
+  async switchBalanceNotification(on = true) {
+    await burgerMenuPage.tapBurgerMenuButton()
+    await burgerMenuPage.tapNotifications()
+    await this.tapBalanceSwitch(on)
+    await commonElsPage.tapBackButton()
+    await burgerMenuPage.dismissBurgerMenu()
+  }
+
+  async verifyNotificationsSwitches(stake: boolean, balance: boolean) {
+    if (stake && balance) {
+      // both switches are ON
+      await actions.waitForElement(this.stakeEnabledSwitch)
+      await actions.waitForElement(this.balanceEnabledSwitch)
+    } else if (stake && !balance) {
+      // only stake switch is ON
+      await actions.waitForElement(this.stakeEnabledSwitch)
+      await actions.waitForElement(this.balanceDisabledSwitch)
+    } else if (!stake && balance) {
+      // only balance switch is ON
+      await actions.waitForElement(this.stakeDisabledSwitch)
+      await actions.waitForElement(this.balanceEnabledSwitch)
+    } else if (!stake && !balance) {
+      // both switches are OFF
+      await actions.waitForElement(this.stakeDisabledSwitch)
+      await actions.waitForElement(this.balanceDisabledSwitch)
+    }
+  }
+
+  async verifyPushNotification() {
+    // TODO: currently push notification is broken on internal build. We can update the methods once it's fixed
+    console.log('verify push notification is received')
+  }
+
+  async tapPushNotification() {
+    // TODO: currently push notification is broken on internal build. We can update the methods once it's fixed
+    console.log('verify the deeplink works properly')
+    await device.launchApp() // temporary solution
+  }
+
+  async verifyNoPushNotification() {
+    // TODO: currently push notification is broken on internal build. We can update the methods once it's fixed
+    console.log('verify the push notification is NOT received')
+  }
+}
+
+export default new Notifications()

--- a/packages/core-mobile/e2e/pages/commonEls.page.ts
+++ b/packages/core-mobile/e2e/pages/commonEls.page.ts
@@ -42,6 +42,10 @@ class CommonElsPage {
     return by.text(commonEls.notNow)
   }
 
+  get turnOnNotifications() {
+    return by.text(commonEls.turnOnNotifications)
+  }
+
   async tapBackButton(index = 0) {
     await Actions.tapElementAtIndex(this.backButton, index)
   }
@@ -117,6 +121,10 @@ class CommonElsPage {
     } catch (e) {
       console.log('Not now button not found')
     }
+  }
+
+  async tapTurnOnNotifications() {
+    await Actions.tapElementAtIndex(this.turnOnNotifications, 0)
   }
 }
 

--- a/packages/core-mobile/e2e/tests/notification/sendNotification.e2e.ts
+++ b/packages/core-mobile/e2e/tests/notification/sendNotification.e2e.ts
@@ -1,0 +1,36 @@
+import { warmup } from '../../helpers/warmup'
+import sendLoc from '../../locators/send.loc'
+import accountManagePage from '../../pages/accountManage.page'
+import notificationsPage from '../../pages/burgerMenu/notifications.page'
+import portfolioPage from '../../pages/portfolio.page'
+import sendPage from '../../pages/send.page'
+
+describe('Send Notification', () => {
+  beforeAll(async () => {
+    await warmup(false, true)
+    await accountManagePage.createSecondAccount()
+  })
+
+  it('should receive send notification', async () => {
+    await sendPage.sendTokenTo2ndAccount(
+      sendLoc.avaxToken,
+      sendLoc.sendingAmount
+    )
+    await device.sendToHome()
+    await notificationsPage.verifyPushNotification()
+    await notificationsPage.tapPushNotification()
+    await portfolioPage.verifyPorfolioScreen()
+  })
+
+  it('should not receive send notification', async () => {
+    await notificationsPage.switchBalanceNotification(false)
+    await sendPage.sendTokenTo2ndAccount(
+      sendLoc.avaxToken,
+      sendLoc.sendingAmount
+    )
+    await device.sendToHome()
+    await notificationsPage.verifyNoPushNotification()
+    await device.launchApp()
+    await portfolioPage.verifyPorfolioScreen()
+  })
+})

--- a/packages/core-mobile/e2e/tests/settings/notification.e2e.smoke.ts
+++ b/packages/core-mobile/e2e/tests/settings/notification.e2e.smoke.ts
@@ -1,0 +1,44 @@
+import { warmup } from '../../helpers/warmup'
+import burgerMenuPage from '../../pages/burgerMenu/burgerMenu.page'
+import notificationsPage from '../../pages/burgerMenu/notifications.page'
+import commonElsPage from '../../pages/commonEls.page'
+
+describe('Notification setting', () => {
+  it('should turn on balance notification when log in', async () => {
+    await warmup(false, true)
+    await burgerMenuPage.tapBurgerMenuButton()
+    await burgerMenuPage.tapNotifications()
+    await notificationsPage.verifyNotificationsSwitches(false, true)
+    await commonElsPage.tapBackButton()
+    await burgerMenuPage.deleteWallet()
+  })
+
+  it('should turn off balance notification when log in', async () => {
+    await warmup()
+    await burgerMenuPage.tapBurgerMenuButton()
+    await burgerMenuPage.tapNotifications()
+    await notificationsPage.verifyNotificationsSwitches(false, false)
+  })
+  it('should turn on all notifications', async () => {
+    await notificationsPage.tapStakeSwitch()
+    await notificationsPage.verifyNotificationsSwitches(true, false)
+    await commonElsPage.tapBackButton()
+    await burgerMenuPage.tapNotifications()
+    await notificationsPage.tapBalanceSwitch()
+    await notificationsPage.verifyNotificationsSwitches(true, true)
+    await commonElsPage.tapBackButton()
+    await burgerMenuPage.tapNotifications()
+    await notificationsPage.verifyNotificationsSwitches(true, true)
+  })
+  it('should turn off all notifications', async () => {
+    await notificationsPage.tapStakeSwitch(false)
+    await notificationsPage.verifyNotificationsSwitches(false, true)
+    await commonElsPage.tapBackButton()
+    await burgerMenuPage.tapNotifications()
+    await notificationsPage.tapBalanceSwitch(false)
+    await notificationsPage.verifyNotificationsSwitches(false, false)
+    await commonElsPage.tapBackButton()
+    await burgerMenuPage.tapNotifications()
+    await notificationsPage.verifyNotificationsSwitches(false, false)
+  })
+})


### PR DESCRIPTION
## Description
- New: notification setting switch toggling testing 
- getting ready for testing notification send/receive after the transaction activity. Currently I marked the test to be ignored because the notification is currently broken - https://ava-labs.atlassian.net/browse/CP-9295
- Please note that `verifyPushNotification`, `tapPushNotification`, and `verifyNoPushNotification` are added as placeholders for future testing. We can update the methods and remove the ignore test label once the push notification is fixed

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
