### PR TITLE
add camera qr scanner to nftSendStack

### DIFF
--- a/packages/core-mobile/app/navigation/wallet/NFTSendStack.tsx
+++ b/packages/core-mobile/app/navigation/wallet/NFTSendStack.tsx
@@ -13,7 +13,7 @@ import { selectIsSendBlocked } from 'store/posthog'
 import { NFTItem, NFTItemData } from 'store/nft'
 import { NftTokenWithBalance, TokenType } from '@avalabs/vm-module-types'
 import { isErc721 } from 'services/nft/utils'
-import { SendContextProvider } from 'contexts/SendContext'
+import { SendContextProvider, useSendContext } from 'contexts/SendContext'
 
 export type NFTSendStackParamList = {
   [AppNavigation.NftSend.Send]: { nft: NFTItem }
@@ -68,9 +68,21 @@ type AddressPickNavigationProp = NFTDetailsSendScreenProps<
 const NftSendScreen = (): JSX.Element => {
   const { navigate } = useNavigation<AddressPickNavigationProp>()
 
+  const navigation = useNavigation<NFTSendScreenProp['navigation']>()
+  const { setToAddress } = useSendContext()
+
+  const handleOpenQRScanner = (): void => {
+    navigation.navigate(AppNavigation.Modal.QRScanner, {
+      onSuccess: (data: string) => {
+        setToAddress(data)
+      }
+    })
+  }
+
   return (
     <NftSend
       onOpenAddressBook={() => navigate(AppNavigation.Wallet.AddressBook)}
+      onOpenQRScanner={() => handleOpenQRScanner()}
     />
   )
 }

--- a/packages/core-mobile/app/screens/nft/send/NftSend.tsx
+++ b/packages/core-mobile/app/screens/nft/send/NftSend.tsx
@@ -33,9 +33,11 @@ import { isUserRejectedError } from 'store/rpc/providers/walletConnect/utils'
 import { showTransactionErrorToast } from 'utils/toast'
 import { getJsonRpcErrorMessage } from 'utils/getJsonRpcErrorMessage'
 import { useSendContext } from 'contexts/SendContext'
+import QRScanSVG from 'components/svg/QRScanSVG'
 
 type NftSendScreenProps = {
   onOpenAddressBook: () => void
+  onOpenQRScanner: () => void
 }
 
 type NftSendNavigationProp = NFTDetailsSendScreenProps<
@@ -43,7 +45,8 @@ type NftSendNavigationProp = NFTDetailsSendScreenProps<
 >
 
 export default function NftSend({
-  onOpenAddressBook
+  onOpenAddressBook,
+  onOpenQRScanner
 }: NftSendScreenProps): JSX.Element {
   const navigation = useNavigation<NftSendNavigationProp['navigation']>()
   const { params } = useRoute<NftSendNavigationProp['route']>()
@@ -172,6 +175,19 @@ export default function NftSend({
             <AvaButton.Icon
               onPress={() => setShowAddressBook(!showAddressBook)}>
               <AddressBookSVG />
+            </AvaButton.Icon>
+          </View>
+        )}
+        {!toAddress && (
+          <View
+            style={{
+              position: 'absolute',
+              right: 64,
+              justifyContent: 'center',
+              height: '100%'
+            }}>
+            <AvaButton.Icon onPress={onOpenQRScanner}>
+              <QRScanSVG />
             </AvaButton.Icon>
           </View>
         )}


### PR DESCRIPTION
## Description

**Ticket: [CP-7922](https://ava-labs.atlassian.net/browse/CP-7922)** 

- Please let me know if there is a better way to do this.  It's been awhile since i've worked on a developer ticket.
- Added the QR scanner to the address field on the Send Nft screen.  
- As a user I don't want to have to type out someones address manually each time to send an nft

## Screenshots/Videos

https://github.com/user-attachments/assets/da08ed95-8c3f-47f4-9f0f-ce24cf56edb2


## Testing


## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-7922]: https://ava-labs.atlassian.net/browse/CP-7922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ