### PR TITLE
QA - New: Test manage token & NFT and plusIcon options by networks

### DIFF
--- a/packages/core-mobile/app/navigation/WalletScreenStack/WalletScreenStack.tsx
+++ b/packages/core-mobile/app/navigation/WalletScreenStack/WalletScreenStack.tsx
@@ -259,7 +259,10 @@ function WalletScreenStack(props: Props): JSX.Element {
           />
           <WalletScreenS.Screen
             options={{
-              ...MainHeaderOptions({ title: 'Manage token list' })
+              ...MainHeaderOptions({
+                title: 'Manage token list',
+                headerBackTestID: 'header_back'
+              })
             }}
             name={AppNavigation.Wallet.TokenManagement}
             component={TokenManagement}

--- a/packages/core-mobile/app/screens/nft/NftManage.tsx
+++ b/packages/core-mobile/app/screens/nft/NftManage.tsx
@@ -115,7 +115,15 @@ const renderItemList = ({
           />
         }
         rightComponent={
-          <Switch value={!isHidden} onValueChange={_ => onHiddenToggle(item)} />
+          <Switch
+            testID={
+              isHidden
+                ? `${item.tokenId}_blocked_nft`
+                : `${item.tokenId}_displayed_nft`
+            }
+            value={!isHidden}
+            onValueChange={_ => onHiddenToggle(item)}
+          />
         }
       />
     </View>

--- a/packages/core-mobile/app/screens/tokenManagement/TokenManagementItem.tsx
+++ b/packages/core-mobile/app/screens/tokenManagement/TokenManagementItem.tsx
@@ -20,6 +20,7 @@ const TokenManagementItem: FC<Props> = ({ id, name, image, symbol }) => {
 
   const isBlacklisted = useSelector(selectIsTokenBlacklisted(id))
 
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   function handleChange() {
     dispatch(toggleBlacklist(id))
   }
@@ -41,7 +42,11 @@ const TokenManagementItem: FC<Props> = ({ id, name, image, symbol }) => {
         justifyContent: 'center',
         alignItems: 'center'
       }}>
-      <Switch value={!isBlacklisted} onValueChange={handleChange} />
+      <Switch
+        testID={isBlacklisted ? `${name}_blocked` : `${name}_displayed`}
+        value={!isBlacklisted}
+        onValueChange={handleChange}
+      />
     </View>
   )
 

--- a/packages/core-mobile/app/screens/tokenManagement/TokenManagementItem.tsx
+++ b/packages/core-mobile/app/screens/tokenManagement/TokenManagementItem.tsx
@@ -20,8 +20,7 @@ const TokenManagementItem: FC<Props> = ({ id, name, image, symbol }) => {
 
   const isBlacklisted = useSelector(selectIsTokenBlacklisted(id))
 
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  function handleChange() {
+  function handleChange(): void {
     dispatch(toggleBlacklist(id))
   }
 

--- a/packages/core-mobile/e2e/locators/collectibles.loc.ts
+++ b/packages/core-mobile/e2e/locators/collectibles.loc.ts
@@ -26,5 +26,6 @@ export default {
   listSvg: 'list_svg',
   nftListView: 'nft_list_view',
   invalidNFT: '#7452 ',
+  manageNft: 'Manage',
   testingNft: 'mint' // Eunji added a lot of NFTs named `mint` on mnemonic wallet for testing purpose.
 }

--- a/packages/core-mobile/e2e/locators/commonEls.loc.ts
+++ b/packages/core-mobile/e2e/locators/commonEls.loc.ts
@@ -8,5 +8,6 @@ export default {
   retryBtn: 'Retry',
   testnetBanner: 'testnet_banner',
   notNow: 'Not Now',
-  turnOnNotifications: 'Turn on Notifications'
+  turnOnNotifications: 'Turn on Notifications',
+  searchBar: 'search_bar__search'
 }

--- a/packages/core-mobile/e2e/locators/plusMenu.loc.ts
+++ b/packages/core-mobile/e2e/locators/plusMenu.loc.ts
@@ -4,7 +4,6 @@ export default {
   sendSVG: 'arrow_svg',
   send: 'tab_navigator__send_button',
   swap: 'tab_navigator__swap_button',
-  walletConnect: 'tab_navigator__wallet_connect_button',
   buy: 'tab_navigator__buy_button',
   receive: 'tab_navigator__receive_button',
   walletConnectSVG: 'wallet_connect_svg',

--- a/packages/core-mobile/e2e/pages/collectibles.page.ts
+++ b/packages/core-mobile/e2e/pages/collectibles.page.ts
@@ -106,6 +106,10 @@ class CollectiblesPage {
     return by.id(Collectibles.nftListView)
   }
 
+  get manageNft() {
+    return by.text(Collectibles.manageNft)
+  }
+
   async tapSaveButton() {
     await Action.tapElementAtIndex(this.saveBtn, 0)
   }
@@ -208,6 +212,10 @@ class CollectiblesPage {
     await Action.setInputText(this.customFeeInput, '1000', 3)
     await this.tapSaveButton()
     await popUpModalPage.tapApproveBtn()
+  }
+
+  async tapManageNft() {
+    await Action.tapElementAtIndex(this.manageNft, 0)
   }
 }
 

--- a/packages/core-mobile/e2e/pages/commonEls.page.ts
+++ b/packages/core-mobile/e2e/pages/commonEls.page.ts
@@ -46,6 +46,15 @@ class CommonElsPage {
     return by.text(commonEls.turnOnNotifications)
   }
 
+  get searchBar() {
+    return by.id(commonEls.searchBar)
+  }
+
+  async typeSearchBar(text: string) {
+    await Actions.waitForElement(this.searchBar)
+    await Actions.setInputText(this.searchBar, text)
+  }
+
   async tapBackButton(index = 0) {
     await Actions.tapElementAtIndex(this.backButton, index)
   }

--- a/packages/core-mobile/e2e/pages/plusMenu.page.ts
+++ b/packages/core-mobile/e2e/pages/plusMenu.page.ts
@@ -82,7 +82,7 @@ class PlusMenuPage {
       PlusMenuLoc.swap,
       PlusMenuLoc.buy,
       PlusMenuLoc.receive,
-      PlusMenuLoc.walletConnect,
+      PlusMenuLoc.walletConnectSVG,
       PlusMenuLoc.bridge
     ]
     for (const option of options) {

--- a/packages/core-mobile/e2e/pages/plusMenu.page.ts
+++ b/packages/core-mobile/e2e/pages/plusMenu.page.ts
@@ -1,5 +1,6 @@
 import Actions from '../helpers/actions'
 import PlusMenuLoc from '../locators/plusMenu.loc'
+import portfolioLoc from '../locators/portfolio.loc'
 import bottomTabsPage from './bottomTabs.page'
 import scanQrCodePage from './scanQrCode.page'
 
@@ -73,6 +74,29 @@ class PlusMenuPage {
 
   async tapWalletConnectButton() {
     await Actions.tap(this.walletConnectButton)
+  }
+
+  async verifyPlusIconOptions(network: string) {
+    const options: string[] = [
+      PlusMenuLoc.send,
+      PlusMenuLoc.swap,
+      PlusMenuLoc.buy,
+      PlusMenuLoc.receive,
+      PlusMenuLoc.walletConnect,
+      PlusMenuLoc.bridge
+    ]
+    for (const option of options) {
+      if (
+        network === portfolioLoc.avaxNetwork ||
+        (option !== PlusMenuLoc.buy && option !== PlusMenuLoc.swap)
+      ) {
+        // Show the option if it's the avaxNetwork or not a restricted option
+        await Actions.waitForElement(by.id(option))
+      } else {
+        // Hide the swap and buy for all the other networks
+        await Actions.waitForElementNotVisible(by.id(option))
+      }
+    }
   }
 }
 

--- a/packages/core-mobile/e2e/pages/portfolio.page.ts
+++ b/packages/core-mobile/e2e/pages/portfolio.page.ts
@@ -294,6 +294,14 @@ class PortfolioPage {
     }
   }
 
+  async tapActiveAvaxNetwork() {
+    await Action.waitForElement(
+      by.id(portfolio.activeNetwork + 'Avalanche (C-Chain)'),
+      60000
+    )
+    await Action.tap(by.id(portfolio.activeNetwork + 'Avalanche (C-Chain)'))
+  }
+
   async verifyActiveNetwork(network: string) {
     await Action.waitForElement(by.id(portfolio.activeNetwork + network), 60000)
     await this.tapNetworksDropdown()

--- a/packages/core-mobile/e2e/tests/network/manageToken.e2e.ts
+++ b/packages/core-mobile/e2e/tests/network/manageToken.e2e.ts
@@ -1,0 +1,49 @@
+import actions from '../../helpers/actions'
+import PortfolioPage from '../../pages/portfolio.page'
+import { warmup } from '../../helpers/warmup'
+import commonElsPage from '../../pages/commonEls.page'
+
+describe('Manage Token', () => {
+  beforeAll(async () => {
+    await warmup()
+  })
+
+  it('should not allow AVAX to hide via manage token', async () => {
+    await PortfolioPage.tapActiveAvaxNetwork()
+    await PortfolioPage.tapManageTokens()
+    await commonElsPage.typeSearchBar('AVAX')
+    await actions.waitForElementNotVisible(by.id('Avalanche_displayed'))
+    await actions.waitForElementNotVisible(by.id('Avalanche_blocked'))
+  })
+
+  it('should hide token via manage token', async () => {
+    await commonElsPage.typeSearchBar('TetherToken')
+    try {
+      await actions.waitForElement(by.id('TetherToken_blocked'))
+      await actions.tap(by.id('TetherToken_blocked'))
+      console.log("Display the token if it's already hidden")
+    } catch (e) {
+      console.log("It's already displayed on token list")
+    }
+    // hide the token and verify it's not visible on token list
+    await actions.tap(by.id(`TetherToken_displayed`))
+    await commonElsPage.goBack()
+    await actions.waitForElementNotVisible(by.text('TetherToken'))
+  })
+
+  it('should show token via manage token', async () => {
+    await PortfolioPage.tapManageTokens()
+    await commonElsPage.typeSearchBar('TetherToken')
+    try {
+      await actions.waitForElement(by.id('TetherToken_display'))
+      await actions.tap(by.id('TetherToken_blocked'))
+      console.log("Block the token if it's already displayed")
+    } catch (e) {
+      console.log("It's already blocked")
+    }
+    // display the token that's hidden and verify it displays on token list
+    await actions.tap(by.id(`TetherToken_blocked`))
+    await commonElsPage.goBack()
+    await actions.waitForElement(by.text('TetherToken'))
+  })
+})

--- a/packages/core-mobile/e2e/tests/network/manageToken.e2e.ts
+++ b/packages/core-mobile/e2e/tests/network/manageToken.e2e.ts
@@ -8,16 +8,19 @@ describe('Manage Token', () => {
     await warmup()
   })
 
-  it('should not allow AVAX to hide via manage token', async () => {
+  it('should not allow to manage AVAX via manage token', async () => {
+    // Search for AVAX on Manage Token Screen
     await PortfolioPage.tapActiveAvaxNetwork()
     await PortfolioPage.tapManageTokens()
     await commonElsPage.typeSearchBar('AVAX')
+    // Verify AVAX is NOT available on Manage Token Screen
     await actions.waitForElementNotVisible(by.id('Avalanche_displayed'))
     await actions.waitForElementNotVisible(by.id('Avalanche_blocked'))
   })
 
   it('should hide token via manage token', async () => {
     await commonElsPage.typeSearchBar('TetherToken')
+    // TryCatch Phrase is for test requirment
     try {
       await actions.waitForElement(by.id('TetherToken_blocked'))
       await actions.tap(by.id('TetherToken_blocked'))
@@ -25,15 +28,17 @@ describe('Manage Token', () => {
     } catch (e) {
       console.log("It's already displayed on token list")
     }
-    // hide the token and verify it's not visible on token list
+    // Hide the token
     await actions.tap(by.id(`TetherToken_displayed`))
     await commonElsPage.goBack()
+    // Verify the token is NOT available
     await actions.waitForElementNotVisible(by.text('TetherToken'))
   })
 
   it('should show token via manage token', async () => {
     await PortfolioPage.tapManageTokens()
     await commonElsPage.typeSearchBar('TetherToken')
+    // TryCatch Phrase is for test requirment
     try {
       await actions.waitForElement(by.id('TetherToken_display'))
       await actions.tap(by.id('TetherToken_blocked'))
@@ -41,9 +46,10 @@ describe('Manage Token', () => {
     } catch (e) {
       console.log("It's already blocked")
     }
-    // display the token that's hidden and verify it displays on token list
+    // Display the token
     await actions.tap(by.id(`TetherToken_blocked`))
     await commonElsPage.goBack()
+    // Verify the token is available
     await actions.waitForElement(by.text('TetherToken'))
   })
 })

--- a/packages/core-mobile/e2e/tests/nft/manageNft.e2e.ts
+++ b/packages/core-mobile/e2e/tests/nft/manageNft.e2e.ts
@@ -1,0 +1,46 @@
+import actions from '../../helpers/actions'
+import PortfolioPage from '../../pages/portfolio.page'
+import { warmup } from '../../helpers/warmup'
+import commonElsPage from '../../pages/commonEls.page'
+import collectiblesPage from '../../pages/collectibles.page'
+
+describe('Manage NFT', () => {
+  beforeAll(async () => {
+    await warmup()
+  })
+
+  it('should hide NFT via Manage List', async () => {
+    await PortfolioPage.tapCollectiblesTab()
+    await collectiblesPage.tapManageNft()
+    await commonElsPage.typeSearchBar('7452')
+    try {
+      await actions.waitForElement(by.id('7452_blocked_nft'))
+      await actions.tap(by.id('7452_blocked_nft'))
+      console.log("Display NFT if it's already hidden")
+    } catch (e) {
+      console.log("It's already displayed on NFT list")
+    }
+    // hide the token and verify it's not visible on token list
+    await actions.tap(by.id(`7452_displayed_nft`))
+    await commonElsPage.goBack()
+    await collectiblesPage.tapListSvg()
+    await actions.waitForElementNotVisible(by.text('#7452 '))
+  })
+
+  it('should show NFT via Manage List', async () => {
+    await PortfolioPage.tapManageTokens()
+    await commonElsPage.typeSearchBar('7452')
+    try {
+      await actions.waitForElement(by.id('7452_displayed_nft'))
+      await actions.tap(by.id('7452_displayed_nft'))
+      console.log("Block NFT if it's already displayed")
+    } catch (e) {
+      console.log("It's already blocked")
+    }
+    // display the token that's hidden and verify it displays on token list
+    await actions.tap(by.id(`7452_blocked_nft`))
+    await commonElsPage.goBack()
+    await collectiblesPage.tapListSvg()
+    await actions.waitForElement(by.text('#7452 '))
+  })
+})

--- a/packages/core-mobile/e2e/tests/nft/manageNft.e2e.ts
+++ b/packages/core-mobile/e2e/tests/nft/manageNft.e2e.ts
@@ -13,6 +13,7 @@ describe('Manage NFT', () => {
     await PortfolioPage.tapCollectiblesTab()
     await collectiblesPage.tapManageNft()
     await commonElsPage.typeSearchBar('7452')
+    // TryCatch Phrase is for test requirment
     try {
       await actions.waitForElement(by.id('7452_blocked_nft'))
       await actions.tap(by.id('7452_blocked_nft'))
@@ -20,9 +21,10 @@ describe('Manage NFT', () => {
     } catch (e) {
       console.log("It's already displayed on NFT list")
     }
-    // hide the token and verify it's not visible on token list
+    // Hide NFT
     await actions.tap(by.id(`7452_displayed_nft`))
     await commonElsPage.goBack()
+    // Verify NFT is NOT availble
     await collectiblesPage.tapListSvg()
     await actions.waitForElementNotVisible(by.text('#7452 '))
   })
@@ -30,6 +32,7 @@ describe('Manage NFT', () => {
   it('should show NFT via Manage List', async () => {
     await PortfolioPage.tapManageTokens()
     await commonElsPage.typeSearchBar('7452')
+    // TryCatch Phrase is for test requirment
     try {
       await actions.waitForElement(by.id('7452_displayed_nft'))
       await actions.tap(by.id('7452_displayed_nft'))
@@ -37,9 +40,10 @@ describe('Manage NFT', () => {
     } catch (e) {
       console.log("It's already blocked")
     }
-    // display the token that's hidden and verify it displays on token list
+    // Display NFT
     await actions.tap(by.id(`7452_blocked_nft`))
     await commonElsPage.goBack()
+    // Verify NFT is available
     await collectiblesPage.tapListSvg()
     await actions.waitForElement(by.text('#7452 '))
   })

--- a/packages/core-mobile/e2e/tests/plusIcon/plusIcon.e2e.ts
+++ b/packages/core-mobile/e2e/tests/plusIcon/plusIcon.e2e.ts
@@ -18,10 +18,10 @@ describe('Dynamic Plus Icon by Network', () => {
   ]
   it('should show dynamic plus icon items by network', async () => {
     for (const network of networks) {
-      // 1. Switch all the networks and check plus icon items
+      // Check PlusIcon Options by network
       await networksManagePage.switchNetwork(network)
       await bottomTabsPage.tapPlusIcon()
-      // 2. Verify swap and buy options are NOT visible for networks except C-Chain
+      // Verify SWAP and BUY are NOT available on all networks except C-Chain
       await plusMenuPage.verifyPlusIconOptions(network)
       await bottomTabsPage.tapPlusIcon()
     }

--- a/packages/core-mobile/e2e/tests/plusIcon/plusIcon.e2e.ts
+++ b/packages/core-mobile/e2e/tests/plusIcon/plusIcon.e2e.ts
@@ -1,0 +1,29 @@
+import { warmup } from '../../helpers/warmup'
+import bottomTabsPage from '../../pages/bottomTabs.page'
+import portfolioLoc from '../../locators/portfolio.loc'
+import plusMenuPage from '../../pages/plusMenu.page'
+import networksManagePage from '../../pages/networksManage.page'
+
+describe('Dynamic Plus Icon by Network', () => {
+  beforeAll(async () => {
+    await warmup()
+  })
+
+  const networks: string[] = [
+    portfolioLoc.avaxNetwork,
+    portfolioLoc.avaxPNetwork,
+    portfolioLoc.avaxXNetwork,
+    portfolioLoc.btcNetwork,
+    portfolioLoc.ethNetwork
+  ]
+  it('should show dynamic plus icon items by network', async () => {
+    for (const network of networks) {
+      // 1. Switch all the networks and check plus icon items
+      await networksManagePage.switchNetwork(network)
+      await bottomTabsPage.tapPlusIcon()
+      // 2. Verify swap and buy options are NOT visible for networks except C-Chain
+      await plusMenuPage.verifyPlusIconOptions(network)
+      await bottomTabsPage.tapPlusIcon()
+    }
+  })
+})


### PR DESCRIPTION
## Description
New
1. ManageToken - Go to manage token screen > toggle ON and OFF > Verify the token is visible and NOT visible 
2. ManageNFT - pretty much same idea with manage token but for NFT 
3. PlusIcon option testing - SWAP & BUY are ONLY available on C-chain. Test the plusIcon options by network 

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
