### PR TITLE
remove NSLocationWhenInUseUsageDescription

### DIFF
--- a/packages/core-mobile/ios/AvaxWallet/Info.plist
+++ b/packages/core-mobile/ios/AvaxWallet/Info.plist
@@ -66,8 +66,6 @@
 	<string>To scan QR we need camera permission.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>$(DISPLAY_NAME) requires Face ID access to allow you quick and secure access to your wallet.</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Inter-Regular.ttf</string>

--- a/packages/core-mobile/ios/AvaxWallet/InfoRelease.plist
+++ b/packages/core-mobile/ios/AvaxWallet/InfoRelease.plist
@@ -66,8 +66,6 @@
 	<string>To scan QR we need camera permission.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>$(DISPLAY_NAME) requires Face ID access to allow you quick and secure access to your wallet.</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Inter-Regular.ttf</string>

--- a/packages/k2-mobile/ios/K2Mobile/Info.plist
+++ b/packages/k2-mobile/ios/K2Mobile/Info.plist
@@ -35,8 +35,6 @@
 			</dict>
 		</dict>
 	</dict>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
looks like this was added way back in the early days. removing it since Apple is complaining we don't have a valid description string for it.