### PR TITLE
Fix balance notification subscription issue

### DIFF
--- a/packages/core-mobile/app/screens/drawer/notifications/Notifications.tsx
+++ b/packages/core-mobile/app/screens/drawer/notifications/Notifications.tsx
@@ -73,11 +73,13 @@ const Notifications = (): JSX.Element => {
           />
         )
       })
-  }, [blockedChannels, isBalanceChangeNotificationsBlocked])
+  }, [blockedChannels, disabledChannels])
 
   return (
     <View style={{ marginTop: 20 }}>
-      {showAllowPushNotificationsCard && <AllowPushNotificationsCard />}
+      {showAllowPushNotificationsCard && (
+        <AllowPushNotificationsCard disabledChannels={disabledChannels} />
+      )}
       {renderNotificationToggles()}
     </View>
   )
@@ -125,14 +127,23 @@ function NotificationToggle({
   )
 }
 
-function AllowPushNotificationsCard(): JSX.Element {
+function AllowPushNotificationsCard({
+  disabledChannels
+}: {
+  disabledChannels: Record<string, boolean>
+}): JSX.Element {
   const { theme } = useApplicationContext()
   const dispatch = useDispatch()
 
   function onEnterSettings(): void {
-    notificationChannels.forEach(channel => {
-      dispatch(setNotificationSubscriptions([channel.id, true]))
-    })
+    // enable all channels that are not disabled
+    notificationChannels
+      .filter(channel => {
+        return !disabledChannels[channel.id]
+      })
+      .forEach(channel => {
+        dispatch(setNotificationSubscriptions([channel.id, true]))
+      })
     NotificationsService.getAllPermissions().catch(Logger.error)
   }
 

--- a/packages/core-mobile/app/store/notifications/listeners/subscribeBalanceChangeNotifications.test.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/subscribeBalanceChangeNotifications.test.ts
@@ -9,10 +9,10 @@ import { ChannelId } from 'services/notifications/channels'
 import { ChainId } from '@avalabs/core-chains-sdk'
 import { subscribeBalanceChangeNotifications } from 'store/notifications/listeners/subscribeBalanceChangeNotifications'
 import { AppListenerEffectAPI } from 'store/index'
-import { selectHasPromptedForBalanceChange } from '../slice'
+import { selectNotificationSubscription } from '../slice'
 
 jest.mock('../slice', () => ({
-  selectHasPromptedForBalanceChange: jest.fn()
+  selectNotificationSubscription: jest.fn()
 }))
 
 jest.mock('store/account', () => ({
@@ -61,7 +61,7 @@ describe('subscribeBalanceChangeNotifications', () => {
     } as unknown as AppListenerEffectAPI
 
     jest.clearAllMocks()
-    ;(selectHasPromptedForBalanceChange as jest.Mock).mockReturnValue(true)
+    ;(selectNotificationSubscription as jest.Mock).mockReturnValue(() => true)
   })
 
   it('should skip subscription if there are no accounts', async () => {
@@ -74,8 +74,8 @@ describe('subscribeBalanceChangeNotifications', () => {
     expect(subscribeForBalanceChange).not.toHaveBeenCalled()
   })
 
-  it('should skip subscription if user has not been prompted before', async () => {
-    ;(selectHasPromptedForBalanceChange as jest.Mock).mockReturnValue(false)
+  it('should skip subscription if user has not enabled balance change notifications', async () => {
+    ;(selectNotificationSubscription as jest.Mock).mockReturnValue(() => false)
 
     await subscribeBalanceChangeNotifications(listenerApi)
 

--- a/packages/core-mobile/app/store/notifications/listeners/subscribeBalanceChangeNotifications.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/subscribeBalanceChangeNotifications.ts
@@ -8,7 +8,7 @@ import { subscribeForBalanceChange } from 'services/notifications/balanceChange/
 import Logger from 'utils/Logger'
 import { ChannelId } from 'services/notifications/channels'
 import NotificationsService from 'services/notifications/NotificationsService'
-import { selectHasPromptedForBalanceChange } from '../slice'
+import { selectNotificationSubscription } from '../slice'
 
 export async function subscribeBalanceChangeNotifications(
   listenerApi: AppListenerEffectAPI
@@ -16,10 +16,13 @@ export async function subscribeBalanceChangeNotifications(
   const { getState } = listenerApi
 
   const state = getState()
-  const hasPromptedForBalanceChange = selectHasPromptedForBalanceChange(state)
 
-  if (!hasPromptedForBalanceChange) {
-    // skip if user has not been prompted for balance change notifications
+  const userHasEnabledBalanceNotification = selectNotificationSubscription(
+    ChannelId.BALANCE_CHANGES
+  )(state)
+
+  if (!userHasEnabledBalanceNotification) {
+    // skip if user has not enabled balance change notifications
     return
   }
 


### PR DESCRIPTION
## Description

**Ticket: [CP-9389]** 

when trying to subscribe to the backend, we will skip the logic if the balance notification prompt has not been presented to user. this means users will never receive any notifications. this happens in 2 cases AFAIK:

case 1:
- balance change notification flag is disabled
- user has latest prod build
- user goes to app settings/notifications 
- the Allow Push Notifications banner is displayed 
- user clicks `Open Device Settings`
- this will toggle all the switches to ON (even for the ones that are not displayed like the `Balance` switch)
- balance change notification flag is enabled
- `Balance` notification switch is displayed with ON value
- user will never receive balance notifications unless he/she toggles the switch to OFF + reopens the app + approves prompt 

case 2
- balance change notification flag is disabled
- user has latest prod build
- user goes to app settings/notifications 
- balance change notification flag is enabled
- `Balance` notification switch is displayed with OFF value
- user toggles the `Balance` notification switch to ON
- user will never receive balance notifications unless he/she toggles the switch to OFF + reopens the app + approves prompt 

this pr fixes the above issue by:
- making sure when `Open Device Settings` is clicked, we only enable all the switches that are displayed to the user at the time 
- adjust the subscribe logic to 1/ always run even if balance change notification prompt has not been presented and 2/ only skip it if the `Balance` notification switch is OFF.


## Screenshots/Videos
I did some testing with these scenarios
1/ disable balance notification flag -> install fresh app -> enable balance notification flag -> reopen app -> approve prompt
https://github.com/user-attachments/assets/eae99b8b-78d5-4040-b30a-a644084f26fe

2/ disable balance notification flag -> install fresh app -> enable balance notification flag -> reopen app -> deny approve prompt -> enable Balance switch
https://github.com/user-attachments/assets/cbf9e0b8-c33d-49d0-a45a-7e05ad74558b

3/ disable balance notification flag -> install fresh app -> enable balance notification flag -> enable Balance switch
https://github.com/user-attachments/assets/2114aa4a-f96c-46d0-918b-50abe7b9dcb7


## Testing
Please make sure 1/ notifications are still working correctly based on user preferences and 2/ production users who are not receiving notifications will start receiving them with this fix

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9389]: https://ava-labs.atlassian.net/browse/CP-9389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ