### PR TITLE
CP-9383 Mobile - unable to stake on prod build 

### DIFF
--- a/packages/core-mobile/app/screens/earn/Confirmation/Confirmation.tsx
+++ b/packages/core-mobile/app/screens/earn/Confirmation/Confirmation.tsx
@@ -90,6 +90,9 @@ export const Confirmation = (): JSX.Element | null => {
 
   const { minStartTime, validatedStakingEndTime, validatedStakingDuration } =
     useValidateStakingEndTime(stakingEndTime, validatorEndTimeUnix)
+  const localValidatedStakingEndTime = useMemo(() => {
+    return new Date(validatedStakingEndTime.getTime())
+  }, [validatedStakingEndTime])
 
   const { data } = useEarnCalcEstimatedRewards({
     amount: deductedStakingAmount,
@@ -349,7 +352,7 @@ export const Confirmation = (): JSX.Element | null => {
             {getReadableDateDuration(validatedStakingEndTime)}
           </AvaText.Heading3>
           <AvaText.Body1>
-            {format(validatedStakingEndTime, 'MM/dd/yy  H:mm aa')}
+            {format(localValidatedStakingEndTime, 'MM/dd/yy  H:mm aa')}
           </AvaText.Body1>
         </Row>
       </View>

--- a/packages/core-mobile/app/screens/earn/components/StakeCard.tsx
+++ b/packages/core-mobile/app/screens/earn/components/StakeCard.tsx
@@ -69,7 +69,7 @@ export const StakeCard = (props: Props): JSX.Element => {
     switch (status) {
       case StakeStatus.Ongoing: {
         const remainingTime = getReadableDateDuration(
-          new UTCDate(props.endTimestamp || 0)
+          new UTCDate((props.endTimestamp || 0) * 1000)
         )
         return (
           <AvaText.Caption testID="time_remaining" color={theme.colorText1}>

--- a/packages/core-mobile/app/screens/earn/components/StakeCard.tsx
+++ b/packages/core-mobile/app/screens/earn/components/StakeCard.tsx
@@ -6,7 +6,7 @@ import AvaText from 'components/AvaText'
 import { Row } from 'components/Row'
 import Separator from 'components/Separator'
 import { Space } from 'components/Space'
-import { format, fromUnixTime } from 'date-fns'
+import { format, fromUnixTime, secondsToMilliseconds } from 'date-fns'
 import { getReadableDateDuration } from 'utils/date/getReadableDateDuration'
 import { StakeStatus } from 'types/earn'
 import { getCardHighLightColor } from 'utils/color/getCardHighLightColor'
@@ -69,7 +69,7 @@ export const StakeCard = (props: Props): JSX.Element => {
     switch (status) {
       case StakeStatus.Ongoing: {
         const remainingTime = getReadableDateDuration(
-          new UTCDate((props.endTimestamp || 0) * 1000)
+          new UTCDate(secondsToMilliseconds(props.endTimestamp || 0))
         )
         return (
           <AvaText.Caption testID="time_remaining" color={theme.colorText1}>

--- a/packages/core-mobile/app/screens/earn/durationScreen/DurationScreen.tsx
+++ b/packages/core-mobile/app/screens/earn/durationScreen/DurationScreen.tsx
@@ -26,7 +26,12 @@ import { BackButton } from 'components/BackButton'
 import { Tooltip } from 'components/Tooltip'
 import InfoSVG from 'components/svg/InfoSVG'
 import AnalyticsService from 'services/analytics/AnalyticsService'
-import { fromUnixTime, getUnixTime } from 'date-fns'
+import {
+  fromUnixTime,
+  getUnixTime,
+  millisecondsToSeconds,
+  secondsToMilliseconds
+} from 'date-fns'
 import { UTCDate } from '@date-fns/utc'
 import { UnixTime } from 'services/earn/types'
 import { CustomDurationOptionItem } from './components/CustomDurationOptionItem'
@@ -38,7 +43,7 @@ type ScreenProps = StakeSetupScreenProps<
 
 export const StakingDuration = (): JSX.Element => {
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
-  const currentUnix = useNow() / 1000
+  const currentUnix = millisecondsToSeconds(useNow())
   const minDelegationTime = isDeveloperMode ? ONE_DAY : TWO_WEEKS
   const [selectedDuration, setSelectedDuration] =
     useState<DurationOption>(minDelegationTime)
@@ -56,7 +61,7 @@ export const StakingDuration = (): JSX.Element => {
   const { stakingAmount } = useRoute<ScreenProps['route']>().params
   const isNextDisabled =
     stakeEndTime === undefined ||
-    (!!stakeEndTime && stakeEndTime < UTCDate.now() / 1000)
+    (!!stakeEndTime && stakeEndTime < millisecondsToSeconds(UTCDate.now()))
 
   const selectMinDuration = useCallback(() => {
     setSelectedDuration(minDelegationTime)
@@ -114,7 +119,7 @@ export const StakingDuration = (): JSX.Element => {
       })
       navigate(AppNavigation.StakeSetup.NodeSearch, {
         stakingAmount,
-        stakingEndTime: new UTCDate(stakeEndTime * 1000)
+        stakingEndTime: new UTCDate(secondsToMilliseconds(stakeEndTime))
       })
     }
   }
@@ -124,7 +129,7 @@ export const StakingDuration = (): JSX.Element => {
       AnalyticsService.capture('StakeSelectAdvancedStaking')
       navigate(AppNavigation.StakeSetup.AdvancedStaking, {
         stakingAmount,
-        stakingEndTime: new UTCDate(stakeEndTime * 1000),
+        stakingEndTime: new UTCDate(secondsToMilliseconds(stakeEndTime)),
         selectedDuration: selectedDuration.title
       })
     }

--- a/packages/core-mobile/app/services/earn/getStakeEndDate.ts
+++ b/packages/core-mobile/app/services/earn/getStakeEndDate.ts
@@ -21,7 +21,7 @@ export const getStakeEndDate = ({
   stakeDurationFormat: StakeDurationFormat
   stakeDurationValue: number
   isDeveloperMode: boolean
-}): UnixTimeMs => {
+}): UnixTime => {
   const currentDate = fromUnixTime(startDateUnix, { in: utc })
   switch (stakeDurationFormat) {
     case StakeDurationFormat.Day:

--- a/packages/core-mobile/app/services/wallet/WalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/WalletService.test.ts
@@ -113,12 +113,13 @@ describe('WalletService', () => {
       }).rejects.toThrow('Start date must be in future: ')
     })
     it('should throw if staking duration is less than 2 weeks for Mainnet', async () => {
-      const twoWeeks = add(new Date(), { weeks: 2 })
+      const twoWeeks = 14 * 24 * 60 * 60
+      const twoSeconds = 2
       const params = {
         nodeId: validNodeId,
         stakeAmount: BigInt(25e9),
         startDate: validStartDate,
-        endDate: getUnixTime(sub(twoWeeks, { seconds: 2 })),
+        endDate: validStartDate + twoWeeks - twoSeconds,
         isDevMode: false
       } as AddDelegatorProps
       await expect(async () => {

--- a/packages/core-mobile/app/services/wallet/WalletService.tsx
+++ b/packages/core-mobile/app/services/wallet/WalletService.tsx
@@ -22,13 +22,14 @@ import { Account } from 'store/account/types'
 import { RpcMethod } from 'store/rpc/types'
 import Logger from 'utils/Logger'
 import { UnsignedTx, utils } from '@avalabs/avalanchejs'
-import { fromUnixTime, getUnixTime } from 'date-fns'
+import { getUnixTime } from 'date-fns'
 import { getMinimumStakeEndTime } from 'services/earn/utils'
 import { SeedlessPubKeysStorage } from 'seedless/services/storage/SeedlessPubKeysStorage'
 import SeedlessWallet from 'seedless/services/wallet/SeedlessWallet'
 import { PChainId } from '@avalabs/glacier-sdk'
 import { MessageTypes, TypedData, TypedDataV1 } from '@avalabs/vm-module-types'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
+import { UTCDate } from '@date-fns/utc'
 import { isAvalancheTransactionRequest, isBtcTransactionRequest } from './utils'
 import WalletInitializer from './WalletInitializer'
 import WalletFactory from './WalletFactory'
@@ -532,7 +533,7 @@ class WalletService {
 
     const minimalStakeEndDate = getMinimumStakeEndTime(
       isDevMode,
-      fromUnixTime(startDate)
+      new UTCDate(startDate * 1000)
     )
 
     if (endDate < getUnixTime(minimalStakeEndDate)) {

--- a/packages/core-mobile/app/services/wallet/WalletService.tsx
+++ b/packages/core-mobile/app/services/wallet/WalletService.tsx
@@ -22,7 +22,7 @@ import { Account } from 'store/account/types'
 import { RpcMethod } from 'store/rpc/types'
 import Logger from 'utils/Logger'
 import { UnsignedTx, utils } from '@avalabs/avalanchejs'
-import { getUnixTime } from 'date-fns'
+import { getUnixTime, secondsToMilliseconds } from 'date-fns'
 import { getMinimumStakeEndTime } from 'services/earn/utils'
 import { SeedlessPubKeysStorage } from 'seedless/services/storage/SeedlessPubKeysStorage'
 import SeedlessWallet from 'seedless/services/wallet/SeedlessWallet'
@@ -533,7 +533,7 @@ class WalletService {
 
     const minimalStakeEndDate = getMinimumStakeEndTime(
       isDevMode,
-      new UTCDate(startDate * 1000)
+      new UTCDate(secondsToMilliseconds(startDate))
     )
 
     if (endDate < getUnixTime(minimalStakeEndDate)) {


### PR DESCRIPTION
## Description

**Ticket: [CP-9383]** 

These are hotfixes for CP-9383 
- fixed display on stake card where it would display "-20 hours" instead of positive time
- fixes "duration too short" error caused by wrongly passed parameter as seconds instead of ms. 

## Screenshots/Videos


## Testing


## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9383]: https://ava-labs.atlassian.net/browse/CP-9383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ