### PR TITLE
QA New: Stake duration selections

### DIFF
--- a/packages/core-mobile/app/components/CalendarInput.tsx
+++ b/packages/core-mobile/app/components/CalendarInput.tsx
@@ -17,7 +17,7 @@ interface CalendarInputProps {
   maximumDate?: Date
 }
 
-const EmptyComponent = () => null
+const EmptyComponent: React.FC = () => null
 
 export const CalendarInput: React.FC<CalendarInputProps> = ({
   date,
@@ -32,7 +32,7 @@ export const CalendarInput: React.FC<CalendarInputProps> = ({
   const positionRef = useRef<View>(null)
   const [position, setPosition] = useState(0)
 
-  const handleDateConfirm = (dateInput: Date) => {
+  const handleDateConfirm = (dateInput: Date): void => {
     onDateSelected(dateInput)
 
     if (Platform.OS === 'android') {
@@ -41,15 +41,16 @@ export const CalendarInput: React.FC<CalendarInputProps> = ({
       setIsDatePickerVisible(false)
     }
   }
-  const showDatePicker = () => {
+  const showDatePicker = (): void => {
     setIsDatePickerVisible(true)
   }
 
-  const handleCancel = () => {
+  const handleCancel = (): void => {
     setIsDatePickerVisible(false)
   }
 
-  const handlOnLayout = () => {
+  const handlOnLayout = (): void => {
+    // eslint-disable-next-line max-params
     positionRef.current?.measure((x, y, width, height, pageX, pageY) => {
       setPosition(pageY + height)
     })
@@ -74,6 +75,7 @@ export const CalendarInput: React.FC<CalendarInputProps> = ({
       </Pressable>
       <View>
         <DateTimePickerModal
+          testID="dateTimePicker"
           display="inline"
           isVisible={isDatePickerVisible}
           mode="date"

--- a/packages/core-mobile/app/utils/debugging/DevDebuggingConfig.ts
+++ b/packages/core-mobile/app/utils/debugging/DevDebuggingConfig.ts
@@ -5,7 +5,7 @@
 const DevDebuggingConfig = {
   WDYR: false,
   STORYBOOK_ENABLED: false,
-  LOGBOX_DISABLED: false,
+  LOGBOX_DISABLED: true,
   SHOW_DEMO_NFTS: false,
   API_MOCKING: false,
   SENTRY_SPOTLIGHT: false,

--- a/packages/core-mobile/app/utils/debugging/DevDebuggingConfig.ts
+++ b/packages/core-mobile/app/utils/debugging/DevDebuggingConfig.ts
@@ -5,7 +5,7 @@
 const DevDebuggingConfig = {
   WDYR: false,
   STORYBOOK_ENABLED: false,
-  LOGBOX_DISABLED: true,
+  LOGBOX_DISABLED: false,
   SHOW_DEMO_NFTS: false,
   API_MOCKING: false,
   SENTRY_SPOTLIGHT: false,

--- a/packages/core-mobile/e2e/helpers/actions.ts
+++ b/packages/core-mobile/e2e/helpers/actions.ts
@@ -18,6 +18,14 @@ const tap = async (item: Detox.NativeMatcher) => {
   await element(item).tap()
 }
 
+const tapAtXAndY = async (
+  item: Detox.NativeMatcher,
+  xOffset = 0,
+  yOffset = 0
+) => {
+  await element(item).tap({ x: xOffset, y: yOffset })
+}
+
 const multiTap = async (
   item: Detox.NativeMatcher,
   count: number,
@@ -351,6 +359,7 @@ const shuffleArray = <T>(array: T[]): T[] =>
 export default {
   balanceToNumber,
   tap,
+  tapAtXAndY,
   multiTap,
   longPress,
   waitForElement,

--- a/packages/core-mobile/e2e/locators/Stake/stakeScreen.loc.ts
+++ b/packages/core-mobile/e2e/locators/Stake/stakeScreen.loc.ts
@@ -61,5 +61,7 @@ export default {
   timeRemainingId: 'time_remaining',
   stakedAmountId: 'staked_amount',
   endDateId: 'end_date',
-  earnedRewardsId: 'earned_rewards'
+  earnedRewardsId: 'earned_rewards',
+  stakingSuccessful: 'Staking successful!',
+  customRadio: 'Custom'
 }

--- a/packages/core-mobile/e2e/locators/commonEls.loc.ts
+++ b/packages/core-mobile/e2e/locators/commonEls.loc.ts
@@ -12,5 +12,8 @@ export default {
   bitcoinSVG: 'bitcoin_svg',
   avaSVG: 'ava_logo',
   reloadSVG: 'reload_svg',
-  carrotSVG: 'carrot_svg'
+  carrotSVG: 'carrot_svg',
+  calendarSVG: 'calendarSVG',
+  datePicker: 'dateTimePicker',
+  okBtn: 'OK'
 }

--- a/packages/core-mobile/e2e/pages/commonEls.page.ts
+++ b/packages/core-mobile/e2e/pages/commonEls.page.ts
@@ -62,6 +62,18 @@ class CommonElsPage {
     return by.id(commonEls.carrotSVG)
   }
 
+  get calendarSVG() {
+    return by.id(commonEls.calendarSVG)
+  }
+
+  get datePicker() {
+    return by.id(commonEls.datePicker)
+  }
+
+  get okBtn() {
+    return by.text(commonEls.okBtn)
+  }
+
   async tapCarrotSVG(index = 0) {
     await Actions.tapElementAtIndex(this.carrotSVG, index)
   }

--- a/packages/core-mobile/e2e/tests/stake/stakingTestnet.e2e.ts
+++ b/packages/core-mobile/e2e/tests/stake/stakingTestnet.e2e.ts
@@ -3,15 +3,11 @@ import Actions from '../../helpers/actions'
 import Assert from '../../helpers/assertions'
 import AccountManagePage from '../../pages/accountManage.page'
 import AdvancedPage from '../../pages/burgerMenu/advanced.page'
-import ConfirmStakingPage from '../../pages/Stake/confirmStaking.page'
 import BottomTabsPage from '../../pages/bottomTabs.page'
-import DurationPage from '../../pages/Stake/duration.page'
 import { warmup } from '../../helpers/warmup'
-import GetStartedScreenPage from '../../pages/Stake/getStartedScreen.page'
 import StakePage from '../../pages/Stake/stake.page'
 import ClaimPage from '../../pages/Stake/claim.page'
 import { cleanup } from '../../helpers/cleanup'
-import accountManagePage from '../../pages/accountManage.page'
 
 describe('Stake on Testnet', () => {
   beforeAll(async () => {
@@ -23,43 +19,50 @@ describe('Stake on Testnet', () => {
     await cleanup()
   })
 
-  it('should test a staking flow for a new account on testnet', async () => {
-    await BottomTabsPage.tapPortfolioTab()
-    await AccountManagePage.createNthAccountAndSwitchToNth(3)
+  it('should stake one day', async () => {
     await BottomTabsPage.tapStakeTab()
-    await StakePage.verifyNoActiveStakesScreenItems()
+    await StakePage.stake('1', '1 Day')
+    await StakePage.verifyStakeSuccessToast()
   })
 
-  it('should test a staking flow on testnet for an existing account', async () => {
-    await BottomTabsPage.tapPortfolioTab()
-    await accountManagePage.switchToFirstAccount()
+  it('should stake one month', async () => {
     await BottomTabsPage.tapStakeTab()
-    await StakePage.tapStakeButton()
-    await GetStartedScreenPage.verifyGetStartedScreenItems()
-    await GetStartedScreenPage.tapNextButton()
-    await StakePage.verifyStakingAmountScreenItems()
-    await StakePage.inputStakingAmount('1')
-    await StakePage.tapNextButton()
-    await DurationPage.verifyDurationScreenItems(true)
-    await StakePage.tapNextButton()
-    await Actions.waitForElement(
-      ConfirmStakingPage.confirmStakingTitle,
-      30000,
-      0
-    )
-    await ConfirmStakingPage.verifyConfirmStakingScreenItems()
+    await StakePage.stake('1', '1 Month')
+    await StakePage.verifyStakeSuccessToast()
   })
 
-  it('should complete the stake on testnet', async () => {
-    await StakePage.tapStakeNow()
-    await Actions.waitForElement(StakePage.notNowButton, 60000, 0)
-    await StakePage.tapNotNowButton()
-    await Actions.waitForElement(StakePage.newStakeTimeRemaining, 15000, 0)
-    await Assert.isVisible(StakePage.newStakeTimeRemaining)
-    await StakePage.verifyActiveTabItems()
+  it('should stake three months', async () => {
+    await BottomTabsPage.tapStakeTab()
+    await StakePage.stake('1', '3 Months')
+    await StakePage.verifyStakeSuccessToast()
   })
 
-  it('should claim the stake on testnet', async () => {
+  it('should stake six months', async () => {
+    await BottomTabsPage.tapStakeTab()
+    await StakePage.stake('1', '6 Months')
+    await StakePage.verifyStakeSuccessToast()
+  })
+
+  it('should stake one year', async () => {
+    await BottomTabsPage.tapStakeTab()
+    await StakePage.stake('1', '1 Year')
+    await StakePage.verifyStakeSuccessToast()
+  })
+
+  it('should stake custom duration', async () => {
+    await BottomTabsPage.tapStakeTab()
+    const maximumDuration = new Date(
+      new Date().setFullYear(new Date().getFullYear() + 2)
+    ).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    })
+    await StakePage.stake('1', maximumDuration, true)
+    await StakePage.verifyStakeSuccessToast()
+  })
+
+  it('should claim the testnet stake', async () => {
     await BottomTabsPage.tapPortfolioTab()
     await BottomTabsPage.tapStakeTab()
     if (await Actions.isVisible(StakePage.stakeClaimButton, 0)) {
@@ -74,5 +77,12 @@ describe('Stake on Testnet', () => {
         jestExpect(newClaimableBalance).toBe(0)
       }
     }
+  })
+
+  it('should test a staking flow for a new account on testnet', async () => {
+    await BottomTabsPage.tapPortfolioTab()
+    await AccountManagePage.createNthAccountAndSwitchToNth(3)
+    await BottomTabsPage.tapStakeTab()
+    await StakePage.verifyNoActiveStakesScreenItems()
   })
 })


### PR DESCRIPTION
## Description
- Stake was blocked due to daylight saving time and we had to do a hotfix release, 0.14.18. 
- This should cover the different timelines for staking, `1 day, 1 month, 3 months, 6 months, 1 year, and custom (maximum time)`  cc @neven-s 
- Tested on both iOS and Android
- We're only testing the different duration stakings on testnet

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
