### PR TITLE
run update script android-e2e workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -445,7 +445,7 @@ workflows:
     - script-runner@0:
         title: Update Android Datadog Dashboard
         inputs:
-        - file_path: scripts/datadog/updateAndroidDatadogDashboard.sh
+        - file_path: scripts/datadog/updateAndroidDashboard.sh
   _upload-detox-artifacts:
     steps:
     - script-runner@0:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -445,7 +445,7 @@ workflows:
     - script-runner@0:
         title: Update Android Datadog Dashboard
         inputs:
-        - file_path: scripts/bitrise/updateAndroidDatadogDashboard.sh
+        - file_path: scripts/datadog/updateAndroidDatadogDashboard.sh
   _upload-detox-artifacts:
     steps:
     - script-runner@0:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -495,7 +495,6 @@ workflows:
     - _install-and-set-env
     - _set-version
     - _build-android-external-for-testing
-    - _update-android-datadog-dashboard
     envs:
     - ENVIRONMENT: production
       opts:
@@ -580,6 +579,7 @@ workflows:
     - _install-and-set-env
     - _set-version
     - _build-android-external-for-testing
+    - _update-android-datadog-dashboard
     after_run:
       - _pull_external_app_files
     envs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -440,6 +440,12 @@ workflows:
         - variables: |- 
             APP_VERSION=$APP_VERSION
             BUILD_NUMBER=$BUILD_NUMBER
+  _update-android-datadog-dashboard:
+    steps:
+    - script-runner@0:
+        title: Update Android Datadog Dashboard
+        inputs:
+        - file_path: scripts/bitrise/updateAndroidDatadogDashboard.sh
   _upload-detox-artifacts:
     steps:
     - script-runner@0:
@@ -489,6 +495,7 @@ workflows:
     - _install-and-set-env
     - _set-version
     - _build-android-external-for-testing
+    - _update-android-datadog-dashboard
     envs:
     - ENVIRONMENT: production
       opts:

--- a/packages/core-mobile/scripts/bitrise/detox/androidE2ENoReuseAppState.sh
+++ b/packages/core-mobile/scripts/bitrise/detox/androidE2ENoReuseAppState.sh
@@ -46,8 +46,6 @@ else
   fi
 fi
 
-./scripts/datadog/updateAndroidDashboard.sh && sleep 5
-
 npx ts-node ./e2e/attachLogsSendResultsToTestrail.ts
 
 if ((test_result != 0)); then

--- a/packages/core-mobile/scripts/datadog/updateAndroidDashboard.sh
+++ b/packages/core-mobile/scripts/datadog/updateAndroidDashboard.sh
@@ -1553,7 +1553,7 @@ curl -X PUT \
                                             "data_source": "rum",
                                             "search":
                                             {
-                                                "query": "@type:view @application.id:4deaf0a2-6489-4a26-b05c-deb1f3673bbb @os.name:Android version:>$BUILD_NUMBER service:com.avaxwallet"
+                                                "query": "@type:view @application.id:4deaf0a2-6489-4a26-b05c-deb1f3673bbb @os.name:Android version:$BUILD_NUMBER service:com.avaxwallet"
                                             },
                                             "indexes":
                                             [


### PR DESCRIPTION
## Description

- The android dashboard was being updated on internal test runs and so I created a bitrise workflow that only gets called on android-e2e builds during regression. 
- Small fix for android dashboard update script

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
