### PR TITLE
CP-9361: User can't hide scam tokens with a large non-zero balance

### DIFF
--- a/packages/core-mobile/app/screens/portfolio/account/AccountItem.tsx
+++ b/packages/core-mobile/app/screens/portfolio/account/AccountItem.tsx
@@ -21,6 +21,7 @@ import { ActivityIndicator } from 'components/ActivityIndicator'
 import AnalyticsService from 'services/analytics/AnalyticsService'
 import { selectWalletType } from 'store/app'
 import { useNetworks } from 'hooks/networks/useNetworks'
+import { selectTokenBlacklist } from 'store/portfolio/slice'
 
 type Props = {
   account: Account
@@ -40,8 +41,9 @@ function AccountItem({
   const { activeNetwork } = useNetworks()
   const walletType = useSelector(selectWalletType)
   const context = useApplicationContext()
+  const tokenBlacklist = useSelector(selectTokenBlacklist)
   const accountBalance = useSelector(
-    selectBalanceTotalInCurrencyForAccount(account.index)
+    selectBalanceTotalInCurrencyForAccount(account.index, tokenBlacklist)
   )
   const isBalanceLoaded = useSelector(
     selectIsBalanceLoadedForAddress(account.index, activeNetwork.chainId)

--- a/packages/core-mobile/app/screens/portfolio/home/components/Cards/ActiveNetworkCard/ActiveNetworkCard.tsx
+++ b/packages/core-mobile/app/screens/portfolio/home/components/Cards/ActiveNetworkCard/ActiveNetworkCard.tsx
@@ -25,6 +25,7 @@ import { useTokenPortfolioPriceChange } from 'hooks/balance/useTokenPortfolioPri
 import { Space } from 'components/Space'
 import { useNetworks } from 'hooks/networks/useNetworks'
 import { isAvmNetwork, isPvmNetwork } from 'utils/network/isAvalancheNetwork'
+import { selectTokenBlacklist } from 'store/portfolio/slice'
 import ZeroState from './ZeroState'
 import Tokens from './Tokens'
 import { PChainAssetList } from './PChainAssetList'
@@ -38,10 +39,12 @@ const ActiveNetworkCard = (): JSX.Element => {
   const { filteredTokenList: tokens } = useSearchableTokenList()
   const { activeNetwork } = useNetworks()
   const account = useSelector(selectActiveAccount)
+  const tokenBlacklist = useSelector(selectTokenBlacklist)
   const totalBalanceInCurrency = useSelector(
     selectBalanceTotalInCurrencyForNetworkAndAccount(
       activeNetwork.chainId,
-      account?.index
+      account?.index,
+      tokenBlacklist
     )
   )
   const { navigate } = useNavigation<NavigationProp>()

--- a/packages/core-mobile/app/screens/portfolio/home/components/Cards/InactiveNetworkCard.tsx
+++ b/packages/core-mobile/app/screens/portfolio/home/components/Cards/InactiveNetworkCard.tsx
@@ -16,6 +16,7 @@ import TopRightBadge from 'components/TopRightBadge'
 import { Text } from '@avalabs/k2-mobile'
 import PriceChangeIndicator from 'screens/watchlist/components/PriceChangeIndicator'
 import { useTokenPortfolioPriceChange } from 'hooks/balance/useTokenPortfolioPriceChange'
+import { selectTokenBlacklist } from 'store/portfolio/slice'
 
 const windowWidth = Dimensions.get('window').width
 
@@ -37,10 +38,12 @@ const InactiveNetworkCard: FC<Props> = ({
   } = useApplicationContext()
   const { theme } = useTheme()
   const account = useSelector(selectActiveAccount)
+  const tokenBlacklist = useSelector(selectTokenBlacklist)
   const totalBalance = useSelector(
     selectBalanceTotalInCurrencyForNetworkAndAccount(
       network.chainId,
-      account?.index
+      account?.index,
+      tokenBlacklist
     )
   )
 

--- a/packages/core-mobile/app/screens/portfolio/home/components/PortfolioHeader.tsx
+++ b/packages/core-mobile/app/screens/portfolio/home/components/PortfolioHeader.tsx
@@ -8,7 +8,7 @@ import {
   selectIsRefetchingBalances,
   selectTokensWithBalanceForAccount
 } from 'store/balance/slice'
-import { selectActiveAccount } from 'store/account'
+import { selectActiveAccount } from 'store/account/slice'
 import { ActivityIndicator } from 'components/ActivityIndicator'
 import PriceChangeIndicator from 'screens/watchlist/components/PriceChangeIndicator'
 import { Icons, Text, useTheme, View } from '@avalabs/k2-mobile'
@@ -16,6 +16,7 @@ import { useTokenPortfolioPriceChange } from 'hooks/balance/useTokenPortfolioPri
 import { Tooltip } from 'components/Tooltip'
 import { Space } from 'components/Space'
 import { RootState } from 'store'
+import { selectTokenBlacklist } from 'store/portfolio/slice'
 import { PortfolioHeaderLoader } from './Loaders/PortfolioHeaderLoader'
 
 function PortfolioHeader(): JSX.Element {
@@ -26,8 +27,12 @@ function PortfolioHeader(): JSX.Element {
   const activeAccount = useSelector(selectActiveAccount)
   const isBalanceLoading = useSelector(selectIsLoadingBalances)
   const isRefetchingBalance = useSelector(selectIsRefetchingBalances)
+  const tokenBlacklist = useSelector(selectTokenBlacklist)
   const balanceTotalInCurrency = useSelector(
-    selectBalanceTotalInCurrencyForAccount(activeAccount?.index ?? 0)
+    selectBalanceTotalInCurrencyForAccount(
+      activeAccount?.index ?? 0,
+      tokenBlacklist
+    )
   )
   const balanceAccurate = useSelector(
     selectBalanceForAccountIsAccurate(activeAccount?.index ?? 0)

--- a/packages/core-mobile/app/screens/portfolio/network/components/NetworkTokensHeader.tsx
+++ b/packages/core-mobile/app/screens/portfolio/network/components/NetworkTokensHeader.tsx
@@ -15,6 +15,7 @@ import PriceChangeIndicator from 'screens/watchlist/components/PriceChangeIndica
 import { useSearchableTokenList } from 'screens/portfolio/useSearchableTokenList'
 import { useTokenPortfolioPriceChange } from 'hooks/balance/useTokenPortfolioPriceChange'
 import { useNetworks } from 'hooks/networks/useNetworks'
+import { selectTokenBlacklist } from 'store/portfolio/slice'
 
 const NetworkTokensHeader = (): JSX.Element => {
   const {
@@ -26,8 +27,13 @@ const NetworkTokensHeader = (): JSX.Element => {
   const isLoadingBalance = useSelector(selectIsLoadingBalances)
   const isRefetchingBalance = useSelector(selectIsRefetchingBalances)
   const account = useSelector(selectActiveAccount)
+  const tokenBlacklist = useSelector(selectTokenBlacklist)
   const balanceTotal = useSelector(
-    selectBalanceTotalInCurrencyForNetworkAndAccount(chainId, account?.index)
+    selectBalanceTotalInCurrencyForNetworkAndAccount(
+      chainId,
+      account?.index,
+      tokenBlacklist
+    )
   )
   const formattedTotalBalance = currencyFormatter(balanceTotal)
 

--- a/packages/core-mobile/app/screens/rpc/components/v2/SessionProposal/AccountItem.tsx
+++ b/packages/core-mobile/app/screens/rpc/components/v2/SessionProposal/AccountItem.tsx
@@ -19,6 +19,7 @@ import {
   selectIsBalanceLoadedForAddress
 } from 'store/balance/slice'
 import { QueryStatus } from 'store/balance/types'
+import { selectTokenBlacklist } from 'store/portfolio/slice'
 
 type Props = {
   account: Account
@@ -29,8 +30,9 @@ type Props = {
 const AccountItem = ({ account, onSelect, selected }: Props): JSX.Element => {
   const { theme } = useApplicationContext()
   const { activeNetwork } = useNetworks()
+  const tokenBlacklist = useSelector(selectTokenBlacklist)
   const accountBalance = useSelector(
-    selectBalanceTotalInCurrencyForAccount(account.index)
+    selectBalanceTotalInCurrencyForAccount(account.index, tokenBlacklist)
   )
 
   const isBalanceLoaded = useSelector(


### PR DESCRIPTION
## Description

**Ticket: [CP-9361]** 

We weren't filtering out blacklisted tokens when counting the total balance. This pr adjusts that.

## Screenshots/Videos
https://github.com/user-attachments/assets/def8932d-ddd4-4aa3-b58b-8bf4be67a238


## Testing
Please make sure this works for all EVM networks

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9361]: https://ava-labs.atlassian.net/browse/CP-9361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ