### PR TITLE
CP-9376: Navigate back to Portfolio after connecting network on NetworkDetails screen

### DIFF
--- a/packages/core-mobile/app/screens/network/NetworkDetails.tsx
+++ b/packages/core-mobile/app/screens/network/NetworkDetails.tsx
@@ -44,6 +44,8 @@ export default function NetworkDetails({
 
   function connect(): void {
     dispatch(setActive(chainId))
+    goBack()
+    goBack()
   }
 
   return (

--- a/packages/core-mobile/metro.config.js
+++ b/packages/core-mobile/metro.config.js
@@ -19,6 +19,7 @@ const baseConfig = {
     customSerializer: createSentryMetroSerializer()
   },
   transformer: {
+    ...defaultConfig.transformer,
     unstable_allowRequireContext: true,
     babelTransformerPath: require.resolve('react-native-svg-transformer')
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -26370,7 +26370,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 6e268fad7aa8b8e56fd28cc95f94f35a33fdac4cec0085ae71a766d092760e3f9af35218706113ff7ae99a74baabc5112d32005dce9e66bdf4fda676fad9aa4e
+  checksum: d396f3dea807077e8789e1d463c87024e1633481d3dff53c0650c82a08d8b7d699db97ceab4e8d2c9de85c3d5378d192c968487254c62edadff77e82a9b8c929
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: [CP-9376]** 

## Screenshots/Videos
https://github.com/user-attachments/assets/fa4be047-1b18-421e-996b-627840e329e0




## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9376]: https://ava-labs.atlassian.net/browse/CP-9376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ