### PR TITLE
Fixed incorrect p-chain token display balance

### DIFF
--- a/packages/core-mobile/app/screens/portfolio/home/components/Cards/ActiveNetworkCard/PChainAssetList.tsx
+++ b/packages/core-mobile/app/screens/portfolio/home/components/Cards/ActiveNetworkCard/PChainAssetList.tsx
@@ -6,7 +6,7 @@ import React, { useMemo } from 'react'
 import { useSearchableTokenList } from 'screens/portfolio/useSearchableTokenList'
 import { assetPDisplayNames } from 'store/balance/types'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
-import { getCChainTokenUnit } from 'utils/units/knownTokens'
+import { getXPChainTokenUnit } from 'utils/units/knownTokens'
 
 type ChainBalanceType = keyof PChainBalance
 
@@ -48,8 +48,8 @@ export const PChainAssetList = ({
     const balanceInAvax = balance
       ? new TokenUnit(
           balance,
-          getCChainTokenUnit().getMaxDecimals(),
-          getCChainTokenUnit().getSymbol()
+          getXPChainTokenUnit().getMaxDecimals(),
+          getXPChainTokenUnit().getSymbol()
         )
       : undefined
 


### PR DESCRIPTION
## Description

- p-chain balance is display in wrong decimal place in active network card
- p-chain staked balance was not showing up in balance dashboard

## Screenshots/Videos
before
<img width="408" alt="Screenshot 2024-11-08 at 9 00 49 AM" src="https://github.com/user-attachments/assets/a861a8a7-fc2b-4f36-967b-4e3b267860a7">
<img width="373" alt="Screenshot 2024-11-08 at 8 47 59 AM" src="https://github.com/user-attachments/assets/8ab7f6e0-19b7-4a1f-8d48-788d5a3fb12f">

after
<img width="395" alt="Screenshot 2024-11-08 at 9 00 04 AM" src="https://github.com/user-attachments/assets/5b1bcdfe-8742-4832-8b39-433af107c828">
<img width="388" alt="Screenshot 2024-11-08 at 8 59 54 AM" src="https://github.com/user-attachments/assets/0b271475-79b1-4b8a-a2b8-0b834718df1f">

## Testing
- manual

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
