### PR TITLE
CP-9377: Fix unable to complete staking 

### DIFF
--- a/packages/core-mobile/app/components/UniversalTokenSelector.tsx
+++ b/packages/core-mobile/app/components/UniversalTokenSelector.tsx
@@ -21,6 +21,8 @@ import {
   isTokenWithBalanceAVM,
   isTokenWithBalancePVM
 } from '@avalabs/avalanche-module'
+import { useSelector } from 'react-redux'
+import { selectSelectedCurrency } from 'store/settings/currency'
 
 interface Props {
   selectedToken?: TokenWithBalance
@@ -57,6 +59,7 @@ const UniversalTokenSelector: FC<Props> = ({
 }) => {
   const theme = useApplicationContext().theme
   const navigation = useNavigation<NavigationProp>()
+  const selectedCurrency = useSelector(selectSelectedCurrency)
   const hasError = !!error
 
   const openTokenSelectorBottomSheet = (): void => {
@@ -190,7 +193,9 @@ const UniversalTokenSelector: FC<Props> = ({
         )}
         <FlexSpacer />
         <AvaText.Body2>
-          {selectedToken && amountInCurrency ? amountInCurrency : '$0.00 USD'}
+          {`${
+            selectedToken && amountInCurrency ? amountInCurrency : '-'
+          } ${selectedCurrency}`}
         </AvaText.Body2>
       </Row>
     </View>

--- a/packages/core-mobile/app/consts/amount.ts
+++ b/packages/core-mobile/app/consts/amount.ts
@@ -1,0 +1,1 @@
+export const UNKNOWN_AMOUNT = '-'

--- a/packages/core-mobile/app/hooks/earn/useClaimFees.ts
+++ b/packages/core-mobile/app/hooks/earn/useClaimFees.ts
@@ -11,6 +11,7 @@ import WalletService from 'services/wallet/WalletService'
 import Logger from 'utils/Logger'
 import { useCChainBaseFee } from 'hooks/useCChainBaseFee'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
+import { weiToNano } from 'utils/units/converter'
 
 const exportPFee = calculatePChainFee()
 
@@ -45,7 +46,7 @@ export const useClaimFees = (): {
 
       const unsignedTx = await WalletService.createImportCTx({
         accountIndex: activeAccount.index,
-        baseFee: instantBaseFee.toSubUnit(),
+        baseFeeInNAvax: weiToNano(instantBaseFee.toSubUnit()),
         avaxXPNetwork,
         sourceChain: 'P',
         destinationAddress: activeAccount.addressC,

--- a/packages/core-mobile/app/hooks/earn/useEstimateStakingFees.ts
+++ b/packages/core-mobile/app/hooks/earn/useEstimateStakingFees.ts
@@ -13,6 +13,7 @@ import { useCChainBaseFee } from 'hooks/useCChainBaseFee'
 import NetworkService from 'services/network/NetworkService'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { zeroAvaxPChain } from 'utils/units/zeroValues'
+import { weiToNano } from 'utils/units/converter'
 
 const importFee = calculatePChainFee()
 
@@ -58,8 +59,8 @@ export const useEstimateStakingFees = (
       const instantBaseFee = WalletService.getInstantBaseFee(baseFee)
 
       const unsignedTx = await WalletService.createExportCTx({
-        amount: totalAmount.toSubUnit(),
-        baseFee: instantBaseFee.toSubUnit(),
+        amountInNAvax: weiToNano(totalAmount.toSubUnit()),
+        baseFeeInNAvax: weiToNano(instantBaseFee.toSubUnit()),
         accountIndex: activeAccount.index,
         avaxXPNetwork,
         destinationChain: 'P',

--- a/packages/core-mobile/app/screens/bridge/Bridge.tsx
+++ b/packages/core-mobile/app/screens/bridge/Bridge.tsx
@@ -59,6 +59,7 @@ import { Audios, audioFeedback } from 'utils/AudioFeedback'
 import { showTransactionErrorToast } from 'utils/toast'
 import { getJsonRpcErrorMessage } from 'utils/getJsonRpcErrorMessage'
 import { isUserRejectedError } from 'store/rpc/providers/walletConnect/utils'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { AssetBalance, BridgeProvider } from './utils/types'
 
 const blockchainTitleMaxWidth = Dimensions.get('window').width * 0.5
@@ -72,7 +73,7 @@ const sourceBlockchains = [
 
 const TRANSFER_ERROR = 'There was a problem with the transfer.'
 
-const NO_AMOUNT = '-'
+const NO_AMOUNT = UNKNOWN_AMOUNT
 
 const formatBalance = (balance: Big | undefined): string | undefined => {
   return balance && formatTokenAmount(balance, 6)

--- a/packages/core-mobile/app/screens/earn/ClaimRewards.tsx
+++ b/packages/core-mobile/app/screens/earn/ClaimRewards.tsx
@@ -26,6 +26,7 @@ import { selectSelectedCurrency } from 'store/settings/currency'
 import { ChainId } from '@avalabs/core-chains-sdk'
 import NetworkService from 'services/network/NetworkService'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { EmptyClaimRewards } from './EmptyClaimRewards'
 import { ConfirmScreen } from './components/ConfirmScreen'
 
@@ -77,7 +78,7 @@ const ClaimRewards = (): JSX.Element | null => {
         unlockedInUnit.mul(avaxPrice).toDisplay()
       ]
     }
-    return ['-', '-']
+    return [UNKNOWN_AMOUNT, UNKNOWN_AMOUNT]
   }, [avaxPrice, data, networkToken.decimals, networkToken.symbol])
 
   const [feesInAvax, feesInCurrency] = useMemo(() => {
@@ -117,7 +118,7 @@ const ClaimRewards = (): JSX.Element | null => {
         </AvaText.Heading6>
         <Space y={4} />
         <AvaText.Body3 testID="network_fee_currency" color={theme.colorText2}>
-          {feesInCurrency}
+          {`${feesInCurrency} ${selectedCurrency}`}
         </AvaText.Body3>
       </View>
     )
@@ -166,7 +167,7 @@ const ClaimRewards = (): JSX.Element | null => {
         <AvaText.Heading3
           textStyle={{ alignSelf: 'flex-end', color: theme.colorText2 }}
           testID="claimable_balance_currency">
-          {claimableAmountInCurrency}
+          {`${claimableAmountInCurrency} ${selectedCurrency}`}
         </AvaText.Heading3>
       </View>
       <Separator />

--- a/packages/core-mobile/app/screens/earn/Confirmation/Confirmation.tsx
+++ b/packages/core-mobile/app/screens/earn/Confirmation/Confirmation.tsx
@@ -43,18 +43,24 @@ import AnalyticsService from 'services/analytics/AnalyticsService'
 import { showTransactionSuccessToast } from 'utils/toast'
 import useCChainNetwork from 'hooks/earn/useCChainNetwork'
 import { useAvaxTokenPriceInSelectedCurrency } from 'hooks/useAvaxTokenPriceInSelectedCurrency'
+import { selectSelectedCurrency } from 'store/settings/currency/slice'
 import { ConfirmScreen } from '../components/ConfirmScreen'
 import UnableToEstimate from '../components/UnableToEstimate'
 import { useValidateStakingEndTime } from './useValidateStakingEndTime'
+
 type ScreenProps = StakeSetupScreenProps<
   typeof AppNavigation.StakeSetup.Confirmation
 >
 
 export const Confirmation = (): JSX.Element | null => {
+  const {
+    appHook: { tokenInCurrencyFormatter }
+  } = useApplicationContext()
   const dispatch = useDispatch()
   const { minStakeAmount } = useStakingParams()
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const isFocused = useIsFocused()
+  const selectedCurrency = useSelector(selectSelectedCurrency)
   const { navigate, getParent } = useNavigation<ScreenProps['navigation']>()
   const { nodeId, stakingAmount, stakingEndTime, onBack } =
     useRoute<ScreenProps['route']>().params
@@ -241,7 +247,9 @@ export const Confirmation = (): JSX.Element | null => {
             {stakingAmountInAvax + ' ' + tokenSymbol}
           </AvaText.Heading1>
           <AvaText.Heading3 textStyle={{ color: theme.colorText2 }}>
-            {stakingAmountInCurrency}
+            {`${tokenInCurrencyFormatter(
+              stakingAmountInCurrency
+            )} ${selectedCurrency}`}
           </AvaText.Heading3>
           <Space x={4} />
         </View>
@@ -266,7 +274,9 @@ export const Confirmation = (): JSX.Element | null => {
           </AvaText.Heading2>
           <AvaText.Body3
             textStyle={{ alignSelf: 'flex-end', color: theme.colorText2 }}>
-            {estimatedRewardInCurrency}
+            {`${tokenInCurrencyFormatter(
+              estimatedRewardInCurrency
+            )} ${selectedCurrency}`}
           </AvaText.Body3>
         </View>
       )

--- a/packages/core-mobile/app/screens/earn/Confirmation/Confirmation.tsx
+++ b/packages/core-mobile/app/screens/earn/Confirmation/Confirmation.tsx
@@ -44,6 +44,7 @@ import { showTransactionSuccessToast } from 'utils/toast'
 import useCChainNetwork from 'hooks/earn/useCChainNetwork'
 import { useAvaxTokenPriceInSelectedCurrency } from 'hooks/useAvaxTokenPriceInSelectedCurrency'
 import { selectSelectedCurrency } from 'store/settings/currency/slice'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { ConfirmScreen } from '../components/ConfirmScreen'
 import UnableToEstimate from '../components/UnableToEstimate'
 import { useValidateStakingEndTime } from './useValidateStakingEndTime'
@@ -301,7 +302,7 @@ export const Confirmation = (): JSX.Element | null => {
       return <Spinner size={22} />
     }
 
-    const networkFeesInAvax = networkFees?.toDisplay() ?? '-'
+    const networkFeesInAvax = networkFees?.toDisplay() ?? UNKNOWN_AMOUNT
 
     return (
       <AvaText.Heading6 testID="network_fee">

--- a/packages/core-mobile/app/screens/earn/StakeDetails.tsx
+++ b/packages/core-mobile/app/screens/earn/StakeDetails.tsx
@@ -27,6 +27,7 @@ import { xpChainToken } from 'utils/units/knownTokens'
 import { UTCDate } from '@date-fns/utc'
 import { selectSelectedCurrency } from 'store/settings/currency/slice'
 import { useSelector } from 'react-redux'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { StatusChip } from './components/StatusChip'
 import { StakeProgress } from './components/StakeProgress'
 
@@ -93,14 +94,21 @@ const StakeDetails = (): JSX.Element | null => {
     const remainingTime = humanize(
       getReadableDateDuration(new UTCDate(endDate.getTime()))
     )
-    const estimatedRewardInAvax = new TokenUnit(
-      stake.estimatedReward || 0,
-      xpChainToken.maxDecimals,
-      xpChainToken.symbol
-    )
-    const estimatedRewardInCurrency = estimatedRewardInAvax
-      .mul(avaxPrice)
-      .toDisplay({ fixedDp: 2 })
+    const estimatedRewardInAvax = stake.estimatedReward
+      ? new TokenUnit(
+          stake.estimatedReward,
+          xpChainToken.maxDecimals,
+          xpChainToken.symbol
+        )
+      : undefined
+    const estimatedRewardInAvaxDisplay =
+      estimatedRewardInAvax?.toDisplay() ?? UNKNOWN_AMOUNT
+    const estimatedRewardInCurrency = estimatedRewardInAvax?.mul(avaxPrice)
+    const estimatedRewardInCurrencyDisplay = estimatedRewardInCurrency
+      ? tokenInCurrencyFormatter(
+          estimatedRewardInCurrency.toDisplay({ fixedDp: 2 })
+        )
+      : UNKNOWN_AMOUNT
 
     return (
       <>
@@ -114,14 +122,10 @@ const StakeDetails = (): JSX.Element | null => {
           </Tooltip>
           <View style={{ alignItems: 'flex-end' }}>
             <AvaText.Heading4 color={theme.colorBgGreen}>
-              {estimatedRewardInAvax.toDisplay()} AVAX
+              {estimatedRewardInAvaxDisplay} AVAX
             </AvaText.Heading4>
             <Space y={2} />
-            <AvaText.Body2>
-              {`${tokenInCurrencyFormatter(
-                estimatedRewardInCurrency
-              )} ${selectedCurrency}`}
-            </AvaText.Body2>
+            <AvaText.Body2>{`${estimatedRewardInCurrencyDisplay} ${selectedCurrency}`}</AvaText.Body2>
           </View>
         </Row>
         <Separator style={styles.line} />
@@ -149,14 +153,22 @@ const StakeDetails = (): JSX.Element | null => {
         utxo.rewardType === RewardType.VALIDATOR
     )
     const rewardUtxoTxHash = rewardUtxo?.txHash || ''
-    const rewardAmountInAvax = new TokenUnit(
-      rewardUtxo?.asset.amount || 0,
-      xpChainToken.maxDecimals,
-      xpChainToken.symbol
-    )
-    const rewardAmountInCurrency = rewardAmountInAvax
-      .mul(avaxPrice)
-      .toDisplay({ fixedDp: 2 })
+    const rewardAmountInAvax = rewardUtxo?.asset.amount
+      ? new TokenUnit(
+          rewardUtxo.asset.amount,
+          xpChainToken.maxDecimals,
+          xpChainToken.symbol
+        )
+      : undefined
+    const rewardAmountInAvaxDisplay =
+      rewardAmountInAvax?.toDisplay() ?? UNKNOWN_AMOUNT
+    const rewardAmountInCurrency = rewardAmountInAvax?.mul(avaxPrice)
+
+    const rewardAmountInCurrencyDisplay = rewardAmountInCurrency
+      ? tokenInCurrencyFormatter(
+          rewardAmountInCurrency.toDisplay({ fixedDp: 2 })
+        )
+      : UNKNOWN_AMOUNT
 
     return (
       <>
@@ -168,14 +180,10 @@ const StakeDetails = (): JSX.Element | null => {
           </AvaText.Body2>
           <View style={{ alignItems: 'flex-end' }}>
             <AvaText.Heading4 color={theme.colorBgGreen}>
-              {rewardAmountInAvax.toDisplay()} AVAX
+              {rewardAmountInAvaxDisplay} AVAX
             </AvaText.Heading4>
             <Space y={2} />
-            <AvaText.Body2>
-              {`${tokenInCurrencyFormatter(
-                rewardAmountInCurrency
-              )} ${selectedCurrency}`}
-            </AvaText.Body2>
+            <AvaText.Body2>{`${rewardAmountInCurrencyDisplay} ${selectedCurrency}`}</AvaText.Body2>
           </View>
         </Row>
         <Separator style={styles.line} />
@@ -206,14 +214,24 @@ const StakeDetails = (): JSX.Element | null => {
   }
   const renderBody = (): JSX.Element => {
     const stakeAmount = stake.amountStaked?.[0]?.amount
-    const stakeAmountInAvax = new TokenUnit(
-      stakeAmount || 0,
-      xpChainToken.maxDecimals,
-      xpChainToken.symbol
-    )
-    const stakeAmountInCurrency = stakeAmountInAvax
-      .mul(avaxPrice)
-      .toDisplay({ fixedDp: 2 })
+    const stakeAmountInAvax = stakeAmount
+      ? new TokenUnit(
+          stakeAmount,
+          xpChainToken.maxDecimals,
+          xpChainToken.symbol
+        )
+      : undefined
+
+    const stakeAmountInAvaxDisplay =
+      stakeAmountInAvax?.toDisplay() ?? UNKNOWN_AMOUNT
+
+    const stakeAmountInCurrency = stakeAmountInAvax?.mul(avaxPrice)
+
+    const stakeAmountInCurrencyDisplay = stakeAmountInCurrency
+      ? tokenInCurrencyFormatter(
+          stakeAmountInCurrency.toDisplay({ fixedDp: 2 })
+        )
+      : UNKNOWN_AMOUNT
 
     return (
       <View>
@@ -224,14 +242,10 @@ const StakeDetails = (): JSX.Element | null => {
             Staked Amount
           </AvaText.Body2>
           <View style={styles.value}>
-            <AvaText.Heading4>
-              {stakeAmountInAvax.toDisplay()} AVAX
-            </AvaText.Heading4>
+            <AvaText.Heading4>{stakeAmountInAvaxDisplay} AVAX</AvaText.Heading4>
             <Space y={4} />
             <AvaText.Body2>
-              {`${tokenInCurrencyFormatter(
-                stakeAmountInCurrency
-              )} ${selectedCurrency}`}
+              {`${stakeAmountInCurrencyDisplay} ${selectedCurrency}`}
             </AvaText.Body2>
           </View>
         </Row>

--- a/packages/core-mobile/app/screens/earn/StakeDetails.tsx
+++ b/packages/core-mobile/app/screens/earn/StakeDetails.tsx
@@ -23,7 +23,7 @@ import { estimatesTooltipText } from 'consts/earn'
 import { Tooltip } from 'components/Tooltip'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { useAvaxTokenPriceInSelectedCurrency } from 'hooks/useAvaxTokenPriceInSelectedCurrency'
-import { getXPChainTokenUnit } from 'utils/units/knownTokens'
+import { xpChainToken } from 'utils/units/knownTokens'
 import { UTCDate } from '@date-fns/utc'
 import { selectSelectedCurrency } from 'store/settings/currency/slice'
 import { useSelector } from 'react-redux'
@@ -95,8 +95,8 @@ const StakeDetails = (): JSX.Element | null => {
     )
     const estimatedRewardInAvax = new TokenUnit(
       stake.estimatedReward || 0,
-      getXPChainTokenUnit().getMaxDecimals(),
-      getXPChainTokenUnit().getSymbol()
+      xpChainToken.maxDecimals,
+      xpChainToken.symbol
     )
     const estimatedRewardInCurrency = estimatedRewardInAvax
       .mul(avaxPrice)
@@ -151,8 +151,8 @@ const StakeDetails = (): JSX.Element | null => {
     const rewardUtxoTxHash = rewardUtxo?.txHash || ''
     const rewardAmountInAvax = new TokenUnit(
       rewardUtxo?.asset.amount || 0,
-      getXPChainTokenUnit().getMaxDecimals(),
-      getXPChainTokenUnit().getSymbol()
+      xpChainToken.maxDecimals,
+      xpChainToken.symbol
     )
     const rewardAmountInCurrency = rewardAmountInAvax
       .mul(avaxPrice)
@@ -208,8 +208,8 @@ const StakeDetails = (): JSX.Element | null => {
     const stakeAmount = stake.amountStaked?.[0]?.amount
     const stakeAmountInAvax = new TokenUnit(
       stakeAmount || 0,
-      getXPChainTokenUnit().getMaxDecimals(),
-      getXPChainTokenUnit().getSymbol()
+      xpChainToken.maxDecimals,
+      xpChainToken.symbol
     )
     const stakeAmountInCurrency = stakeAmountInAvax
       .mul(avaxPrice)

--- a/packages/core-mobile/app/screens/earn/StakingAmount.tsx
+++ b/packages/core-mobile/app/screens/earn/StakingAmount.tsx
@@ -27,6 +27,7 @@ import { useNetworks } from 'hooks/networks/useNetworks'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { zeroAvaxPChain } from 'utils/units/zeroValues'
 import { cChainToken } from 'utils/units/knownTokens'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
 
 type ScreenProps = StakeSetupScreenProps<
   typeof AppNavigation.StakeSetup.SmartStakeAmount
@@ -82,7 +83,7 @@ export default function StakingAmount(): JSX.Element {
   const inputValid =
     !amountNotEnough && !notEnoughBalance && !inputAmount.isZero()
 
-  const balanceInAvax = cumulativeBalance?.toDisplay() ?? '-'
+  const balanceInAvax = cumulativeBalance?.toDisplay() ?? UNKNOWN_AMOUNT
 
   function handleAmountChange(amount: TokenUnit): void {
     setInputAmount(amount)

--- a/packages/core-mobile/app/screens/earn/StakingAmount.tsx
+++ b/packages/core-mobile/app/screens/earn/StakingAmount.tsx
@@ -26,7 +26,7 @@ import AnalyticsService from 'services/analytics/AnalyticsService'
 import { useNetworks } from 'hooks/networks/useNetworks'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { zeroAvaxPChain } from 'utils/units/zeroValues'
-import { getCChainTokenUnit } from 'utils/units/knownTokens'
+import { cChainToken } from 'utils/units/knownTokens'
 
 type ScreenProps = StakeSetupScreenProps<
   typeof AppNavigation.StakeSetup.SmartStakeAmount
@@ -43,8 +43,8 @@ export default function StakingAmount(): JSX.Element {
       cChainBalance?.data?.balance
         ? new TokenUnit(
             cChainBalance?.data?.balance || 0,
-            getCChainTokenUnit().getMaxDecimals(),
-            getCChainTokenUnit().getSymbol()
+            cChainToken.maxDecimals,
+            cChainToken.symbol
           )
         : undefined,
     [cChainBalance?.data?.balance]

--- a/packages/core-mobile/app/screens/earn/components/CircularProgress.tsx
+++ b/packages/core-mobile/app/screens/earn/components/CircularProgress.tsx
@@ -27,7 +27,7 @@ export const CircularProgress: FC<CircularProgressProps> = ({ data }) => {
   let end = 0
   const total = useMemo(() => {
     return data.reduce((item, acc) => {
-      item += acc.amount
+      item += acc.amount ?? 0
       return item
     }, 0)
   }, [data])
@@ -38,7 +38,7 @@ export const CircularProgress: FC<CircularProgressProps> = ({ data }) => {
         {data.map((item, index) => {
           const strokeColor = getStakePrimaryColor(item.type, theme)
           const shadowColor = getStakeShadowColor(item.type, theme)
-          const amountPercent = item.amount / total
+          const amountPercent = item.amount ?? 0 / total
 
           // This will calculate the start and end of each section of the the circular path
           if (index !== 0) {

--- a/packages/core-mobile/app/screens/earn/components/StakeCard.tsx
+++ b/packages/core-mobile/app/screens/earn/components/StakeCard.tsx
@@ -22,6 +22,7 @@ import NetworkService from 'services/network/NetworkService'
 import { useSelector } from 'react-redux'
 import { getXPChainTokenUnit } from 'utils/units/knownTokens'
 import { UTCDate } from '@date-fns/utc'
+import { selectSelectedCurrency } from 'store/settings/currency/slice'
 import { StatusChip } from './StatusChip'
 
 type BaseProps = {
@@ -48,10 +49,14 @@ type NavigationProp = TabsScreenProps<
 >['navigation']
 
 export const StakeCard = (props: Props): JSX.Element => {
-  const { theme } = useApplicationContext()
+  const {
+    theme,
+    appHook: { tokenInCurrencyFormatter }
+  } = useApplicationContext()
   const navigation = useNavigation<NavigationProp>()
   const { txHash, status, title, stakeAmount } = props
   const avaxPrice = useAvaxTokenPriceInSelectedCurrency()
+  const selectedCurrency = useSelector(selectSelectedCurrency)
   const isDevMode = useSelector(selectIsDeveloperMode)
   const { networkToken: pChainNetworkToken } =
     NetworkService.getAvalancheNetworkP(isDevMode)
@@ -88,27 +93,25 @@ export const StakeCard = (props: Props): JSX.Element => {
   }
 
   const renderContents = (): JSX.Element => {
-    const stakeAmountInAvax = stakeAmount
-      ? new TokenUnit(
-          stakeAmount,
-          pChainNetworkToken.decimals,
-          pChainNetworkToken.symbol
-        )
-      : undefined
-    const stakeAmountInCurrency =
-      stakeAmountInAvax?.mul(avaxPrice).toDisplay({ fixedDp: 2 }) ?? '-'
+    const stakeAmountInAvax = new TokenUnit(
+      stakeAmount || 0,
+      pChainNetworkToken.decimals,
+      pChainNetworkToken.symbol
+    )
+    const stakeAmountInCurrency = stakeAmountInAvax
+      .mul(avaxPrice)
+      .toDisplay({ fixedDp: 2 })
 
     switch (status) {
       case StakeStatus.Ongoing: {
-        const estimatedRewardInAvax = props.estimatedReward
-          ? new TokenUnit(
-              props.estimatedReward,
-              pChainNetworkToken.decimals,
-              pChainNetworkToken.symbol
-            )
-          : undefined
-        const estimatedRewardInCurrency =
-          estimatedRewardInAvax?.mul(avaxPrice).toDisplay({ fixedDp: 2 }) ?? '-'
+        const estimatedRewardInAvax = new TokenUnit(
+          props.estimatedReward || 0,
+          pChainNetworkToken.decimals,
+          pChainNetworkToken.symbol
+        )
+        const estimatedRewardInCurrency = estimatedRewardInAvax
+          .mul(avaxPrice)
+          .toDisplay({ fixedDp: 2 })
 
         return (
           <>
@@ -124,9 +127,13 @@ export const StakeCard = (props: Props): JSX.Element => {
               </AvaText.Body2>
               <View style={{ alignItems: 'flex-end' }}>
                 <AvaText.Heading6 testID="staked_amount">
-                  {stakeAmountInAvax?.toDisplay() ?? '-'} AVAX
+                  {stakeAmountInAvax.toDisplay()} AVAX
                 </AvaText.Heading6>
-                <AvaText.Overline>{stakeAmountInCurrency}</AvaText.Overline>
+                <AvaText.Overline>
+                  {`${tokenInCurrencyFormatter(
+                    stakeAmountInCurrency
+                  )} ${selectedCurrency}`}
+                </AvaText.Overline>
               </View>
             </Row>
             <Space y={8} />
@@ -141,9 +148,13 @@ export const StakeCard = (props: Props): JSX.Element => {
                 <AvaText.Heading6
                   testID="estimated_rewards"
                   color={theme.colorBgGreen}>
-                  {estimatedRewardInAvax?.toDisplay() ?? '-'} AVAX
+                  {estimatedRewardInAvax.toDisplay()} AVAX
                 </AvaText.Heading6>
-                <AvaText.Overline>{estimatedRewardInCurrency}</AvaText.Overline>
+                <AvaText.Overline>
+                  {`${tokenInCurrencyFormatter(
+                    estimatedRewardInCurrency
+                  )} ${selectedCurrency}`}
+                </AvaText.Overline>
               </View>
             </Row>
           </>
@@ -153,15 +164,14 @@ export const StakeCard = (props: Props): JSX.Element => {
         const endDate = props.endTimestamp
           ? format(fromUnixTime(props.endTimestamp), 'MM/dd/yyyy')
           : 'N/A'
-        const rewardAmountInAvax = props.rewardAmount
-          ? new TokenUnit(
-              props.rewardAmount,
-              getXPChainTokenUnit().getMaxDecimals(),
-              getXPChainTokenUnit().getSymbol()
-            )
-          : undefined
-        const rewardAmountInCurrency =
-          rewardAmountInAvax?.mul(avaxPrice).toDisplay({ fixedDp: 2 }) ?? '-'
+        const rewardAmountInAvax = new TokenUnit(
+          props.rewardAmount || 0,
+          getXPChainTokenUnit().getMaxDecimals(),
+          getXPChainTokenUnit().getSymbol()
+        )
+        const rewardAmountInCurrency = rewardAmountInAvax
+          .mul(avaxPrice)
+          .toDisplay({ fixedDp: 2 })
 
         return (
           <>
@@ -177,7 +187,7 @@ export const StakeCard = (props: Props): JSX.Element => {
               </AvaText.Body2>
               <View style={{ alignItems: 'flex-end' }}>
                 <AvaText.Heading6 testID="staked_amount">
-                  {stakeAmountInAvax?.toDisplay() ?? '-'} AVAX
+                  {stakeAmountInAvax.toDisplay()} AVAX
                 </AvaText.Heading6>
                 <AvaText.Overline>{stakeAmountInCurrency}</AvaText.Overline>
               </View>
@@ -196,7 +206,7 @@ export const StakeCard = (props: Props): JSX.Element => {
                 <AvaText.Heading6
                   testID="earned_rewards"
                   color={theme.colorBgGreen}>
-                  {rewardAmountInAvax?.toDisplay() ?? '-'} AVAX
+                  {rewardAmountInAvax.toDisplay()} AVAX
                 </AvaText.Heading6>
                 <AvaText.Overline>{rewardAmountInCurrency}</AvaText.Overline>
               </View>

--- a/packages/core-mobile/app/screens/earn/components/StakeCard.tsx
+++ b/packages/core-mobile/app/screens/earn/components/StakeCard.tsx
@@ -23,6 +23,7 @@ import { useSelector } from 'react-redux'
 import { xpChainToken } from 'utils/units/knownTokens'
 import { UTCDate } from '@date-fns/utc'
 import { selectSelectedCurrency } from 'store/settings/currency/slice'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { StatusChip } from './StatusChip'
 
 type BaseProps = {
@@ -92,26 +93,47 @@ export const StakeCard = (props: Props): JSX.Element => {
     }
   }
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   const renderContents = (): JSX.Element => {
-    const stakeAmountInAvax = new TokenUnit(
-      stakeAmount || 0,
-      pChainNetworkToken.decimals,
-      pChainNetworkToken.symbol
-    )
-    const stakeAmountInCurrency = stakeAmountInAvax
-      .mul(avaxPrice)
-      .toDisplay({ fixedDp: 2 })
-
-    switch (status) {
-      case StakeStatus.Ongoing: {
-        const estimatedRewardInAvax = new TokenUnit(
-          props.estimatedReward || 0,
+    const stakeAmountInAvax = stakeAmount
+      ? new TokenUnit(
+          stakeAmount,
           pChainNetworkToken.decimals,
           pChainNetworkToken.symbol
         )
-        const estimatedRewardInCurrency = estimatedRewardInAvax
-          .mul(avaxPrice)
-          .toDisplay({ fixedDp: 2 })
+      : undefined
+
+    const stakeAmountInAvaxDisplay =
+      stakeAmountInAvax?.toDisplay() ?? UNKNOWN_AMOUNT
+
+    const stakeAmountInCurrency = stakeAmountInAvax?.mul(avaxPrice)
+
+    const stakeAmountInCurrencyDisplay = stakeAmountInCurrency
+      ? tokenInCurrencyFormatter(
+          stakeAmountInCurrency.toDisplay({ fixedDp: 2 })
+        )
+      : UNKNOWN_AMOUNT
+
+    switch (status) {
+      case StakeStatus.Ongoing: {
+        const estimatedRewardInAvax = props.estimatedReward
+          ? new TokenUnit(
+              props.estimatedReward,
+              pChainNetworkToken.decimals,
+              pChainNetworkToken.symbol
+            )
+          : undefined
+
+        const estimatedRewardInAvaxDisplay =
+          estimatedRewardInAvax?.toDisplay() ?? UNKNOWN_AMOUNT
+
+        const estimatedRewardInCurrency = estimatedRewardInAvax?.mul(avaxPrice)
+
+        const estimatedRewardInCurrencyDisplay = estimatedRewardInCurrency
+          ? tokenInCurrencyFormatter(
+              estimatedRewardInCurrency.toDisplay({ fixedDp: 2 })
+            )
+          : UNKNOWN_AMOUNT
 
         return (
           <>
@@ -127,12 +149,10 @@ export const StakeCard = (props: Props): JSX.Element => {
               </AvaText.Body2>
               <View style={{ alignItems: 'flex-end' }}>
                 <AvaText.Heading6 testID="staked_amount">
-                  {stakeAmountInAvax.toDisplay()} AVAX
+                  {stakeAmountInAvaxDisplay} AVAX
                 </AvaText.Heading6>
                 <AvaText.Overline>
-                  {`${tokenInCurrencyFormatter(
-                    stakeAmountInCurrency
-                  )} ${selectedCurrency}`}
+                  {`${stakeAmountInCurrencyDisplay} ${selectedCurrency}`}
                 </AvaText.Overline>
               </View>
             </Row>
@@ -148,12 +168,10 @@ export const StakeCard = (props: Props): JSX.Element => {
                 <AvaText.Heading6
                   testID="estimated_rewards"
                   color={theme.colorBgGreen}>
-                  {estimatedRewardInAvax.toDisplay()} AVAX
+                  {estimatedRewardInAvaxDisplay} AVAX
                 </AvaText.Heading6>
                 <AvaText.Overline>
-                  {`${tokenInCurrencyFormatter(
-                    estimatedRewardInCurrency
-                  )} ${selectedCurrency}`}
+                  {`${estimatedRewardInCurrencyDisplay} ${selectedCurrency}`}
                 </AvaText.Overline>
               </View>
             </Row>
@@ -164,14 +182,24 @@ export const StakeCard = (props: Props): JSX.Element => {
         const endDate = props.endTimestamp
           ? format(fromUnixTime(props.endTimestamp), 'MM/dd/yyyy')
           : 'N/A'
-        const rewardAmountInAvax = new TokenUnit(
-          props.rewardAmount || 0,
-          xpChainToken.maxDecimals,
-          xpChainToken.symbol
-        )
-        const rewardAmountInCurrency = rewardAmountInAvax
-          .mul(avaxPrice)
-          .toDisplay({ fixedDp: 2 })
+        const rewardAmountInAvax = props.rewardAmount
+          ? new TokenUnit(
+              props.rewardAmount,
+              xpChainToken.maxDecimals,
+              xpChainToken.symbol
+            )
+          : undefined
+
+        const rewardAmountInAvaxDisplay =
+          rewardAmountInAvax?.toDisplay() ?? UNKNOWN_AMOUNT
+
+        const rewardAmountInCurrency = rewardAmountInAvax?.mul(avaxPrice)
+
+        const rewardAmountInCurrencyDisplay = rewardAmountInCurrency
+          ? tokenInCurrencyFormatter(
+              rewardAmountInCurrency.toDisplay({ fixedDp: 2 })
+            )
+          : UNKNOWN_AMOUNT
 
         return (
           <>
@@ -187,9 +215,11 @@ export const StakeCard = (props: Props): JSX.Element => {
               </AvaText.Body2>
               <View style={{ alignItems: 'flex-end' }}>
                 <AvaText.Heading6 testID="staked_amount">
-                  {stakeAmountInAvax.toDisplay()} AVAX
+                  {stakeAmountInAvaxDisplay} AVAX
                 </AvaText.Heading6>
-                <AvaText.Overline>{stakeAmountInCurrency}</AvaText.Overline>
+                <AvaText.Overline>
+                  {`${stakeAmountInCurrencyDisplay} ${selectedCurrency}`}
+                </AvaText.Overline>
               </View>
             </Row>
             <Space y={8} />
@@ -206,9 +236,11 @@ export const StakeCard = (props: Props): JSX.Element => {
                 <AvaText.Heading6
                   testID="earned_rewards"
                   color={theme.colorBgGreen}>
-                  {rewardAmountInAvax.toDisplay()} AVAX
+                  {rewardAmountInAvaxDisplay} AVAX
                 </AvaText.Heading6>
-                <AvaText.Overline>{rewardAmountInCurrency}</AvaText.Overline>
+                <AvaText.Overline>
+                  {`${rewardAmountInCurrencyDisplay} ${selectedCurrency}`}
+                </AvaText.Overline>
               </View>
             </Row>
             <Space y={8} />

--- a/packages/core-mobile/app/screens/earn/components/StakeCard.tsx
+++ b/packages/core-mobile/app/screens/earn/components/StakeCard.tsx
@@ -20,7 +20,7 @@ import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import NetworkService from 'services/network/NetworkService'
 import { useSelector } from 'react-redux'
-import { getXPChainTokenUnit } from 'utils/units/knownTokens'
+import { xpChainToken } from 'utils/units/knownTokens'
 import { UTCDate } from '@date-fns/utc'
 import { selectSelectedCurrency } from 'store/settings/currency/slice'
 import { StatusChip } from './StatusChip'
@@ -166,8 +166,8 @@ export const StakeCard = (props: Props): JSX.Element => {
           : 'N/A'
         const rewardAmountInAvax = new TokenUnit(
           props.rewardAmount || 0,
-          getXPChainTokenUnit().getMaxDecimals(),
-          getXPChainTokenUnit().getSymbol()
+          xpChainToken.maxDecimals,
+          xpChainToken.symbol
         )
         const rewardAmountInCurrency = rewardAmountInAvax
           .mul(avaxPrice)

--- a/packages/core-mobile/app/screens/earn/durationScreen/components/CustomDurationOptionItem.tsx
+++ b/packages/core-mobile/app/screens/earn/durationScreen/components/CustomDurationOptionItem.tsx
@@ -24,6 +24,7 @@ import { differenceInMilliseconds } from 'date-fns'
 import { useNow } from 'hooks/time/useNow'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { UTCDate } from '@date-fns/utc'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
 
 export const CustomDurationOptionItem = ({
   stakeAmount,
@@ -89,7 +90,7 @@ export const CustomDurationOptionItem = ({
             </AvaText.Body1>
             <AvaText.Caption textStyle={{ color: theme.colorText1 }}>
               {`Estimated Rewards: ${
-                estimatedRewardsInAvax?.toDisplay() ?? '-'
+                estimatedRewardsInAvax?.toDisplay() ?? UNKNOWN_AMOUNT
               } AVAX`}
             </AvaText.Caption>
           </View>

--- a/packages/core-mobile/app/screens/earn/durationScreen/components/DurationOptionItem.tsx
+++ b/packages/core-mobile/app/screens/earn/durationScreen/components/DurationOptionItem.tsx
@@ -13,6 +13,7 @@ import AvaText from 'components/AvaText'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { useSelector } from 'react-redux'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
 
 export const DurationOptionItem = ({
   stakeAmount,
@@ -54,7 +55,7 @@ export const DurationOptionItem = ({
           <AvaText.Caption textStyle={{ color: theme.colorText2 }}>
             {item.title !== StakeDurationTitle.CUSTOM
               ? `Estimated Rewards: ${
-                  estimatedRewardsInAvax?.toDisplay() ?? '-'
+                  estimatedRewardsInAvax?.toDisplay() ?? UNKNOWN_AMOUNT
                 } AVAX`
               : 'Enter your desired end date'}
           </AvaText.Caption>

--- a/packages/core-mobile/app/screens/portfolio/home/components/Cards/ActiveNetworkCard/PChainAssetList.tsx
+++ b/packages/core-mobile/app/screens/portfolio/home/components/Cards/ActiveNetworkCard/PChainAssetList.tsx
@@ -7,6 +7,7 @@ import { useSearchableTokenList } from 'screens/portfolio/useSearchableTokenList
 import { assetPDisplayNames } from 'store/balance/types'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { xpChainToken } from 'utils/units/knownTokens'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
 
 type ChainBalanceType = keyof PChainBalance
 
@@ -52,7 +53,7 @@ export const PChainAssetList = ({
     const formattedBalance =
       balanceInAvax
         ?.mul(token?.priceInCurrency ?? 0)
-        .toDisplay({ fixedDp: 2 }) ?? '-'
+        .toDisplay({ fixedDp: 2 }) ?? UNKNOWN_AMOUNT
 
     const assetName = assetPDisplayNames[assetType]
 
@@ -83,7 +84,7 @@ export const PChainAssetList = ({
                 variant="overline"
                 sx={{ color: '$neutral50' }}
                 ellipsizeMode="tail">
-                {balanceInAvax?.toDisplay() ?? '-'}
+                {balanceInAvax?.toDisplay() ?? UNKNOWN_AMOUNT}
               </Text>
               <Space x={4} />
               <Text variant="overline" numberOfLines={1} ellipsizeMode="tail">

--- a/packages/core-mobile/app/screens/portfolio/home/components/Cards/ActiveNetworkCard/PChainAssetList.tsx
+++ b/packages/core-mobile/app/screens/portfolio/home/components/Cards/ActiveNetworkCard/PChainAssetList.tsx
@@ -8,6 +8,8 @@ import { assetPDisplayNames } from 'store/balance/types'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { xpChainToken } from 'utils/units/knownTokens'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
+import { useSelector } from 'react-redux'
+import { selectSelectedCurrency } from 'store/settings/currency'
 
 type ChainBalanceType = keyof PChainBalance
 
@@ -23,7 +25,7 @@ export const PChainAssetList = ({
   ItemSeparator?: React.ComponentType | null
 }): React.JSX.Element => {
   const { filteredTokenList: tokens } = useSearchableTokenList()
-
+  const selectedCurrency = useSelector(selectSelectedCurrency)
   const token = tokens.find(t => isTokenWithBalancePVM(t))
 
   const assetTypes = useMemo(() => {
@@ -97,7 +99,7 @@ export const PChainAssetList = ({
               alignSelf: 'center'
             }}>
             <Text variant="buttonMedium" numberOfLines={1}>
-              {formattedBalance}
+              {`${formattedBalance} ${selectedCurrency}`}
             </Text>
           </View>
         </View>

--- a/packages/core-mobile/app/screens/portfolio/home/components/Cards/ActiveNetworkCard/PChainAssetList.tsx
+++ b/packages/core-mobile/app/screens/portfolio/home/components/Cards/ActiveNetworkCard/PChainAssetList.tsx
@@ -6,7 +6,7 @@ import React, { useMemo } from 'react'
 import { useSearchableTokenList } from 'screens/portfolio/useSearchableTokenList'
 import { assetPDisplayNames } from 'store/balance/types'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
-import { getXPChainTokenUnit } from 'utils/units/knownTokens'
+import { xpChainToken } from 'utils/units/knownTokens'
 
 type ChainBalanceType = keyof PChainBalance
 
@@ -46,11 +46,7 @@ export const PChainAssetList = ({
         ? token.balancePerType[assetType as ChainBalanceType]
         : 0
     const balanceInAvax = balance
-      ? new TokenUnit(
-          balance,
-          getXPChainTokenUnit().getMaxDecimals(),
-          getXPChainTokenUnit().getSymbol()
-        )
+      ? new TokenUnit(balance, xpChainToken.maxDecimals, xpChainToken.symbol)
       : undefined
 
     const formattedBalance =

--- a/packages/core-mobile/app/screens/portfolio/home/components/Cards/ActiveNetworkCard/XChainAssetList.tsx
+++ b/packages/core-mobile/app/screens/portfolio/home/components/Cards/ActiveNetworkCard/XChainAssetList.tsx
@@ -6,6 +6,7 @@ import React, { useMemo } from 'react'
 import { useSearchableTokenList } from 'screens/portfolio/useSearchableTokenList'
 import { assetXDisplayNames } from 'store/balance/types'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
 
 type ChainBalanceType = keyof XChainBalances
 
@@ -48,7 +49,7 @@ export const XChainAssetList = ({
     const formattedBalance =
       token?.priceInCurrency && balanceInAvax
         ? balanceInAvax.mul(token.priceInCurrency).toDisplay({ fixedDp: 2 })
-        : '-'
+        : UNKNOWN_AMOUNT
 
     const assetName = assetXDisplayNames[assetType]
 
@@ -81,7 +82,7 @@ export const XChainAssetList = ({
                 variant="overline"
                 sx={{ color: '$neutral50' }}
                 ellipsizeMode="tail">
-                {balanceInAvax?.toDisplay() ?? '-'}
+                {balanceInAvax?.toDisplay() ?? UNKNOWN_AMOUNT}
               </Text>
               <Space x={4} />
               <Text variant="overline" numberOfLines={1} ellipsizeMode="tail">

--- a/packages/core-mobile/app/screens/portfolio/home/components/Cards/ActiveNetworkCard/XChainAssetList.tsx
+++ b/packages/core-mobile/app/screens/portfolio/home/components/Cards/ActiveNetworkCard/XChainAssetList.tsx
@@ -7,6 +7,8 @@ import { useSearchableTokenList } from 'screens/portfolio/useSearchableTokenList
 import { assetXDisplayNames } from 'store/balance/types'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
+import { useSelector } from 'react-redux'
+import { selectSelectedCurrency } from 'store/settings/currency'
 
 type ChainBalanceType = keyof XChainBalances
 
@@ -20,7 +22,7 @@ export const XChainAssetList = ({
   ItemSeparator?: React.ComponentType | null
 }): React.JSX.Element => {
   const { filteredTokenList: tokens } = useSearchableTokenList()
-
+  const selectedCurrency = useSelector(selectSelectedCurrency)
   const token = tokens.find(t => isTokenWithBalanceAVM(t))
 
   const assetTypes = useMemo(() => {
@@ -95,7 +97,7 @@ export const XChainAssetList = ({
               alignSelf: 'center'
             }}>
             <Text variant="buttonMedium" numberOfLines={1}>
-              {formattedBalance}
+              {`${formattedBalance} ${selectedCurrency}`}
             </Text>
           </View>
         </View>

--- a/packages/core-mobile/app/screens/portfolio/home/components/PortfolioHeader.tsx
+++ b/packages/core-mobile/app/screens/portfolio/home/components/PortfolioHeader.tsx
@@ -17,6 +17,7 @@ import { Tooltip } from 'components/Tooltip'
 import { Space } from 'components/Space'
 import { RootState } from 'store'
 import { selectTokenBlacklist } from 'store/portfolio/slice'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { PortfolioHeaderLoader } from './Loaders/PortfolioHeaderLoader'
 
 function PortfolioHeader(): JSX.Element {
@@ -40,7 +41,7 @@ function PortfolioHeader(): JSX.Element {
   const { selectedCurrency, currencyFormatter } = context.appHook
   const currencyBalance =
     !balanceAccurate && balanceTotalInCurrency === 0
-      ? '-'
+      ? UNKNOWN_AMOUNT
       : currencyFormatter(balanceTotalInCurrency)
 
   const tokens = useSelector((state: RootState) =>

--- a/packages/core-mobile/app/screens/send/utils/avm/send.ts
+++ b/packages/core-mobile/app/screens/send/utils/avm/send.ts
@@ -85,7 +85,7 @@ const getTransactionRequest = ({
       const destinationAddress = 'X-' + stripChainAddress(toAddress ?? '')
       const unsignedTx = await WalletService.createSendXTx({
         accountIndex,
-        amount,
+        amountInNAvax: amount,
         avaxXPNetwork: network,
         destinationAddress: destinationAddress,
         sourceAddress: fromAddress

--- a/packages/core-mobile/app/screens/send/utils/pvm/send.ts
+++ b/packages/core-mobile/app/screens/send/utils/pvm/send.ts
@@ -85,7 +85,7 @@ const getTransactionRequest = ({
       const destinationAddress = 'P-' + stripChainAddress(toAddress ?? '')
       const unsignedTx = await WalletService.createSendPTx({
         accountIndex,
-        amount,
+        amountInNAvax: amount,
         avaxXPNetwork: network,
         destinationAddress: destinationAddress,
         sourceAddress: fromAddress

--- a/packages/core-mobile/app/services/earn/EarnService.ts
+++ b/packages/core-mobile/app/services/earn/EarnService.ts
@@ -228,6 +228,7 @@ class EarnService {
     const endDateUnix = getUnixTime(endDate)
     const avaxXPNetwork = NetworkService.getAvalancheNetworkP(isDevMode)
     const rewardAddress = activeAccount.addressPVM
+
     const unsignedTx = await WalletService.createAddDelegatorTx({
       accountIndex: activeAccount.index,
       avaxXPNetwork,
@@ -235,7 +236,7 @@ class EarnService {
       nodeId,
       startDate: startDateUnix,
       endDate: endDateUnix,
-      stakeAmount,
+      stakeAmountInNAvax: stakeAmount,
       isDevMode
     } as AddDelegatorProps)
 

--- a/packages/core-mobile/app/services/earn/exportC.test.ts
+++ b/packages/core-mobile/app/services/earn/exportC.test.ts
@@ -9,7 +9,7 @@ import { Network } from '@avalabs/core-chains-sdk'
 
 describe('earn/exportC', () => {
   describe('exportC', () => {
-    const baseFeeMockFn = jest.fn().mockReturnValue(BigInt(25e9))
+    const baseFeeMockFn = jest.fn().mockReturnValue(BigInt(0.003 * 1e9))
     const getAtomicTxStatusMockFn = jest.fn().mockReturnValue({
       status: 'Accepted'
     })
@@ -61,7 +61,7 @@ describe('earn/exportC', () => {
       await expect(async () => {
         await exportC({
           cChainBalance: BigInt(1e18),
-          requiredAmount: BigInt(10e18),
+          requiredAmount: BigInt(10e9),
           isDevMode: false,
           activeAccount: {} as Account
         })
@@ -70,8 +70,8 @@ describe('earn/exportC', () => {
 
     it('should call avaxProvider.getApiC().getBaseFee()', async () => {
       await exportC({
-        cChainBalance: BigInt(1e18),
-        requiredAmount: BigInt(0.1e18),
+        cChainBalance: BigInt(10e18),
+        requiredAmount: BigInt(1e9),
         isDevMode: false,
         activeAccount: {} as Account
       })
@@ -81,14 +81,14 @@ describe('earn/exportC', () => {
     it('should call walletService.createExportCTx', async () => {
       expect(async () => {
         await exportC({
-          cChainBalance: BigInt(1e18),
-          requiredAmount: BigInt(0.1e18),
+          cChainBalance: BigInt(10e18),
+          requiredAmount: BigInt(1e9),
           isDevMode: false,
           activeAccount: {} as Account
         })
         expect(WalletService.createExportCTx).toHaveBeenCalledWith({
-          amount: BigInt(0.101e18),
-          baseFee: BigInt(30e9),
+          amountInNAvax: 1001000000n,
+          baseFeeInNAvax: 0n,
           accountIndex: undefined,
           avaxXPNetwork: NetworkService.getAvalancheNetworkP(false),
           destinationChain: 'P',
@@ -100,8 +100,8 @@ describe('earn/exportC', () => {
     it('should call walletService.signAvaxTx', async () => {
       expect(async () => {
         await exportC({
-          cChainBalance: BigInt(1e18),
-          requiredAmount: BigInt(0.1e18),
+          cChainBalance: BigInt(10e18),
+          requiredAmount: BigInt(1e9),
           isDevMode: false,
           activeAccount: {} as Account
         })
@@ -112,8 +112,8 @@ describe('earn/exportC', () => {
     it('should call networkService.sendTransaction', async () => {
       expect(async () => {
         await exportC({
-          cChainBalance: BigInt(1e18),
-          requiredAmount: BigInt(0.1e18),
+          cChainBalance: BigInt(10e18),
+          requiredAmount: BigInt(1e9),
           isDevMode: false,
           activeAccount: {} as Account
         })

--- a/packages/core-mobile/app/services/earn/exportP.test.ts
+++ b/packages/core-mobile/app/services/earn/exportP.test.ts
@@ -76,7 +76,7 @@ describe('earn/exportP', () => {
           activeAccount: {} as Account
         })
         expect(WalletService.createExportPTx).toHaveBeenCalledWith({
-          amount: BigInt(10000000000),
+          amountInNAvax: BigInt(10000000000),
           accountIndex: undefined,
           avaxXPNetwork: NetworkService.getAvalancheNetworkP(false),
           destinationChain: 'C',

--- a/packages/core-mobile/app/services/earn/exportP.ts
+++ b/packages/core-mobile/app/services/earn/exportP.ts
@@ -30,7 +30,7 @@ export async function exportP({
   const avaxXPNetwork = NetworkService.getAvalancheNetworkP(isDevMode)
 
   const unsignedTx = await WalletService.createExportPTx({
-    amount: requiredAmount.toSubUnit(),
+    amountInNAvax: requiredAmount.toSubUnit(),
     accountIndex: activeAccount.index,
     avaxXPNetwork,
     destinationChain: 'C',

--- a/packages/core-mobile/app/services/earn/importC.test.ts
+++ b/packages/core-mobile/app/services/earn/importC.test.ts
@@ -63,7 +63,7 @@ describe('earn/importC', () => {
       })
       expect(WalletService.createImportCTx).toHaveBeenCalledWith({
         accountIndex: undefined,
-        baseFee: BigInt(0.0003 * 10 ** 18),
+        baseFeeInNAvax: BigInt(0.0003 * 10 ** 9),
         avaxXPNetwork: NetworkService.getAvalancheNetworkP(false),
         sourceChain: 'P',
         destinationAddress: undefined

--- a/packages/core-mobile/app/services/earn/importC.ts
+++ b/packages/core-mobile/app/services/earn/importC.ts
@@ -7,7 +7,7 @@ import { AvalancheTransactionRequest } from 'services/wallet/types'
 import { UnsignedTx } from '@avalabs/avalanchejs'
 import { FundsStuckError } from 'hooks/earn/errors'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
-import { getCChainTokenUnit } from 'utils/units/knownTokens'
+import { cChainToken } from 'utils/units/knownTokens'
 import { weiToNano } from 'utils/units/converter'
 import {
   maxTransactionCreationRetries,
@@ -30,8 +30,8 @@ export async function importC({
   const baseFee = await avaxProvider.getApiC().getBaseFee() //in WEI
   const baseFeeAvax = new TokenUnit(
     baseFee,
-    getCChainTokenUnit().getMaxDecimals(),
-    getCChainTokenUnit().getSymbol()
+    cChainToken.maxDecimals,
+    cChainToken.symbol
   )
   const instantBaseFee = WalletService.getInstantBaseFee(baseFeeAvax)
 

--- a/packages/core-mobile/app/services/earn/importC.ts
+++ b/packages/core-mobile/app/services/earn/importC.ts
@@ -8,6 +8,7 @@ import { UnsignedTx } from '@avalabs/avalanchejs'
 import { FundsStuckError } from 'hooks/earn/errors'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { getCChainTokenUnit } from 'utils/units/knownTokens'
+import { weiToNano } from 'utils/units/converter'
 import {
   maxTransactionCreationRetries,
   maxTransactionStatusCheckRetries
@@ -36,7 +37,7 @@ export async function importC({
 
   const unsignedTx = await WalletService.createImportCTx({
     accountIndex: activeAccount.index,
-    baseFee: instantBaseFee.toSubUnit(),
+    baseFeeInNAvax: weiToNano(instantBaseFee.toSubUnit()),
     avaxXPNetwork,
     sourceChain: 'P',
     destinationAddress: activeAccount.addressC

--- a/packages/core-mobile/app/services/earn/types.ts
+++ b/packages/core-mobile/app/services/earn/types.ts
@@ -41,7 +41,7 @@ export enum StakeTypeEnum {
   Claimable = 'Claimable'
 }
 
-export type StakingBalanceType = { type: StakeTypeEnum; amount: number }
+export type StakingBalanceType = { type: StakeTypeEnum; amount?: number }
 
 export enum RecoveryEvents {
   Idle,

--- a/packages/core-mobile/app/services/wallet/WalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/WalletService.test.ts
@@ -91,7 +91,7 @@ describe('WalletService', () => {
     it('should throw if staking amount is less than 1Avax on Fuji', async () => {
       const params = {
         nodeId: validNodeId,
-        stakeAmount: BigInt(1e8),
+        stakeAmountInNAvax: BigInt(1e8),
         isDevMode: true
       } as AddDelegatorProps
       await expect(async () => {
@@ -101,7 +101,7 @@ describe('WalletService', () => {
     it('should throw if staking amount is less than 25Avax on Mainnet', async () => {
       const params = {
         nodeId: validNodeId,
-        stakeAmount: BigInt(24e9),
+        stakeAmountInNAvax: BigInt(24e9),
         isDevMode: false
       } as AddDelegatorProps
       await expect(async () => {
@@ -111,7 +111,7 @@ describe('WalletService', () => {
     it('should throw if staking date is in past', async () => {
       const params = {
         nodeId: validNodeId,
-        stakeAmount: fujiValidStakeAmount,
+        stakeAmountInNAvax: fujiValidStakeAmount,
         startDate: getUnixTime(sub(new Date(), { minutes: 1 })),
         isDevMode: true
       } as AddDelegatorProps
@@ -124,7 +124,7 @@ describe('WalletService', () => {
       const twoSeconds = 2
       const params = {
         nodeId: validNodeId,
-        stakeAmount: BigInt(25e9),
+        stakeAmountInNAvax: BigInt(25e9),
         startDate: validStartDate,
         endDate: validStartDate + twoWeeks - twoSeconds,
         isDevMode: false
@@ -136,7 +136,7 @@ describe('WalletService', () => {
     it('should throw if staking duration is less than 24 hours for Fuji', async () => {
       const params = {
         nodeId: validNodeId,
-        stakeAmount: fujiValidStakeAmount,
+        stakeAmountInNAvax: fujiValidStakeAmount,
         startDate: validStartDate,
         endDate: getUnixTime(sub(day, { seconds: 2 })),
         isDevMode: true
@@ -148,7 +148,7 @@ describe('WalletService', () => {
     it('should throw if reward address is not from P chain', async () => {
       const params = {
         nodeId: validNodeId,
-        stakeAmount: fujiValidStakeAmount,
+        stakeAmountInNAvax: fujiValidStakeAmount,
         startDate: validStartDate,
         endDate: getUnixTime(day),
         rewardAddress: 'invalid address',
@@ -163,7 +163,7 @@ describe('WalletService', () => {
       const params = {
         avaxXPNetwork: network,
         nodeId: validNodeId,
-        stakeAmount: fujiValidStakeAmount,
+        stakeAmountInNAvax: fujiValidStakeAmount,
         startDate: validStartDate,
         endDate: validEndDateFuji,
         rewardAddress: validRewardAddress,
@@ -183,7 +183,7 @@ describe('WalletService', () => {
       const params = {
         avaxXPNetwork: network,
         nodeId: validNodeId,
-        stakeAmount: fujiValidStakeAmount,
+        stakeAmountInNAvax: fujiValidStakeAmount,
         startDate: validStartDate,
         endDate: validEndDateFuji,
         rewardAddress: validRewardAddress,
@@ -204,7 +204,7 @@ describe('WalletService', () => {
       const params = {
         avaxXPNetwork: network,
         nodeId: validNodeId,
-        stakeAmount: fujiValidStakeAmount,
+        stakeAmountInNAvax: fujiValidStakeAmount,
         startDate: validStartDate,
         endDate: validEndDateFuji,
         rewardAddress: validRewardAddress,

--- a/packages/core-mobile/app/services/wallet/types.ts
+++ b/packages/core-mobile/app/services/wallet/types.ts
@@ -46,7 +46,7 @@ export type AddDelegatorProps = {
   // Id of the node to delegate. starts with “NodeID-”
   nodeId: string
   //Amount to be delegated in nAVAX
-  stakeAmount: bigint
+  stakeAmountInNAvax: bigint
   // The Unix time when the delegation starts.
   startDate: number
   // The Unix time when the delegation ends.
@@ -66,13 +66,13 @@ export interface CommonAvalancheTxParamsBase {
 
 export type CreateExportCTxParams = CommonAvalancheTxParamsBase & {
   /**
-   * In `Wei`
+   * In `Nano Avax`
    */
-  amount: bigint
+  amountInNAvax: bigint
   /**
-   * In `Wei`
+   * In `Nano Avax`
    */
-  baseFee: bigint
+  baseFeeInNAvax: bigint
   destinationChain: 'P' | 'X'
 }
 
@@ -81,15 +81,15 @@ export type CreateImportPTxParams = CommonAvalancheTxParamsBase & {
 }
 
 export type CreateExportPTxParams = CommonAvalancheTxParamsBase & {
-  amount: bigint
+  amountInNAvax: bigint
   destinationChain: 'C' | 'X'
 }
 
 export type CreateImportCTxParams = CommonAvalancheTxParamsBase & {
   /**
-   * In `Wei`
+   * In `Nano Avax`
    */
-  baseFee: bigint
+  baseFeeInNAvax: bigint
   sourceChain: 'P' | 'X'
 }
 
@@ -97,7 +97,7 @@ export type CreateSendPTxParams = CommonAvalancheTxParamsBase & {
   /**
    * In `nAvax`
    */
-  amount: bigint
+  amountInNAvax: bigint
   sourceAddress: string
 }
 

--- a/packages/core-mobile/app/utils/units/converter.ts
+++ b/packages/core-mobile/app/utils/units/converter.ts
@@ -1,0 +1,3 @@
+export const nanoToWei = (number: bigint): bigint => number * BigInt(10 ** 9)
+
+export const weiToNano = (number: bigint): bigint => number / BigInt(10 ** 9)

--- a/packages/core-mobile/app/utils/units/knownTokens.ts
+++ b/packages/core-mobile/app/utils/units/knownTokens.ts
@@ -3,6 +3,17 @@ import { TokenUnit } from '@avalabs/core-utils-sdk'
 export function getCChainTokenUnit(): TokenUnit {
   return new TokenUnit(0, 18, 'AVAX')
 }
+
 export function getXPChainTokenUnit(): TokenUnit {
   return new TokenUnit(0, 9, 'AVAX')
+}
+
+export const cChainToken = {
+  maxDecimals: 18,
+  symbol: 'AVAX'
+}
+
+export const xpChainToken = {
+  maxDecimals: 9,
+  symbol: 'AVAX'
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,9 +48,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/avalanche-module@npm:0.11.7":
-  version: 0.11.7
-  resolution: "@avalabs/avalanche-module@npm:0.11.7"
+"@avalabs/avalanche-module@npm:0.11.5":
+  version: 0.11.5
+  resolution: "@avalabs/avalanche-module@npm:0.11.5"
   dependencies:
     "@avalabs/avalanchejs": 4.1.0-alpha.15
     "@avalabs/core-chains-sdk": 3.1.0-alpha.11
@@ -60,12 +60,12 @@ __metadata:
     "@avalabs/core-wallets-sdk": 3.1.0-alpha.11
     "@avalabs/glacier-sdk": 3.1.0-alpha.11
     "@avalabs/types": 3.1.0-alpha.11
-    "@avalabs/vm-module-types": 0.11.7
+    "@avalabs/vm-module-types": 0.11.5
     "@metamask/rpc-errors": 6.3.0
     big.js: 6.2.1
     bn.js: 5.2.1
     zod: 3.23.8
-  checksum: f8c0a47620c0f7dfd566fb24acd30b41d686605f93bfa9cb1dd77f3d68a1bbb31ac783fd863dd0144fad9926f209b9e012802ff972b70d951c89bda3b6ea185c
+  checksum: 1b17c04a00071310942dd8968dea9b7aa78dbbbee45334f2922fe82c83b247c24d17a88180f68259c292e5d983b672bae4c699d80be7f6e95e323fb55bacaaaa
   languageName: node
   linkType: hard
 
@@ -82,20 +82,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/bitcoin-module@npm:0.11.7":
-  version: 0.11.7
-  resolution: "@avalabs/bitcoin-module@npm:0.11.7"
+"@avalabs/bitcoin-module@npm:0.11.5":
+  version: 0.11.5
+  resolution: "@avalabs/bitcoin-module@npm:0.11.5"
   dependencies:
     "@avalabs/core-coingecko-sdk": 3.1.0-alpha.11
     "@avalabs/core-utils-sdk": 3.1.0-alpha.11
     "@avalabs/core-wallets-sdk": 3.1.0-alpha.11
-    "@avalabs/vm-module-types": 0.11.7
+    "@avalabs/vm-module-types": 0.11.5
     "@metamask/rpc-errors": 6.3.0
     big.js: 6.2.1
     bitcoinjs-lib: 5.2.0
     bn.js: 5.2.1
     zod: 3.23.8
-  checksum: f9bb19850aa6d4a2c258d3a58fe30c4971fdb26ba64a4d3217f58ee14cab298f23693e1a8330bed8b7589cd059dac8a0e67c8901d0eb476664132bc3e3c6124a
+  checksum: d4d1accc2a14b357edb569d77070b4d274740b3b11f9cc91e2f17307fc770fa7c04d4510f986b99a4a5a9dc6001248049d6aa910e3ef3d2b424b3a6fc62491a9
   languageName: node
   linkType: hard
 
@@ -158,22 +158,22 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@avalabs/core-mobile@workspace:packages/core-mobile"
   dependencies:
-    "@avalabs/avalanche-module": 0.11.7
+    "@avalabs/avalanche-module": 0.11.5
     "@avalabs/avalanchejs": 4.1.0-alpha.15
-    "@avalabs/bitcoin-module": 0.11.7
+    "@avalabs/bitcoin-module": 0.11.5
     "@avalabs/bridge-unified": 2.1.0
     "@avalabs/core-bridge-sdk": 3.1.0-alpha.11
     "@avalabs/core-chains-sdk": 3.1.0-alpha.11
     "@avalabs/core-coingecko-sdk": 3.1.0-alpha.11
     "@avalabs/core-utils-sdk": 3.1.0-alpha.11
     "@avalabs/core-wallets-sdk": 3.1.0-alpha.11
-    "@avalabs/evm-module": 0.11.7
+    "@avalabs/evm-module": 0.11.5
     "@avalabs/glacier-sdk": 3.1.0-alpha.11
     "@avalabs/k2-alpine": "workspace:*"
     "@avalabs/k2-mobile": "workspace:*"
     "@avalabs/tsconfig-mobile": "workspace:*"
     "@avalabs/types": 3.1.0-alpha.11
-    "@avalabs/vm-module-types": 0.11.7
+    "@avalabs/vm-module-types": 0.11.5
     "@babel/core": 7.25.7
     "@babel/plugin-proposal-nullish-coalescing-operator": 7.18.6
     "@babel/plugin-syntax-object-rest-spread": 7.8.3
@@ -433,9 +433,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/evm-module@npm:0.11.7":
-  version: 0.11.7
-  resolution: "@avalabs/evm-module@npm:0.11.7"
+"@avalabs/evm-module@npm:0.11.5":
+  version: 0.11.5
+  resolution: "@avalabs/evm-module@npm:0.11.5"
   dependencies:
     "@avalabs/core-coingecko-sdk": 3.1.0-alpha.11
     "@avalabs/core-etherscan-sdk": 3.1.0-alpha.11
@@ -443,7 +443,7 @@ __metadata:
     "@avalabs/core-wallets-sdk": 3.1.0-alpha.11
     "@avalabs/glacier-sdk": 3.1.0-alpha.11
     "@avalabs/types": 3.1.0-alpha.11
-    "@avalabs/vm-module-types": 0.11.7
+    "@avalabs/vm-module-types": 0.11.5
     "@blockaid/client": 0.11.0
     "@metamask/rpc-errors": 6.3.0
     "@openzeppelin/contracts": 4.9.6
@@ -453,7 +453,7 @@ __metadata:
     zod: 3.23.8
   peerDependencies:
     ethers: 6.8.1
-  checksum: 830cf0f54db002eed9a31036fad9842893ec03717a0bfc3fcdac8ea056c6732cd7cb00fdca44db3d98416c18f2fcc46ef25ded4390595b3231033c67d22e78c3
+  checksum: 706eaa319dfb36bf128ccbf15ae49aab6a398b5d020b9ca6499c9b5dbf79d56ec6156ac058c32e2638b7646a1266b4e018216ae3fcd3c7a62eba1f053f63b9b0
   languageName: node
   linkType: hard
 
@@ -583,9 +583,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/vm-module-types@npm:0.11.7":
-  version: 0.11.7
-  resolution: "@avalabs/vm-module-types@npm:0.11.7"
+"@avalabs/vm-module-types@npm:0.11.5":
+  version: 0.11.5
+  resolution: "@avalabs/vm-module-types@npm:0.11.5"
   dependencies:
     "@avalabs/core-wallets-sdk": 3.1.0-alpha.11
     "@avalabs/glacier-sdk": 3.1.0-alpha.11
@@ -594,7 +594,7 @@ __metadata:
     zod: 3.23.8
   peerDependencies:
     ethers: 6.8.1
-  checksum: 959ed29c6bc186413899f7004d1d2907de58842b81f6d3e056e70f09b606771d56a29e8406e6ffb75fbdd0537b48cef6702edc8e9c2ed1427c3476254081f4ae
+  checksum: 8a9f531ee926f5897b3f980da15ec693e8a5fa14f145afb05b451dc74521ce41d3ebd45f042b73793d43997576369e12ed5c67e7de9636852d75a9e82e42fcfa
   languageName: node
   linkType: hard
 
@@ -26370,7 +26370,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: a187edd718e1ea3a6b1e5da167744e6ee324bc3c3e492bcb0a9d028ab68a82907f053f37c23aa4229d6a9091541cee3c73549c3c850056e4cf5eb5b3cb2c9ffc
+  checksum: d396f3dea807077e8789e1d463c87024e1633481d3dff53c0650c82a08d8b7d699db97ceab4e8d2c9de85c3d5378d192c968487254c62edadff77e82a9b8c929
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,9 +48,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/avalanche-module@npm:0.11.5":
-  version: 0.11.5
-  resolution: "@avalabs/avalanche-module@npm:0.11.5"
+"@avalabs/avalanche-module@npm:0.11.7":
+  version: 0.11.7
+  resolution: "@avalabs/avalanche-module@npm:0.11.7"
   dependencies:
     "@avalabs/avalanchejs": 4.1.0-alpha.15
     "@avalabs/core-chains-sdk": 3.1.0-alpha.11
@@ -60,12 +60,12 @@ __metadata:
     "@avalabs/core-wallets-sdk": 3.1.0-alpha.11
     "@avalabs/glacier-sdk": 3.1.0-alpha.11
     "@avalabs/types": 3.1.0-alpha.11
-    "@avalabs/vm-module-types": 0.11.5
+    "@avalabs/vm-module-types": 0.11.7
     "@metamask/rpc-errors": 6.3.0
     big.js: 6.2.1
     bn.js: 5.2.1
     zod: 3.23.8
-  checksum: 1b17c04a00071310942dd8968dea9b7aa78dbbbee45334f2922fe82c83b247c24d17a88180f68259c292e5d983b672bae4c699d80be7f6e95e323fb55bacaaaa
+  checksum: f8c0a47620c0f7dfd566fb24acd30b41d686605f93bfa9cb1dd77f3d68a1bbb31ac783fd863dd0144fad9926f209b9e012802ff972b70d951c89bda3b6ea185c
   languageName: node
   linkType: hard
 
@@ -82,20 +82,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/bitcoin-module@npm:0.11.5":
-  version: 0.11.5
-  resolution: "@avalabs/bitcoin-module@npm:0.11.5"
+"@avalabs/bitcoin-module@npm:0.11.7":
+  version: 0.11.7
+  resolution: "@avalabs/bitcoin-module@npm:0.11.7"
   dependencies:
     "@avalabs/core-coingecko-sdk": 3.1.0-alpha.11
     "@avalabs/core-utils-sdk": 3.1.0-alpha.11
     "@avalabs/core-wallets-sdk": 3.1.0-alpha.11
-    "@avalabs/vm-module-types": 0.11.5
+    "@avalabs/vm-module-types": 0.11.7
     "@metamask/rpc-errors": 6.3.0
     big.js: 6.2.1
     bitcoinjs-lib: 5.2.0
     bn.js: 5.2.1
     zod: 3.23.8
-  checksum: d4d1accc2a14b357edb569d77070b4d274740b3b11f9cc91e2f17307fc770fa7c04d4510f986b99a4a5a9dc6001248049d6aa910e3ef3d2b424b3a6fc62491a9
+  checksum: f9bb19850aa6d4a2c258d3a58fe30c4971fdb26ba64a4d3217f58ee14cab298f23693e1a8330bed8b7589cd059dac8a0e67c8901d0eb476664132bc3e3c6124a
   languageName: node
   linkType: hard
 
@@ -158,22 +158,22 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@avalabs/core-mobile@workspace:packages/core-mobile"
   dependencies:
-    "@avalabs/avalanche-module": 0.11.5
+    "@avalabs/avalanche-module": 0.11.7
     "@avalabs/avalanchejs": 4.1.0-alpha.15
-    "@avalabs/bitcoin-module": 0.11.5
+    "@avalabs/bitcoin-module": 0.11.7
     "@avalabs/bridge-unified": 2.1.0
     "@avalabs/core-bridge-sdk": 3.1.0-alpha.11
     "@avalabs/core-chains-sdk": 3.1.0-alpha.11
     "@avalabs/core-coingecko-sdk": 3.1.0-alpha.11
     "@avalabs/core-utils-sdk": 3.1.0-alpha.11
     "@avalabs/core-wallets-sdk": 3.1.0-alpha.11
-    "@avalabs/evm-module": 0.11.5
+    "@avalabs/evm-module": 0.11.7
     "@avalabs/glacier-sdk": 3.1.0-alpha.11
     "@avalabs/k2-alpine": "workspace:*"
     "@avalabs/k2-mobile": "workspace:*"
     "@avalabs/tsconfig-mobile": "workspace:*"
     "@avalabs/types": 3.1.0-alpha.11
-    "@avalabs/vm-module-types": 0.11.5
+    "@avalabs/vm-module-types": 0.11.7
     "@babel/core": 7.25.7
     "@babel/plugin-proposal-nullish-coalescing-operator": 7.18.6
     "@babel/plugin-syntax-object-rest-spread": 7.8.3
@@ -433,9 +433,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/evm-module@npm:0.11.5":
-  version: 0.11.5
-  resolution: "@avalabs/evm-module@npm:0.11.5"
+"@avalabs/evm-module@npm:0.11.7":
+  version: 0.11.7
+  resolution: "@avalabs/evm-module@npm:0.11.7"
   dependencies:
     "@avalabs/core-coingecko-sdk": 3.1.0-alpha.11
     "@avalabs/core-etherscan-sdk": 3.1.0-alpha.11
@@ -443,7 +443,7 @@ __metadata:
     "@avalabs/core-wallets-sdk": 3.1.0-alpha.11
     "@avalabs/glacier-sdk": 3.1.0-alpha.11
     "@avalabs/types": 3.1.0-alpha.11
-    "@avalabs/vm-module-types": 0.11.5
+    "@avalabs/vm-module-types": 0.11.7
     "@blockaid/client": 0.11.0
     "@metamask/rpc-errors": 6.3.0
     "@openzeppelin/contracts": 4.9.6
@@ -453,7 +453,7 @@ __metadata:
     zod: 3.23.8
   peerDependencies:
     ethers: 6.8.1
-  checksum: 706eaa319dfb36bf128ccbf15ae49aab6a398b5d020b9ca6499c9b5dbf79d56ec6156ac058c32e2638b7646a1266b4e018216ae3fcd3c7a62eba1f053f63b9b0
+  checksum: 830cf0f54db002eed9a31036fad9842893ec03717a0bfc3fcdac8ea056c6732cd7cb00fdca44db3d98416c18f2fcc46ef25ded4390595b3231033c67d22e78c3
   languageName: node
   linkType: hard
 
@@ -583,9 +583,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/vm-module-types@npm:0.11.5":
-  version: 0.11.5
-  resolution: "@avalabs/vm-module-types@npm:0.11.5"
+"@avalabs/vm-module-types@npm:0.11.7":
+  version: 0.11.7
+  resolution: "@avalabs/vm-module-types@npm:0.11.7"
   dependencies:
     "@avalabs/core-wallets-sdk": 3.1.0-alpha.11
     "@avalabs/glacier-sdk": 3.1.0-alpha.11
@@ -594,7 +594,7 @@ __metadata:
     zod: 3.23.8
   peerDependencies:
     ethers: 6.8.1
-  checksum: 8a9f531ee926f5897b3f980da15ec693e8a5fa14f145afb05b451dc74521ce41d3ebd45f042b73793d43997576369e12ed5c67e7de9636852d75a9e82e42fcfa
+  checksum: 959ed29c6bc186413899f7004d1d2907de58842b81f6d3e056e70f09b606771d56a29e8406e6ffb75fbdd0537b48cef6702edc8e9c2ed1427c3476254081f4ae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: [CP-9377]** 

The migration to TokenUnit created some regression. This pr fixes the staking flow. There are probably other places that need fixing as well. Here are the list of issues that I fixed:
- the pricing was missing in various staking screens: for example, it was showing 28.2 instead of $28.2 USD
- quite a few places were using the wrong maxDecimals with TokenUnit (nano AVAX vs wei AVAX)

## Screenshots/Videos
add a stake
https://github.com/user-attachments/assets/90bb4a0b-3849-4f8d-a93b-f6c4d1271493

claim stake rewards
https://github.com/user-attachments/assets/fa866e60-3f1b-4bed-80c5-6f2c18813832

send on X-Chain
https://github.com/user-attachments/assets/b0492006-11c8-487a-8d4c-ddd761dd2f4e


## Testing
Please test all transactions for X & P chains: staking, export/import C/P/X, send X/P

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9377]: https://ava-labs.atlassian.net/browse/CP-9377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ