### PR TITLE
CP-9503: Should not display Get Started screen for user with active stakes history on Testnet Stake tab

### DIFF
--- a/packages/core-mobile/app/components/HeaderAccountSelector.tsx
+++ b/packages/core-mobile/app/components/HeaderAccountSelector.tsx
@@ -29,6 +29,7 @@ export default function HeaderAccountSelector({
             testID="account_dropdown_title"
             variant="subtitle1"
             ellipsizeMode={'middle'}
+            numberOfLines={1}
             sx={{
               marginRight: 11,
               lineHeight: 22,

--- a/packages/core-mobile/app/hooks/earn/useStakes.ts
+++ b/packages/core-mobile/app/hooks/earn/useStakes.ts
@@ -24,7 +24,16 @@ export const useStakes = (): UseStakesReturnType => {
   // otherwise, it will be fetching even when the wallet is locked
   // and on some Android devices, it can continue running even if app
   // is in the background, which can lead to getting rate limited by glacier
-  const enabled = Boolean(pAddress) && walletState === WalletState.ACTIVE
+  const isWalletActive = walletState === WalletState.ACTIVE
+
+  // when we toggle developer mode, it will take a brief moment for the address to update
+  // in that brief moment, we don't want to fetch the stakes as the address will still be the old one
+  // this check is to ensure that the address is of the correct developer mode before fetching the stakes
+  const isAddressValid = isDeveloperMode
+    ? Boolean(pAddress) && pAddress.includes('fuji')
+    : Boolean(pAddress) && !pAddress.includes('fuji')
+
+  const enabled = isWalletActive && isAddressValid
 
   return useRefreshableQuery({
     refetchInterval: refetchIntervals.stakes,


### PR DESCRIPTION
## Description

**Ticket: [CP-9503]** 

The bug actually happens on mainnet as well. It happens because the address is updated async after we toggle developer mode. In that brief moment, if we try to open up Stake screen, it will try to fetch stakes for the old address, which will return 0 stakes. This pr fixes it by making sure we fetch stakes with the correct address for the current developer mode. For example, when developer mode is on, we will only allow fetching with address like `P-fuji1k38sj9z9n5vfw5239vv68cns68x579k4rw8yhe`.

## Screenshots/Videos
https://github.com/user-attachments/assets/8f25ab38-ee35-4bd6-b176-1d096b13513b

## Testing
Please make sure stakes are being fetching correctly everywhere in the app

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9503]: https://ava-labs.atlassian.net/browse/CP-9503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ