### PR TITLE
CP-9507: Don't show `$NaN USD` on Stake Card  & Send/Swap Form

### DIFF
--- a/packages/core-mobile/app/AppHook.ts
+++ b/packages/core-mobile/app/AppHook.ts
@@ -19,7 +19,7 @@ export type AppHook = {
   deleteWallet: () => void
   signOut: () => void
   currencyFormatter(num: number | string, notation?: NotationTypes): string
-  tokenInCurrencyFormatter(num: number | string): string
+  tokenInCurrencyFormatter(num: number): string
 }
 
 export function useApp(): AppHook {

--- a/packages/core-mobile/app/components/UniversalTokenSelector.tsx
+++ b/packages/core-mobile/app/components/UniversalTokenSelector.tsx
@@ -80,7 +80,7 @@ const UniversalTokenSelector: FC<Props> = ({
 
   const amountInCurrency = useMemo(() => {
     if (!inputAmount || !selectedTokenDecimals) {
-      return ''
+      return undefined
     }
     const inputInTokenUnit = new TokenUnit(
       inputAmount,
@@ -90,7 +90,7 @@ const UniversalTokenSelector: FC<Props> = ({
     return selectedToken?.priceInCurrency
       ? inputInTokenUnit
           .mul(selectedToken.priceInCurrency)
-          .toDisplay({ fixedDp: 2 })
+          .toDisplay({ fixedDp: 2, asNumber: true })
       : undefined
   }, [inputAmount, selectedToken, selectedTokenDecimals])
 

--- a/packages/core-mobile/app/screens/earn/Confirmation/Confirmation.tsx
+++ b/packages/core-mobile/app/screens/earn/Confirmation/Confirmation.tsx
@@ -236,7 +236,7 @@ export const Confirmation = (): JSX.Element | null => {
     const stakingAmountInAvax = deductedStakingAmount.toDisplay()
     const stakingAmountInCurrency = deductedStakingAmount
       .mul(avaxPrice)
-      .toDisplay({ fixedDp: 2 })
+      .toDisplay({ fixedDp: 2, asNumber: true })
 
     return (
       <Row style={{ justifyContent: 'space-between' }}>
@@ -263,7 +263,7 @@ export const Confirmation = (): JSX.Element | null => {
       const estimatedRewardInAvax = data.estimatedTokenReward.toDisplay()
       const estimatedRewardInCurrency = data.estimatedTokenReward
         .mul(avaxPrice)
-        .toDisplay({ fixedDp: 2 })
+        .toDisplay({ fixedDp: 2, asNumber: true })
 
       return (
         <View

--- a/packages/core-mobile/app/screens/earn/StakeDetails.tsx
+++ b/packages/core-mobile/app/screens/earn/StakeDetails.tsx
@@ -106,7 +106,7 @@ const StakeDetails = (): JSX.Element | null => {
     const estimatedRewardInCurrency = estimatedRewardInAvax?.mul(avaxPrice)
     const estimatedRewardInCurrencyDisplay = estimatedRewardInCurrency
       ? tokenInCurrencyFormatter(
-          estimatedRewardInCurrency.toDisplay({ fixedDp: 2 })
+          estimatedRewardInCurrency.toDisplay({ fixedDp: 2, asNumber: true })
         )
       : UNKNOWN_AMOUNT
 
@@ -166,7 +166,7 @@ const StakeDetails = (): JSX.Element | null => {
 
     const rewardAmountInCurrencyDisplay = rewardAmountInCurrency
       ? tokenInCurrencyFormatter(
-          rewardAmountInCurrency.toDisplay({ fixedDp: 2 })
+          rewardAmountInCurrency.toDisplay({ fixedDp: 2, asNumber: true })
         )
       : UNKNOWN_AMOUNT
 
@@ -229,7 +229,7 @@ const StakeDetails = (): JSX.Element | null => {
 
     const stakeAmountInCurrencyDisplay = stakeAmountInCurrency
       ? tokenInCurrencyFormatter(
-          stakeAmountInCurrency.toDisplay({ fixedDp: 2 })
+          stakeAmountInCurrency.toDisplay({ fixedDp: 2, asNumber: true })
         )
       : UNKNOWN_AMOUNT
 

--- a/packages/core-mobile/app/screens/earn/components/StakeCard.tsx
+++ b/packages/core-mobile/app/screens/earn/components/StakeCard.tsx
@@ -107,10 +107,9 @@ export const StakeCard = (props: Props): JSX.Element => {
       stakeAmountInAvax?.toDisplay() ?? UNKNOWN_AMOUNT
 
     const stakeAmountInCurrency = stakeAmountInAvax?.mul(avaxPrice)
-
     const stakeAmountInCurrencyDisplay = stakeAmountInCurrency
       ? tokenInCurrencyFormatter(
-          stakeAmountInCurrency.toDisplay({ fixedDp: 2 })
+          stakeAmountInCurrency.toDisplay({ fixedDp: 2, asNumber: true })
         )
       : UNKNOWN_AMOUNT
 
@@ -131,7 +130,10 @@ export const StakeCard = (props: Props): JSX.Element => {
 
         const estimatedRewardInCurrencyDisplay = estimatedRewardInCurrency
           ? tokenInCurrencyFormatter(
-              estimatedRewardInCurrency.toDisplay({ fixedDp: 2 })
+              estimatedRewardInCurrency.toDisplay({
+                fixedDp: 2,
+                asNumber: true
+              })
             )
           : UNKNOWN_AMOUNT
 
@@ -197,7 +199,7 @@ export const StakeCard = (props: Props): JSX.Element => {
 
         const rewardAmountInCurrencyDisplay = rewardAmountInCurrency
           ? tokenInCurrencyFormatter(
-              rewardAmountInCurrency.toDisplay({ fixedDp: 2 })
+              rewardAmountInCurrency.toDisplay({ fixedDp: 2, asNumber: true })
             )
           : UNKNOWN_AMOUNT
 

--- a/packages/core-mobile/app/screens/watchlist/components/WatchList.tsx
+++ b/packages/core-mobile/app/screens/watchlist/components/WatchList.tsx
@@ -26,7 +26,7 @@ import { WatchlistFilter } from '../types'
 
 const getDisplayValue = (
   price: PriceData,
-  currencyFormatter: (num: number | string) => string
+  currencyFormatter: (num: number) => string
 ): string => {
   const priceInCurrency = price.priceInCurrency
   return currencyFormatter(priceInCurrency)


### PR DESCRIPTION
## Description

**Ticket: [CP-9507]** 

We were passing strings to the formatter and when the amount is over $1000, it will break the formatter since the string will contain a comma. For example, 1,000.00. This pr makes sure we only pass numbers to the formatter.

## Screenshots/Videos
<img src="https://github.com/user-attachments/assets/adc27d5c-e723-4a31-bbfa-7752d9c5b8e0" width=300/>
<img src="https://github.com/user-attachments/assets/3dd6bf2b-85ab-48ab-88fd-8f5e8baac429" width=300/>
<img src="https://github.com/user-attachments/assets/9b1d04c2-4616-482a-9a5b-27cff34eb07a" width=300/>
<img src="https://github.com/user-attachments/assets/249e1043-b36d-4f6d-a525-2409025a7c7d" width=300/>

## Testing
Please make sure to test Stake Card, Stake Details, Stake Confirmation and Send

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9507]: https://ava-labs.atlassian.net/browse/CP-9507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ