### PR TITLE
CP-9507: Don't show `$NaN USD` on Token Details, Network Fee Selector, Edit Fee and Spend Limit

### DIFF
--- a/packages/core-mobile/app/AppHook.ts
+++ b/packages/core-mobile/app/AppHook.ts
@@ -18,7 +18,7 @@ export type AppHook = {
   selectedCurrency: string
   deleteWallet: () => void
   signOut: () => void
-  currencyFormatter(num: number | string, notation?: NotationTypes): string
+  currencyFormatter(num: number, notation?: NotationTypes): string
   tokenInCurrencyFormatter(num: number): string
 }
 

--- a/packages/core-mobile/app/components/NetworkFeeSelector.tsx
+++ b/packages/core-mobile/app/components/NetworkFeeSelector.tsx
@@ -34,6 +34,7 @@ import { isAvmNetwork, isPvmNetwork } from 'utils/network/isAvalancheNetwork'
 import { useNetworks } from 'hooks/networks/useNetworks'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { bigIntToFeeDenomination } from 'utils/units/fees'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { Tooltip } from './Tooltip'
 
 export enum FeePreset {
@@ -88,7 +89,7 @@ const NetworkFeeSelector = ({
   const [selectedPreset, setSelectedPreset] = useState(FeePreset.Normal)
   const [calculatedFees, setCalculatedFees] = useState<GasAndFees>()
   const calculatedMaxTotalFeeDisplayed = useMemo(() => {
-    if (!calculatedFees?.maxTotalFee) return '0'
+    if (!calculatedFees?.maxTotalFee) return '-'
     const unit = new TokenUnit(
       calculatedFees.maxTotalFee,
       networkToken.decimals,
@@ -290,9 +291,9 @@ const NetworkFeeSelector = ({
         </Row>
         <Row style={{ justifyContent: 'flex-end' }}>
           <Text variant="caption" sx={{ color: '$neutral400', lineHeight: 15 }}>
-            {currencyFormatter(calculatedFees?.maxTotalFeeInCurrency ?? 0) +
-              ' ' +
-              selectedCurrency}
+            {calculatedFees?.maxTotalFeeInCurrency
+              ? currencyFormatter(calculatedFees.maxTotalFeeInCurrency)
+              : UNKNOWN_AMOUNT + ' ' + selectedCurrency}
           </Text>
         </Row>
       </View>

--- a/packages/core-mobile/app/components/NetworkFeeSelector.tsx
+++ b/packages/core-mobile/app/components/NetworkFeeSelector.tsx
@@ -89,7 +89,7 @@ const NetworkFeeSelector = ({
   const [selectedPreset, setSelectedPreset] = useState(FeePreset.Normal)
   const [calculatedFees, setCalculatedFees] = useState<GasAndFees>()
   const calculatedMaxTotalFeeDisplayed = useMemo(() => {
-    if (!calculatedFees?.maxTotalFee) return '-'
+    if (!calculatedFees?.maxTotalFee) return UNKNOWN_AMOUNT
     const unit = new TokenUnit(
       calculatedFees.maxTotalFee,
       networkToken.decimals,

--- a/packages/core-mobile/app/screens/portfolio/ownedTokenDetail/OwnedTokenDetail.tsx
+++ b/packages/core-mobile/app/screens/portfolio/ownedTokenDetail/OwnedTokenDetail.tsx
@@ -25,6 +25,8 @@ import { useNetworks } from 'hooks/networks/useNetworks'
 import { UI, useIsUIDisabled } from 'hooks/useIsUIDisabled'
 import useBridge from 'screens/bridge/hooks/useBridge'
 import { TokenWithBalance } from '@avalabs/vm-module-types'
+import { toNumber } from 'utils/string/toNumber'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
 import OwnedTokenActionButtons from './components/OwnedTokenActionButtons'
 
 type ScreenProps = WalletScreenProps<
@@ -158,7 +160,11 @@ const OwnedTokenDetail: FC = () => {
           rightComponent={
             <View sx={{ alignItems: 'flex-end' }}>
               <Text variant="heading5" ellipsizeMode={'tail'}>
-                {currencyFormatter(token?.balanceCurrencyDisplayValue ?? '0')}
+                {token?.balanceCurrencyDisplayValue !== undefined
+                  ? currencyFormatter(
+                      toNumber(token.balanceCurrencyDisplayValue)
+                    )
+                  : UNKNOWN_AMOUNT}
               </Text>
               {token?.symbol && token?.balanceInCurrency
                 ? renderMarketTrend(token.balanceInCurrency, token.symbol)

--- a/packages/core-mobile/app/screens/rpc/components/v2/SpendLimits.tsx
+++ b/packages/core-mobile/app/screens/rpc/components/v2/SpendLimits.tsx
@@ -7,6 +7,7 @@ import AvaText from 'components/AvaText'
 import { Row } from 'components/Row'
 import { useApplicationContext } from 'contexts/ApplicationContext'
 import { Limit, SpendLimit } from 'hooks/useSpendLimits'
+import { toNumber } from 'utils/string/toNumber'
 import React from 'react'
 
 export const SpendLimits = ({
@@ -89,7 +90,9 @@ export const SpendLimits = ({
                 {spendLimit.tokenApproval.usdPrice !== undefined &&
                   spendLimit.limitType === Limit.DEFAULT && (
                     <Text variant="body2">
-                      {currencyFormatter(spendLimit.tokenApproval.usdPrice)}
+                      {currencyFormatter(
+                        toNumber(spendLimit.tokenApproval.usdPrice)
+                      )}
                     </Text>
                   )}
               </View>

--- a/packages/core-mobile/app/utils/Utils.ts
+++ b/packages/core-mobile/app/utils/Utils.ts
@@ -120,7 +120,7 @@ export function titleToInitials(title: string): string {
 
 export type GasAndFees = {
   maxTotalFee: bigint
-  maxTotalFeeInCurrency: string
+  maxTotalFeeInCurrency: number
 } & Eip1559Fees
 
 export type Eip1559Fees = {
@@ -150,7 +150,9 @@ export function calculateGasAndFees({
     maxPriorityFeePerGas,
     gasLimit,
     maxTotalFee,
-    maxTotalFeeInCurrency: maxFeeInUnit.mul(tokenPrice).toDisplay()
+    maxTotalFeeInCurrency: maxFeeInUnit
+      .mul(tokenPrice)
+      .toDisplay({ asNumber: true })
   }
 }
 

--- a/packages/core-mobile/app/utils/string/toNumber.ts
+++ b/packages/core-mobile/app/utils/string/toNumber.ts
@@ -1,0 +1,16 @@
+import Logger from 'utils/Logger'
+
+export const toNumber = (num: string): number => {
+  // remove all commas from the string
+  const sanitizedStr = num.replace(/,/g, '')
+
+  // convert to number
+  const parsedNumber = Number(sanitizedStr)
+
+  if (Number.isNaN(parsedNumber)) {
+    Logger.error('string is not a valid number', num)
+    return 0
+  }
+
+  return parsedNumber
+}


### PR DESCRIPTION
## Description

**Ticket: [CP-9507]** 

We were passing strings to the formatter and when the amount is over $1000, it will break the formatter since the string will contain a comma. For example, 1,000.00. This pr makes sure we only pass numbers to the formatter.

## Screenshots/Videos
<img src="https://github.com/user-attachments/assets/6e59c6d7-9fb0-4495-a245-6e588c9246f0" width=300/>
<img src="https://github.com/user-attachments/assets/dd2ed502-aa0a-412f-8cc8-f422da0653dd" width=300/>
<img src="https://github.com/user-attachments/assets/654a2a74-c216-4e4a-bdc6-ed64a532bdbc" width=300/>

## Testing
Please make sure the amounts are showing correctly on Token Details, Network Fee Selector, Edit Fee and Spend Limit

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9507]: https://ava-labs.atlassian.net/browse/CP-9507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ