### PR TITLE
CP-9512: Fix Seedless reauth not working 

### DIFF
--- a/packages/core-mobile/app/seedless/services/SeedlessSessionManager.ts
+++ b/packages/core-mobile/app/seedless/services/SeedlessSessionManager.ts
@@ -160,6 +160,7 @@ class SeedlessSessionManager {
       operation: async _ => {
         return await sessionMgr.refresh().catch(err => {
           //if status is 403 means the token has expired and we need to refresh it
+          Logger.error('sessionMgr.refresh() failed', err)
 
           if ('status' in err && err.status === 403) {
             return {

--- a/packages/core-mobile/app/seedless/store/listeners.ts
+++ b/packages/core-mobile/app/seedless/store/listeners.ts
@@ -54,8 +54,15 @@ const registerSeedlessErrorHandler = async (
     // an example url https://prod.signer.cubist.dev/v1/org/Org%23db7f2cac-7bd0-4e5f-b7c2-b5881a4bb4e7/eth1/sign/0xD0E99cEa490Cdb54ba555922bf325952F0DE38bd
     Logger.error('seedless error', JSON.stringify({ ...e, url: '' }))
 
-    // handle re-auth for expired token
-    if (e.isSessionExpiredError()) {
+    // the following check is what cubist does internally for GlobalEvents.onSessionExpired
+    //
+    // if status is 403 and error matches one of the "invalid session" error codes
+    // or when "signerSessionRefresh" fails (errors returned by the authorizer lambda are not forwarded to the client)
+    // we will prompt user to re-authenticate
+    if (
+      e.status === 403 &&
+      (e.isSessionExpiredError() || e.operation === 'signerSessionRefresh')
+    ) {
       dispatch(onTokenExpired)
     }
   }


### PR DESCRIPTION
## Description

**Ticket: [CP-9512]** 

We are not prompting re-auth for certain token refresh errors. I talked to Cubist and they recommended adding another check for `e.operation === 'signerSessionRefresh'`.

## Screenshots/Videos
Testing with setting `session_lifetime` to 1 minute
**Before**
https://github.com/user-attachments/assets/f5d67a9e-9a82-4012-8b8d-1aaf083a7956

**After**

https://github.com/user-attachments/assets/1c219e20-d2ab-4158-be6d-bd4924869b87

https://github.com/user-attachments/assets/4fbef4a6-1ff9-4887-87ea-6165c5d2dbac

I did try playing around with `refresh_lifetime` but our current code is working fine for that 

## Testing
Please make sure token refresh is still working and users are only prompted for re-auth when necessary. Please use builds `0.0.0.4125` and `0.0.0.4126` to test (I set the session lifetime to 1 minute)

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9512]: https://ava-labs.atlassian.net/browse/CP-9512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ