### PR TITLE
CP-9545: Fix error with insufficient balance error when hit max with native tokens

### DIFF
--- a/packages/core-mobile/app/screens/bridge/Bridge.tsx
+++ b/packages/core-mobile/app/screens/bridge/Bridge.tsx
@@ -90,7 +90,8 @@ const Bridge: FC = () => {
     bridgeAssets,
     selectedBridgeAsset,
     setSelectedBridgeAsset,
-    error
+    error,
+    estimatedReceiveAmount
   } = useBridge()
 
   const activeAccount = useSelector(selectActiveAccount)
@@ -107,7 +108,7 @@ const Bridge: FC = () => {
 
   const { currencyFormatter } = useApplicationContext().appHook
   const isAmountTooLow = amount !== 0n && minimum && amount < minimum
-  const isAmountTooLarge = amount !== 0n && maximum && amount > maximum
+  const isAmountTooLarge = false //amount !== 0n && maximum && amount > maximum
   const isNativeBalanceNotEnoughForNetworkFee = Boolean(
     amount !== 0n &&
       networkFee &&
@@ -118,13 +119,10 @@ const Bridge: FC = () => {
 
   const hasValidAmount = !isAmountTooLow && amount > 0n
 
-  const receiveAmount = useMemo(
-    () => (bridgeFee !== undefined ? amount - bridgeFee : undefined),
-    [amount, bridgeFee]
-  )
-
   const hasInvalidReceiveAmount =
-    hasValidAmount && receiveAmount !== undefined && receiveAmount === 0n
+    hasValidAmount &&
+    estimatedReceiveAmount !== undefined &&
+    estimatedReceiveAmount === 0n
 
   const formattedAmountCurrency =
     hasValidAmount && price && selectedBridgeAsset
@@ -136,16 +134,18 @@ const Bridge: FC = () => {
       : UNKNOWN_AMOUNT
 
   const formattedReceiveAmount =
-    hasValidAmount && receiveAmount && selectedBridgeAsset
+    hasValidAmount && estimatedReceiveAmount && selectedBridgeAsset
       ? bigToLocaleString(
-          bigintToBig(receiveAmount, selectedBridgeAsset.decimals)
+          bigintToBig(estimatedReceiveAmount, selectedBridgeAsset.decimals)
         )
       : UNKNOWN_AMOUNT
   const formattedReceiveAmountCurrency =
-    hasValidAmount && price && receiveAmount && selectedBridgeAsset
+    hasValidAmount && price && estimatedReceiveAmount && selectedBridgeAsset
       ? currencyFormatter(
           price
-            .mul(bigintToBig(receiveAmount, selectedBridgeAsset.decimals))
+            .mul(
+              bigintToBig(estimatedReceiveAmount, selectedBridgeAsset.decimals)
+            )
             .toNumber()
         )
       : UNKNOWN_AMOUNT

--- a/packages/core-mobile/app/screens/bridge/Bridge.tsx
+++ b/packages/core-mobile/app/screens/bridge/Bridge.tsx
@@ -108,7 +108,7 @@ const Bridge: FC = () => {
 
   const { currencyFormatter } = useApplicationContext().appHook
   const isAmountTooLow = amount !== 0n && minimum && amount < minimum
-  const isAmountTooLarge = false //amount !== 0n && maximum && amount > maximum
+  const isAmountTooLarge = amount !== 0n && maximum && amount > maximum
   const isNativeBalanceNotEnoughForNetworkFee = Boolean(
     amount !== 0n &&
       networkFee &&

--- a/packages/core-mobile/app/screens/bridge/hooks/useBridgeNetworkPrice.ts
+++ b/packages/core-mobile/app/screens/bridge/hooks/useBridgeNetworkPrice.ts
@@ -16,12 +16,12 @@ export const useBridgeNetworkPrice = (chain?: Blockchain | Chain): Big => {
     }
 
     if (typeof chain === 'object') {
-      const caip2ChainId = getChainIdFromCaip2(chain.chainId)
-      if (!caip2ChainId) {
+      const chainId = getChainIdFromCaip2(chain.chainId)
+      if (!chainId) {
         return undefined
       }
 
-      const network = networks[caip2ChainId]
+      const network = networks[chainId]
 
       if (!network) {
         return undefined

--- a/packages/core-mobile/app/screens/bridge/hooks/useBridgeNetworkPrice.ts
+++ b/packages/core-mobile/app/screens/bridge/hooks/useBridgeNetworkPrice.ts
@@ -2,8 +2,8 @@ import { Blockchain, usePriceForChain } from '@avalabs/core-bridge-sdk'
 import { Chain } from '@avalabs/bridge-unified'
 import Big from 'big.js'
 import { useMemo } from 'react'
-import { caipToChainId } from 'utils/data/caip'
 import { useNetworks } from 'hooks/networks/useNetworks'
+import { getChainIdFromCaip2 } from 'utils/caip2ChainIds'
 import { networkToBlockchain } from '../utils/bridgeUtils'
 
 export const useBridgeNetworkPrice = (chain?: Blockchain | Chain): Big => {
@@ -16,7 +16,12 @@ export const useBridgeNetworkPrice = (chain?: Blockchain | Chain): Big => {
     }
 
     if (typeof chain === 'object') {
-      const network = networks[caipToChainId(chain.chainId)]
+      const caip2ChainId = getChainIdFromCaip2(chain.chainId)
+      if (!caip2ChainId) {
+        return undefined
+      }
+
+      const network = networks[caip2ChainId]
 
       if (!network) {
         return undefined

--- a/packages/core-mobile/app/screens/bridge/hooks/useEstimatedReceiveAmount.ts
+++ b/packages/core-mobile/app/screens/bridge/hooks/useEstimatedReceiveAmount.ts
@@ -1,0 +1,64 @@
+import { BridgeAsset } from '@avalabs/bridge-unified'
+import { Network } from '@avalabs/core-chains-sdk'
+import { useEffect, useState } from 'react'
+import { useSelector } from 'react-redux'
+import { selectActiveAccount } from 'store/account'
+import { isBitcoinNetwork } from 'utils/network/isBitcoinNetwork'
+import UnifiedBridgeService from 'services/bridge/UnifiedBridgeService'
+import { useNetworkFee } from 'hooks/useNetworkFee'
+import Logger from 'utils/Logger'
+
+export const useEstimatedReceiveAmount = ({
+  amount,
+  bridgeAsset,
+  sourceNetwork,
+  targetNetwork
+}: {
+  amount: bigint
+  bridgeAsset: BridgeAsset | undefined
+  sourceNetwork: Network | undefined
+  targetNetwork: Network | undefined
+}): bigint | undefined => {
+  const activeAccount = useSelector(selectActiveAccount)
+  const { data: networkFeeRate } = useNetworkFee()
+
+  const [estimatedAmount, setEstimatedAmount] = useState<bigint | undefined>()
+
+  useEffect(() => {
+    async function getEstimatedReceiveAmount(): Promise<bigint | undefined> {
+      if (!bridgeAsset || !sourceNetwork || !targetNetwork || !activeAccount) {
+        return
+      }
+
+      const fromAddress = isBitcoinNetwork(sourceNetwork)
+        ? activeAccount.addressBTC
+        : activeAccount.addressC
+
+      const { amount: _estimatedAmount } =
+        await UnifiedBridgeService.estimateReceiveAmount({
+          asset: bridgeAsset,
+          fromAddress,
+          amount,
+          sourceNetwork,
+          targetNetwork,
+          gasSettings:
+            sourceNetwork && networkFeeRate && isBitcoinNetwork(sourceNetwork)
+              ? { price: networkFeeRate.low.maxFeePerGas }
+              : undefined
+        })
+
+      return _estimatedAmount
+    }
+
+    getEstimatedReceiveAmount().then(setEstimatedAmount).catch(Logger.error)
+  }, [
+    bridgeAsset,
+    targetNetwork,
+    activeAccount,
+    amount,
+    sourceNetwork,
+    networkFeeRate
+  ])
+
+  return estimatedAmount
+}

--- a/packages/core-mobile/app/screens/bridge/hooks/useGetBridgeFees.ts
+++ b/packages/core-mobile/app/screens/bridge/hooks/useGetBridgeFees.ts
@@ -7,62 +7,65 @@ import { selectActiveAccount } from 'store/account'
 import { isBitcoinNetwork } from 'utils/network/isBitcoinNetwork'
 
 export const useGetBridgeFees = ({
-  amount,
   bridgeAsset,
   sourceNetwork,
   targetNetwork
 }: {
-  amount: bigint
   bridgeAsset: BridgeAsset | undefined
   sourceNetwork: Network | undefined
   targetNetwork: Network | undefined
 }): {
-  getBridgeFee: () => Promise<bigint | undefined>
-  getEstimatedGas: () => Promise<bigint | undefined>
+  getBridgeFee: (amount: bigint) => Promise<bigint | undefined>
+  getEstimatedGas: (amount: bigint) => Promise<bigint | undefined>
 } => {
   const activeAccount = useSelector(selectActiveAccount)
 
-  const getBridgeFee = useCallback(async () => {
-    if (!bridgeAsset || !targetNetwork || !sourceNetwork || amount === 0n) {
-      return undefined
-    }
+  const getBridgeFee = useCallback(
+    async (amount: bigint) => {
+      if (!bridgeAsset || !targetNetwork || !sourceNetwork || amount === 0n) {
+        return undefined
+      }
 
-    return await UnifiedBridgeService.getFee({
-      asset: bridgeAsset,
-      amount,
-      sourceNetwork,
-      targetNetwork
-    })
-  }, [amount, bridgeAsset, sourceNetwork, targetNetwork])
+      return await UnifiedBridgeService.getFee({
+        asset: bridgeAsset,
+        amount,
+        sourceNetwork,
+        targetNetwork
+      })
+    },
+    [bridgeAsset, sourceNetwork, targetNetwork]
+  )
 
-  const getEstimatedGas = useCallback(async () => {
-    if (!activeAccount || !bridgeAsset || !sourceNetwork || amount === 0n)
-      return
+  const getEstimatedGas = useCallback(
+    async (amount: bigint) => {
+      if (!activeAccount || !bridgeAsset || !sourceNetwork) return
 
-    if (!activeAccount) {
-      throw new Error('no active account found')
-    }
+      if (!activeAccount) {
+        throw new Error('no active account found')
+      }
 
-    if (!targetNetwork) {
-      throw new Error('no target network found')
-    }
+      if (!targetNetwork) {
+        throw new Error('no target network found')
+      }
 
-    const fromAddress = isBitcoinNetwork(sourceNetwork)
-      ? activeAccount.addressBTC
-      : activeAccount.addressC
+      const fromAddress = isBitcoinNetwork(sourceNetwork)
+        ? activeAccount.addressBTC
+        : activeAccount.addressC
 
-    const gasLimit = await UnifiedBridgeService.estimateGas({
-      asset: bridgeAsset,
-      fromAddress,
-      amount,
-      sourceNetwork,
-      targetNetwork
-    })
+      const gasLimit = await UnifiedBridgeService.estimateGas({
+        asset: bridgeAsset,
+        fromAddress,
+        amount,
+        sourceNetwork,
+        targetNetwork
+      })
 
-    if (gasLimit) {
-      return gasLimit
-    }
-  }, [activeAccount, amount, bridgeAsset, sourceNetwork, targetNetwork])
+      if (gasLimit) {
+        return gasLimit
+      }
+    },
+    [activeAccount, bridgeAsset, sourceNetwork, targetNetwork]
+  )
 
   return { getBridgeFee, getEstimatedGas }
 }

--- a/packages/core-mobile/app/screens/bridge/hooks/useMaxTransferAmount.ts
+++ b/packages/core-mobile/app/screens/bridge/hooks/useMaxTransferAmount.ts
@@ -41,7 +41,7 @@ const useMaxTransferAmount = ({
 
   useEffect(() => {
     if (assetBalance?.balance !== undefined) {
-      getEstimatedGas(assetBalance?.balance)
+      getEstimatedGas(assetBalance.balance)
         .then(estimatedGas => {
           if (estimatedGas) {
             setGasLimit(estimatedGas)

--- a/packages/core-mobile/app/screens/bridge/hooks/useMaxTransferAmount.ts
+++ b/packages/core-mobile/app/screens/bridge/hooks/useMaxTransferAmount.ts
@@ -53,11 +53,20 @@ const useMaxTransferAmount = ({
     }
   }, [getEstimatedGas, assetBalance])
 
-  return assetBalance?.balance && networkFee
-    ? assetBalance.asset.type === TokenType.NATIVE
-      ? assetBalance.balance - networkFee
-      : assetBalance.balance
-    : undefined
+  const maxAmount =
+    assetBalance?.balance && networkFee
+      ? assetBalance.asset.type === TokenType.NATIVE
+        ? assetBalance.balance - networkFee
+        : assetBalance.balance
+      : undefined
+
+  if (maxAmount !== undefined && maxAmount < 0n) {
+    // we set the calculated max amount only when it is greater than 0.
+    // otherwise we return the asset balance to show the user that they don't have enough balance
+    return assetBalance?.balance
+  }
+
+  return maxAmount
 }
 
 export default useMaxTransferAmount

--- a/packages/core-mobile/app/screens/bridge/hooks/usePendingBridgeTransactions.ts
+++ b/packages/core-mobile/app/screens/bridge/hooks/usePendingBridgeTransactions.ts
@@ -7,8 +7,8 @@ import { isAvalancheNetwork } from 'services/network/utils/isAvalancheNetwork'
 import { isEthereumNetwork } from 'services/network/utils/isEthereumNetwork'
 import { selectBridgeTransactions } from 'store/bridge'
 import { selectPendingTransfers } from 'store/unifiedBridge/slice'
-import { caipToChainId } from 'utils/data/caip'
 import { isBitcoinNetwork } from 'utils/network/isBitcoinNetwork'
+import { getChainIdFromCaip2 } from 'utils/caip2ChainIds'
 
 const usePendingLegacyBridgeTransactions = (
   network?: Network
@@ -49,8 +49,8 @@ const usePendingUnifiedBridgeTransactions = (
       ...Object.values(pendingTransfer).filter(
         tx =>
           // filter pending transactions that don't belong to the given network
-          network?.chainId === caipToChainId(tx.sourceChain.chainId) ||
-          network?.chainId === caipToChainId(tx.targetChain.chainId)
+          network?.chainId === getChainIdFromCaip2(tx.sourceChain.chainId) ||
+          network?.chainId === getChainIdFromCaip2(tx.targetChain.chainId)
       )
     ]
   }, [pendingTransfer, network?.chainId])

--- a/packages/core-mobile/app/services/bridge/UnifiedBridgeService.ts
+++ b/packages/core-mobile/app/services/bridge/UnifiedBridgeService.ts
@@ -13,7 +13,8 @@ import {
   AnalyzeTxResult,
   AnalyzeTxParams,
   BridgeInitializer,
-  GasSettings
+  GasSettings,
+  Asset
 } from '@avalabs/bridge-unified'
 import { Network } from '@avalabs/core-chains-sdk'
 import { assertNotUndefined } from 'utils/assertions'
@@ -99,6 +100,34 @@ export class UnifiedBridgeService {
     }
 
     return feeMap[identifier.toLowerCase()] ?? undefined
+  }
+
+  async estimateReceiveAmount({
+    asset,
+    amount,
+    targetNetwork,
+    sourceNetwork,
+    fromAddress,
+    gasSettings
+  }: {
+    asset: BridgeAsset
+    amount: bigint
+    targetNetwork: Network
+    sourceNetwork: Network
+    fromAddress: string
+    gasSettings?: GasSettings
+  }): Promise<{ asset: Asset; amount: bigint }> {
+    const sourceChain = await this.buildChain(sourceNetwork)
+    const targetChain = await this.buildChain(targetNetwork)
+
+    return await this.service.estimateReceiveAmount({
+      asset,
+      fromAddress,
+      amount,
+      sourceChain,
+      targetChain,
+      gasSettings
+    })
   }
 
   async transfer({

--- a/packages/core-mobile/app/utils/data/caip.ts
+++ b/packages/core-mobile/app/utils/data/caip.ts
@@ -1,5 +1,0 @@
-import { caip2 } from '@avalabs/bridge-unified'
-
-export const caipToChainId = (identifier: string): number => {
-  return parseInt(caip2.toJSON(identifier).reference)
-}

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -15,6 +15,7 @@ import {
   showTransactionErrorToast,
   showTransactionSuccessToast
 } from 'utils/toast'
+import { btcSignTransaction } from 'vmModule/handlers/btcSignTransaction'
 import { avalancheSignTransaction } from '../handlers/avalancheSignTransaction'
 import { ethSendTransaction } from '../handlers/ethSendTransaction'
 import { signMessage } from '../handlers/signMessage'
@@ -57,6 +58,16 @@ class ApprovalController implements VmModuleApprovalController {
             btcSendTransaction({
               transactionData: signingData.data,
               finalFeeRate: Number(maxFeePerGas || 0),
+              account,
+              network,
+              resolve
+            })
+
+            break
+          }
+          case RpcMethod.BITCOIN_SIGN_TRANSACTION: {
+            btcSignTransaction({
+              transactionData: signingData.data,
               account,
               network,
               resolve

--- a/packages/core-mobile/app/vmModule/handlers/btcSignTransaction.ts
+++ b/packages/core-mobile/app/vmModule/handlers/btcSignTransaction.ts
@@ -1,0 +1,41 @@
+import { Network } from '@avalabs/core-chains-sdk'
+import { ApprovalResponse, BitcoingSignTxData } from '@avalabs/vm-module-types'
+import WalletService from 'services/wallet/WalletService'
+import { rpcErrors } from '@metamask/rpc-errors'
+import { Account } from 'store/account/types'
+import { BtcTransactionRequest } from 'services/wallet/types'
+
+export const btcSignTransaction = async ({
+  transactionData,
+  network,
+  account,
+  resolve
+}: {
+  transactionData: BitcoingSignTxData
+  network: Network
+  account: Account
+  resolve: (value: ApprovalResponse) => void
+}): Promise<void> => {
+  const { inputs, outputs } = transactionData
+
+  try {
+    const transaction: BtcTransactionRequest = { inputs, outputs }
+
+    const signedTx = await WalletService.sign({
+      transaction,
+      accountIndex: account.index,
+      network
+    })
+
+    resolve({
+      signedData: signedTx
+    })
+  } catch (error) {
+    resolve({
+      error: rpcErrors.internal({
+        message: 'Failed to sign btc transaction',
+        data: { cause: error }
+      })
+    })
+  }
+}


### PR DESCRIPTION
## Description

**Ticket: [CP-9545]** 

* implement `useMaxTransferAmount` for calculating max amount
* implement `useEstimatedReceiveAmount` to show estimated receive amount, using `estimateReceiveAmount` function in unified bridge
* implement missing `btcSignMessage` handler

[CP-9545]: https://ava-labs.atlassian.net/browse/CP-9545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ