### PR TITLE
CP-9556: Use correct gas limit for swap

### DIFF
--- a/packages/core-mobile/app/contexts/SwapContext/performSwap/performSwap.ts
+++ b/packages/core-mobile/app/contexts/SwapContext/performSwap/performSwap.ts
@@ -186,8 +186,10 @@ export async function performSwap({
     {
       from: userAddress,
       to: txBuildData.to,
-      // @ts-ignore
-      gas: bigIntToHex(txBuildData.gas), //gas property is not defined in Transaction@paraswap type but api does return this prop
+      gas:
+        txBuildData.gas !== undefined
+          ? bigIntToHex(BigInt(txBuildData.gas))
+          : undefined,
       data: txBuildData.data,
       value: isSrcTokenNative ? bigIntToHex(BigInt(sourceAmount)) : undefined // AVAX value needs to be sent with the transaction
     }


### PR DESCRIPTION
## Description

**Ticket: [CP-9556]** 

We were using string instead of number/bigint for `txBuildData.gas` so we would get something like `0x181883` instead of  `0x2c67b`

## Screenshots/Videos
<img src="https://github.com/user-attachments/assets/98262e7c-92c4-4752-966a-0cf06d75a10c" width=300/>

## Testing
Please make sure swapping still works

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9556]: https://ava-labs.atlassian.net/browse/CP-9556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ