### PR TITLE
CP-9562: Fix unable to claim rewards on testnet

### DIFF
--- a/packages/core-mobile/app/hooks/earn/useClaimFees.ts
+++ b/packages/core-mobile/app/hooks/earn/useClaimFees.ts
@@ -38,6 +38,7 @@ export const useClaimFees = (
   exportPFee?: TokenUnit
   totalClaimable?: TokenUnit
   defaultTxFee?: TokenUnit
+  feeCalculationError?: Error
 } => {
   const isDevMode = useSelector(selectIsDeveloperMode)
   const activeAccount = useSelector(selectActiveAccount)
@@ -45,6 +46,7 @@ export const useClaimFees = (
   const [totalFees, setTotalFees] = useState<TokenUnit>()
   const [exportFee, setExportFee] = useState<TokenUnit>()
   const [defaultTxFee, setDefaultTxFee] = useState<TokenUnit>()
+  const [feeCalculationError, setFeeCalculationError] = useState<Error>()
   const { getFeeState, defaultFeeState } = useGetFeeState()
   const pChainBalance = usePChainBalance()
   const xpProvider = useAvalancheXpProvider()
@@ -138,9 +140,14 @@ export const useClaimFees = (
       setExportFee(exportPFee)
     }
 
-    calculateFees().catch(err => {
-      Logger.error(err)
-    })
+    calculateFees()
+      .then(() => {
+        setFeeCalculationError(undefined)
+      })
+      .catch(err => {
+        setFeeCalculationError(err)
+        Logger.warn(err)
+      })
   }, [
     activeAccount,
     isDevMode,
@@ -155,7 +162,8 @@ export const useClaimFees = (
     totalFees,
     exportPFee: exportFee,
     totalClaimable,
-    defaultTxFee
+    defaultTxFee,
+    feeCalculationError
   }
 }
 

--- a/packages/core-mobile/app/hooks/earn/useClaimRewards.ts
+++ b/packages/core-mobile/app/hooks/earn/useClaimRewards.ts
@@ -15,6 +15,7 @@ import { selectActiveNetwork } from 'store/network'
 import { isDevnet } from 'utils/isDevnet'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { useMemo } from 'react'
+import { SendErrorMessage } from 'screens/send/utils/types'
 import { useClaimFees } from './useClaimFees'
 import { useGetFeeState } from './useGetFeeState'
 
@@ -34,7 +35,7 @@ export const useClaimRewards = (
   mutation: UseMutationResult<void, Error, void, unknown>
   defaultTxFee?: TokenUnit
   totalFees?: TokenUnit
-  feeCalculationError?: Error
+  feeCalculationError?: SendErrorMessage
   // eslint-disable-next-line max-params
 } => {
   const queryClient = useQueryClient()

--- a/packages/core-mobile/app/hooks/earn/useClaimRewards.ts
+++ b/packages/core-mobile/app/hooks/earn/useClaimRewards.ts
@@ -34,6 +34,7 @@ export const useClaimRewards = (
   mutation: UseMutationResult<void, Error, void, unknown>
   defaultTxFee?: TokenUnit
   totalFees?: TokenUnit
+  feeCalculationError?: Error
   // eslint-disable-next-line max-params
 } => {
   const queryClient = useQueryClient()
@@ -42,8 +43,13 @@ export const useClaimRewards = (
   const activeNetwork = useSelector(selectActiveNetwork)
   const selectedCurrency = useSelector(selectSelectedCurrency)
   const { getFeeState } = useGetFeeState()
-  const { totalFees, exportPFee, totalClaimable, defaultTxFee } =
-    useClaimFees(gasPrice)
+  const {
+    totalFees,
+    exportPFee,
+    totalClaimable,
+    defaultTxFee,
+    feeCalculationError
+  } = useClaimFees(gasPrice)
 
   const feeState = useMemo(() => getFeeState(gasPrice), [getFeeState, gasPrice])
 
@@ -98,7 +104,7 @@ export const useClaimRewards = (
       }
     }
   })
-  return { mutation, defaultTxFee, totalFees }
+  return { mutation, defaultTxFee, totalFees, feeCalculationError }
 }
 
 /**

--- a/packages/core-mobile/app/hooks/earn/utils/extractNeededAmount.test.ts
+++ b/packages/core-mobile/app/hooks/earn/utils/extractNeededAmount.test.ts
@@ -1,0 +1,44 @@
+import { extractNeededAmount } from './extractNeededAmount'
+
+it('should return the correct BigInt amount for a matching error message', () => {
+  const errorMessage =
+    'Insufficient funds: provided UTXOs need 10057 more nAVAX (asset id: U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK)'
+  const assetId = 'U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK'
+
+  const result = extractNeededAmount(errorMessage, assetId)
+  expect(result).toBe(BigInt(10057))
+})
+
+it('should return null for an error message that does not match the regex', () => {
+  const errorMessage = 'Some random error message without needed amount'
+  const assetId = 'U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK'
+
+  const result = extractNeededAmount(errorMessage, assetId)
+  expect(result).toBeNull()
+})
+
+it('should return null if the asset ID in the error message does not match the provided asset ID', () => {
+  const errorMessage =
+    'Insufficient funds: provided UTXOs need 10057 more nAVAX (asset id: U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK)'
+  const assetId = 'DifferentAssetId'
+
+  const result = extractNeededAmount(errorMessage, assetId)
+  expect(result).toBeNull()
+})
+
+it('should return null if the needed amount is not present in the error message', () => {
+  const errorMessage =
+    'Insufficient funds: provided UTXOs need more nAVAX (asset id: U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK)'
+  const assetId = 'U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK'
+
+  const result = extractNeededAmount(errorMessage, assetId)
+  expect(result).toBeNull()
+})
+
+it('should handle edge cases like empty error messages gracefully', () => {
+  const errorMessage = ''
+  const assetId = 'U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK'
+
+  const result = extractNeededAmount(errorMessage, assetId)
+  expect(result).toBeNull()
+})

--- a/packages/core-mobile/app/hooks/earn/utils/extractNeededAmount.ts
+++ b/packages/core-mobile/app/hooks/earn/utils/extractNeededAmount.ts
@@ -1,0 +1,16 @@
+// use a regex to match "Insufficient funds" and capture the missing amount
+export const extractNeededAmount = (
+  errorMessage: string,
+  assetId: string
+): bigint | null => {
+  const regex = new RegExp(
+    `Insufficient funds.*need (\\d+) more nAVAX \\(asset id: ${assetId}\\)`
+  )
+  const match = errorMessage.match(regex)
+
+  if (match && match[1]) {
+    return BigInt(match[1]) // convert to BigInt and return
+  }
+
+  return null // return null if no match is found
+}

--- a/packages/core-mobile/app/screens/earn/ClaimRewards.tsx
+++ b/packages/core-mobile/app/screens/earn/ClaimRewards.tsx
@@ -228,7 +228,7 @@ const ClaimRewards = (): JSX.Element | null => {
           />
           {excessiveNetworkFee && (
             <Text
-              testID="error_msg"
+              testID="excessive_fee_error_msg"
               variant="body2"
               sx={{ color: '$dangerMain' }}>
               {SendErrorMessage.EXCESSIVE_NETWORK_FEE}
@@ -239,7 +239,7 @@ const ClaimRewards = (): JSX.Element | null => {
               .toLowerCase()
               .includes('insufficient funds: provided utxos need') && (
               <Text
-                testID="error_msg"
+                testID="insufficent_balance_error_msg"
                 variant="body2"
                 sx={{ color: '$dangerMain' }}>
                 {SendErrorMessage.INSUFFICIENT_BALANCE_FOR_FEE}

--- a/packages/core-mobile/app/screens/earn/ClaimRewards.tsx
+++ b/packages/core-mobile/app/screens/earn/ClaimRewards.tsx
@@ -63,7 +63,8 @@ const ClaimRewards = (): JSX.Element | null => {
   const {
     mutation: claimRewardsMutation,
     defaultTxFee,
-    totalFees
+    totalFees,
+    feeCalculationError
   } = useClaimRewards(onClaimSuccess, onClaimError, onFundsStuck, gasPrice)
   const isFocused = useIsFocused()
   const unableToGetFees = totalFees === undefined
@@ -72,6 +73,9 @@ const ClaimRewards = (): JSX.Element | null => {
     isFocused && unableToGetFees, // re-enable this checking whenever this screen is focused
     timeToShowNetworkFeeError
   )
+
+  const shouldDisableClaimButton =
+    unableToGetFees || excessiveNetworkFee || Boolean(feeCalculationError)
 
   useEffect(() => {
     if (showFeeError) {
@@ -177,7 +181,7 @@ const ClaimRewards = (): JSX.Element | null => {
       header="Claim Rewards"
       confirmBtnTitle="Claim Now"
       cancelBtnTitle="Cancel"
-      confirmBtnDisabled={unableToGetFees || excessiveNetworkFee}>
+      confirmBtnDisabled={shouldDisableClaimButton}>
       <View style={styles.verticalPadding}>
         <Row style={{ justifyContent: 'space-between' }}>
           <AvaText.Body2>Claimable Amount</AvaText.Body2>
@@ -230,6 +234,17 @@ const ClaimRewards = (): JSX.Element | null => {
               {SendErrorMessage.EXCESSIVE_NETWORK_FEE}
             </Text>
           )}
+          {feeCalculationError &&
+            feeCalculationError.message
+              .toLowerCase()
+              .includes('insufficient funds: provided utxos need') && (
+              <Text
+                testID="error_msg"
+                variant="body2"
+                sx={{ color: '$dangerMain' }}>
+                {SendErrorMessage.INSUFFICIENT_BALANCE_FOR_FEE}
+              </Text>
+            )}
         </>
       )}
     </ConfirmScreen>

--- a/packages/core-mobile/app/screens/earn/ClaimRewards.tsx
+++ b/packages/core-mobile/app/screens/earn/ClaimRewards.tsx
@@ -73,15 +73,18 @@ const ClaimRewards = (): JSX.Element | null => {
     isFocused && unableToGetFees, // re-enable this checking whenever this screen is focused
     timeToShowNetworkFeeError
   )
+  const insufficientBalanceForFee =
+    feeCalculationError === SendErrorMessage.INSUFFICIENT_BALANCE_FOR_FEE
 
   const shouldDisableClaimButton =
-    unableToGetFees || excessiveNetworkFee || Boolean(feeCalculationError)
+    unableToGetFees || excessiveNetworkFee || insufficientBalanceForFee
 
   useEffect(() => {
-    if (showFeeError) {
+    if (showFeeError && !insufficientBalanceForFee) {
       navigate(AppNavigation.Earn.FeeUnavailable)
     }
-  }, [navigate, showFeeError])
+  }, [navigate, showFeeError, insufficientBalanceForFee])
+
   const [claimableAmountInAvax, claimableAmountInCurrency] = useMemo(() => {
     if (data?.balancePerType.unlockedUnstaked) {
       const unlockedInUnit = new TokenUnit(
@@ -234,18 +237,15 @@ const ClaimRewards = (): JSX.Element | null => {
               {SendErrorMessage.EXCESSIVE_NETWORK_FEE}
             </Text>
           )}
-          {feeCalculationError &&
-            feeCalculationError.message
-              .toLowerCase()
-              .includes('insufficient funds: provided utxos need') && (
-              <Text
-                testID="insufficent_balance_error_msg"
-                variant="body2"
-                sx={{ color: '$dangerMain' }}>
-                {SendErrorMessage.INSUFFICIENT_BALANCE_FOR_FEE}
-              </Text>
-            )}
         </>
+      )}
+      {insufficientBalanceForFee && (
+        <Text
+          testID="insufficent_balance_error_msg"
+          variant="body2"
+          sx={{ color: '$dangerMain' }}>
+          {SendErrorMessage.INSUFFICIENT_BALANCE_FOR_FEE}
+        </Text>
       )}
     </ConfirmScreen>
   )

--- a/packages/core-mobile/app/screens/send/utils/types.ts
+++ b/packages/core-mobile/app/screens/send/utils/types.ts
@@ -13,12 +13,12 @@ export enum SendErrorMessage {
   ADDRESS_REQUIRED = 'Address required',
   INVALID_ADDRESS = 'Address is invalid',
   INVALID_NETWORK_FEE = 'Network Fee is invalid',
-  BALANCE_NOT_FOUND = 'Unable to fetch balance.',
-  INSUFFICIENT_BALANCE = 'Insufficient balance.',
-  INSUFFICIENT_BALANCE_FOR_FEE = 'Insufficient balance for fee.',
+  BALANCE_NOT_FOUND = 'Unable to fetch balance',
+  INSUFFICIENT_BALANCE = 'Insufficient balance',
+  INSUFFICIENT_BALANCE_FOR_FEE = 'Insufficient balance for fee',
   TOKEN_REQUIRED = 'Token is required',
   UNSUPPORTED_TOKEN = 'Unsupported token',
-  INVALID_GAS_LIMIT = 'Unable to send token, invalid gas limit.',
+  INVALID_GAS_LIMIT = 'Unable to send token - invalid gas limit',
   UNKNOWN_ERROR = 'Unknown error',
   EXCESSIVE_NETWORK_FEE = 'Selected fee is too high'
 }

--- a/packages/core-mobile/app/services/wallet/WalletService.tsx
+++ b/packages/core-mobile/app/services/wallet/WalletService.tsx
@@ -41,6 +41,11 @@ import {
 import WalletInitializer from './WalletInitializer'
 import WalletFactory from './WalletFactory'
 import MnemonicWalletInstance from './MnemonicWallet'
+import {
+  getAssetId,
+  TESTNET_AVAX_ASSET_ID,
+  MAINNET_AVAX_ASSET_ID
+} from './utils'
 
 type InitProps = {
   mnemonic: string
@@ -56,10 +61,6 @@ const EVM_FEE_TOLERANCE = 50
 
 // We increase C chain base fee by 20% for instant speed
 const BASE_FEE_MULTIPLIER = 0.2
-
-const MAINNET_AVAX_ASSET_ID = Avalanche.MainnetContext.avaxAssetID
-const TESTNET_AVAX_ASSET_ID = Avalanche.FujiContext.avaxAssetID
-const DEVNET_AVAX_ASSET_ID = Avalanche.DevnetContext.avaxAssetID
 
 class WalletService {
   #walletType: WalletType = WalletType.UNSET
@@ -457,11 +458,7 @@ class WalletService {
       chain: 'P',
       toAddress: destinationAddress,
       amountsPerAsset: {
-        [isDevnet(avaxXPNetwork)
-          ? DEVNET_AVAX_ASSET_ID
-          : avaxXPNetwork.isTestnet
-          ? TESTNET_AVAX_ASSET_ID
-          : MAINNET_AVAX_ASSET_ID]: amountInNAvax
+        [getAssetId(avaxXPNetwork)]: amountInNAvax
       },
       options: {
         changeAddresses: [changeAddress]
@@ -693,11 +690,7 @@ class WalletService {
       accountIndex,
       avaxXPNetwork
     )
-    const assetId = isDevnet(avaxXPNetwork)
-      ? DEVNET_AVAX_ASSET_ID
-      : avaxXPNetwork.isTestnet
-      ? TESTNET_AVAX_ASSET_ID
-      : MAINNET_AVAX_ASSET_ID
+    const assetId = getAssetId(avaxXPNetwork)
 
     const utxos = getTransferOutputUtxos({
       amt: stakingAmount,

--- a/packages/core-mobile/app/services/wallet/utils.ts
+++ b/packages/core-mobile/app/services/wallet/utils.ts
@@ -9,11 +9,18 @@ import {
   TransferOutput,
   Utxo
 } from '@avalabs/avalanchejs'
+import { Avalanche } from '@avalabs/core-wallets-sdk'
+import { isDevnet } from 'utils/isDevnet'
+import { Network } from '@avalabs/core-chains-sdk'
 import {
   AvalancheTransactionRequest,
   BtcTransactionRequest,
   SignTransactionRequest
 } from './types'
+
+export const MAINNET_AVAX_ASSET_ID = Avalanche.MainnetContext.avaxAssetID
+export const TESTNET_AVAX_ASSET_ID = Avalanche.FujiContext.avaxAssetID
+export const DEVNET_AVAX_ASSET_ID = Avalanche.DevnetContext.avaxAssetID
 
 export const isBtcTransactionRequest = (
   request: SignTransactionRequest
@@ -69,3 +76,11 @@ export const getStakeableOutUtxos = ({
       )
     )
   )
+
+export const getAssetId = (avaxXPNetwork: Network): string => {
+  return isDevnet(avaxXPNetwork)
+    ? DEVNET_AVAX_ASSET_ID
+    : avaxXPNetwork.isTestnet
+    ? TESTNET_AVAX_ASSET_ID
+    : MAINNET_AVAX_ASSET_ID
+}

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -27,7 +27,7 @@
     "@avalabs/core-bridge-sdk": "3.1.0-alpha.19",
     "@avalabs/core-chains-sdk": "3.1.0-alpha.19",
     "@avalabs/core-coingecko-sdk": "3.1.0-alpha.19",
-    "@avalabs/core-utils-sdk": "3.1.0-alpha.19",
+    "@avalabs/core-utils-sdk": "3.1.0-alpha.23",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.19",
     "@avalabs/evm-module": "0.11.12",
     "@avalabs/glacier-sdk": "3.1.0-alpha.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,6 +69,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@avalabs/avalanchejs@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@avalabs/avalanchejs@npm:4.1.0"
+  dependencies:
+    "@noble/curves": 1.3.0
+    "@noble/hashes": 1.3.3
+    "@noble/secp256k1": 2.0.0
+    "@scure/base": 1.1.5
+    micro-eth-signer: 0.7.2
+  checksum: b758551e1b10e3a36f65529f9bb1cb0d7dd9862b41706c4363bdf23304c1e9630d58e02fb7d25e36b9bc90ef73185b806b9a16a5ecbb285454b4c9486a2ce4db
+  languageName: node
+  linkType: hard
+
 "@avalabs/avalanchejs@npm:4.1.0-alpha.25":
   version: 4.1.0-alpha.25
   resolution: "@avalabs/avalanchejs@npm:4.1.0-alpha.25"
@@ -170,7 +183,7 @@ __metadata:
     "@avalabs/core-bridge-sdk": 3.1.0-alpha.19
     "@avalabs/core-chains-sdk": 3.1.0-alpha.19
     "@avalabs/core-coingecko-sdk": 3.1.0-alpha.19
-    "@avalabs/core-utils-sdk": 3.1.0-alpha.19
+    "@avalabs/core-utils-sdk": 3.1.0-alpha.23
     "@avalabs/core-wallets-sdk": 3.1.0-alpha.19
     "@avalabs/evm-module": 0.11.12
     "@avalabs/glacier-sdk": 3.1.0-alpha.19
@@ -407,6 +420,21 @@ __metadata:
     bn.js: ^5.2.1
     ethers: ^6.7.1
   checksum: adbe4917f5cd83c8c19fcf3467465c7182145b564645c278de1a6761cad06ae937018949e6158b87d6282c8fc482b558d8d93b1045caea730ac13c30d94dadd3
+  languageName: node
+  linkType: hard
+
+"@avalabs/core-utils-sdk@npm:3.1.0-alpha.23":
+  version: 3.1.0-alpha.23
+  resolution: "@avalabs/core-utils-sdk@npm:3.1.0-alpha.23"
+  dependencies:
+    "@avalabs/avalanchejs": 4.1.0
+    "@hpke/core": 1.2.5
+    is-ipfs: 6.0.2
+  peerDependencies:
+    big.js: ^6.2.1
+    bn.js: ^5.2.1
+    ethers: ^6.7.1
+  checksum: 86e093611d405f6a11030639db90317c70daed478efeef68b0e4ffb58032f5b7ba4fa8de505b24109a42f4a30933cfd399ad2b80c6d194048bddf22bd57a5e04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: [CP-9562]** 

Issue 1: we were rounding up fee calculation which results in a case where actual balance - fee (rounded up) doesn't equal to actual balance - fee (raw). @neven-s adjusted the round up logic in token unit in the utils sdk to make it round down instead. it seems to be working. 

Issue 2: when calculating the estimated export P fee, we were using a fake amount that is less than available balance to try to estimate the fee. however, this is not reliable and usually much smaller than the actual required fee. instead of doing that, I have adjusted it so that we would try with the actual available amount. if it errors out with the insufficient funds message, we will grab the `missing amount` from the message and deduct it from the available amount. this will guarantee we always have enough balance.

## Screenshots/Videos
claim rewards
https://github.com/user-attachments/assets/fc5d3d36-4ac9-4262-aba9-c67ec3147d52

disable claim button and show error when fee is higher than balance
https://github.com/user-attachments/assets/a85fa0d1-3c53-46f2-9efb-f80f39f95bde



## Testing
Please make sure claiming rewards works

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9562]: https://ava-labs.atlassian.net/browse/CP-9562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ