### PR TITLE
CP-9586: Fix not able to stake on mainnet and testnet

### DIFF
--- a/packages/core-mobile/app/hooks/earn/useClaimFees.ts
+++ b/packages/core-mobile/app/hooks/earn/useClaimFees.ts
@@ -228,41 +228,41 @@ const getExportPFee = async ({
         getAssetId(avaxXPNetwork)
       )
 
-      if (missingAmount) {
-        const amountAvailable = amountInNAvax.toSubUnit()
-        const ratio = Number(missingAmount) / Number(amountAvailable)
-
-        if (ratio > pFeeAdjustmentThreshold) {
-          // rethrow insufficient funds error when missing fee is too much compared to total token amount
-          Logger.error('Failed to simulate export p due to excessive fees', {
-            missingAmount,
-            ratio
-          })
-          throw error
-        }
-
-        const amountAvailableToClaim = amountAvailable - missingAmount
-
-        if (amountAvailableToClaim <= 0) {
-          Logger.error('Failed to simulate export p due to excessive fees', {
-            missingAmount
-          })
-          // rethrow insufficient funds error when balance is not enough to cover fee
-          throw error
-        }
-
-        unsignedTxP = await WalletService.createExportPTx({
-          amountInNAvax: amountAvailableToClaim,
-          accountIndex: activeAccount.index,
-          avaxXPNetwork,
-          destinationAddress: activeAccount.addressPVM,
-          destinationChain: 'C',
-          feeState
-        })
-      } else {
+      if (!missingAmount) {
         // rethrow error if it's not an insufficient funds error
         throw error
       }
+
+      const amountAvailable = amountInNAvax.toSubUnit()
+      const ratio = Number(missingAmount) / Number(amountAvailable)
+
+      if (ratio > pFeeAdjustmentThreshold) {
+        // rethrow insufficient funds error when missing fee is too much compared to total token amount
+        Logger.error('Failed to simulate export p due to excessive fees', {
+          missingAmount,
+          ratio
+        })
+        throw error
+      }
+
+      const amountAvailableToClaim = amountAvailable - missingAmount
+
+      if (amountAvailableToClaim <= 0) {
+        Logger.error('Failed to simulate export p due to excessive fees', {
+          missingAmount
+        })
+        // rethrow insufficient funds error when balance is not enough to cover fee
+        throw error
+      }
+
+      unsignedTxP = await WalletService.createExportPTx({
+        amountInNAvax: amountAvailableToClaim,
+        accountIndex: activeAccount.index,
+        avaxXPNetwork,
+        destinationAddress: activeAccount.addressPVM,
+        destinationChain: 'C',
+        feeState
+      })
     }
 
     const tx = await Avalanche.parseAvalancheTx(

--- a/packages/core-mobile/app/hooks/earn/useClaimFees.ts
+++ b/packages/core-mobile/app/hooks/earn/useClaimFees.ts
@@ -234,7 +234,7 @@ const getExportPFee = async ({
 
         if (ratio > pFeeAdjustmentThreshold) {
           // rethrow insufficient funds error when missing fee is too much compared to total token amount
-          Logger.error('Transaction rejected due to excessive fees.', {
+          Logger.error('Failed to simulate export p due to excessive fees', {
             missingAmount,
             ratio
           })
@@ -244,7 +244,7 @@ const getExportPFee = async ({
         const amountAvailableToClaim = amountAvailable - missingAmount
 
         if (amountAvailableToClaim <= 0) {
-          Logger.error('Transaction rejected due to excessive fees.', {
+          Logger.error('Failed to simulate export p due to excessive fees', {
             missingAmount
           })
           // rethrow insufficient funds error when balance is not enough to cover fee

--- a/packages/core-mobile/app/hooks/earn/useClaimFees.ts
+++ b/packages/core-mobile/app/hooks/earn/useClaimFees.ts
@@ -4,14 +4,15 @@ import {
   calculatePChainFee
 } from 'services/earn/calculateCrossChainFees'
 import { useSelector } from 'react-redux'
-import { selectIsDeveloperMode } from 'store/settings/advanced'
+import { selectIsDeveloperMode } from 'store/settings/advanced/slice'
+import { selectPFeeAdjustmentThreshold } from 'store/posthog/slice'
 import NetworkService from 'services/network/NetworkService'
-import { selectActiveAccount } from 'store/account'
+import { selectActiveAccount } from 'store/account/slice'
 import WalletService from 'services/wallet/WalletService'
 import Logger from 'utils/Logger'
 import { useCChainBaseFee } from 'hooks/useCChainBaseFee'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
-import { selectActiveNetwork } from 'store/network'
+import { selectActiveNetwork } from 'store/network/slice'
 import { isDevnet } from 'utils/isDevnet'
 import { weiToNano } from 'utils/units/converter'
 import { CorePrimaryAccount } from '@avalabs/types'
@@ -46,6 +47,7 @@ export const useClaimFees = (
   const isDevMode = useSelector(selectIsDeveloperMode)
   const activeAccount = useSelector(selectActiveAccount)
   const activeNetwork = useSelector(selectActiveNetwork)
+  const pFeeAdjustmentThreshold = useSelector(selectPFeeAdjustmentThreshold)
   const [totalFees, setTotalFees] = useState<TokenUnit>()
   const [exportFee, setExportFee] = useState<TokenUnit>()
   const [defaultTxFee, setDefaultTxFee] = useState<TokenUnit>()
@@ -92,7 +94,8 @@ export const useClaimFees = (
         activeAccount,
         avaxXPNetwork,
         provider: xpProvider,
-        feeState: defaultFeeState
+        feeState: defaultFeeState,
+        pFeeAdjustmentThreshold
       })
       setDefaultTxFee(txFee)
     }
@@ -102,7 +105,8 @@ export const useClaimFees = (
     avaxXPNetwork,
     xpProvider,
     totalClaimable,
-    defaultFeeState
+    defaultFeeState,
+    pFeeAdjustmentThreshold
   ])
 
   useEffect(() => {
@@ -136,7 +140,8 @@ export const useClaimFees = (
         activeAccount,
         avaxXPNetwork,
         provider: xpProvider,
-        feeState
+        feeState,
+        pFeeAdjustmentThreshold
       })
 
       Logger.info('importCFee', importCFee.toDisplay())
@@ -175,7 +180,8 @@ export const useClaimFees = (
     avaxXPNetwork,
     totalClaimable,
     xpProvider,
-    feeState
+    feeState,
+    pFeeAdjustmentThreshold
   ])
 
   return {
@@ -192,7 +198,8 @@ const getExportPFee = async ({
   activeAccount,
   avaxXPNetwork,
   provider,
-  feeState
+  feeState,
+  pFeeAdjustmentThreshold
 }: {
   amountInNAvax: TokenUnit
   activeAccount: CorePrimaryAccount
@@ -200,6 +207,7 @@ const getExportPFee = async ({
   provider: Avalanche.JsonRpcProvider
   feeState?: pvm.FeeState
   missingAvax?: bigint
+  pFeeAdjustmentThreshold: number
 }): Promise<TokenUnit> => {
   if (provider.isEtnaEnabled()) {
     let unsignedTxP
@@ -221,9 +229,24 @@ const getExportPFee = async ({
       )
 
       if (missingAmount) {
-        const amountAvailableToClaim = amountInNAvax.toSubUnit() - missingAmount
+        const amountAvailable = amountInNAvax.toSubUnit()
+        const ratio = Number(missingAmount) / Number(amountAvailable)
+
+        if (ratio > pFeeAdjustmentThreshold) {
+          // rethrow insufficient funds error when missing fee is too much compared to total token amount
+          Logger.error('Transaction rejected due to excessive fees.', {
+            missingAmount,
+            ratio
+          })
+          throw error
+        }
+
+        const amountAvailableToClaim = amountAvailable - missingAmount
 
         if (amountAvailableToClaim <= 0) {
+          Logger.error('Transaction rejected due to excessive fees.', {
+            missingAmount
+          })
           // rethrow insufficient funds error when balance is not enough to cover fee
           throw error
         }

--- a/packages/core-mobile/app/hooks/earn/useEstimateStakingFees.ts
+++ b/packages/core-mobile/app/hooks/earn/useEstimateStakingFees.ts
@@ -173,7 +173,7 @@ const getStakingFeeFromDummyTx = async ({
   feeState?: pvm.FeeState
 }): Promise<TokenUnit> => {
   if (provider.isEtnaEnabled() && feeState) {
-    const unsignedImportTx = await WalletService.createDummyImportPTx({
+    const unsignedImportTx = await WalletService.simulateImportPTx({
       stakingAmount: stakingAmount.toSubUnit(),
       accountIndex: activeAccount.index,
       sourceChain: 'C',
@@ -188,7 +188,7 @@ const getStakingFeeFromDummyTx = async ({
       activeAccount.addressPVM
     )
     const unsignedAddPermissionlessDelegatorTx =
-      await WalletService.createDummyAddPermissionlessDelegatorTx({
+      await WalletService.simulateAddPermissionlessDelegatorTx({
         amountInNAvax: stakingAmount.toSubUnit(),
         accountIndex: activeAccount.index,
         destinationChain: 'C',

--- a/packages/core-mobile/app/hooks/earn/useIssueDelegation.ts
+++ b/packages/core-mobile/app/hooks/earn/useIssueDelegation.ts
@@ -6,9 +6,10 @@ import {
 } from '@tanstack/react-query'
 import { useSelector } from 'react-redux'
 import EarnService from 'services/earn/EarnService'
-import { selectIsDeveloperMode } from 'store/settings/advanced'
-import { selectActiveAccount } from 'store/account'
-import { selectSelectedCurrency } from 'store/settings/currency'
+import { selectIsDeveloperMode } from 'store/settings/advanced/slice'
+import { selectActiveAccount } from 'store/account/slice'
+import { selectSelectedCurrency } from 'store/settings/currency/slice'
+import { selectPFeeAdjustmentThreshold } from 'store/posthog/slice'
 import { calculateAmountForCrossChainTransferBigint } from 'hooks/earn/useGetAmountForCrossChainTransfer'
 import Logger from 'utils/Logger'
 import { FundsStuckError } from 'hooks/earn/errors'
@@ -19,7 +20,7 @@ import { coingeckoInMemoryCache } from 'utils/coingeckoInMemoryCache'
 import { isTokenWithBalancePVM } from '@avalabs/avalanche-module'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { isDevnet } from 'utils/isDevnet'
-import { selectActiveNetwork } from 'store/network'
+import { selectActiveNetwork } from 'store/network/slice'
 import { nanoToWei } from 'utils/units/converter'
 import { useCChainBalance } from './useCChainBalance'
 import { useGetFeeState } from './useGetFeeState'
@@ -56,6 +57,7 @@ export const useIssueDelegation = (
       isDeveloperMode,
       isDevnet(activeNetwork)
     )
+  const pFeeAdjustmentThreshold = useSelector(selectPFeeAdjustmentThreshold)
 
   const pAddress = activeAccount?.addressPVM ?? ''
   const cAddress = activeAccount?.addressC ?? ''
@@ -147,7 +149,8 @@ export const useIssueDelegation = (
         stakeAmountNanoAvax: data.stakingAmountNanoAvax,
         startDate: data.startDate,
         isDevnet: isDevnet(activeNetwork),
-        feeState: getFeeState(data.gasPrice)
+        feeState: getFeeState(data.gasPrice),
+        pFeeAdjustmentThreshold
       })
     },
     onSuccess: txId => {

--- a/packages/core-mobile/app/screens/earn/components/Balance.tsx
+++ b/packages/core-mobile/app/screens/earn/components/Balance.tsx
@@ -220,7 +220,9 @@ export const Balance = (): JSX.Element | null => {
             <BalanceItem
               balanceType={StakeTypeEnum.Claimable}
               iconColor={getStakePrimaryColor(StakeTypeEnum.Claimable, theme)}
-              balance={claimableInAvax?.toDisplay() ?? UNKNOWN_AMOUNT}
+              balance={
+                claimableInAvax?.toDisplay({ fixedDp: 4 }) ?? UNKNOWN_AMOUNT
+              }
               poppableItem={
                 [
                   RecoveryEvents.ImportPStart,
@@ -232,7 +234,7 @@ export const Balance = (): JSX.Element | null => {
         </Row>
       </View>
       <View>
-        {claimableInAvax?.gt(0)
+        {claimableInAvax?.gt(0.05)
           ? renderStakeAndClaimButton()
           : renderStakeButton()}
       </View>

--- a/packages/core-mobile/app/services/earn/EarnService.ts
+++ b/packages/core-mobile/app/services/earn/EarnService.ts
@@ -258,7 +258,8 @@ class EarnService {
     endDate,
     isDevMode,
     isDevnet,
-    feeState
+    feeState,
+    pFeeAdjustmentThreshold
   }: AddDelegatorTransactionProps): Promise<string> {
     const startDateUnix = getUnixTime(startDate)
     const endDateUnix = getUnixTime(endDate)
@@ -277,7 +278,8 @@ class EarnService {
       endDate: endDateUnix,
       stakeAmountInNAvax: stakeAmountNanoAvax,
       isDevMode,
-      feeState
+      feeState,
+      pFeeAdjustmentThreshold
     } as AddDelegatorProps)
 
     const signedTxJson = await WalletService.sign({

--- a/packages/core-mobile/app/services/earn/exportC.test.ts
+++ b/packages/core-mobile/app/services/earn/exportC.test.ts
@@ -90,7 +90,7 @@ describe('earn/exportC', () => {
           isDevnet: false
         })
         expect(WalletService.createExportCTx).toHaveBeenCalledWith({
-          amountInNAvax: 1001000000n,
+          amountInNAvax: 1000000000n,
           baseFeeInNAvax: 0n,
           accountIndex: undefined,
           avaxXPNetwork: NetworkService.getAvalancheNetworkP(false, false),

--- a/packages/core-mobile/app/services/earn/types.ts
+++ b/packages/core-mobile/app/services/earn/types.ts
@@ -14,6 +14,7 @@ export type AddDelegatorTransactionProps = {
   isDevMode: boolean
   isDevnet: boolean
   feeState?: pvm.FeeState
+  pFeeAdjustmentThreshold: number
 }
 
 export type UnixTimeMs = number

--- a/packages/core-mobile/app/services/posthog/types.ts
+++ b/packages/core-mobile/app/services/posthog/types.ts
@@ -35,7 +35,8 @@ export enum FeatureGates {
 }
 
 export enum FeatureVars {
-  SENTRY_SAMPLE_RATE = 'sentry-sample-rate'
+  SENTRY_SAMPLE_RATE = 'sentry-sample-rate',
+  P_FEE_ADJUSTMENT_THRESHOLD = 'p-fee-adjustment-threshold'
 }
 
 // posthog response can be an empty object when all features are disabled

--- a/packages/core-mobile/app/services/wallet/types.ts
+++ b/packages/core-mobile/app/services/wallet/types.ts
@@ -56,6 +56,7 @@ export type AddDelegatorProps = {
   isDevMode: boolean
   shouldValidateBurnedAmount?: boolean
   feeState?: pvm.FeeState
+  pFeeAdjustmentThreshold: number
 }
 
 export interface CommonAvalancheTxParamsBase {

--- a/packages/core-mobile/app/store/posthog/slice.ts
+++ b/packages/core-mobile/app/store/posthog/slice.ts
@@ -172,6 +172,13 @@ export const selectSentrySampleRate = (state: RootState): number => {
   )
 }
 
+export const selectPFeeAdjustmentThreshold = (state: RootState): number => {
+  const { featureFlags } = state.posthog
+  return parseFloat(
+    featureFlags[FeatureVars.P_FEE_ADJUSTMENT_THRESHOLD] as string
+  )
+}
+
 export const selectUseLeftFab = (state: RootState): boolean => {
   const { featureFlags } = state.posthog
   return (

--- a/packages/core-mobile/app/store/posthog/types.ts
+++ b/packages/core-mobile/app/store/posthog/types.ts
@@ -13,6 +13,7 @@ export const DefaultFeatureFlagConfig = {
   [FeatureGates.SEND_NFT_IOS]: true,
   [FeatureGates.SEND_NFT_ANDROID]: true,
   [FeatureVars.SENTRY_SAMPLE_RATE]: '10', // 10% of events/errors
+  [FeatureVars.P_FEE_ADJUSTMENT_THRESHOLD]: '1e-3', // 0.1%
   [FeatureGates.BUY_COINBASE_PAY]: true,
   [FeatureGates.DEFI]: true,
   [FeatureGates.BROWSER]: true,


### PR DESCRIPTION
## Description

**Ticket: [CP-9586]** 

This pr follows the same solution in https://github.com/ava-labs/core-mobile/pull/2127. We can't rely on our simulated utxos to calculate correct fees. The fees will always be smaller than the actual needed fees. Hence, we will just grab whatever missing amount from the error message when submitting the delegation and deduct that from the total staking amount and retry. 

To prevent the case where the missing amount is super large, I added `p-fee-adjustment-threshold` feature flag, which is set to 0.1% currently. When the missing amount goes over 0.1%, we will reject the transaction. From my testing, the ratio seems to be less than 0.005%. 

`p-fee-adjustment-threshold`
```This flag defines the maximum allowable ratio of the additional fee adjustment (missingAmount) to the total transaction amount (amountAvailable). It is used to ensure that fee adjustments (for claiming rewards and delegation within Core Mobile) remain reasonable and prevent excessive fees from being deducted from the transaction. For example, setting this threshold to 1e-3 (scientific notation for 0.001) means the app will reject a transaction if the required fee adjustment exceeds 0.1% of the total transaction amount. This safeguard protects users from incurring disproportionately high fees.```


## Screenshots/Videos
with small amount on P-Chain
https://github.com/user-attachments/assets/7c239daa-3572-4c6e-bca4-faf664712db0

with medium amount on P-Chain
https://github.com/user-attachments/assets/8514bb5b-a145-4edf-8e5d-b38b5c5caac8

## Testing
Please make sure staking still works for both mainnet and testnet

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9586]: https://ava-labs.atlassian.net/browse/CP-9586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ