### PR TITLE
CP-9613: Add back @walletConnect/react-native-compat

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
       - dependency-name: "@react-native/babel-preset"
       - dependency-name: "react-native-reanimated"
       - dependency-name: "react-native-mmkv" # we're currently on 2.12.2 which is the latest version compatible with react-native 0.73.7
+      - dependency-name: "@walletconnect/react-native-compat"
       - dependency-name: "@walletconnect/types"
       - dependency-name: "@walletconnect/utils"
       - dependency-name: "@avalabs/*"

--- a/packages/core-mobile/ios/Podfile.lock
+++ b/packages/core-mobile/ios/Podfile.lock
@@ -1032,7 +1032,7 @@ PODS:
     - React-Core
   - react-native-camera/RN (4.2.1):
     - React-Core
-  - react-native-compat (2.17.2):
+  - react-native-compat (2.11.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1793,7 +1793,7 @@ SPEC CHECKSUMS:
   react-native-aes: c6e4e3ffcff410535e31e161fca95d50e608d4ee
   react-native-blur: 4568dd93d1d82748c180df8beb2d929c97b13b47
   react-native-camera: 3eae183c1d111103963f3dd913b65d01aef8110f
-  react-native-compat: 6ac0ab0d47351dbf56342cf817f6659af8db59d2
+  react-native-compat: 5a5b7a043bec932a7814dc35f0649712bc10324e
   react-native-config: 8f7283449bbb048902f4e764affbbf24504454af
   react-native-menu: c30eb7a85d7b04d51945f61ea8a8986ed366ac5c
   react-native-mmkv: 1fdc81aa70c1aba09370718e6a63a09cbbbac8d2

--- a/packages/core-mobile/ios/Podfile.lock
+++ b/packages/core-mobile/ios/Podfile.lock
@@ -1032,6 +1032,10 @@ PODS:
     - React-Core
   - react-native-camera/RN (4.2.1):
     - React-Core
+  - react-native-compat (2.17.2):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
+    - React-Core
   - react-native-config (1.5.3):
     - react-native-config/App (= 1.5.3)
   - react-native-config/App (1.5.3):
@@ -1388,6 +1392,7 @@ DEPENDENCIES:
   - react-native-aes (from `../node_modules/react-native-aes-crypto`)
   - "react-native-blur (from `../node_modules/@react-native-community/blur`)"
   - react-native-camera (from `../node_modules/react-native-camera`)
+  - "react-native-compat (from `../node_modules/@walletconnect/react-native-compat`)"
   - react-native-config (from `../node_modules/react-native-config`)
   - "react-native-menu (from `../node_modules/@react-native-menu/menu`)"
   - react-native-mmkv (from `../node_modules/react-native-mmkv`)
@@ -1579,6 +1584,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/blur"
   react-native-camera:
     :path: "../node_modules/react-native-camera"
+  react-native-compat:
+    :path: "../node_modules/@walletconnect/react-native-compat"
   react-native-config:
     :path: "../node_modules/react-native-config"
   react-native-menu:
@@ -1786,6 +1793,7 @@ SPEC CHECKSUMS:
   react-native-aes: c6e4e3ffcff410535e31e161fca95d50e608d4ee
   react-native-blur: 4568dd93d1d82748c180df8beb2d929c97b13b47
   react-native-camera: 3eae183c1d111103963f3dd913b65d01aef8110f
+  react-native-compat: 6ac0ab0d47351dbf56342cf817f6659af8db59d2
   react-native-config: 8f7283449bbb048902f4e764affbbf24504454af
   react-native-menu: c30eb7a85d7b04d51945f61ea8a8986ed366ac5c
   react-native-mmkv: 1fdc81aa70c1aba09370718e6a63a09cbbbac8d2

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -81,6 +81,7 @@
     "@tanstack/react-query": "5.59.8",
     "@tanstack/react-query-persist-client": "5.59.6",
     "@tradle/react-native-http": "2.0.1",
+    "@walletconnect/react-native-compat": "2.17.2",
     "@walletconnect/types": "2.17.2",
     "@walletconnect/utils": "2.17.2",
     "@zodios/core": "10.9.6",

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -81,7 +81,7 @@
     "@tanstack/react-query": "5.59.8",
     "@tanstack/react-query-persist-client": "5.59.6",
     "@tradle/react-native-http": "2.0.1",
-    "@walletconnect/react-native-compat": "2.17.2",
+    "@walletconnect/react-native-compat": "2.11.0",
     "@walletconnect/types": "2.17.2",
     "@walletconnect/utils": "2.17.2",
     "@zodios/core": "10.9.6",

--- a/packages/core-mobile/patches/@walletconnect+react-native-compat+2.11.0.patch
+++ b/packages/core-mobile/patches/@walletconnect+react-native-compat+2.11.0.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/@walletconnect/react-native-compat/index.js b/node_modules/@walletconnect/react-native-compat/index.js
+index 9ae7d20..6a7a34e 100644
+--- a/node_modules/@walletconnect/react-native-compat/index.js
++++ b/node_modules/@walletconnect/react-native-compat/index.js
+@@ -4,15 +4,15 @@ import { getApplicationModule } from "./module";
+ import "fast-text-encoding";
+ 
+ // Polyfill crypto.getRandomvalues
+-import "react-native-get-random-values";
++// import "react-native-get-random-values";
+ 
+ // Polyfill URL()
+-import "react-native-url-polyfill/auto";
++// import "react-native-url-polyfill/auto";
+ 
+ // Polyfill Buffer
+-if (typeof Buffer === "undefined") {
+-  global.Buffer = require("buffer").Buffer;
+-}
++// if (typeof Buffer === "undefined") {
++//   global.Buffer = require("buffer").Buffer;
++// }
+ 
+ if (typeof global?.Linking === "undefined") {
+   try {

--- a/packages/core-mobile/polyfills/index.js
+++ b/packages/core-mobile/polyfills/index.js
@@ -1,6 +1,7 @@
 import './promise'
 import 'react-native-gesture-handler'
 import 'react-native-quick-crypto' // to override the global.crypto object
+import '@walletconnect/react-native-compat'
 import 'react-native-url-polyfill/auto'
 import '../shim'
 import './read_as_array_buffer_shim'

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,7 +271,7 @@ __metadata:
     "@types/react-dom": 18.3.0
     "@types/react-test-renderer": 18.3.0
     "@types/semver": 7.5.4
-    "@walletconnect/react-native-compat": 2.17.2
+    "@walletconnect/react-native-compat": 2.11.0
     "@walletconnect/types": 2.17.2
     "@walletconnect/utils": 2.17.2
     "@welldone-software/why-did-you-render": 8.0.3
@@ -12122,23 +12122,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/react-native-compat@npm:2.17.2":
-  version: 2.17.2
-  resolution: "@walletconnect/react-native-compat@npm:2.17.2"
+"@walletconnect/react-native-compat@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@walletconnect/react-native-compat@npm:2.11.0"
   dependencies:
     events: 3.3.0
-    fast-text-encoding: 1.0.6
-    react-native-url-polyfill: 2.0.0
+    fast-text-encoding: ^1.0.6
+    react-native-url-polyfill: ^2.0.0
   peerDependencies:
     "@react-native-async-storage/async-storage": "*"
     "@react-native-community/netinfo": "*"
     expo-application: "*"
-    react-native: "*"
     react-native-get-random-values: "*"
   peerDependenciesMeta:
     expo-application:
       optional: true
-  checksum: a038f29cc4e77a4493b735e14c4227f7883728845ad49ba5583e0598f0b3aaddfe5cf2a1550869d478e138d9b089ec177a5e28952c320b9c2f7e7fd84987d8cb
+  checksum: fea0720cfc3bb0479eb02dd4baeb49b2a311b99d3ca95108e47cade3e21bb95394b27bbf05a96e42acd135e4a1530858f092baf13a7dffdb652e3800cf699838
   languageName: node
   linkType: hard
 
@@ -18025,7 +18024,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-text-encoding@npm:1.0.6":
+"fast-text-encoding@npm:^1.0.6":
   version: 1.0.6
   resolution: "fast-text-encoding@npm:1.0.6"
   checksum: 9d58f694314b3283e785bf61954902536da228607ad246905e30256f9ab8331f780ac987e7222c9f5eafd04168d07e12b8054c85cedb76a2c05af0e82387a903
@@ -26621,7 +26620,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-url-polyfill@npm:2.0.0":
+"react-native-url-polyfill@npm:2.0.0, react-native-url-polyfill@npm:^2.0.0":
   version: 2.0.0
   resolution: "react-native-url-polyfill@npm:2.0.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,6 +271,7 @@ __metadata:
     "@types/react-dom": 18.3.0
     "@types/react-test-renderer": 18.3.0
     "@types/semver": 7.5.4
+    "@walletconnect/react-native-compat": 2.17.2
     "@walletconnect/types": 2.17.2
     "@walletconnect/utils": 2.17.2
     "@welldone-software/why-did-you-render": 8.0.3
@@ -12121,6 +12122,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@walletconnect/react-native-compat@npm:2.17.2":
+  version: 2.17.2
+  resolution: "@walletconnect/react-native-compat@npm:2.17.2"
+  dependencies:
+    events: 3.3.0
+    fast-text-encoding: 1.0.6
+    react-native-url-polyfill: 2.0.0
+  peerDependencies:
+    "@react-native-async-storage/async-storage": "*"
+    "@react-native-community/netinfo": "*"
+    expo-application: "*"
+    react-native: "*"
+    react-native-get-random-values: "*"
+  peerDependenciesMeta:
+    expo-application:
+      optional: true
+  checksum: a038f29cc4e77a4493b735e14c4227f7883728845ad49ba5583e0598f0b3aaddfe5cf2a1550869d478e138d9b089ec177a5e28952c320b9c2f7e7fd84987d8cb
+  languageName: node
+  linkType: hard
+
 "@walletconnect/relay-api@npm:1.0.11":
   version: 1.0.11
   resolution: "@walletconnect/relay-api@npm:1.0.11"
@@ -18001,6 +18022,13 @@ __metadata:
   version: 2.1.1
   resolution: "fast-safe-stringify@npm:2.1.1"
   checksum: a851cbddc451745662f8f00ddb622d6766f9bd97642dabfd9a405fb0d646d69fc0b9a1243cbf67f5f18a39f40f6fa821737651ff1bceeba06c9992ca2dc5bd3d
+  languageName: node
+  linkType: hard
+
+"fast-text-encoding@npm:1.0.6":
+  version: 1.0.6
+  resolution: "fast-text-encoding@npm:1.0.6"
+  checksum: 9d58f694314b3283e785bf61954902536da228607ad246905e30256f9ab8331f780ac987e7222c9f5eafd04168d07e12b8054c85cedb76a2c05af0e82387a903
   languageName: node
   linkType: hard
 
@@ -26640,7 +26668,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: a187edd718e1ea3a6b1e5da167744e6ee324bc3c3e492bcb0a9d028ab68a82907f053f37c23aa4229d6a9091541cee3c73549c3c850056e4cf5eb5b3cb2c9ffc
+  checksum: 6e268fad7aa8b8e56fd28cc95f94f35a33fdac4cec0085ae71a766d092760e3f9af35218706113ff7ae99a74baabc5112d32005dce9e66bdf4fda676fad9aa4e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: [CP-9613]** 

- app is crashed on real device, adding back `@walletConnect/react-native-compat` fixed it.

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9613]: https://ava-labs.atlassian.net/browse/CP-9613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ