### PR TITLE
QA - skip share pipeline vars

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -437,6 +437,7 @@ workflows:
         - build_gradle_path: $BITRISE_SOURCE_DIR/$ANDROID_PROJECT_LOCATION/app/build.gradle
     - share-pipeline-variable@1:
         inputs:
+        - is_skippable: true
         - variables: |- 
             APP_VERSION=$APP_VERSION
             BUILD_NUMBER=$BUILD_NUMBER


### PR DESCRIPTION
## Description

- We want to be able to run workflows outside of pipelines on bitrise.  This change makes the `share-pipeline-variables` step skippable and the build is successful.

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
