### PR TITLE
CP-9517: Use tokenInCurrencyFormatter to show rewards and fees for staking

### DIFF
--- a/packages/core-mobile/app/screens/earn/ClaimRewards.tsx
+++ b/packages/core-mobile/app/screens/earn/ClaimRewards.tsx
@@ -96,7 +96,7 @@ const ClaimRewards = (): JSX.Element | null => {
         return [
           unlockedInUnit.toDisplay(),
           appHook.tokenInCurrencyFormatter(
-            Number(unlockedInUnit.mul(avaxPrice).toString())
+            unlockedInUnit.mul(avaxPrice).toDisplay({ asNumber: true })
           )
         ]
       }
@@ -117,7 +117,7 @@ const ClaimRewards = (): JSX.Element | null => {
     return [
       totalFees.toDisplay(),
       appHook.tokenInCurrencyFormatter(
-        Number(totalFees.mul(avaxPrice).toString())
+        totalFees.mul(avaxPrice).toDisplay({ asNumber: true })
       )
     ]
   }, [avaxPrice, totalFees, appHook])

--- a/packages/core-mobile/app/screens/earn/components/StakeCard.tsx
+++ b/packages/core-mobile/app/screens/earn/components/StakeCard.tsx
@@ -22,7 +22,6 @@ import NetworkService from 'services/network/NetworkService'
 import { useSelector } from 'react-redux'
 import { xpChainToken } from 'utils/units/knownTokens'
 import { UTCDate } from '@date-fns/utc'
-import { selectSelectedCurrency } from 'store/settings/currency/slice'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { selectActiveNetwork } from 'store/network'
 import { isDevnet } from 'utils/isDevnet'
@@ -59,7 +58,6 @@ export const StakeCard = (props: Props): JSX.Element => {
   const navigation = useNavigation<NavigationProp>()
   const { txHash, status, title, stakeAmount } = props
   const avaxPrice = useAvaxTokenPriceInSelectedCurrency()
-  const selectedCurrency = useSelector(selectSelectedCurrency)
   const isDevMode = useSelector(selectIsDeveloperMode)
   const activeNetwork = useSelector(selectActiveNetwork)
   const { networkToken: pChainNetworkToken } =
@@ -112,7 +110,7 @@ export const StakeCard = (props: Props): JSX.Element => {
     const stakeAmountInCurrency = stakeAmountInAvax?.mul(avaxPrice)
     const stakeAmountInCurrencyDisplay = stakeAmountInCurrency
       ? tokenInCurrencyFormatter(
-          stakeAmountInCurrency.toDisplay({ fixedDp: 2, asNumber: true })
+          stakeAmountInCurrency.toDisplay({ asNumber: true })
         )
       : UNKNOWN_AMOUNT
 
@@ -157,7 +155,7 @@ export const StakeCard = (props: Props): JSX.Element => {
                   {stakeAmountInAvaxDisplay} AVAX
                 </AvaText.Heading6>
                 <AvaText.Overline>
-                  {`${stakeAmountInCurrencyDisplay} ${selectedCurrency}`}
+                  {`${stakeAmountInCurrencyDisplay}`}
                 </AvaText.Overline>
               </View>
             </Row>
@@ -176,7 +174,7 @@ export const StakeCard = (props: Props): JSX.Element => {
                   {estimatedRewardInAvaxDisplay} AVAX
                 </AvaText.Heading6>
                 <AvaText.Overline>
-                  {`${estimatedRewardInCurrencyDisplay} ${selectedCurrency}`}
+                  {`${estimatedRewardInCurrencyDisplay}`}
                 </AvaText.Overline>
               </View>
             </Row>
@@ -202,7 +200,7 @@ export const StakeCard = (props: Props): JSX.Element => {
 
         const rewardAmountInCurrencyDisplay = rewardAmountInCurrency
           ? tokenInCurrencyFormatter(
-              rewardAmountInCurrency.toDisplay({ fixedDp: 2, asNumber: true })
+              rewardAmountInCurrency.toDisplay({ asNumber: true })
             )
           : UNKNOWN_AMOUNT
 
@@ -223,7 +221,7 @@ export const StakeCard = (props: Props): JSX.Element => {
                   {stakeAmountInAvaxDisplay} AVAX
                 </AvaText.Heading6>
                 <AvaText.Overline>
-                  {`${stakeAmountInCurrencyDisplay} ${selectedCurrency}`}
+                  {`${stakeAmountInCurrencyDisplay}`}
                 </AvaText.Overline>
               </View>
             </Row>
@@ -244,7 +242,7 @@ export const StakeCard = (props: Props): JSX.Element => {
                   {rewardAmountInAvaxDisplay} AVAX
                 </AvaText.Heading6>
                 <AvaText.Overline>
-                  {`${rewardAmountInCurrencyDisplay} ${selectedCurrency}`}
+                  {`${rewardAmountInCurrencyDisplay}`}
                 </AvaText.Overline>
               </View>
             </Row>


### PR DESCRIPTION
## Description

**Ticket: [CP-9517]** 

* Use the tokenInCurrencyFormatter function to correctly display the claimable amount and fee.
* Fixed a bug where the currency symbol was duplicated when using currencies other than USD. 

## Screenshots/Videos
|| Before | After |
| --- | --- | --- |
| Stakes(USD) | <img src=https://github.com/user-attachments/assets/4e4b24aa-1b44-4ce5-9608-78b35113b1fd width=320 /> | <img src=https://github.com/user-attachments/assets/6dadbdb1-a29b-4486-973a-bf1007543407 width=320 /> |
| Stakes(CLP) | <img src=https://github.com/user-attachments/assets/31d0de11-5c10-42f3-91a7-cef4171b1e6c width=320 /> | <img src=https://github.com/user-attachments/assets/b7716c63-2bfc-457c-be1c-827d67299e40 width=320 /> |
| Claim Rewards(USD) | <img src=https://github.com/user-attachments/assets/4de26a11-6c4e-4575-a64e-bd4eafeb7165 width=320 /> | <img src=https://github.com/user-attachments/assets/6dca5253-7c66-4e1e-8dfc-ef1dcc2f4105 width=320 /> |

[CP-9517]: https://ava-labs.atlassian.net/browse/CP-9517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ