### PR TITLE
CP-9622: Set the default background color of the token logo to white.

### DIFF
--- a/packages/core-mobile/app/components/Avatar.tsx
+++ b/packages/core-mobile/app/components/Avatar.tsx
@@ -119,6 +119,7 @@ const AvatarBase: FC<AvatarBaseProps> = ({
       onLoad={() => setFailedToLoad(false)}
       onError={() => setFailedToLoad(true)}
       testID="avatar__logo_avatar"
+      contentFit="contain"
     />
   )
 }
@@ -129,6 +130,7 @@ interface TokenAvatarProps {
   logoUri: string | undefined
   size?: number
   testID?: string
+  backgroundColor?: string
 }
 
 const TokenAvatar: FC<TokenAvatarProps> = props => {
@@ -138,6 +140,7 @@ const TokenAvatar: FC<TokenAvatarProps> = props => {
       title={props.name}
       tokenSymbol={props.symbol}
       testID={props.symbol}
+      backgroundColor={props.backgroundColor}
     />
   )
 }

--- a/packages/core-mobile/app/screens/watchlist/TokenDetails/TokenDetail.tsx
+++ b/packages/core-mobile/app/screens/watchlist/TokenDetails/TokenDetail.tsx
@@ -180,6 +180,7 @@ const TokenDetail: FC = () => {
                 symbol={symbol}
                 logoUri={logoUri}
                 size={48}
+                backgroundColor="white"
               />
             )
           }

--- a/packages/core-mobile/app/screens/watchlist/components/WatchListItem.tsx
+++ b/packages/core-mobile/app/screens/watchlist/components/WatchListItem.tsx
@@ -91,12 +91,13 @@ const LeftComponent = ({
           <Space x={9} />
         </>
       )}
-      <Avatar.Custom
+      <Avatar.Token
         name={name}
         symbol={symbol}
         logoUri={logoUri}
         size={32}
         testID={`${name}`}
+        backgroundColor="white"
       />
     </View>
   )


### PR DESCRIPTION
## Description

**Ticket: [CP-9622]** 

* Set the default background color of the token logo to white.

## Screenshots/Videos
| | before | after |
| --- | --- | --- |
| Watchlist | <img src=https://github.com/user-attachments/assets/0fc56754-f793-4bdc-b27f-b25ef8c4f713 width=320 /> | <img src=https://github.com/user-attachments/assets/41a6f9d3-fbc4-4332-8ad1-20a815d87d02 width=320 /> |
| XLM | <img src=https://github.com/user-attachments/assets/6e0bd158-2d84-4c21-b27b-46173b67b5b2 width=320 /> | <img src=https://github.com/user-attachments/assets/d1d9b18c-2d74-4b0d-a0fe-7f0a8913d42f width=320 /> |
|| <img src=https://github.com/user-attachments/assets/5d9fcfd6-04da-43ac-8ae6-6c109aa3f72d width=320 /> | <img src=https://github.com/user-attachments/assets/53e55a7d-d6e1-46ff-a22c-182803a2641d width=320 /> |

[CP-9622]: https://ava-labs.atlassian.net/browse/CP-9622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ