### PR TITLE
CP-9375 Don't show Use Wallet Connect dialog if not interacted with app

### DIFF
--- a/packages/core-mobile/app/hooks/browser/useInjectedJavascript.ts
+++ b/packages/core-mobile/app/hooks/browser/useInjectedJavascript.ts
@@ -132,7 +132,7 @@ export function useInjectedJavascript(): InjectedJavascripts {
     setTimeout(() => {
       let notified = false;
       const request = async function (json) {
-        if (!notified) {
+        if (!notified && window.hasInteracted) {
           const message = {
             method: 'window_ethereum_used',
             payload: json
@@ -173,11 +173,15 @@ export function useInjectedJavascript(): InjectedJavascripts {
     }
   })();`
 
+  /**
+   * Caution, the coreConnectInterceptor function depends on window.hasInteracted which is manipulated here
+   */
   const injectCustomPrompt = `(async function(){
     var focused = false;
     Object.freeze(Object);
     window.onfocus = function(){
       focused = true;
+      window.hasInteracted = true;
     };
     window.onblur = function(){
       focused = false;


### PR DESCRIPTION
## Description

**Ticket: [CP-9375]** 

This is **best effort** to not show `Use Wallet Connect` dialog which pops up randomly in some cases.
The fix is that we track if user have interacted with dApp and only then allow detection of underlying ethereum callbacks upon which we conclude that dApp tried to connect with non-core wallet.

However, there still can be cases when dialog pops up since this is not documented feature.

## Screenshots/Videos

https://github.com/user-attachments/assets/d24509c8-12e1-42a8-adf2-8110832e2906

## Testing
- go to Browser tab
- select Pangolin from suggested list
- observe it doesn't pop up Use Wallet Connect dialog until you try to connect wallet

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [x] I have updated the documentation


[CP-9375]: https://ava-labs.atlassian.net/browse/CP-9375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ