### PR TITLE
Handle Watchlist Deeplinks

### DIFF
--- a/packages/core-mobile/app/components/NotFoundError.tsx
+++ b/packages/core-mobile/app/components/NotFoundError.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
+import { ErrorSVG } from './TopLevelErrorFallback'
+
+// same as TopLevelErrorFallback but with a different button
+export const NotFoundError = ({
+  title,
+  description
+}: {
+  title: string
+  description: string
+}): React.ReactNode => {
+  const navigation = useNavigation()
+
+  return (
+    <View
+      style={[
+        StyleSheet.absoluteFill,
+        {
+          backgroundColor: '#000000',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 16
+        }
+      ]}>
+      <View style={{ marginBottom: 30 }}>
+        <ErrorSVG />
+      </View>
+      {/* Heading3 */}
+      <Text
+        style={{
+          color: '#F8F8FB',
+          fontFamily: 'Inter-SemiBold',
+          fontSize: 16,
+          lineHeight: 24
+        }}>
+        {title}
+      </Text>
+      {/* Body2 */}
+      <Text
+        style={{
+          color: '#F8F8FB',
+          fontFamily: 'Inter-Regular',
+          fontSize: 14,
+          lineHeight: 17
+        }}>
+        {description}
+      </Text>
+      <Pressable
+        onPress={() => {
+          navigation.goBack()
+        }}
+        style={{
+          alignSelf: 'auto',
+          alignItems: 'center',
+          backgroundColor: '#FFFFFF',
+          borderRadius: 25,
+          bottom: 75,
+          height: 48,
+          justifyContent: 'center',
+          paddingHorizontal: 24,
+          paddingVertical: 12,
+          position: 'absolute',
+          width: '100%'
+        }}>
+        <Text
+          style={{
+            color: '#1A1A1C',
+            fontFamily: 'Inter-SemiBold',
+            fontSize: 18,
+            lineHeight: 22
+          }}>
+          Go Back
+        </Text>
+      </Pressable>
+    </View>
+  )
+}

--- a/packages/core-mobile/app/components/TopLevelErrorFallback.tsx
+++ b/packages/core-mobile/app/components/TopLevelErrorFallback.tsx
@@ -6,7 +6,7 @@ import Svg, { Path } from 'react-native-svg'
 /**
  * !!! Not using `theme` because this component is rendered before it's available !!!
  */
-export const TopLevelErrorFallback = () => (
+export const TopLevelErrorFallback = (): React.ReactNode => (
   <View
     style={[
       StyleSheet.absoluteFill,
@@ -68,7 +68,7 @@ export const TopLevelErrorFallback = () => (
   </View>
 )
 
-const ErrorSVG = () => (
+export const ErrorSVG = (): React.ReactNode => (
   <Svg width="60" height="60" viewBox="0 0 60 60" fill="none">
     <Path
       d="M30.5 15C32.15 15 33.5 16.35 33.5 18V30C33.5 31.65 32.15 33 30.5 33C28.85 33 27.5 31.65 27.5 30V18C27.5 16.35 28.85 15 30.5 15ZM30.47 0C13.91 0 0.5 13.44 0.5 30C0.5 46.56 13.91 60 30.47 60C47.06 60 60.5 46.56 60.5 30C60.5 13.44 47.06 0 30.47 0ZM30.5 54C17.24 54 6.5 43.26 6.5 30C6.5 16.74 17.24 6 30.5 6C43.76 6 54.5 16.74 54.5 30C54.5 43.26 43.76 54 30.5 54ZM33.5 45H27.5V39H33.5V45Z"

--- a/packages/core-mobile/app/contexts/DeeplinkContext/DeeplinkContext.tsx
+++ b/packages/core-mobile/app/contexts/DeeplinkContext/DeeplinkContext.tsx
@@ -14,6 +14,7 @@ import Logger from 'utils/Logger'
 import { selectIsEarnBlocked, selectIsNotificationBlocked } from 'store/posthog'
 import { FIDO_CALLBACK_URL } from 'services/passkey/consts'
 import { processNotificationData } from 'store/notifications'
+import useInAppBrowser from 'hooks/useInAppBrowser'
 import { handleDeeplink } from './utils/handleDeeplink'
 import {
   DeepLink,
@@ -39,6 +40,7 @@ export const DeeplinkContextProvider = ({
   const isNotificationBlocked = useSelector(selectIsNotificationBlocked)
   const isEarnBlocked = useSelector(selectIsEarnBlocked)
   const [pendingDeepLink, setPendingDeepLink] = useState<DeepLink>()
+  const { openUrl } = useInAppBrowser()
 
   const handleNotificationCallback: HandleNotificationCallback = useCallback(
     (data: NotificationData | undefined) => {
@@ -131,11 +133,16 @@ export const DeeplinkContextProvider = ({
    *****************************************************************************/
   useEffect(() => {
     if (pendingDeepLink && isWalletActive) {
-      handleDeeplink(pendingDeepLink, dispatch, isEarnBlocked)
+      handleDeeplink({
+        deeplink: pendingDeepLink,
+        dispatch,
+        isEarnBlocked,
+        openUrl
+      })
       // once we used the url, we can expire it
       setPendingDeepLink(undefined)
     }
-  }, [isWalletActive, pendingDeepLink, dispatch, isEarnBlocked])
+  }, [isWalletActive, pendingDeepLink, dispatch, isEarnBlocked, openUrl])
 
   return (
     <DeeplinkContext.Provider

--- a/packages/core-mobile/app/contexts/DeeplinkContext/types.ts
+++ b/packages/core-mobile/app/contexts/DeeplinkContext/types.ts
@@ -31,7 +31,8 @@ export enum StakeActions {
 export const ACTIONS = {
   WC: 'wc',
   StakeComplete: StakeActions.StakeComplete,
-  OpenChainPortfolio: 'openchainportfolio'
+  Portfolio: 'portfolio',
+  WatchList: 'watchlist'
 }
 
 export type NotificationData = { [p: string]: string | number | object }

--- a/packages/core-mobile/app/contexts/DeeplinkContext/utils/handleDeeplink.test.ts
+++ b/packages/core-mobile/app/contexts/DeeplinkContext/utils/handleDeeplink.test.ts
@@ -1,11 +1,17 @@
 import crypto from 'crypto'
-import * as utils from 'services/earn/utils'
 import * as Toast from 'utils/toast'
+import * as navigationUtils from 'navigation/utils'
 import { DeepLink } from '../types'
 import { handleDeeplink } from './handleDeeplink'
 
 const mockShowTransactionSuccessToast = jest.fn()
 const mockShowTransactionErrorToast = jest.fn()
+const mockDispatch = jest.fn()
+const mockNavigateToClaimRewards = jest.fn()
+const mockNavigateToChainPortfolio = jest.fn()
+const mockNavigateToWatchlist = jest.fn()
+const mockOpenUrl = jest.fn()
+
 jest
   .spyOn(Toast, 'showTransactionSuccessToast')
   .mockImplementation(mockShowTransactionSuccessToast)
@@ -13,8 +19,17 @@ jest
   .spyOn(Toast, 'showTransactionErrorToast')
   .mockImplementation(mockShowTransactionErrorToast)
 
-const mockDispatch = jest.fn()
-const mockNavigateToClaimRewards = jest.fn()
+jest
+  .spyOn(navigationUtils, 'navigateToClaimRewards')
+  .mockImplementation(mockNavigateToClaimRewards)
+
+jest
+  .spyOn(navigationUtils, 'navigateToChainPortfolio')
+  .mockImplementation(mockNavigateToChainPortfolio)
+
+jest
+  .spyOn(navigationUtils, 'navigateToWatchlist')
+  .mockImplementation(mockNavigateToWatchlist)
 
 describe('handleDeeplink', () => {
   describe('handle walletConnect urls', () => {
@@ -22,7 +37,12 @@ describe('handleDeeplink', () => {
       const mockDeeplink = {
         url: 'https://core.app/wc?uri=wc%3Ab08d4b7be6bd25662c5922faadf82ff94d525af4282e0bdc9a78ae2ed9e086ec%402%3Frelay-protocol%3Dirn%26symKey%3Da33be37bb809cfbfbc788a54649bfbf1baa8cdbfe2fe21657fb51ef1bc7ab1fb'
       }
-      handleDeeplink(mockDeeplink as DeepLink, mockDispatch, false)
+      handleDeeplink({
+        deeplink: mockDeeplink as DeepLink,
+        dispatch: mockDispatch,
+        isEarnBlocked: false,
+        openUrl: mockOpenUrl
+      })
       expect(mockDispatch).toHaveBeenCalledWith({
         payload:
           'wc:b08d4b7be6bd25662c5922faadf82ff94d525af4282e0bdc9a78ae2ed9e086ec@2?relay-protocol=irn&symKey=a33be37bb809cfbfbc788a54649bfbf1baa8cdbfe2fe21657fb51ef1bc7ab1fb',
@@ -34,7 +54,12 @@ describe('handleDeeplink', () => {
       const mockDeeplink = {
         url: 'wc:b08d4b7be6bd25662c5922faadf82ff94d525af4282e0bdc9a78ae2ed9e086ec@2?relay-protocol=irn&symKey=a33be37bb809cfbfbc788a54649bfbf1baa8cdbfe2fe21657fb51ef1bc7ab1fb'
       }
-      handleDeeplink(mockDeeplink as DeepLink, mockDispatch, false)
+      handleDeeplink({
+        deeplink: mockDeeplink as DeepLink,
+        dispatch: mockDispatch,
+        isEarnBlocked: false,
+        openUrl: mockOpenUrl
+      })
       expect(mockDispatch).toHaveBeenCalledWith({
         payload:
           'wc:b08d4b7be6bd25662c5922faadf82ff94d525af4282e0bdc9a78ae2ed9e086ec@2?relay-protocol=irn&symKey=a33be37bb809cfbfbc788a54649bfbf1baa8cdbfe2fe21657fb51ef1bc7ab1fb',
@@ -46,7 +71,12 @@ describe('handleDeeplink', () => {
       const mockDeeplink = {
         url: 'core://wc?uri=wc%3Ab08d4b7be6bd25662c5922faadf82ff94d525af4282e0bdc9a78ae2ed9e086ec%402%3Frelay-protocol%3Dirn%26symKey%3Da33be37bb809cfbfbc788a54649bfbf1baa8cdbfe2fe21657fb51ef1bc7ab1fb'
       }
-      handleDeeplink(mockDeeplink as DeepLink, mockDispatch, false)
+      handleDeeplink({
+        deeplink: mockDeeplink as DeepLink,
+        dispatch: mockDispatch,
+        isEarnBlocked: false,
+        openUrl: mockOpenUrl
+      })
       expect(mockDispatch).toHaveBeenCalledWith({
         payload:
           'wc:b08d4b7be6bd25662c5922faadf82ff94d525af4282e0bdc9a78ae2ed9e086ec@2?relay-protocol=irn&symKey=a33be37bb809cfbfbc788a54649bfbf1baa8cdbfe2fe21657fb51ef1bc7ab1fb',
@@ -54,43 +84,144 @@ describe('handleDeeplink', () => {
       })
     })
 
-    it('should not dispatch wallet connect with http url', () => {
+    it('should ignore http url', () => {
       const mockDeeplink = {
         url: 'http://core.app/wc?uri=wc%3Ab08d4b7be6bd25662c5922faadf82ff94d525af4282e0bdc9a78ae2ed9e086ec%402%3Frelay-protocol%3Dirn%26symKey%3Da33be37bb809cfbfbc788a54649bfbf1baa8cdbfe2fe21657fb51ef1bc7ab1fb'
       }
-      handleDeeplink(mockDeeplink as DeepLink, mockDispatch, false)
+      handleDeeplink({
+        deeplink: mockDeeplink as DeepLink,
+        dispatch: mockDispatch,
+        isEarnBlocked: false,
+        openUrl: mockOpenUrl
+      })
       expect(mockDispatch).not.toHaveBeenCalled()
     })
 
-    it('should not dispatch wallet connect with random string', () => {
+    it('should ignore url with random string', () => {
       const randomString = crypto.randomBytes(16).toString('hex')
       const mockDeeplink = {
         url: randomString
       }
-      handleDeeplink(mockDeeplink as DeepLink, mockDispatch, false)
+      handleDeeplink({
+        deeplink: mockDeeplink as DeepLink,
+        dispatch: mockDispatch,
+        isEarnBlocked: false,
+        openUrl: mockOpenUrl
+      })
       expect(mockDispatch).not.toHaveBeenCalled()
     })
   })
 
+  describe('handle https urls', () => {
+    it('should open https link', () => {
+      const mockDeeplink = {
+        url: 'https://www.avax.network/blog'
+      }
+      handleDeeplink({
+        deeplink: mockDeeplink as DeepLink,
+        dispatch: mockDispatch,
+        isEarnBlocked: false,
+        openUrl: mockOpenUrl
+      })
+      expect(mockOpenUrl).toHaveBeenCalledWith(mockDeeplink.url)
+    })
+
+    it('should ignore http link', () => {
+      const mockDeeplink = {
+        url: 'http://www.avax.network/blog'
+      }
+      handleDeeplink({
+        deeplink: mockDeeplink as DeepLink,
+        dispatch: mockDispatch,
+        isEarnBlocked: false,
+        openUrl: mockOpenUrl
+      })
+      expect(mockOpenUrl).not.toHaveBeenCalled()
+    })
+
+    it('should ignore url with random string', () => {
+      const randomString = crypto.randomBytes(16).toString('hex')
+      const mockDeeplink = {
+        url: randomString
+      }
+      handleDeeplink({
+        deeplink: mockDeeplink as DeepLink,
+        dispatch: mockDispatch,
+        isEarnBlocked: false,
+        openUrl: mockOpenUrl
+      })
+      expect(mockOpenUrl).not.toHaveBeenCalled()
+    })
+  })
+
   describe('handle stakecomplete deeplink', () => {
-    jest
-      .spyOn(utils, 'navigateToClaimRewards')
-      .mockImplementation(mockNavigateToClaimRewards)
+    it('should navigate to claim reward', () => {
+      const mockDeeplink = {
+        url: 'core://stakecomplete'
+      }
+      handleDeeplink({
+        deeplink: mockDeeplink as DeepLink,
+        dispatch: mockDispatch,
+        isEarnBlocked: false,
+        openUrl: mockOpenUrl
+      })
+      expect(mockNavigateToClaimRewards).toHaveBeenCalled()
+    })
+
+    it('should not navigate to claim reward when earn flag is blocked', () => {
+      const mockDeeplink = {
+        url: 'core://stakecomplet'
+      }
+      handleDeeplink({
+        deeplink: mockDeeplink as DeepLink,
+        dispatch: mockDispatch,
+        isEarnBlocked: true,
+        openUrl: mockOpenUrl
+      })
+      expect(mockNavigateToClaimRewards).not.toHaveBeenCalled()
+    })
   })
 
-  it('should have called navigateToClaimReward', () => {
-    const mockDeeplink = {
-      url: 'core://stakecomplete'
-    }
-    handleDeeplink(mockDeeplink as DeepLink, mockDispatch, false)
-    expect(mockNavigateToClaimRewards).toHaveBeenCalled()
+  describe('handle portfolio deeplink', () => {
+    it('should navigate to portfolio', () => {
+      const mockDeeplink = {
+        url: 'core://portfolio'
+      }
+      handleDeeplink({
+        deeplink: mockDeeplink as DeepLink,
+        dispatch: mockDispatch,
+        isEarnBlocked: false,
+        openUrl: mockOpenUrl
+      })
+      expect(mockNavigateToChainPortfolio).toHaveBeenCalled()
+    })
   })
 
-  it('should not have called navigateToClaimReward', () => {
-    const mockDeeplink = {
-      url: 'core://stakecomplet'
-    }
-    handleDeeplink(mockDeeplink as DeepLink, mockDispatch, false)
-    expect(mockNavigateToClaimRewards).not.toHaveBeenCalled()
+  describe('handle watchlist deeplink', () => {
+    it('should navigate to watchlist', () => {
+      const mockDeeplink = {
+        url: 'core://watchlist'
+      }
+      handleDeeplink({
+        deeplink: mockDeeplink as DeepLink,
+        dispatch: mockDispatch,
+        isEarnBlocked: false,
+        openUrl: mockOpenUrl
+      })
+      expect(mockNavigateToWatchlist).toHaveBeenCalledWith(undefined)
+    })
+
+    it('should navigate to a watchlist token', () => {
+      const mockDeeplink = {
+        url: 'core://watchlist/avalanche-2'
+      }
+      handleDeeplink({
+        deeplink: mockDeeplink as DeepLink,
+        dispatch: mockDispatch,
+        isEarnBlocked: false,
+        openUrl: mockOpenUrl
+      })
+      expect(mockNavigateToWatchlist).toHaveBeenCalledWith('avalanche-2')
+    })
   })
 })

--- a/packages/core-mobile/app/navigation/utils.ts
+++ b/packages/core-mobile/app/navigation/utils.ts
@@ -3,7 +3,41 @@ import { navigate } from 'utils/Navigation'
 import AppNavigation from 'navigation/AppNavigation'
 import { NetworkTokensTabs } from 'screens/portfolio/network/NetworkTokens'
 
-export const navigateToChainPortfolio = async (): Promise<void> => {
+const DELAY_NAVIGATION = 1000
+
+export const navigateToWatchlist = (coingeckoId: string | undefined): void => {
+  setTimeout(async () => {
+    Logger.info('navigating to watchlist tab')
+    navigate({
+      name: AppNavigation.Root.Wallet,
+      params: {
+        screen: AppNavigation.Wallet.Drawer,
+        params: {
+          screen: AppNavigation.Wallet.Tabs,
+          params: {
+            screen: AppNavigation.Tabs.Watchlist
+          }
+        }
+      }
+    })
+
+    if (coingeckoId) {
+      Logger.info(`navigating to watchlist token ${coingeckoId}`)
+
+      navigate({
+        name: AppNavigation.Root.Wallet,
+        params: {
+          screen: AppNavigation.Wallet.TokenDetail,
+          params: {
+            tokenId: coingeckoId
+          }
+        }
+      })
+    }
+  }, DELAY_NAVIGATION)
+}
+
+export const navigateToChainPortfolio = (): void => {
   setTimeout(async () => {
     Logger.info('navigating to chain portfolio')
     navigate({
@@ -13,4 +47,26 @@ export const navigateToChainPortfolio = async (): Promise<void> => {
       params: { tabIndex: NetworkTokensTabs.Tokens }
     })
   }, 300)
+}
+
+export const navigateToClaimRewards = (): void => {
+  setTimeout(async () => {
+    Logger.info('navigating to claim rewards')
+    navigate({
+      name: AppNavigation.Root.Wallet,
+      params: {
+        screen: AppNavigation.Wallet.Earn,
+        params: {
+          screen: AppNavigation.Earn.ClaimRewards,
+          params: {
+            onBack: () =>
+              navigate({
+                //@ts-ignore
+                name: AppNavigation.Tabs.Stake
+              })
+          }
+        }
+      }
+    })
+  }, DELAY_NAVIGATION)
 }

--- a/packages/core-mobile/app/screens/watchlist/TokenDetails/TokenDetail.tsx
+++ b/packages/core-mobile/app/screens/watchlist/TokenDetails/TokenDetail.tsx
@@ -30,6 +30,7 @@ import { StarButton } from 'components/StarButton'
 import { AnimatedText } from 'components/AnimatedText'
 import { useDispatch, useSelector } from 'react-redux'
 import { GraphPoint } from 'react-native-graph'
+import { NotFoundError } from 'components/NotFoundError'
 import { DataItem } from './DataItem'
 import { Overlay } from './Overlay'
 
@@ -69,6 +70,7 @@ const TokenDetail: FC = () => {
   const hyperLinkStyle = { color: theme.colorPrimary1 }
 
   const {
+    noData,
     isFavorite,
     openMoonPay,
     openUrl,
@@ -163,6 +165,15 @@ const TokenDetail: FC = () => {
     ),
     [animatedPrice, theme.neutral50]
   )
+
+  if (noData) {
+    return (
+      <NotFoundError
+        title="Token not found"
+        description="Tap the button below to go back."
+      />
+    )
+  }
 
   return (
     <ScrollView style={styles.container}>

--- a/packages/core-mobile/app/screens/watchlist/useTokenDetail.ts
+++ b/packages/core-mobile/app/screens/watchlist/useTokenDetail.ts
@@ -126,6 +126,7 @@ export function useTokenDetail(coingeckoId: string) {
     name: coinInfo?.name,
     logoUri: coinInfo?.image?.large,
     // @ts-ignore contract_address exists in CoinsInfoResponse
-    contractAddress: coinInfo?.contract_address as string
+    contractAddress: coinInfo?.contract_address as string,
+    noData: chartData?.length === 0 && !coinInfo
   }
 }

--- a/packages/core-mobile/app/services/earn/utils.test.ts
+++ b/packages/core-mobile/app/services/earn/utils.test.ts
@@ -4,6 +4,7 @@ import { addDays, addYears } from 'date-fns'
 import * as Navigation from 'utils/Navigation'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { zeroAvaxPChain } from 'utils/units/zeroValues'
+import { navigateToClaimRewards } from 'navigation/utils'
 import {
   calculateMaxWeight,
   getAvailableDelegationWeight,
@@ -13,7 +14,6 @@ import {
   getSimpleSortedValidators,
   getSortedValidatorsByEndTime,
   isEndTimeOverOneYear,
-  navigateToClaimRewards,
   comparePeerVersion
 } from './utils'
 

--- a/packages/core-mobile/app/services/earn/utils.ts
+++ b/packages/core-mobile/app/services/earn/utils.ts
@@ -10,8 +10,6 @@ import { AdvancedSortFilter, NodeValidator, NodeValidators } from 'types/earn'
 import { random } from 'lodash'
 import { FujiParams, MainnetParams, StakingConfig } from 'utils/NetworkParams'
 import { MAX_VALIDATOR_WEIGHT_FACTOR } from 'consts/earn'
-import * as Navigation from 'utils/Navigation'
-import AppNavigation from 'navigation/AppNavigation'
 import Logger from 'utils/Logger'
 import { valid, compare } from 'semver'
 import { Peer } from '@avalabs/avalanchejs/dist/info/model'
@@ -347,28 +345,6 @@ export const getSortedValidatorsByEndTime = (
   return validators.sort(
     (a, b): number => Number(b.endTime) - Number(a.endTime)
   )
-}
-
-export const navigateToClaimRewards = async (): Promise<void> => {
-  setTimeout(async () => {
-    Logger.info('navigating to claim rewards')
-    Navigation.navigate({
-      name: AppNavigation.Root.Wallet,
-      params: {
-        screen: AppNavigation.Wallet.Earn,
-        params: {
-          screen: AppNavigation.Earn.ClaimRewards,
-          params: {
-            onBack: () =>
-              Navigation.navigate({
-                //@ts-ignore
-                name: AppNavigation.Tabs.Stake
-              })
-          }
-        }
-      }
-    })
-  }, 1000)
 }
 
 export const getTransformedTransactions = async (

--- a/packages/core-mobile/app/services/fcm/types.ts
+++ b/packages/core-mobile/app/services/fcm/types.ts
@@ -1,16 +1,38 @@
-import z, { object, string, nativeEnum } from 'zod'
+import z, { object, string, nativeEnum, literal } from 'zod'
 import { ChannelId } from 'services/notifications/channels'
-export const NotificationsBalanceChangeDataSchema = object({
+
+export enum NewsEvents {
+  PRODUCT_ANNOUNCEMENTS = 'PRODUCT_ANNOUNCEMENTS',
+  OFFERS_AND_PROMOTIONS = 'OFFERS_AND_PROMOTIONS',
+  MARKET_NEWS = 'MARKET_NEWS'
+}
+
+export enum BalanceChangeEvents {
+  BALANCES_SPENT = 'BALANCES_SPENT',
+  BALANCES_RECEIVED = 'BALANCES_RECEIVED',
+  ALLOWANCE_APPROVED = 'ALLOWANCE_APPROVED'
+}
+
+export const BalanceChangeDataSchema = object({
+  type: literal('balance').optional(), // TODO use correct type from backend
+  event: nativeEnum(BalanceChangeEvents),
+  title: string().optional(),
+  body: string().optional(),
   accountAddress: string().startsWith('0x'),
   chainId: string(),
-  event: string(),
-  transactionHash: string().startsWith('0x'),
-  title: string().optional(),
-  body: string().optional()
+  transactionHash: string().startsWith('0x')
 })
 
-export const NotificationsBalanceChangeSchema = object({
-  data: NotificationsBalanceChangeDataSchema,
+export const NewsDataSchema = object({
+  type: literal('news').optional(), // TODO use correct type from backend
+  event: nativeEnum(NewsEvents), // TODO use correct events from backend
+  title: string().optional(),
+  body: string().optional(),
+  url: string()
+})
+
+export const NotificationPayloadSchema = object({
+  data: BalanceChangeDataSchema.or(NewsDataSchema),
   notification: object({
     title: string(),
     body: string(),
@@ -25,16 +47,8 @@ export const NotificationsBalanceChangeSchema = object({
   }).optional()
 })
 
-export type NotificationsBalanceChange = z.infer<
-  typeof NotificationsBalanceChangeSchema
->
+export type NotificationPayload = z.infer<typeof NotificationPayloadSchema>
 
-export type NotificationsBalanceChangeData = z.infer<
-  typeof NotificationsBalanceChangeDataSchema
->
+export type BalanceChangeData = z.infer<typeof BalanceChangeDataSchema>
 
-export enum BalanceChangeEvents {
-  BALANCES_SPENT = 'BALANCES_SPENT',
-  BALANCES_RECEIVED = 'BALANCES_RECEIVED',
-  ALLOWANCE_APPROVED = 'ALLOWANCE_APPROVED'
-}
+export type NewsData = z.infer<typeof NewsDataSchema>


### PR DESCRIPTION
## Description

we can now handle these links:
- `core://watchlist/avalanche-2`: will direct to AVAX watchlist token screen (avalanche-2 is a coingecko id)
- `core://watchlist`: will direct to watchlist tab
- any https link: will open with the in-app browser

## Screenshots/Videos
**core://watchlist/avalanche-2** 

https://github.com/user-attachments/assets/ff638e6c-51b3-4cab-accb-885a488ddd02

**core://watchlist/somethingnotvalid**

this also applies to any tokens that our backend doesn't index/cache

https://github.com/user-attachments/assets/04231ad0-797b-4607-bdd3-e6abd9c2a943

**https link**

https://github.com/user-attachments/assets/3570f8de-201e-4b63-b8d4-9346907b7d95

## Testing
In DeeplinkContext.tsx file, you can manually call this to test this new behavior
```
useEffect(() => {
    setPendingDeepLink({
      url: 'core://watchlist/avalanche-2',
      origin: DeepLinkOrigin.ORIGIN_NOTIFICATION
    })
  }, [])
```

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
