### PR TITLE
CP-9664: Add missing news events to channel Id mapping

### DIFF
--- a/packages/core-mobile/app/contexts/DeeplinkContext/DeeplinkContext.tsx
+++ b/packages/core-mobile/app/contexts/DeeplinkContext/DeeplinkContext.tsx
@@ -11,7 +11,10 @@ import { noop } from '@avalabs/core-utils-sdk'
 import { Linking } from 'react-native'
 import NotificationsService from 'services/notifications/NotificationsService'
 import Logger from 'utils/Logger'
-import { selectIsEarnBlocked, selectIsNotificationBlocked } from 'store/posthog'
+import {
+  selectIsEarnBlocked,
+  selectIsAllNotificationsBlocked
+} from 'store/posthog'
 import { FIDO_CALLBACK_URL } from 'services/passkey/consts'
 import { processNotificationData } from 'store/notifications'
 import useInAppBrowser from 'hooks/useInAppBrowser'
@@ -37,7 +40,7 @@ export const DeeplinkContextProvider = ({
   const dispatch = useDispatch()
   const walletState = useSelector(selectWalletState)
   const isWalletActive = walletState === WalletState.ACTIVE
-  const isNotificationBlocked = useSelector(selectIsNotificationBlocked)
+  const isAllNotificationsBlocked = useSelector(selectIsAllNotificationsBlocked)
   const isEarnBlocked = useSelector(selectIsEarnBlocked)
   const [pendingDeepLink, setPendingDeepLink] = useState<DeepLink>()
   const { openUrl } = useInAppBrowser()
@@ -70,17 +73,17 @@ export const DeeplinkContextProvider = ({
    * Start listeners that will receive the deep link url
    *****************************************************************************/
   useEffect(() => {
-    if (isNotificationBlocked) return
+    if (isAllNotificationsBlocked) return
     NotificationsService.getInitialNotification(
       handleNotificationCallback
     ).catch(reason => {
       Logger.error(`[DeeplinkContext.tsx][getInitialNotification]${reason}`)
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isNotificationBlocked])
+  }, [isAllNotificationsBlocked])
 
   useEffect(() => {
-    if (isNotificationBlocked) return
+    if (isAllNotificationsBlocked) return
 
     const unsubscribeForegroundEvent = NotificationsService.onForegroundEvent(
       handleNotificationCallback
@@ -91,7 +94,7 @@ export const DeeplinkContextProvider = ({
     return () => {
       unsubscribeForegroundEvent()
     }
-  }, [handleNotificationCallback, isNotificationBlocked])
+  }, [handleNotificationCallback, isAllNotificationsBlocked])
 
   useEffect(() => {
     // triggered if app is running

--- a/packages/core-mobile/app/services/fcm/FCMService.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.ts
@@ -8,7 +8,8 @@ import {
   BalanceChangeData,
   NewsData,
   NotificationPayloadSchema,
-  NotificationTypes
+  NotificationTypes,
+  NewsEvents
 } from 'services/fcm/types'
 import { Platform } from 'react-native'
 import { DisplayNotificationParams } from 'services/notifications/types'
@@ -19,7 +20,11 @@ type UnsubscribeFunc = () => void
 const EVENT_TO_CH_ID: Record<string, ChannelId> = {
   [BalanceChangeEvents.ALLOWANCE_APPROVED]: ChannelId.BALANCE_CHANGES,
   [BalanceChangeEvents.BALANCES_SPENT]: ChannelId.BALANCE_CHANGES,
-  [BalanceChangeEvents.BALANCES_RECEIVED]: ChannelId.BALANCE_CHANGES
+  [BalanceChangeEvents.BALANCES_RECEIVED]: ChannelId.BALANCE_CHANGES,
+  [NewsEvents.MARKET_NEWS]: ChannelId.MARKET_NEWS,
+  [NewsEvents.OFFERS_AND_PROMOTIONS]: ChannelId.OFFERS_AND_PROMOTIONS,
+  [NewsEvents.PRICE_ALERTS]: ChannelId.PRICE_ALERTS,
+  [NewsEvents.PRODUCT_ANNOUNCEMENTS]: ChannelId.PRODUCT_ANNOUNCEMENTS
 }
 
 /**

--- a/packages/core-mobile/app/services/notifications/NotificationsService.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationsService.ts
@@ -20,6 +20,7 @@ import { StakeCompleteNotification } from 'store/notifications'
 import Logger from 'utils/Logger'
 import { HandleNotificationCallback } from 'contexts/DeeplinkContext/types'
 import { DisplayNotificationParams } from 'services/notifications/types'
+import { audioFiles } from 'utils/AudioFeedback'
 import {
   LAUNCH_ACTIVITY,
   PressActionId,
@@ -335,9 +336,7 @@ class NotificationsService {
       },
       data
     }
-    if (sound) {
-      notification.ios = { sound: sound }
-    }
+    notification.ios = { sound: sound ?? audioFiles.Default.file }
     await notifee.displayNotification(notification).catch(Logger.error)
   }
 }

--- a/packages/core-mobile/app/store/posthog/slice.ts
+++ b/packages/core-mobile/app/store/posthog/slice.ts
@@ -113,11 +113,6 @@ export const selectIsEarnBlocked = (state: RootState): boolean => {
   )
 }
 
-export const selectIsNotificationBlocked = (state: RootState): boolean => {
-  // in the future, other feature required notifications should go here
-  return selectIsEarnBlocked(state)
-}
-
 export const selectIsSendNftBlockediOS = (state: RootState): boolean => {
   const { featureFlags } = state.posthog
   return (

--- a/packages/core-mobile/app/utils/AudioFeedback.ts
+++ b/packages/core-mobile/app/utils/AudioFeedback.ts
@@ -11,7 +11,11 @@ type Audio = {
   hapticType: HapticFeedbackTypes
 }
 
-const audioFiles = {
+export const audioFiles = {
+  Default: {
+    file: 'default.wav',
+    hapticType: HapticFeedbackTypes.soft
+  },
   Send: {
     file: 'core_send.wav',
     hapticType: HapticFeedbackTypes.notificationSuccess


### PR DESCRIPTION
## Description

**Ticket: [CP-9664]** 

- News events to channel id mapping was missing, so the android news notification was not delivered.
- use default sound for new notifications

## Screenshots/Videos

- android notification

https://github.com/user-attachments/assets/7b248d86-03ad-44eb-bd71-18440ade63e2

- default sound for ios notification

https://github.com/user-attachments/assets/5f1c0276-3d2f-4d64-af9b-50f47856aa0a

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9664]: https://ava-labs.atlassian.net/browse/CP-9664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ