### PR TITLE
fix iOS background deeplink issue

### DIFF
--- a/packages/core-mobile/app/services/notifications/NotificationsService.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationsService.ts
@@ -21,6 +21,7 @@ import Logger from 'utils/Logger'
 import { HandleNotificationCallback } from 'contexts/DeeplinkContext/types'
 import { DisplayNotificationParams } from 'services/notifications/types'
 import { audioFiles } from 'utils/AudioFeedback'
+import messaging from '@react-native-firebase/messaging'
 import {
   LAUNCH_ACTIVITY,
   PressActionId,
@@ -290,10 +291,11 @@ class NotificationsService {
   getInitialNotification = async (
     callback: HandleNotificationCallback
   ): Promise<void> => {
-    const event = await notifee.getInitialNotification()
-    if (event) {
-      callback(event.notification.data)
-    }
+    return messaging()
+      .getInitialNotification()
+      .then(notification => {
+        callback(notification?.data)
+      })
   }
 
   cancelAllNotifications = async (): Promise<void> => {


### PR DESCRIPTION
## Description

- notifee.getInitialNotification does not triggerred callback to handle notification data as expected.  switch to use firebaseMessaging.getInitialNotification instead.

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
