### PR TITLE
CP-9632 Buy flow starts over if app is put in background or inactive while native in-app browser is open on Android

### DIFF
--- a/packages/core-mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/core-mobile/android/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
             android:exported="true"
             android:label="@string/app_name"
-            android:launchMode="singleTask"
+            android:launchMode="singleTop"
             android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/BootTheme"

--- a/packages/core-mobile/app/hooks/useInAppBrowser.ts
+++ b/packages/core-mobile/app/hooks/useInAppBrowser.ts
@@ -70,7 +70,8 @@ const useInAppBrowser = (): {
       navigationBarDividerColor: 'white',
       enableUrlBarHiding: false,
       enableDefaultShare: true,
-      forceCloseOnRedirection: false
+      forceCloseOnRedirection: false,
+      showInRecents: true
     }
     openInAppBrowser(url, options)
   }


### PR DESCRIPTION
## Description

**Ticket: [CP-9632]** 

This PR fixes named titled issue by:
- passing option `showInRecents` when starting in-app browser which enables switching back to it from "app switcher" (recent app list)
- changing launch mode for Android activity to `singleTop` which keeps in-app browser on top of the task when launching app from homescreen

## Screenshots/Videos


## Testing
- please follow steps from ticket and observe normal operation


## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9632]: https://ava-labs.atlassian.net/browse/CP-9632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ