### PR TITLE
use get over getSecurityKey to authenticate passkey

### DIFF
--- a/packages/core-mobile/app/services/passkey/PasskeyService.ts
+++ b/packages/core-mobile/app/services/passkey/PasskeyService.ts
@@ -46,7 +46,7 @@ class PasskeyService {
     const request = this.prepareAuthenticationRequest(challengeOptions)
 
     const result = withSecurityKey
-      ? await Passkey.getSecurityKey(request)
+      ? await Passkey.get(request)
       : await Passkey.getPlatformKey(request)
 
     return this.convertAuthenticationResult(result)

--- a/packages/core-mobile/app/services/passkey/PasskeyService.ts
+++ b/packages/core-mobile/app/services/passkey/PasskeyService.ts
@@ -45,6 +45,11 @@ class PasskeyService {
   ): Promise<FIDOAuthenticationResult> {
     const request = this.prepareAuthenticationRequest(challengeOptions)
 
+    // use Passkey.get() to get the credential
+    // on iOS, Passkey.getSecurityKey() only shows prompt with security key
+    // since currently we don't have a way to detect if the recovery method is for security key or platform key
+    // we want to always show the prompt with both options on iOS
+    // TODO: once we have support from Cubist to store and send the FIDO metadata, we can show more accurate prompt to user
     const result = withSecurityKey
       ? await Passkey.get(request)
       : await Passkey.getPlatformKey(request)


### PR DESCRIPTION
## Description

- update getCredential to use get() instead of getSecurityKey() to avoid iOS prompt only for security key.

## Testing
- tested on both android and iOS with getCrentials(), and they are both working.

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
