### PR TITLE
CP-9743: prompt user to enable notification if disabled in settings

### DIFF
--- a/packages/core-mobile/app/services/posthog/types.ts
+++ b/packages/core-mobile/app/services/posthog/types.ts
@@ -31,7 +31,8 @@ export enum FeatureGates {
   LOG_ERRORS_TO_SENTRY = 'log-errors-to-sentry',
   BLOCKAID_TRANSACTION_VALIDATION = 'blockaid-transaction-validation',
   BLOCKAID_DAPP_SCAN = 'blockaid-dapp-scan',
-  ALL_NOTIFICATIONS = 'all-notifications'
+  ALL_NOTIFICATIONS = 'all-notifications',
+  ENABLE_NOTIFICATION_PROMPT = 'enable-notification-prompt'
 }
 
 export enum FeatureVars {

--- a/packages/core-mobile/app/store/notifications/listeners/handlePromptNotifications.test.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/handlePromptNotifications.test.ts
@@ -32,6 +32,14 @@ jest.mock('store/viewOnce/types', () => ({
   }
 }))
 
+jest.mock('store/posthog/slice', () => {
+  const actual = jest.requireActual('store/posthog/slice')
+  return {
+    ...actual,
+    selectIsEnableNotificationPromptBlocked: jest.fn()
+  }
+})
+
 function getNotificationsPrompt(): string {
   return AppNavigation.Modal.EnableNotificationsPrompt
 }

--- a/packages/core-mobile/app/store/notifications/listeners/handlePromptNotifications.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/handlePromptNotifications.ts
@@ -6,6 +6,7 @@ import { selectHasBeenViewedOnce, setViewOnce } from 'store/viewOnce/slice'
 import { ViewOnceKey } from 'store/viewOnce/types'
 import NotificationsService from 'services/notifications/NotificationsService'
 import { AuthorizationStatus } from '@notifee/react-native'
+import { selectIsEnableNotificationPromptBlocked } from 'store/posthog'
 import { turnOnAllNotifications } from '../slice'
 
 let isWaitingForIntroMux = false
@@ -18,15 +19,26 @@ export const handlePromptNotifications = async (
   if (isWaitingForIntroMux) return //if already waiting ignore this handler
   await waitIfIntroScreenIsYetNotDismissed(listenerApi)
   isWaitingForIntroMux = false
-
+  const isEnableNotificationPromptBlocked =
+    selectIsEnableNotificationPromptBlocked(state)
   const hasPromptedForNotifications = selectHasBeenViewedOnce(
     ViewOnceKey.NOTIFICATIONS_PROMPT
   )(state)
 
-  if (hasPromptedForNotifications) return
-
   const authorizationStatus =
     await NotificationsService.getNotificationSettings()
+
+  // show prompt if any of the following is true
+  //   - if user has not seen the prompt
+  //   - if user has denied/not determined permissions and ff is enabled
+  if (
+    hasPromptedForNotifications &&
+    ((authorizationStatus !== AuthorizationStatus.DENIED &&
+      authorizationStatus !== AuthorizationStatus.NOT_DETERMINED) ||
+      isEnableNotificationPromptBlocked)
+  )
+    return
+
   // if user has not seen the prompt and has granted permissions
   // this means user is re-logging into wallet
   // we will silently turn on all notifications

--- a/packages/core-mobile/app/store/posthog/slice.ts
+++ b/packages/core-mobile/app/store/posthog/slice.ts
@@ -301,6 +301,16 @@ export const selectIsAllNotificationsBlocked = (state: RootState): boolean => {
   )
 }
 
+export const selectIsEnableNotificationPromptBlocked = (
+  state: RootState
+): boolean => {
+  const { featureFlags } = state.posthog
+  return (
+    !featureFlags[FeatureGates.ENABLE_NOTIFICATION_PROMPT] ||
+    !featureFlags[FeatureGates.EVERYTHING]
+  )
+}
+
 // actions
 export const { regenerateUserId, toggleAnalytics, setFeatureFlags } =
   posthogSlice.actions


### PR DESCRIPTION
## Description

**Ticket: [CP-9743]** 

- if user has disabled system notifications, always prompt them to take them to system settings to enable it.
- ff enable-notification-prompt can be turned off to skip prompting user if it becomes an issue.

## Screenshots/Videos

https://github.com/user-attachments/assets/030f7e74-b4ce-493e-9f59-b7cf8b3ccdbc

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9743]: https://ava-labs.atlassian.net/browse/CP-9743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ