### PR TITLE
CP-9832: Update the swap amount correctly with debounce

### DIFF
--- a/packages/core-mobile/app/contexts/SwapContext/SwapContext.tsx
+++ b/packages/core-mobile/app/contexts/SwapContext/SwapContext.tsx
@@ -5,7 +5,8 @@ import React, {
   useCallback,
   useContext,
   useEffect,
-  useState
+  useState,
+  useRef
 } from 'react'
 import { getSwapRate, getTokenAddress } from 'swap/getSwapRate'
 import { SwapSide, OptimalRate } from '@paraswap/sdk'
@@ -27,7 +28,10 @@ import { showTransactionErrorToast } from 'utils/toast'
 import { audioFeedback, Audios } from 'utils/AudioFeedback'
 import { TokenWithBalance } from '@avalabs/vm-module-types'
 import { isUserRejectedError } from 'store/rpc/providers/walletConnect/utils'
+import { useDebounce } from 'hooks/useDebounce'
 import { performSwap } from './performSwap/performSwap'
+
+const DEFAULT_DEBOUNCE_MILLISECONDS = 150
 
 // success here just means the transaction was sent, not that it was successful/confirmed
 export type SwapStatus = 'Idle' | 'Swapping' | 'Success' | 'Fail'
@@ -69,6 +73,7 @@ export const SwapContextProvider = ({
 }: {
   children: ReactNode
 }): JSX.Element => {
+  const abortControllerRef = useRef<AbortController | null>(null)
   const { request } = useInAppRequest()
   const { activeNetwork } = useNetworks()
   const activeAccount = useSelector(selectActiveAccount)
@@ -82,6 +87,7 @@ export const SwapContextProvider = ({
   const [swapStatus, setSwapStatus] = useState<SwapStatus>('Idle')
   const [amount, setAmount] = useState<Amount | undefined>() //the amount that's gonna be passed to paraswap
   const [isFetchingOptimalRate, setIsFetchingOptimalRate] = useState(false)
+  const debouncedAmount = useDebounce(amount, DEFAULT_DEBOUNCE_MILLISECONDS) // debounce since fetching rates via paraswaps can take awhile
 
   const getOptimalRateForAmount = useCallback(
     (amnt: Amount | undefined) => {
@@ -93,6 +99,15 @@ export const SwapContextProvider = ({
         toToken &&
         'decimals' in toToken
       ) {
+        // abort previous request if it exists
+        if (abortControllerRef.current) {
+          abortControllerRef.current.abort()
+        }
+
+        // create new AbortController
+        const controller = new AbortController()
+        abortControllerRef.current = controller
+
         return getSwapRate({
           fromTokenAddress: getTokenAddress(fromToken),
           toTokenAddress: getTokenAddress(toToken),
@@ -101,7 +116,8 @@ export const SwapContextProvider = ({
           amount: amnt.bn.toString(),
           swapSide: destination,
           network: activeNetwork,
-          account: activeAccount
+          account: activeAccount,
+          abortSignal: controller.signal
         })
       } else {
         return Promise.reject('invalid data')
@@ -111,9 +127,9 @@ export const SwapContextProvider = ({
   )
 
   const getOptimalRate = useCallback(() => {
-    if (activeAccount && amount) {
+    if (activeAccount && debouncedAmount) {
       setIsFetchingOptimalRate(true)
-      getOptimalRateForAmount(amount)
+      getOptimalRateForAmount(debouncedAmount)
         .then(({ optimalRate: opRate, error: err }) => {
           setError(err ?? '')
           setOptimalRate(opRate)
@@ -126,7 +142,7 @@ export const SwapContextProvider = ({
           setIsFetchingOptimalRate(false)
         })
     }
-  }, [activeAccount, amount, getOptimalRateForAmount])
+  }, [activeAccount, debouncedAmount, getOptimalRateForAmount])
 
   useEffect(() => {
     //call getOptimalRate every time its params change to get fresh rates

--- a/packages/core-mobile/app/hooks/useDebounce.ts
+++ b/packages/core-mobile/app/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react'
+
+export const useDebounce = <T>(value: T, delay: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}

--- a/packages/core-mobile/app/screens/swap/SwapView.tsx
+++ b/packages/core-mobile/app/screens/swap/SwapView.tsx
@@ -49,7 +49,6 @@ export default function SwapView(): JSX.Element {
   const [maxFromValue, setMaxFromValue] = useState<bigint | undefined>()
   const [fromTokenValue, setFromTokenValue] = useState<Amount>()
   const [toTokenValue, setToTokenValue] = useState<Amount>()
-
   const [localError, setLocalError] = useState<string>('')
 
   const canSwap: boolean =
@@ -178,6 +177,24 @@ export default function SwapView(): JSX.Element {
     setAmount(totalBalance)
   }, [fromToken, setAmount, setDestination])
 
+  const onFromAmountChange = useCallback(
+    (value: Amount): void => {
+      setFromTokenValue(value)
+      setDestination(SwapSide.SELL)
+      setAmount(value)
+    },
+    [setDestination, setAmount]
+  )
+
+  const onToAmountChange = useCallback(
+    (value: Amount): void => {
+      setToTokenValue(value)
+      setDestination(SwapSide.BUY)
+      setAmount(value)
+    },
+    [setDestination, setAmount]
+  )
+
   return (
     <View style={styles.container}>
       <ScrollView style={styles.container}>
@@ -197,11 +214,7 @@ export default function SwapView(): JSX.Element {
               AnalyticsService.capture('Swap_TokenSelected')
             }}
             onMax={handleOnMax}
-            onAmountChange={value => {
-              setFromTokenValue(value)
-              setDestination(SwapSide.SELL)
-              setAmount(value)
-            }}
+            onAmountChange={onFromAmountChange}
             selectedToken={fromToken}
             inputAmount={fromTokenValue?.bn}
             hideErrorMessage
@@ -234,11 +247,7 @@ export default function SwapView(): JSX.Element {
               setToToken(tkWithBalance)
               AnalyticsService.capture('Swap_TokenSelected')
             }}
-            onAmountChange={value => {
-              setToTokenValue(value)
-              setDestination(SwapSide.BUY)
-              setAmount(value)
-            }}
+            onAmountChange={onToAmountChange}
             selectedToken={toToken}
             inputAmount={toTokenValue?.bn}
             hideErrorMessage

--- a/packages/core-mobile/app/services/swap/SwapService.ts
+++ b/packages/core-mobile/app/services/swap/SwapService.ts
@@ -65,6 +65,7 @@ interface SwapRate {
   network: Network
   account: Account
   sentryTrx?: SentryTransaction
+  abortSignal?: AbortSignal
 }
 
 const SUPPORTED_SWAP_NETWORKS = [
@@ -106,7 +107,8 @@ class SwapService {
     swapSide,
     network,
     account,
-    sentryTrx
+    sentryTrx,
+    abortSignal
   }: SwapRate): Promise<OptimalRate> {
     return SentryWrapper.createSpanFor(sentryTrx)
       .setContext('svc.swap.get_rate')
@@ -120,15 +122,18 @@ class SwapService {
         if (!account) {
           throw new Error('Account address missing')
         }
-        return await this.getParaSwapSDK(network.chainId).swap.getRate({
-          srcToken,
-          destToken,
-          amount: srcAmount,
-          userAddress: account.addressC,
-          side: swapSide,
-          srcDecimals,
-          destDecimals
-        })
+        return await this.getParaSwapSDK(network.chainId).swap.getRate(
+          {
+            srcToken,
+            destToken,
+            amount: srcAmount,
+            userAddress: account.addressC,
+            side: swapSide,
+            srcDecimals,
+            destDecimals
+          },
+          abortSignal
+        )
       })
   }
 

--- a/packages/core-mobile/app/swap/getSwapRate.ts
+++ b/packages/core-mobile/app/swap/getSwapRate.ts
@@ -19,7 +19,8 @@ export async function getSwapRate({
   amount,
   swapSide,
   account,
-  network
+  network,
+  abortSignal
 }: {
   fromTokenAddress?: string
   toTokenAddress?: string
@@ -29,6 +30,7 @@ export async function getSwapRate({
   swapSide: SwapSide
   account: Account
   network: Network
+  abortSignal?: AbortSignal
 }): Promise<{
   destAmount?: string
   optimalRate?: OptimalRate
@@ -61,7 +63,8 @@ export async function getSwapRate({
       srcAmount: amount,
       swapSide: swapSide,
       network: network,
-      account: account
+      account: account,
+      abortSignal
     })
     return {
       optimalRate: priceResponse,


### PR DESCRIPTION
## Description

**Ticket: [CP-9832]** 

Fetching rates via paraswap can take a bit of time and we were fetching on every keystroke. This pr adds some debounce as well as logic to cancel existing requests.

## Screenshots/Videos
https://github.com/user-attachments/assets/8a4989ee-5529-4ee4-8583-fe636097f88f




## Testing
Please make sure swapping is still working normally

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9832]: https://ava-labs.atlassian.net/browse/CP-9832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ