### PR TITLE
CP-9863: Fix endless spinner on Claim Rewards screen 

### DIFF
--- a/packages/core-mobile/app/hooks/earn/utils/extractNeededAmount.test.ts
+++ b/packages/core-mobile/app/hooks/earn/utils/extractNeededAmount.test.ts
@@ -2,11 +2,11 @@ import { extractNeededAmount } from './extractNeededAmount'
 
 it('should return the correct BigInt amount for a matching error message', () => {
   const errorMessage =
-    'Insufficient funds: provided UTXOs need 10057 more nAVAX (asset id: U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK)'
+    'Insufficient funds: provided UTXOs need 15979 more unlocked nAVAX (asset id: U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK) to cover fee.'
   const assetId = 'U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK'
 
   const result = extractNeededAmount(errorMessage, assetId)
-  expect(result).toBe(BigInt(10057))
+  expect(result).toBe(BigInt(15979))
 })
 
 it('should return null for an error message that does not match the regex', () => {
@@ -19,7 +19,7 @@ it('should return null for an error message that does not match the regex', () =
 
 it('should return null if the asset ID in the error message does not match the provided asset ID', () => {
   const errorMessage =
-    'Insufficient funds: provided UTXOs need 10057 more nAVAX (asset id: U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK)'
+    'Insufficient funds: provided UTXOs need 15979 more unlocked nAVAX (asset id: U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK) to cover fee.)'
   const assetId = 'DifferentAssetId'
 
   const result = extractNeededAmount(errorMessage, assetId)
@@ -28,7 +28,7 @@ it('should return null if the asset ID in the error message does not match the p
 
 it('should return null if the needed amount is not present in the error message', () => {
   const errorMessage =
-    'Insufficient funds: provided UTXOs need more nAVAX (asset id: U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK)'
+    'Insufficient funds: provided UTXOs need more unlocked nAVAX (asset id: U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK)'
   const assetId = 'U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK'
 
   const result = extractNeededAmount(errorMessage, assetId)

--- a/packages/core-mobile/app/hooks/earn/utils/extractNeededAmount.ts
+++ b/packages/core-mobile/app/hooks/earn/utils/extractNeededAmount.ts
@@ -4,7 +4,8 @@ export const extractNeededAmount = (
   assetId: string
 ): bigint | null => {
   const regex = new RegExp(
-    `Insufficient funds.*need (\\d+) more nAVAX \\(asset id: ${assetId}\\)`
+    `insufficient funds: provided utxos need (\\d+) more unlocked navax \\(asset id: ${assetId}\\) to cover fee.`,
+    'i'
   )
   const match = errorMessage.match(regex)
 

--- a/packages/core-mobile/app/hooks/useCChainBaseFee.ts
+++ b/packages/core-mobile/app/hooks/useCChainBaseFee.ts
@@ -26,10 +26,12 @@ export const useCChainBaseFee = (): UseQueryResult<
     retry: false,
     refetchInterval: REFETCH_INTERVAL,
     queryKey: ['cChainBaseFee', isDeveloperMode, cChainNetwork, avaxProvider],
+    enabled: !!avaxProvider && !!cChainNetwork,
     queryFn: async () => {
       if (!cChainNetwork || !avaxProvider) {
         return Promise.reject('cChainNetwork or avaxProvider is not available')
       }
+
       const baseFeeWei = await avaxProvider.getApiC().getBaseFee()
 
       return new TokenUnit(

--- a/packages/core-mobile/app/screens/earn/ClaimRewards.tsx
+++ b/packages/core-mobile/app/screens/earn/ClaimRewards.tsx
@@ -95,7 +95,7 @@ const ClaimRewards = (): JSX.Element | null => {
     }
 
     return [
-      totalFees.toDisplay(),
+      totalFees.toDisplay({ fixedDp: 10 }),
       appHook.tokenInCurrencyFormatter(
         totalFees.mul(avaxPrice).toDisplay({ asNumber: true })
       )


### PR DESCRIPTION
## Description

**Ticket: [CP-9863]** 

avalanchejs `4.1.2-alpha.3` adjusts the error message for insufficient nAVAX to cover fee via this commit https://github.com/ava-labs/avalanchejs/commit/ef80a858787f158d7361ee26a67d33ec36e9e25c. staking is not working due to us not being able to grab the missing amount. this pr adjusts the regrex to match it. 


## Testing
please re-test all staking operations that involves transferring from C-Chain as well as claiming rewards

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
