### PR TITLE
CP-9606: Forgot PIN Flow

### DIFF
--- a/packages/core-mobile/app/new/features/onboarding/components/EnterRecoveryPhrase.tsx
+++ b/packages/core-mobile/app/new/features/onboarding/components/EnterRecoveryPhrase.tsx
@@ -10,6 +10,7 @@ import {
 import ScreenHeader from 'common/components/ScreenHeader'
 import * as bip39 from 'bip39'
 import AnalyticsService from 'services/analytics/AnalyticsService'
+import WalletSDK from 'utils/WalletSDK'
 import RecoveryPhraseInput from './RecoveryPhraseInput'
 
 export const EnterRecoveryPhrase = ({
@@ -18,6 +19,7 @@ export const EnterRecoveryPhrase = ({
   onNext: (mnemonic: string) => void
 }): React.JSX.Element => {
   const [mnemonic, setMnemonic] = useState('')
+  const testMnemonic = WalletSDK.testMnemonic()
 
   function handleNext(): void {
     const trimmed = mnemonic.toLowerCase().trim()
@@ -45,6 +47,10 @@ export const EnterRecoveryPhrase = ({
     }
   }
 
+  function handleEnterTestWallet(): void {
+    onNext(testMnemonic)
+  }
+
   return (
     <BlurredBarsContentLayout>
       <SafeAreaView sx={{ flex: 1 }}>
@@ -64,8 +70,17 @@ export const EnterRecoveryPhrase = ({
         <View
           sx={{
             padding: 16,
-            backgroundColor: '$surfacePrimary'
+            backgroundColor: '$surfacePrimary',
+            gap: 12
           }}>
+          {__DEV__ && bip39.validateMnemonic(testMnemonic) && (
+            <Button
+              size="large"
+              type="tertiary"
+              onPress={handleEnterTestWallet}>
+              Enter test HD wallet
+            </Button>
+          )}
           <Button
             size="large"
             type="primary"

--- a/packages/core-mobile/app/new/routes/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/_layout.tsx
@@ -119,7 +119,10 @@ export default function RootLayout(): JSX.Element | null {
                     animationEnabled: false
                   }}
                 />
-                <Stack.Screen name="forgotPin" />
+                <Stack.Screen
+                  name="forgotPin"
+                  options={{ headerShown: true }}
+                />
                 <Stack.Screen name="+not-found" />
                 <Stack.Screen name="onboarding" />
               </Stack>


### PR DESCRIPTION
## Description

**Ticket: [CP-9606]** 

* Implement fade-in/out animation for `Forgot PIN` button
* add `Enter test HD wallet` for testing convenience

## Screenshots/Videos
https://github.com/user-attachments/assets/62e1c924-d3e0-4f63-85b1-1b0e34002c49

[CP-9606]: https://ava-labs.atlassian.net/browse/CP-9606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ