### PR TITLE
CP-9864: Fix "export tx failed due to insufficient funds" error message when staking 

### DIFF
--- a/packages/core-mobile/app/hooks/earn/useDelegation.ts
+++ b/packages/core-mobile/app/hooks/earn/useDelegation.ts
@@ -7,7 +7,8 @@ import { useCChainBaseFee } from 'hooks/useCChainBaseFee'
 import { selectActiveNetwork } from 'store/network/slice'
 import {
   selectPFeeAdjustmentThreshold,
-  selectPFeeMultiplier
+  selectPFeeMultiplier,
+  selectCBaseFeeMultiplier
 } from 'store/posthog/slice'
 import { isDevnet } from 'utils/isDevnet'
 import { selectActiveAccount } from 'store/account/slice'
@@ -43,6 +44,7 @@ export const useDelegation = (): {
   const selectedCurrency = useSelector(selectSelectedCurrency)
   const pFeeAdjustmentThreshold = useSelector(selectPFeeAdjustmentThreshold)
   const pFeeMultiplier = useSelector(selectPFeeMultiplier)
+  const cBaseFeeMultiplier = useSelector(selectCBaseFeeMultiplier)
   const { defaultFeeState } = useGetFeeState()
   const cChainNetwork = useCChainNetwork()
   const avaxProvider = useAvalancheXpProvider(isDeveloperMode)
@@ -82,6 +84,7 @@ export const useDelegation = (): {
         provider: avaxProvider,
         pFeeAdjustmentThreshold,
         pFeeMultiplier,
+        cBaseFeeMultiplier,
         cChainBaseFee: cChainBaseFee.data,
         feeState: defaultFeeState,
         stakeAmount: stakeAmount
@@ -99,6 +102,7 @@ export const useDelegation = (): {
       isDeveloperMode,
       pFeeAdjustmentThreshold,
       pFeeMultiplier,
+      cBaseFeeMultiplier,
       selectedCurrency,
       avaxProvider
     ]
@@ -164,7 +168,8 @@ export const useDelegation = (): {
               requiredAmountWei: nanoToWei(step.amount),
               activeAccount,
               isDevMode: isDeveloperMode,
-              isDevnet: isDevNetwork
+              isDevnet: isDevNetwork,
+              cBaseFeeMultiplier
             })
             break
 
@@ -187,7 +192,8 @@ export const useDelegation = (): {
       defaultFeeState,
       isDeveloperMode,
       pFeeAdjustmentThreshold,
-      selectedCurrency
+      selectedCurrency,
+      cBaseFeeMultiplier
     ]
   )
 

--- a/packages/core-mobile/app/hooks/earn/useImportAnyStuckFunds.ts
+++ b/packages/core-mobile/app/hooks/earn/useImportAnyStuckFunds.ts
@@ -4,6 +4,7 @@ import { selectIsDeveloperMode } from 'store/settings/advanced'
 import EarnService from 'services/earn/EarnService'
 import { selectActiveAccount } from 'store/account'
 import { RecoveryEvents } from 'services/earn/types'
+import { selectCBaseFeeMultiplier } from 'store/posthog/slice'
 import { assertNotUndefined } from 'utils/assertions'
 import { selectSelectedCurrency } from 'store/settings/currency'
 import { selectActiveNetwork } from 'store/network'
@@ -24,6 +25,7 @@ export const useImportAnyStuckFunds = (
   const isDevMode = useSelector(selectIsDeveloperMode)
   const selectedCurrency = useSelector(selectSelectedCurrency)
   const activeNetwork = useSelector(selectActiveNetwork)
+  const cBaseFeeMultiplier = useSelector(selectCBaseFeeMultiplier)
   const { defaultFeeState } = useGetFeeState()
   const devnet = isDevnet(activeNetwork)
 
@@ -48,7 +50,8 @@ export const useImportAnyStuckFunds = (
         selectedCurrency,
         progressEvents: handleRecoveryEvent,
         feeState: defaultFeeState,
-        isDevnet: devnet
+        isDevnet: devnet,
+        cBaseFeeMultiplier
       })
       return true
     }

--- a/packages/core-mobile/app/screens/earn/ClaimRewards.tsx
+++ b/packages/core-mobile/app/screens/earn/ClaimRewards.tsx
@@ -73,6 +73,10 @@ const ClaimRewards = (): JSX.Element | null => {
   useEffect(() => {
     if (claimRewardsMutation.isPending) return
 
+    // the balance is usually updated faster than the tx "committed" event
+    // and we don't want to show the updated balance while the tx is still pending (spinner is being displayed)
+    // as that might confuse the user
+    // thus, we only update the balance if the tx is not pending
     if (data?.balancePerType.unlockedUnstaked) {
       const unlockedInUnit = new TokenUnit(
         data.balancePerType.unlockedUnstaked,

--- a/packages/core-mobile/app/services/earn/EarnService.ts
+++ b/packages/core-mobile/app/services/earn/EarnService.ts
@@ -69,7 +69,8 @@ class EarnService {
     selectedCurrency,
     progressEvents,
     isDevnet,
-    feeState
+    feeState,
+    cBaseFeeMultiplier
   }: {
     activeAccount: Account
     isDevMode: boolean
@@ -77,6 +78,7 @@ class EarnService {
     progressEvents?: (events: RecoveryEvents) => void
     isDevnet: boolean
     feeState?: pvm.FeeState
+    cBaseFeeMultiplier: number
   }): Promise<void> {
     Logger.trace('Start importAnyStuckFunds')
     const avaxXPNetwork = NetworkService.getAvalancheNetworkP(
@@ -116,7 +118,8 @@ class EarnService {
       await importC({
         activeAccount,
         isDevMode,
-        isDevnet
+        isDevnet,
+        cBaseFeeMultiplier
       })
       progressEvents?.(RecoveryEvents.ImportCFinish)
     }
@@ -131,15 +134,23 @@ class EarnService {
    * @param activeAccount
    * @param isDevMode
    */
-  // eslint-disable-next-line max-params
-  async claimRewards(
-    pChainBalance: TokenUnit,
-    requiredAmount: TokenUnit,
-    activeAccount: Account,
-    isDevMode: boolean,
-    isDevnet: boolean,
+  async claimRewards({
+    pChainBalance,
+    requiredAmount,
+    activeAccount,
+    isDevMode,
+    isDevnet,
+    feeState,
+    cBaseFeeMultiplier
+  }: {
+    pChainBalance: TokenUnit
+    requiredAmount: TokenUnit
+    activeAccount: Account
+    isDevMode: boolean
+    isDevnet: boolean
     feeState?: pvm.FeeState
-  ): Promise<void> {
+    cBaseFeeMultiplier: number
+  }): Promise<void> {
     await exportP({
       pChainBalance,
       requiredAmount,
@@ -151,7 +162,8 @@ class EarnService {
     await importC({
       activeAccount,
       isDevMode,
-      isDevnet
+      isDevnet,
+      cBaseFeeMultiplier
     })
   }
 

--- a/packages/core-mobile/app/services/earn/computeDelegationSteps/computeDelegationSteps.test.ts
+++ b/packages/core-mobile/app/services/earn/computeDelegationSteps/computeDelegationSteps.test.ts
@@ -36,7 +36,8 @@ describe('computeDelegationSteps', () => {
     cChainBaseFee: {} as TokenUnit,
     provider: {} as Avalanche.JsonRpcProvider,
     pFeeAdjustmentThreshold: 5,
-    pFeeMultiplier: 0.2
+    pFeeMultiplier: 0.2,
+    cBaseFeeMultiplier: 1
   }
 
   it('should throw an error when there is insufficient balance', async () => {

--- a/packages/core-mobile/app/services/earn/computeDelegationSteps/computeDelegationSteps.ts
+++ b/packages/core-mobile/app/services/earn/computeDelegationSteps/computeDelegationSteps.ts
@@ -33,7 +33,8 @@ export const computeDelegationSteps = async ({
   cChainBaseFee,
   provider,
   pFeeAdjustmentThreshold,
-  pFeeMultiplier
+  pFeeMultiplier,
+  cBaseFeeMultiplier
 }: {
   pAddress: string
   stakeAmount: bigint
@@ -47,6 +48,7 @@ export const computeDelegationSteps = async ({
   provider: Avalanche.JsonRpcProvider
   pFeeAdjustmentThreshold: number
   pFeeMultiplier: number
+  cBaseFeeMultiplier: number
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }): Promise<Step[]> => {
   let pChainBalance: bigint | undefined
@@ -155,7 +157,8 @@ export const computeDelegationSteps = async ({
           cChainBaseFee,
           accountIndex,
           avaxXPNetwork,
-          pAddress
+          pAddress,
+          cBaseFeeMultiplier
         })
 
         const importPFee = await getImportPFeePostCExport({

--- a/packages/core-mobile/app/services/earn/computeDelegationSteps/utils.ts
+++ b/packages/core-mobile/app/services/earn/computeDelegationSteps/utils.ts
@@ -18,6 +18,7 @@ import { getAssetId } from 'services/wallet/utils'
 import { weiToNano } from 'utils/units/converter'
 import { calculateCChainFee } from 'services/earn/calculateCrossChainFees'
 import { extractNeededAmount } from 'hooks/earn/utils/extractNeededAmount'
+import { addBufferToCChainBaseFee } from 'services/wallet/utils'
 import Logger from 'utils/Logger'
 
 const DUMMY_AMOUNT = 1000000n
@@ -297,14 +298,19 @@ export const getExportCFee = async ({
   cChainBaseFee,
   accountIndex,
   avaxXPNetwork,
-  pAddress
+  pAddress,
+  cBaseFeeMultiplier
 }: {
   cChainBaseFee: TokenUnit
   accountIndex: number
   avaxXPNetwork: Network
   pAddress: string
+  cBaseFeeMultiplier: number
 }): Promise<bigint> => {
-  const paddedCChainBaseFee = WalletService.getInstantBaseFee(cChainBaseFee)
+  const paddedCChainBaseFee = addBufferToCChainBaseFee(
+    cChainBaseFee,
+    cBaseFeeMultiplier
+  )
 
   // using a dummy amount as the amount doesn't affect fee
   const unsignedTx = await WalletService.createExportCTx({

--- a/packages/core-mobile/app/services/earn/exportC.test.ts
+++ b/packages/core-mobile/app/services/earn/exportC.test.ts
@@ -7,6 +7,8 @@ import { avaxSerial, EVM, UnsignedTx, utils } from '@avalabs/avalanchejs'
 import mockNetworks from 'tests/fixtures/networks.json'
 import { Network } from '@avalabs/core-chains-sdk'
 
+const testCBaseFeeMultiplier = 1
+
 describe('earn/exportC', () => {
   describe('exportC', () => {
     const baseFeeMockFn = jest.fn().mockReturnValue(BigInt(0.003 * 1e9))
@@ -64,7 +66,8 @@ describe('earn/exportC', () => {
           requiredAmountWei: BigInt(10e18),
           isDevMode: false,
           activeAccount: {} as Account,
-          isDevnet: false
+          isDevnet: false,
+          cBaseFeeMultiplier: testCBaseFeeMultiplier
         })
       }).rejects.toThrow('Not enough balance on C chain')
     })
@@ -75,7 +78,8 @@ describe('earn/exportC', () => {
         requiredAmountWei: BigInt(1e18),
         isDevMode: false,
         activeAccount: {} as Account,
-        isDevnet: false
+        isDevnet: false,
+        cBaseFeeMultiplier: testCBaseFeeMultiplier
       })
       expect(baseFeeMockFn).toHaveBeenCalled()
     })
@@ -87,7 +91,8 @@ describe('earn/exportC', () => {
           requiredAmountWei: BigInt(1e18),
           isDevMode: false,
           activeAccount: {} as Account,
-          isDevnet: false
+          isDevnet: false,
+          cBaseFeeMultiplier: testCBaseFeeMultiplier
         })
         expect(WalletService.createExportCTx).toHaveBeenCalledWith({
           amountInNAvax: 1000000000n,
@@ -107,7 +112,8 @@ describe('earn/exportC', () => {
           requiredAmountWei: BigInt(1e18),
           isDevMode: false,
           activeAccount: {} as Account,
-          isDevnet: false
+          isDevnet: false,
+          cBaseFeeMultiplier: testCBaseFeeMultiplier
         })
         expect(WalletService.sign).toHaveBeenCalled()
       }).not.toThrow()
@@ -120,7 +126,8 @@ describe('earn/exportC', () => {
           requiredAmountWei: BigInt(1e18),
           isDevMode: false,
           activeAccount: {} as Account,
-          isDevnet: false
+          isDevnet: false,
+          cBaseFeeMultiplier: testCBaseFeeMultiplier
         })
         expect(NetworkService.sendTransaction).toHaveBeenCalled()
       }).not.toThrow()

--- a/packages/core-mobile/app/services/earn/importC.test.ts
+++ b/packages/core-mobile/app/services/earn/importC.test.ts
@@ -5,6 +5,8 @@ import { Avalanche } from '@avalabs/core-wallets-sdk'
 import { avaxSerial, EVM, UnsignedTx, utils } from '@avalabs/avalanchejs'
 import { importC } from 'services/earn/importC'
 
+const testCBaseFeeMultiplier = 1
+
 describe('earn/importC', () => {
   describe('importC', () => {
     const baseFeeMockFn = jest.fn().mockReturnValue(BigInt(250000e9))
@@ -60,11 +62,12 @@ describe('earn/importC', () => {
       await importC({
         activeAccount: {} as Account,
         isDevMode: false,
-        isDevnet: false
+        isDevnet: false,
+        cBaseFeeMultiplier: testCBaseFeeMultiplier
       })
       expect(WalletService.createImportCTx).toHaveBeenCalledWith({
         accountIndex: undefined,
-        baseFeeInNAvax: BigInt(0.0003 * 10 ** 9),
+        baseFeeInNAvax: BigInt(0.0005 * 10 ** 9),
         avaxXPNetwork: NetworkService.getAvalancheNetworkP(false, false),
         sourceChain: 'P',
         destinationAddress: undefined
@@ -75,7 +78,8 @@ describe('earn/importC', () => {
       await importC({
         activeAccount: {} as Account,
         isDevMode: false,
-        isDevnet: false
+        isDevnet: false,
+        cBaseFeeMultiplier: testCBaseFeeMultiplier
       })
       expect(WalletService.sign).toHaveBeenCalled()
     })
@@ -84,7 +88,8 @@ describe('earn/importC', () => {
       await importC({
         activeAccount: {} as Account,
         isDevMode: false,
-        isDevnet: false
+        isDevnet: false,
+        cBaseFeeMultiplier: testCBaseFeeMultiplier
       })
       expect(NetworkService.sendTransaction).toHaveBeenCalled()
     })

--- a/packages/core-mobile/app/services/earn/utils.ts
+++ b/packages/core-mobile/app/services/earn/utils.ts
@@ -19,8 +19,8 @@ import { UTCDate } from '@date-fns/utc'
 import EarnService from './EarnService'
 
 // the max num of times we should check transaction status
-export const maxTransactionStatusCheckRetries = 7 // ~ 2 minutes
-export const maxTransactionCreationRetries = 6 // ~ 1 minute
+export const maxTransactionStatusCheckRetries = 8 // ~ 4 minutes
+export const maxTransactionCreationRetries = 7 // ~ 2 minute
 export const maxBalanceCheckRetries = 10
 export const maxGetAtomicUTXOsRetries = 10
 

--- a/packages/core-mobile/app/services/posthog/types.ts
+++ b/packages/core-mobile/app/services/posthog/types.ts
@@ -39,7 +39,8 @@ export enum FeatureGates {
 export enum FeatureVars {
   SENTRY_SAMPLE_RATE = 'sentry-sample-rate',
   P_FEE_ADJUSTMENT_THRESHOLD = 'p-fee-adjustment-threshold',
-  P_FEE_MULTIPLIER = 'p-fee-multiplier'
+  P_FEE_MULTIPLIER = 'p-fee-multiplier',
+  C_BASE_FEE_MULTIPLIER = 'c-base-fee-multiplier'
 }
 
 // posthog response can be an empty object when all features are disabled

--- a/packages/core-mobile/app/services/wallet/WalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/WalletService.test.ts
@@ -4,7 +4,6 @@ import { add, getUnixTime, sub } from 'date-fns'
 import { Utxo } from '@avalabs/avalanchejs'
 import { PChainId } from '@avalabs/glacier-sdk'
 import NetworkService from 'services/network/NetworkService'
-import { TokenUnit } from '@avalabs/core-utils-sdk'
 
 jest.mock('@avalabs/core-wallets-sdk', () => ({
   ...jest.requireActual('@avalabs/core-wallets-sdk'),
@@ -20,14 +19,6 @@ jest.mock('@avalabs/core-wallets-sdk', () => ({
 }))
 
 describe('WalletService', () => {
-  describe('getInstantBaseFee', () => {
-    it('should increase base fee by 20%', async () => {
-      const baseFee = new TokenUnit(1_000_000_000, 9, 'AVAX')
-      const instantFee = WalletService.getInstantBaseFee(baseFee)
-      expect(instantFee.eq(new TokenUnit(1_200_000_000, 9, 'AVAX'))).toBe(true)
-    })
-  })
-
   describe('createAddDelegatorTx', () => {
     const network = NetworkService.getAvalancheNetworkP(false, false)
     const validNodeId = 'NodeID-23420390293d9j09v'

--- a/packages/core-mobile/app/services/wallet/WalletService.tsx
+++ b/packages/core-mobile/app/services/wallet/WalletService.tsx
@@ -32,7 +32,6 @@ import {
   TypedData,
   TypedDataV1
 } from '@avalabs/vm-module-types'
-import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { UTCDate } from '@date-fns/utc'
 import { nanoToWei } from 'utils/units/converter'
 import { isDevnet } from 'utils/isDevnet'
@@ -54,9 +53,6 @@ type InitProps = {
 
 // Tolerate 50% buffer for burn amount for EVM transactions
 const EVM_FEE_TOLERANCE = 50
-
-// We increase C chain base fee by 20% for instant speed
-const C_CHAIN_BASE_FEE_MULTIPLIER = 0.2
 
 class WalletService {
   #walletType: WalletType = WalletType.UNSET
@@ -351,10 +347,6 @@ class WalletService {
     )
 
     return readOnlySigner.getUTXOs('P')
-  }
-
-  public getInstantBaseFee<T extends TokenUnit>(baseFee: T): TokenUnit {
-    return baseFee.add(baseFee.mul(C_CHAIN_BASE_FEE_MULTIPLIER))
   }
 
   public async createExportCTx({

--- a/packages/core-mobile/app/services/wallet/utils.test.ts
+++ b/packages/core-mobile/app/services/wallet/utils.test.ts
@@ -1,0 +1,16 @@
+import { TokenUnit } from '@avalabs/core-utils-sdk'
+import { addBufferToCChainBaseFee } from './utils'
+
+describe('addBufferToCChainBaseFee', () => {
+  it('should increase base fee by 20%', async () => {
+    const baseFee = new TokenUnit(1_000_000_000, 9, 'AVAX')
+    const instantFee = addBufferToCChainBaseFee(baseFee, 0.2)
+    expect(instantFee.eq(new TokenUnit(1_200_000_000, 9, 'AVAX'))).toBe(true)
+  })
+
+  it('should increase base fee by 150%', async () => {
+    const baseFee = new TokenUnit(1_000_000_000, 9, 'AVAX')
+    const instantFee = addBufferToCChainBaseFee(baseFee, 1.5)
+    expect(instantFee.eq(new TokenUnit(2_500_000_000, 9, 'AVAX'))).toBe(true)
+  })
+})

--- a/packages/core-mobile/app/services/wallet/utils.ts
+++ b/packages/core-mobile/app/services/wallet/utils.ts
@@ -1,6 +1,7 @@
 import { Avalanche } from '@avalabs/core-wallets-sdk'
 import { isDevnet } from 'utils/isDevnet'
 import { Network } from '@avalabs/core-chains-sdk'
+import { TokenUnit } from '@avalabs/core-utils-sdk'
 import {
   AvalancheTransactionRequest,
   BtcTransactionRequest,
@@ -29,4 +30,12 @@ export const getAssetId = (avaxXPNetwork: Network): string => {
     : avaxXPNetwork.isTestnet
     ? TESTNET_AVAX_ASSET_ID
     : MAINNET_AVAX_ASSET_ID
+}
+
+// we add some buffer to C chain base fee to gain better speed
+export const addBufferToCChainBaseFee = (
+  baseFee: TokenUnit,
+  multiplier: number
+): TokenUnit => {
+  return baseFee.add(baseFee.mul(multiplier))
 }

--- a/packages/core-mobile/app/store/posthog/slice.ts
+++ b/packages/core-mobile/app/store/posthog/slice.ts
@@ -179,6 +179,11 @@ export const selectPFeeMultiplier = (state: RootState): number => {
   return parseFloat(featureFlags[FeatureVars.P_FEE_MULTIPLIER] as string)
 }
 
+export const selectCBaseFeeMultiplier = (state: RootState): number => {
+  const { featureFlags } = state.posthog
+  return parseFloat(featureFlags[FeatureVars.C_BASE_FEE_MULTIPLIER] as string)
+}
+
 export const selectUseLeftFab = (state: RootState): boolean => {
   const { featureFlags } = state.posthog
   return (

--- a/packages/core-mobile/app/store/posthog/types.ts
+++ b/packages/core-mobile/app/store/posthog/types.ts
@@ -15,6 +15,7 @@ export const DefaultFeatureFlagConfig = {
   [FeatureVars.SENTRY_SAMPLE_RATE]: '10', // 10% of events/errors
   [FeatureVars.P_FEE_ADJUSTMENT_THRESHOLD]: '1e-3', // 0.1%
   [FeatureVars.P_FEE_MULTIPLIER]: '2e-1', // 20%
+  [FeatureVars.C_BASE_FEE_MULTIPLIER]: '1e0', // 100%
   [FeatureGates.BUY_COINBASE_PAY]: true,
   [FeatureGates.DEFI]: true,
   [FeatureGates.BROWSER]: true,


### PR DESCRIPTION
## Description

**Ticket: [CP-9864]** 

This pr fixes a couple of things:
- import C and export C "tx failed due to insufficient funds" issue (https://ava-labs.atlassian.net/browse/CP-9864) :
  - this affects delegation as well as claiming rewards
  - the error message actually just means the supplied base fee is too low. the fix is just to increase base C-Chain fee by 100%. web did the same [here](https://github.com/ava-labs/core-web/pull/73) 
  - I also go ahead and make this c-chain base fee multiplier dynamic via the posthog flag`c-base-fee-multiplier`
- unable to claim issue (https://ava-labs.atlassian.net/browse/CP-9833)
  - this is due to us using the wrong amount for export P. the fix is in this [commit](https://github.com/ava-labs/core-mobile/pull/2223/commits/fe20e8839a20980aba42bb6d4fabee89b140eab9).
- some UI/UX improvements:
  - [make sure we freeze balance amount and don't show error while claiming is in progress](https://github.com/ava-labs/core-mobile/pull/2223/commits/d056ea6e4156df0a1b6c355392b6e27ca04fab4b)
  
## Screenshots/Videos
claiming rewards
https://github.com/user-attachments/assets/00b49c50-359e-4304-a3a6-5109ce288953

staking
https://github.com/user-attachments/assets/a1052b12-4154-4126-ad53-078d49eff989

## Testing
please re-test all the different staking cases as well as claiming rewards

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9864]: https://ava-labs.atlassian.net/browse/CP-9864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ