### PR TITLE
CP-9880: add a buffer to all fees for cross chain amount

### DIFF
--- a/packages/core-mobile/app/hooks/earn/useDelegation.ts
+++ b/packages/core-mobile/app/hooks/earn/useDelegation.ts
@@ -7,7 +7,7 @@ import { useCChainBaseFee } from 'hooks/useCChainBaseFee'
 import { selectActiveNetwork } from 'store/network/slice'
 import {
   selectPFeeAdjustmentThreshold,
-  selectPFeeMultiplier,
+  selectCrossChainFeesMultiplier,
   selectCBaseFeeMultiplier
 } from 'store/posthog/slice'
 import { isDevnet } from 'utils/isDevnet'
@@ -43,12 +43,13 @@ export const useDelegation = (): {
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const selectedCurrency = useSelector(selectSelectedCurrency)
   const pFeeAdjustmentThreshold = useSelector(selectPFeeAdjustmentThreshold)
-  const pFeeMultiplier = useSelector(selectPFeeMultiplier)
+  const crossChainFeesMultiplier = useSelector(selectCrossChainFeesMultiplier)
   const cBaseFeeMultiplier = useSelector(selectCBaseFeeMultiplier)
   const { defaultFeeState } = useGetFeeState()
   const cChainNetwork = useCChainNetwork()
   const avaxProvider = useAvalancheXpProvider(isDeveloperMode)
   const cChainBaseFee = useCChainBaseFee()
+
   const networkFees = useMemo(
     () =>
       steps.reduce((sum, transaction) => {
@@ -56,6 +57,7 @@ export const useDelegation = (): {
       }, BigInt(0)),
     [steps]
   )
+
   const isDevNetwork = isDevnet(activeNetwork)
 
   const compute: Compute = useCallback(
@@ -83,11 +85,11 @@ export const useDelegation = (): {
         cChainNetwork,
         provider: avaxProvider,
         pFeeAdjustmentThreshold,
-        pFeeMultiplier,
         cBaseFeeMultiplier,
         cChainBaseFee: cChainBaseFee.data,
         feeState: defaultFeeState,
-        stakeAmount: stakeAmount
+        stakeAmount: stakeAmount,
+        crossChainFeesMultiplier
       })
 
       setSteps(result)
@@ -101,8 +103,8 @@ export const useDelegation = (): {
       defaultFeeState,
       isDeveloperMode,
       pFeeAdjustmentThreshold,
-      pFeeMultiplier,
       cBaseFeeMultiplier,
+      crossChainFeesMultiplier,
       selectedCurrency,
       avaxProvider
     ]
@@ -116,7 +118,7 @@ export const useDelegation = (): {
       }
 
       if (steps.length === 0) {
-        throw new Error('No valid delegation steps found')
+        throw new Error('An unexpected error occurred. Please retry.')
       }
 
       Logger.info(

--- a/packages/core-mobile/app/screens/earn/Confirmation/Confirmation.tsx
+++ b/packages/core-mobile/app/screens/earn/Confirmation/Confirmation.tsx
@@ -140,7 +140,7 @@ export const Confirmation = (): JSX.Element | null => {
         networkFees,
         pNetwork.networkToken.decimals,
         pNetwork.networkToken.symbol
-      ).toDisplay(),
+      ).toDisplay({ fixedDp: 6 }),
     [networkFees, pNetwork.networkToken.decimals, pNetwork.networkToken.symbol]
   )
 
@@ -404,11 +404,11 @@ export const Confirmation = (): JSX.Element | null => {
           }}>
           <Tooltip
             content={renderPopoverInfoText(
-              'Fee paid to the network to execute the transaction'
+              'Estimated fee paid to the network to execute the transaction'
             )}
             position="right"
             style={{ width: 200 }}>
-            Network Fee
+            Estimated Network Fee
           </Tooltip>
           {renderNetworkFee()}
         </Row>

--- a/packages/core-mobile/app/services/earn/computeDelegationSteps/computeDelegationSteps.test.ts
+++ b/packages/core-mobile/app/services/earn/computeDelegationSteps/computeDelegationSteps.test.ts
@@ -10,6 +10,7 @@ import { computeDelegationSteps } from './computeDelegationSteps'
 jest.mock('services/balance/getPChainBalance')
 jest.mock('services/balance/getCChainBalance')
 jest.mock('./utils', () => ({
+  ...jest.requireActual('./utils'),
   getPChainAtomicBalance: jest.fn(),
   getDelegationFee: jest.fn(),
   getImportPFee: jest.fn(),
@@ -36,7 +37,7 @@ describe('computeDelegationSteps', () => {
     cChainBaseFee: {} as TokenUnit,
     provider: {} as Avalanche.JsonRpcProvider,
     pFeeAdjustmentThreshold: 5,
-    pFeeMultiplier: 0.2,
+    crossChainFeesMultiplier: 4,
     cBaseFeeMultiplier: 1
   }
 
@@ -113,7 +114,7 @@ describe('computeDelegationSteps', () => {
     expect(steps).toEqual([
       {
         operation: 'exportC',
-        amount: 43n,
+        amount: 120n,
         fee: 5n
       },
       { operation: 'importP', fee: 5n },

--- a/packages/core-mobile/app/services/earn/computeDelegationSteps/computeDelegationSteps.ts
+++ b/packages/core-mobile/app/services/earn/computeDelegationSteps/computeDelegationSteps.ts
@@ -14,7 +14,8 @@ import {
   getImportPFeePostCExport,
   getDelegationFee,
   getDelegationFeePostPImport,
-  getDelegationFeePostCExportAndPImport
+  getDelegationFeePostCExportAndPImport,
+  bigIntDiff
 } from './utils'
 
 const INSUFFICIENT_BALANCE_ERROR = new Error(
@@ -33,8 +34,8 @@ export const computeDelegationSteps = async ({
   cChainBaseFee,
   provider,
   pFeeAdjustmentThreshold,
-  pFeeMultiplier,
-  cBaseFeeMultiplier
+  cBaseFeeMultiplier,
+  crossChainFeesMultiplier
 }: {
   pAddress: string
   stakeAmount: bigint
@@ -47,8 +48,8 @@ export const computeDelegationSteps = async ({
   cChainBaseFee: TokenUnit | undefined
   provider: Avalanche.JsonRpcProvider
   pFeeAdjustmentThreshold: number
-  pFeeMultiplier: number
   cBaseFeeMultiplier: number
+  crossChainFeesMultiplier: number
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }): Promise<Step[]> => {
   let pChainBalance: bigint | undefined
@@ -181,39 +182,28 @@ export const computeDelegationSteps = async ({
           pFeeAdjustmentThreshold
         })
 
+        Logger.info(
+          `applying ${crossChainFeesMultiplier} multiplier to all fees`
+        )
+
+        // add some padding to the fees before calculating the amount to transfer
+        const adjustedAllFees = BigInt(
+          Math.ceil(
+            Number(exportCFee + importPFee + delegationFee) *
+              (1 + crossChainFeesMultiplier)
+          )
+        )
+
+        const amountToTransfer =
+          bigIntDiff(stakeAmount, pChainBalance) -
+          pChainAtomicBalance +
+          adjustedAllFees
+
         // we need to check if we have enough balance on C-Chain to transfer
-        if (
-          weiToNano(cChainBalance.balance) +
-            pChainAtomicBalance +
-            pChainBalance -
-            exportCFee -
-            importPFee -
-            delegationFee <
-          stakeAmount
-        ) {
+        if (amountToTransfer >= weiToNano(cChainBalance.balance)) {
           Logger.error('Case 2.1, 2.2, 3.1, 3.2 failed: insufficient balance')
           throw INSUFFICIENT_BALANCE_ERROR
         }
-
-        Logger.info(
-          `applying ${pFeeMultiplier} multiplier to importPFee and delegationFee`
-        )
-
-        const adjustedImportPFee = BigInt(
-          Math.ceil(Number(importPFee) * (1 + pFeeMultiplier))
-        )
-        const adjustedDelegationFee = BigInt(
-          Math.ceil(Number(delegationFee) * (1 + pFeeMultiplier))
-        )
-
-        // add some padding to the amount to transfer to account for the fees (import and delegation fees)
-        const amountToTransfer =
-          stakeAmount -
-          pChainAtomicBalance -
-          pChainBalance +
-          exportCFee +
-          adjustedImportPFee +
-          adjustedDelegationFee
 
         return [
           {

--- a/packages/core-mobile/app/services/earn/computeDelegationSteps/utils.ts
+++ b/packages/core-mobile/app/services/earn/computeDelegationSteps/utils.ts
@@ -369,6 +369,6 @@ const getTransferOutputUtxos = ({
     )
   )
 
-const bigIntDiff = (a: bigint, b: bigint): bigint => {
+export const bigIntDiff = (a: bigint, b: bigint): bigint => {
   return a > b ? a - b : b - a
 }

--- a/packages/core-mobile/app/services/posthog/types.ts
+++ b/packages/core-mobile/app/services/posthog/types.ts
@@ -40,7 +40,8 @@ export enum FeatureVars {
   SENTRY_SAMPLE_RATE = 'sentry-sample-rate',
   P_FEE_ADJUSTMENT_THRESHOLD = 'p-fee-adjustment-threshold',
   P_FEE_MULTIPLIER = 'p-fee-multiplier',
-  C_BASE_FEE_MULTIPLIER = 'c-base-fee-multiplier'
+  C_BASE_FEE_MULTIPLIER = 'c-base-fee-multiplier',
+  CROSS_CHAIN_FEES_MULTIPLIER = 'cross-chain-fees-multiplier'
 }
 
 // posthog response can be an empty object when all features are disabled

--- a/packages/core-mobile/app/store/posthog/slice.ts
+++ b/packages/core-mobile/app/store/posthog/slice.ts
@@ -174,9 +174,17 @@ export const selectPFeeAdjustmentThreshold = (state: RootState): number => {
   )
 }
 
+// TODO deprecate since we no longer use this
 export const selectPFeeMultiplier = (state: RootState): number => {
   const { featureFlags } = state.posthog
   return parseFloat(featureFlags[FeatureVars.P_FEE_MULTIPLIER] as string)
+}
+
+export const selectCrossChainFeesMultiplier = (state: RootState): number => {
+  const { featureFlags } = state.posthog
+  return parseFloat(
+    featureFlags[FeatureVars.CROSS_CHAIN_FEES_MULTIPLIER] as string
+  )
 }
 
 export const selectCBaseFeeMultiplier = (state: RootState): number => {

--- a/packages/core-mobile/app/store/posthog/types.ts
+++ b/packages/core-mobile/app/store/posthog/types.ts
@@ -15,6 +15,7 @@ export const DefaultFeatureFlagConfig = {
   [FeatureVars.SENTRY_SAMPLE_RATE]: '10', // 10% of events/errors
   [FeatureVars.P_FEE_ADJUSTMENT_THRESHOLD]: '1e-3', // 0.1%
   [FeatureVars.P_FEE_MULTIPLIER]: '2e-1', // 20%
+  [FeatureVars.CROSS_CHAIN_FEES_MULTIPLIER]: '4e0', // 400%
   [FeatureVars.C_BASE_FEE_MULTIPLIER]: '1e0', // 100%
   [FeatureGates.BUY_COINBASE_PAY]: true,
   [FeatureGates.DEFI]: true,


### PR DESCRIPTION
## Description

**Ticket: [CP-9880]** 

Looks like we will occasionally run into situations where we are missing 10000-100000 nAVAX (0.0001 AVAX) when trying to do a delegation that involves a cross chain transfer from C-Chain. This pr adds a buffer (currently configured at 400% via the `cross-chain-fees-multiplier` feature flag) to all the fees, which are then added to the final amount to transfer. This seems to work okay since the actual fees are usually way lesser. The only drawback is users will have a little bit AVAX remaining on P-Chain after submitting the delegation.  

## Screenshots/Videos
https://github.com/user-attachments/assets/8146bed0-1fa3-4a8b-93f7-df91e3e780e0


## Testing
Please re-test all the different staking scenarios

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9880]: https://ava-labs.atlassian.net/browse/CP-9880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ