### PR TITLE
CP-9750: Fix in-app browser cutting off token search bar in LFJ

### DIFF
--- a/packages/core-mobile/app/App.tsx
+++ b/packages/core-mobile/app/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { KeyboardAvoidingView, Platform, SafeAreaView } from 'react-native'
 import RootScreenStack from 'navigation/RootScreenStack'
 import { NavigationContainer } from '@react-navigation/native'
@@ -9,25 +9,49 @@ import SentryService from 'services/sentry/SentryService'
 import DataDogService from 'services/datadog/DataDogService'
 import Logger from 'utils/Logger'
 
+const BROWSER_TAB_ROUTE_NAME = 'BrowserScreens.TabView'
+
 function App(): JSX.Element {
   const context = useApplicationContext()
   const [backgroundStyle] = useState(context.appBackgroundStyle)
+  const routeNameRef = React.useRef<string>()
+
+  const handleNavigationStateChange = useCallback(() => {
+    const previousRouteName = routeNameRef.current
+    const currentRouteName = navigationRef?.current?.getCurrentRoute?.()?.name
+
+    if (previousRouteName !== currentRouteName) {
+      // Save the current route name for later comparison
+      routeNameRef.current = currentRouteName
+    }
+  }, [])
+
+  const handleNavigationReady = useCallback(() => {
+    routeNameRef.current = navigationRef.current?.getCurrentRoute?.()?.name
+    SentryService.routingInstrumentation.registerNavigationContainer(
+      navigationRef
+    )
+    DataDogService.init(navigationRef).catch(Logger.error)
+  }, [])
+
+  // only enable the keyboard avoiding view when we are not in the browser tab
+  // reason: we don't want the webview's content to be pushed up when the keyboard is shown
+  // this prevents issues such as "In-app browser cutting off token search bar in LFJ"
+  // https://ava-labs.atlassian.net/browse/CP-9750
+  const shouldEnableKeyboardAvoidingView =
+    routeNameRef.current !== BROWSER_TAB_ROUTE_NAME
 
   return (
     <SafeAreaView style={backgroundStyle}>
       <KeyboardAvoidingView
-        enabled={context.keyboardAvoidingViewEnabled}
+        enabled={shouldEnableKeyboardAvoidingView}
         style={{ flex: 1 }}
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
         <NavigationContainer
           theme={context.navContainerTheme}
           ref={navigationRef}
-          onReady={() => {
-            SentryService.routingInstrumentation.registerNavigationContainer(
-              navigationRef
-            )
-            DataDogService.init(navigationRef).catch(Logger.error)
-          }}>
+          onStateChange={handleNavigationStateChange}
+          onReady={handleNavigationReady}>
           <RootScreenStack />
         </NavigationContainer>
       </KeyboardAvoidingView>

--- a/packages/core-mobile/app/navigation/NavUtils.tsx
+++ b/packages/core-mobile/app/navigation/NavUtils.tsx
@@ -77,6 +77,7 @@ export const SubHeaderOptions = (
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const getCommonBottomTabOptions = (theme: AppTheme) => ({
+  tabBarHideOnKeyboard: true,
   tabBarShowLabel: false,
   headerShown: true,
   tabBarAllowFontScaling: false,


### PR DESCRIPTION
## Description

**Ticket: [CP-9750]** 

- disable KeyboardAvoidingView when we are in the browser tab to prevent webview's content from being pushed up
- also hide bottom tab bar globally whenever keyboard appears

## Screenshots/Videos
https://github.com/user-attachments/assets/5bd6e0d2-e1bc-4a9d-8d8d-7f824420a73b

## Testing
Please retest all dapp interaction within the browser

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9750]: https://ava-labs.atlassian.net/browse/CP-9750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ