### PR TITLE
CP-9742: Reset userDefault badgeCount when app becomes active

### DIFF
--- a/packages/core-mobile/ios/AppDelegate.mm
+++ b/packages/core-mobile/ios/AppDelegate.mm
@@ -78,10 +78,10 @@
 #endif
 }
 
-- (void)applicationWillEnterForeground:(UIApplication *)application {
+- (void)applicationDidBecomeActive:(UIApplication *)application {
   // this only reset the badgeCount in app group userDefaults,
   // the actual badge count is reset in handleNotificationCleanup
   // inside react native project
-    [[[NSUserDefaults alloc] initWithSuiteName:@"group.org.avalabs.corewallet"] setInteger:0 forKey:@"badgeCount"];
+  [[[NSUserDefaults alloc] initWithSuiteName:@"group.org.avalabs.corewallet"] setInteger:0 forKey:@"badgeCount"];
 }
 @end


### PR DESCRIPTION
## Description

**Ticket: [CP-9742]** 

- use ApplicationDidbecomeActive to reset badgeCount in userDefaults to 0 whenever app is active

## Screenshots/Videos

https://github.com/user-attachments/assets/622660bd-5f01-4297-8455-f8dedace9738

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-9742]: https://ava-labs.atlassian.net/browse/CP-9742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ