### PR TITLE
QA Chore - transactions structured automation tests

### DIFF
--- a/packages/core-mobile/e2e/tests/plusIcon/bridge/bridge.e2e.ts
+++ b/packages/core-mobile/e2e/tests/plusIcon/bridge/bridge.e2e.ts
@@ -4,7 +4,6 @@ import bridgeTabPage from '../../../pages/bridgeTab.page'
 import portfolioLoc from '../../../locators/portfolio.loc'
 import commonElsPage from '../../../pages/commonEls.page'
 import sendPage from '../../../pages/send.page'
-import popUpModalPage from '../../../pages/popUpModal.page'
 import bridgeTabLoc from '../../../locators/bridgeTab.loc'
 import { cleanup } from '../../../helpers/cleanup'
 
@@ -56,49 +55,6 @@ describe('Bridge Screen', () => {
 
       // Exit bridge screen
       await bridgeTabPage.tapBridgeToggleBtn()
-      await commonElsPage.goBack()
-    })
-  })
-
-  networks.forEach(({ network, token }) => {
-    it(`should show Bridge Approval Modal for Avalanche to ${network}`, async () => {
-      // Avalanche > Select token with Max amount
-      if (token === 'BTC') token = 'BTC.b'
-      await bridgeTabPage.goToBridge()
-      await bridgeTabPage.tapSelectToken()
-      await sendPage.selectToken(token)
-      await sendPage.tapMax()
-
-      // Verify approve modal with legit fee > Reject
-      await bridgeTabPage.tapBridgeBtn()
-      await popUpModalPage.verifyFeeIsLegit(true, false, 0.02)
-      await popUpModalPage.tapRejectBtn()
-
-      // Exit bridge screen
-      await commonElsPage.goBack()
-    })
-  })
-
-  networks.forEach(({ network, token }) => {
-    it(`should show Bridge Approval Modal for ${network} to Avalanche`, async () => {
-      // Select Ethereum network
-      await bridgeTabPage.goToBridge()
-      await bridgeTabPage.tapFromNetwork()
-      await commonElsPage.tapDropdownItem(network, platformIndex)
-
-      // Select token. If Ethereum, update token to `ETH`
-      await bridgeTabPage.tapSelectToken()
-      token = network === portfolioLoc.ethNetwork ? 'ETH' : token
-      await sendPage.selectToken(token)
-      await sendPage.tapMax()
-      // Verify approve modal with legit fee > Reject
-      await bridgeTabPage.tapBridgeBtn()
-      if (network === portfolioLoc.ethNetwork) {
-        await popUpModalPage.verifyFeeIsLegit(false, false, 0.02)
-      }
-      await popUpModalPage.tapRejectBtn()
-
-      // Exit bridge screen
       await commonElsPage.goBack()
     })
   })

--- a/packages/core-mobile/e2e/tests/transactions/bitcoin/bridgeBitcoin.e2e.ts
+++ b/packages/core-mobile/e2e/tests/transactions/bitcoin/bridgeBitcoin.e2e.ts
@@ -1,0 +1,32 @@
+import { warmup } from '../../../helpers/warmup'
+import bridgeTabPage from '../../../pages/bridgeTab.page'
+import commonElsPage from '../../../pages/commonEls.page'
+import sendPage from '../../../pages/send.page'
+import popUpModalPage from '../../../pages/popUpModal.page'
+import { cleanup } from '../../../helpers/cleanup'
+import bottomTabsPage from '../../../pages/bottomTabs.page'
+import portfolioPage from '../../../pages/portfolio.page'
+
+// Please note that the tests here are NOT for completing the bridge transactions,
+// but for verifying the bridge screen and its elements'
+// Since Bridge Transactions are expensive, we are just testing the flow between networks on e2e daily run.
+describe('Bridge Bitcoin', () => {
+  beforeAll(async () => {
+    await warmup()
+  })
+
+  afterAll(async () => {
+    await cleanup()
+  })
+
+  it(`should verify Bridge Flow from Bitcoin to Avalanche`, async () => {
+    await bottomTabsPage.tapPortfolioTab()
+    await portfolioPage.tapNetworksDropdown()
+    await portfolioPage.tapNetworksDropdownBTC()
+    await bridgeTabPage.goToBridge()
+    await sendPage.tapMax()
+    await bridgeTabPage.tapBridgeBtn()
+    await popUpModalPage.tapRejectBtn()
+    await commonElsPage.goBack()
+  })
+})

--- a/packages/core-mobile/e2e/tests/transactions/bitcoin/sendBitcoin.e2e.ts
+++ b/packages/core-mobile/e2e/tests/transactions/bitcoin/sendBitcoin.e2e.ts
@@ -3,23 +3,35 @@ import { cleanup } from '../../../helpers/cleanup'
 import { warmup } from '../../../helpers/warmup'
 import sendLoc from '../../../locators/send.loc'
 import accountManagePage from '../../../pages/accountManage.page'
-import activityTabPage from '../../../pages/activityTab.page'
 import bottomTabsPage from '../../../pages/bottomTabs.page'
 import advancedPage from '../../../pages/burgerMenu/advanced.page'
 import networksManagePage from '../../../pages/networksManage.page'
 import portfolioPage from '../../../pages/portfolio.page'
 import sendPage from '../../../pages/send.page'
 
-describe('Send BTC', () => {
+describe('Bitcoin Transaction', () => {
   beforeAll(async () => {
     await warmup()
+    await accountManagePage.createSecondAccount()
   })
 
   afterAll(async () => {
     await cleanup()
   })
 
-  it('Should switch to Bitcoin TestNet', async () => {
+  it('should send BTC', async () => {
+    await bottomTabsPage.tapPortfolioTab()
+    await portfolioPage.tapNetworksDropdown()
+    await portfolioPage.tapNetworksDropdownBTC()
+    await sendPage.sendTokenTo2ndAccount(
+      sendLoc.btcToken,
+      sendLoc.sendingAmount,
+      false
+    )
+    await sendPage.verifySuccessToast()
+  })
+
+  it('Should send BTC on testnet', async () => {
     await bottomTabsPage.tapPortfolioTab()
     await advancedPage.switchToTestnet()
     await networksManagePage.switchToBitcoinTestNet()
@@ -27,23 +39,11 @@ describe('Send BTC', () => {
       networksManagePage.bitcoinTestnetNetwork,
       60000
     )
-  }, 120000)
-
-  it('Should send Bitcoin Testnet', async () => {
-    await accountManagePage.createSecondAccount()
-    await sendPage.sendTokenTo2ndAccount(sendLoc.btcToken, '0.0001')
+    await sendPage.sendTokenTo2ndAccount(
+      sendLoc.btcToken,
+      sendLoc.sendingAmount,
+      false
+    )
     await sendPage.verifySuccessToast()
-  })
-
-  it('Should verify the BTC transaction on TestNet ', async () => {
-    await networksManagePage.tapBitcoinTestNetwork(1)
-    await portfolioPage.tapActivityTab()
-    const sendRow = await activityTabPage.getLatestActivityRow()
-    await activityTabPage.verifyActivityRow(sendRow, 'Send')
-
-    await accountManagePage.switchToSecondAccount()
-    const receiveRow = await activityTabPage.getLatestActivityRow()
-    await activityTabPage.verifyActivityRow(receiveRow, 'Receive')
-    await accountManagePage.switchToFirstAccount()
-  })
+  }, 120000)
 })

--- a/packages/core-mobile/e2e/tests/transactions/cchain/bridge/bridge.e2e.ts
+++ b/packages/core-mobile/e2e/tests/transactions/cchain/bridge/bridge.e2e.ts
@@ -1,0 +1,38 @@
+import { warmup } from '../../../../helpers/warmup'
+import bridgeTabPage from '../../../../pages/bridgeTab.page'
+import portfolioLoc from '../../../../locators/portfolio.loc'
+import commonElsPage from '../../../../pages/commonEls.page'
+import sendPage from '../../../../pages/send.page'
+import popUpModalPage from '../../../../pages/popUpModal.page'
+
+// Please note that the tests here are NOT for completing the bridge transactions,
+// but for verifying the bridge screen and its elements'
+// Since Bridge Transactions are expensive, we are just testing the flow between networks on e2e daily run.
+describe('Bridge C-Chain', () => {
+  beforeAll(async () => {
+    await warmup()
+  })
+
+  const networks = [
+    { network: portfolioLoc.ethNetwork, token: 'USDC' },
+    { network: portfolioLoc.btcNetwork, token: 'BTC.b' }
+  ]
+
+  networks.forEach(({ network, token }) => {
+    it(`should verify Bridge Flow from Avalanche to ${network}`, async () => {
+      // Avalanche > Select token with Max amount
+      await bridgeTabPage.goToBridge()
+      await bridgeTabPage.tapSelectToken()
+      await sendPage.selectToken(token)
+      await sendPage.tapMax()
+
+      // Verify approve modal with legit fee > Reject
+      await bridgeTabPage.tapBridgeBtn()
+      await popUpModalPage.verifyFeeIsLegit(true, false, 0.02)
+      await popUpModalPage.tapRejectBtn()
+
+      // Exit bridge screen
+      await commonElsPage.goBack()
+    })
+  })
+})

--- a/packages/core-mobile/e2e/tests/transactions/cchain/send/send.e2e.smoke.ts
+++ b/packages/core-mobile/e2e/tests/transactions/cchain/send/send.e2e.smoke.ts
@@ -1,9 +1,9 @@
-import { warmup } from '../../../helpers/warmup'
-import sendLoc from '../../../locators/send.loc'
-import accountManagePage from '../../../pages/accountManage.page'
-import activityTabPage from '../../../pages/activityTab.page'
-import portfolioPage from '../../../pages/portfolio.page'
-import sendPage from '../../../pages/send.page'
+import { warmup } from '../../../../helpers/warmup'
+import sendLoc from '../../../../locators/send.loc'
+import accountManagePage from '../../../../pages/accountManage.page'
+import activityTabPage from '../../../../pages/activityTab.page'
+import portfolioPage from '../../../../pages/portfolio.page'
+import sendPage from '../../../../pages/send.page'
 
 describe('Send AVAX', () => {
   beforeAll(async () => {

--- a/packages/core-mobile/e2e/tests/transactions/cchain/send/sendERC20.e2e.parameterized.ts
+++ b/packages/core-mobile/e2e/tests/transactions/cchain/send/sendERC20.e2e.parameterized.ts
@@ -1,8 +1,8 @@
-import actions from '../../../helpers/actions'
-import { Tokens } from '../../../helpers/tokens'
-import { warmup } from '../../../helpers/warmup'
-import accountManagePage from '../../../pages/accountManage.page'
-import sendPage from '../../../pages/send.page'
+import actions from '../../../../helpers/actions'
+import { Tokens } from '../../../../helpers/tokens'
+import { warmup } from '../../../../helpers/warmup'
+import accountManagePage from '../../../../pages/accountManage.page'
+import sendPage from '../../../../pages/send.page'
 
 describe('Send ERC20', () => {
   beforeAll(async () => {

--- a/packages/core-mobile/e2e/tests/transactions/cchain/send/sendNft.e2e.ts
+++ b/packages/core-mobile/e2e/tests/transactions/cchain/send/sendNft.e2e.ts
@@ -1,10 +1,10 @@
-import AccountManagePage from '../../pages/accountManage.page'
-import PortfolioPage from '../../pages/portfolio.page'
-import CollectiblesPage from '../../pages/collectibles.page'
-import { warmup } from '../../helpers/warmup'
-import activityTabPage from '../../pages/activityTab.page'
-import { cleanup } from '../../helpers/cleanup'
-import sendPage from '../../pages/send.page'
+import AccountManagePage from '../../../../pages/accountManage.page'
+import PortfolioPage from '../../../../pages/portfolio.page'
+import CollectiblesPage from '../../../../pages/collectibles.page'
+import { warmup } from '../../../../helpers/warmup'
+import activityTabPage from '../../../../pages/activityTab.page'
+import { cleanup } from '../../../../helpers/cleanup'
+import sendPage from '../../../../pages/send.page'
 
 describe('Send NFT', () => {
   beforeAll(async () => {

--- a/packages/core-mobile/e2e/tests/transactions/cchain/stake/stakingMainnet.e2e.ts
+++ b/packages/core-mobile/e2e/tests/transactions/cchain/stake/stakingMainnet.e2e.ts
@@ -1,13 +1,13 @@
-import Actions from '../../helpers/actions'
-import ConfirmStakingPage from '../../pages/Stake/confirmStaking.page'
-import BottomTabsPage from '../../pages/bottomTabs.page'
-import DurationPage from '../../pages/Stake/duration.page'
-import { warmup } from '../../helpers/warmup'
-import GetStartedScreenPage from '../../pages/Stake/getStartedScreen.page'
-import StakePage from '../../pages/Stake/stake.page'
-import AccountManagePage from '../../pages/accountManage.page'
-import commonElsPage from '../../pages/commonEls.page'
-import advancedPage from '../../pages/burgerMenu/advanced.page'
+import Actions from '../../../../helpers/actions'
+import ConfirmStakingPage from '../../../../pages/Stake/confirmStaking.page'
+import BottomTabsPage from '../../../../pages/bottomTabs.page'
+import DurationPage from '../../../../pages/Stake/duration.page'
+import { warmup } from '../../../../helpers/warmup'
+import GetStartedScreenPage from '../../../../pages/Stake/getStartedScreen.page'
+import StakePage from '../../../../pages/Stake/stake.page'
+import AccountManagePage from '../../../../pages/accountManage.page'
+import commonElsPage from '../../../../pages/commonEls.page'
+import advancedPage from '../../../../pages/burgerMenu/advanced.page'
 
 describe('Stake on Mainnet', () => {
   beforeAll(async () => {

--- a/packages/core-mobile/e2e/tests/transactions/cchain/stake/stakingTestnet.e2e.ts
+++ b/packages/core-mobile/e2e/tests/transactions/cchain/stake/stakingTestnet.e2e.ts
@@ -1,10 +1,10 @@
-import Actions from '../../helpers/actions'
-import AdvancedPage from '../../pages/burgerMenu/advanced.page'
-import BottomTabsPage from '../../pages/bottomTabs.page'
-import { warmup } from '../../helpers/warmup'
-import StakePage from '../../pages/Stake/stake.page'
-import ClaimPage from '../../pages/Stake/claim.page'
-import advancedPage from '../../pages/burgerMenu/advanced.page'
+import Actions from '../../../../helpers/actions'
+import AdvancedPage from '../../../../pages/burgerMenu/advanced.page'
+import BottomTabsPage from '../../../../pages/bottomTabs.page'
+import { warmup } from '../../../../helpers/warmup'
+import StakePage from '../../../../pages/Stake/stake.page'
+import ClaimPage from '../../../../pages/Stake/claim.page'
+import advancedPage from '../../../../pages/burgerMenu/advanced.page'
 
 describe('Stake on Testnet', () => {
   beforeAll(async () => {

--- a/packages/core-mobile/e2e/tests/transactions/cchain/swap/swap.e2e.parameterized.ts
+++ b/packages/core-mobile/e2e/tests/transactions/cchain/swap/swap.e2e.parameterized.ts
@@ -1,9 +1,9 @@
-import actions from '../../../helpers/actions'
-import { SwapTokens } from '../../../helpers/tokens'
-import { warmup } from '../../../helpers/warmup'
-import swapTabLoc from '../../../locators/swapTab.loc'
-import SendPage from '../../../pages/send.page'
-import SwapTabPage from '../../../pages/swapTab.page'
+import actions from '../../../../helpers/actions'
+import { SwapTokens } from '../../../../helpers/tokens'
+import { warmup } from '../../../../helpers/warmup'
+import swapTabLoc from '../../../../locators/swapTab.loc'
+import SendPage from '../../../../pages/send.page'
+import SwapTabPage from '../../../../pages/swapTab.page'
 
 describe('Swap AVAX to Parameterized Tokens', () => {
   beforeEach(async () => {

--- a/packages/core-mobile/e2e/tests/transactions/cchain/swap/swap.e2e.smoke.ts
+++ b/packages/core-mobile/e2e/tests/transactions/cchain/swap/swap.e2e.smoke.ts
@@ -1,6 +1,6 @@
-import { warmup } from '../../../helpers/warmup'
-import SendPage from '../../../pages/send.page'
-import SwapTabPage from '../../../pages/swapTab.page'
+import { warmup } from '../../../../helpers/warmup'
+import SendPage from '../../../../pages/send.page'
+import SwapTabPage from '../../../../pages/swapTab.page'
 
 describe('Swap', () => {
   beforeAll(async () => {

--- a/packages/core-mobile/e2e/tests/transactions/cchain/swap/swapDapps.e2e.ts
+++ b/packages/core-mobile/e2e/tests/transactions/cchain/swap/swapDapps.e2e.ts
@@ -1,7 +1,7 @@
-import { warmup } from '../../../helpers/warmup'
-import browserPage from '../../../pages/browser.page'
-import popUpModalPage from '../../../pages/popUpModal.page'
-import swapTabPage from '../../../pages/swapTab.page'
+import { warmup } from '../../../../helpers/warmup'
+import browserPage from '../../../../pages/browser.page'
+import popUpModalPage from '../../../../pages/popUpModal.page'
+import swapTabPage from '../../../../pages/swapTab.page'
 
 describe('Dapp Swap', () => {
   beforeEach(async () => {

--- a/packages/core-mobile/e2e/tests/transactions/ethereum/bridgeEthereum.e2e.ts
+++ b/packages/core-mobile/e2e/tests/transactions/ethereum/bridgeEthereum.e2e.ts
@@ -1,0 +1,35 @@
+import { warmup } from '../../../helpers/warmup'
+import bridgeTabPage from '../../../pages/bridgeTab.page'
+import commonElsPage from '../../../pages/commonEls.page'
+import sendPage from '../../../pages/send.page'
+import popUpModalPage from '../../../pages/popUpModal.page'
+import { cleanup } from '../../../helpers/cleanup'
+import bottomTabsPage from '../../../pages/bottomTabs.page'
+import portfolioPage from '../../../pages/portfolio.page'
+
+// Please note that the tests here are NOT for completing the bridge transactions,
+// but for verifying the bridge screen and its elements'
+// Since Bridge Transactions are expensive, we are just testing the flow between networks on e2e daily run.
+describe('Bridge Ethereum', () => {
+  beforeAll(async () => {
+    await warmup()
+  })
+
+  afterAll(async () => {
+    await cleanup()
+  })
+
+  it(`should verify Bridge Flow from Ethereum to Avalanche`, async () => {
+    await bottomTabsPage.tapPortfolioTab()
+    await portfolioPage.tapNetworksDropdown()
+    await portfolioPage.tapNetworksDropdownETH()
+    await bridgeTabPage.goToBridge()
+    await bridgeTabPage.tapSelectToken()
+    await sendPage.selectToken('ETH')
+    await sendPage.tapMax()
+    await bridgeTabPage.tapBridgeBtn()
+    await popUpModalPage.verifyFeeIsLegit(false, false, 0.02)
+    await popUpModalPage.tapRejectBtn()
+    await commonElsPage.goBack()
+  })
+})

--- a/packages/core-mobile/e2e/tests/transactions/ethereum/sendEth.e2e.ts
+++ b/packages/core-mobile/e2e/tests/transactions/ethereum/sendEth.e2e.ts
@@ -1,0 +1,45 @@
+import { cleanup } from '../../../helpers/cleanup'
+import { warmup } from '../../../helpers/warmup'
+import sendLoc from '../../../locators/send.loc'
+import accountManagePage from '../../../pages/accountManage.page'
+import bottomTabsPage from '../../../pages/bottomTabs.page'
+import advancedPage from '../../../pages/burgerMenu/advanced.page'
+import networksManagePage from '../../../pages/networksManage.page'
+import portfolioPage from '../../../pages/portfolio.page'
+import sendPage from '../../../pages/send.page'
+
+describe('Ethereum Transaction', () => {
+  beforeAll(async () => {
+    await warmup()
+    await accountManagePage.createSecondAccount()
+  })
+
+  afterAll(async () => {
+    await cleanup()
+  })
+
+  it('Should send Eth on MainNet', async () => {
+    await bottomTabsPage.tapPortfolioTab()
+    await portfolioPage.tapNetworksDropdown()
+    await portfolioPage.tapNetworksDropdownETH()
+    await sendPage.sendTokenTo2ndAccount(
+      sendLoc.ethToken,
+      sendLoc.sendingAmount,
+      false
+    )
+    await sendPage.verifySuccessToast()
+  })
+
+  it('Should send Sepolia Eth on TestNet', async () => {
+    await bottomTabsPage.tapPortfolioTab()
+    await advancedPage.switchToTestnet()
+    await networksManagePage.switchToEthereumSepoliaNetwork()
+    await portfolioPage.verifyActiveNetwork('Ethereum Sepolia')
+    await sendPage.sendTokenTo2ndAccount(
+      sendLoc.ethToken,
+      sendLoc.sendingAmount,
+      false
+    )
+    await sendPage.verifySuccessToast()
+  }, 120000)
+})

--- a/packages/core-mobile/e2e/tests/transactions/ethereum/sendEthNft.e2e.ts
+++ b/packages/core-mobile/e2e/tests/transactions/ethereum/sendEthNft.e2e.ts
@@ -1,12 +1,12 @@
-import AccountManagePage from '../../pages/accountManage.page'
-import PortfolioPage from '../../pages/portfolio.page'
-import CollectiblesPage from '../../pages/collectibles.page'
-import { warmup } from '../../helpers/warmup'
-import { cleanup } from '../../helpers/cleanup'
-import sendPage from '../../pages/send.page'
-import networksManagePage from '../../pages/networksManage.page'
+import AccountManagePage from '../../../pages/accountManage.page'
+import PortfolioPage from '../../../pages/portfolio.page'
+import CollectiblesPage from '../../../pages/collectibles.page'
+import { warmup } from '../../../helpers/warmup'
+import { cleanup } from '../../../helpers/cleanup'
+import sendPage from '../../../pages/send.page'
+import networksManagePage from '../../../pages/networksManage.page'
 
-describe('Send NFT', () => {
+describe('Ethereum NFT Transaction', () => {
   beforeAll(async () => {
     await warmup()
     await AccountManagePage.createSecondAccount()

--- a/packages/core-mobile/e2e/tests/transactions/pchain/sendPchain.e2e.ts
+++ b/packages/core-mobile/e2e/tests/transactions/pchain/sendPchain.e2e.ts
@@ -8,7 +8,7 @@ import { cleanup } from '../../../helpers/cleanup'
 import actions from '../../../helpers/actions'
 import portfolioLoc from '../../../locators/portfolio.loc'
 
-describe('Send AVAX', () => {
+describe('P-Chain Transaction', () => {
   beforeAll(async () => {
     await warmup()
     await accountManagePage.createSecondAccount()
@@ -16,14 +16,6 @@ describe('Send AVAX', () => {
 
   afterAll(async () => {
     await cleanup()
-  })
-
-  it('should send AVAX on C-Chain', async () => {
-    await sendPage.sendTokenTo2ndAccount(
-      sendLoc.avaxToken,
-      sendLoc.sendingAmount
-    )
-    await sendPage.verifySuccessToast()
   })
 
   it('should send AVAX on P-Chain', async () => {
@@ -34,24 +26,6 @@ describe('Send AVAX', () => {
     )
     await actions.waitForElement(
       by.id(portfolioLoc.activeNetwork + portfolioLoc.avaxPNetwork)
-    )
-    const hasBalance = await sendPage.sendTokenTo2ndAccount(
-      sendLoc.avaxToken,
-      sendLoc.sendingAmount,
-      false,
-      true
-    )
-    await sendPage.verifySuccessToast(hasBalance)
-  })
-
-  it('should send AVAX on X-Chain', async () => {
-    await bottomTabsPage.tapPortfolioTab()
-    await portfolioPage.tapNetworksDropdown()
-    await portfolioPage.tapNetworksDropdownAVAX(
-      portfolioPage.networksDropdownXChain
-    )
-    await actions.waitForElement(
-      by.id(portfolioLoc.activeNetwork + portfolioLoc.avaxXNetwork)
     )
     const hasBalance = await sendPage.sendTokenTo2ndAccount(
       sendLoc.avaxToken,

--- a/packages/core-mobile/e2e/tests/transactions/xchain/sendXchain.e2e.ts
+++ b/packages/core-mobile/e2e/tests/transactions/xchain/sendXchain.e2e.ts
@@ -1,0 +1,38 @@
+import accountManagePage from '../../../pages/accountManage.page'
+import sendPage from '../../../pages/send.page'
+import sendLoc from '../../../locators/send.loc'
+import portfolioPage from '../../../pages/portfolio.page'
+import { warmup } from '../../../helpers/warmup'
+import bottomTabsPage from '../../../pages/bottomTabs.page'
+import { cleanup } from '../../../helpers/cleanup'
+import actions from '../../../helpers/actions'
+import portfolioLoc from '../../../locators/portfolio.loc'
+
+describe('X-Chain Transaction', () => {
+  beforeAll(async () => {
+    await warmup()
+    await accountManagePage.createSecondAccount()
+  })
+
+  afterAll(async () => {
+    await cleanup()
+  })
+
+  it('should send AVAX on X-Chain', async () => {
+    await bottomTabsPage.tapPortfolioTab()
+    await portfolioPage.tapNetworksDropdown()
+    await portfolioPage.tapNetworksDropdownAVAX(
+      portfolioPage.networksDropdownXChain
+    )
+    await actions.waitForElement(
+      by.id(portfolioLoc.activeNetwork + portfolioLoc.avaxXNetwork)
+    )
+    const hasBalance = await sendPage.sendTokenTo2ndAccount(
+      sendLoc.avaxToken,
+      sendLoc.sendingAmount,
+      false,
+      true
+    )
+    await sendPage.verifySuccessToast(hasBalance)
+  })
+})


### PR DESCRIPTION
## Description
The detox tests are restructured to run for transactions tests only. Sometimes we're requested to run tests only for transactions. I've collected and refine all the transaction related tests into `transactions` directory and it has all networks, C/P/X/Ethereum/Bitcoin. 

We can now just run tests with the command `detox .... e2e/tests/transactions` 

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
