### PR TITLE
fix swapping AVAX/wAVAX

### DIFF
--- a/packages/core-mobile/app/services/swap/SwapService.ts
+++ b/packages/core-mobile/app/services/swap/SwapService.ts
@@ -125,10 +125,13 @@ class SwapService {
           throw new Error('Account address missing')
         }
 
+        const isFromTokenNative = network.networkToken.symbol === srcToken
+        const isDestTokenNative = network.networkToken.symbol === destToken
+
         return await this.getParaSwapSDK(network.chainId).swap.getRate(
           {
-            srcToken,
-            destToken,
+            srcToken: isFromTokenNative ? ETHER_ADDRESS : srcToken,
+            destToken: isDestTokenNative ? ETHER_ADDRESS : destToken,
             amount: srcAmount,
             userAddress: account.addressC,
             side: swapSide,


### PR DESCRIPTION
## Description

from @meeh0w 

```
my guess is something must've changed on Paraswap side, because previously when we would fetch swap rates for AVAX, we could pass srcToken=AVAX as parameter, now we need to change it to srcToken=0xeee(...) (all Es).
I'm basing my guess solely off of the fact that it's also broken for Mobile atm. and as far as I can tell, this portion of code was changed ~10months ago for mobile.
```
same fix as https://github.com/ava-labs/core-extension/pull/149

## Screenshots/Videos
**before**
https://github.com/user-attachments/assets/d013466e-b836-465e-9c1c-c8fa454fd85a

**after**
https://github.com/user-attachments/assets/b4a2dd64-6f39-4b56-b918-6b2a1e0f999c

## Testing
Please test swapping AVAX/wAVAX

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
