### PR TITLE
CP-9984: Set url and history when finished loading

### DIFF
--- a/packages/core-mobile/app/screens/browser/Browser.tsx
+++ b/packages/core-mobile/app/screens/browser/Browser.tsx
@@ -49,8 +49,11 @@ type TabViewNavigationProp = BrowserScreenProps<
 export default function Browser({ tabId }: { tabId: string }): JSX.Element {
   const dispatch = useDispatch()
   const { setPendingDeepLink } = useDeeplink()
-  const [urlEntry, setUrlEntry] = useState('')
-  const [urlToLoad, setUrlToLoad] = useState('')
+  const activeTab = useSelector(selectTab(tabId))
+  const activeHistory = activeTab?.activeHistory
+  const activeHistoryUrl = activeHistory?.url ?? ''
+  const [urlEntry, setUrlEntry] = useState(activeHistoryUrl)
+  const [urlToLoad, setUrlToLoad] = useState(activeHistoryUrl)
   const clipboard = useClipboardWatcher()
   const {
     injectCoreAsRecent,
@@ -59,8 +62,6 @@ export default function Browser({ tabId }: { tabId: string }): JSX.Element {
     injectCustomWindowOpen,
     injectCustomPrompt
   } = useInjectedJavascript()
-  const activeTab = useSelector(selectTab(tabId))
-  const activeHistory = activeTab?.activeHistory
   const webViewRef = useRef<RNWebView>(null)
   const [favicon, setFavicon] = useState<string | undefined>(undefined)
   const [description, setDescription] = useState('')
@@ -265,7 +266,11 @@ export default function Browser({ tabId }: { tabId: string }): JSX.Element {
         }
         url={urlToLoad}
         onLoad={event => {
-          if (event.nativeEvent.url.startsWith('about:blank')) return
+          if (
+            event.nativeEvent.url.startsWith('about:blank') ||
+            event.nativeEvent.loading
+          )
+            return
           const includeDescriptionAndFavicon =
             description !== '' && favicon !== undefined
           const history: AddHistoryPayload = includeDescriptionAndFavicon


### PR DESCRIPTION
## Description

**Ticket: [CP-9984]** 

* Set url and add history when finished loading in onLoad callback, to prevent address bar spoofing 

## Screenshots/Videos
### iOS
https://github.com/user-attachments/assets/4fb026ec-75dd-4c31-bba3-ff8f0e580d17

### Android
https://github.com/user-attachments/assets/25b7d592-78c9-43de-952f-b9ffae148f3a

## Testing
* Please refer to the [link](https://ava-labs.atlassian.net/jira/software/c/projects/CP/boards/60?selectedIssue=CP-9984) for the reported bug details.
* Visit the mock attacker’s website (https://muhnabil04.github.io/halodek/spoof.html) and check if the address bar incorrectly displays google.com:81 while showing the message: `This is not Google. This is a hacker website.`, 
* You can compare it with the existing behavior on Android. iOS had no such issue.

[CP-9984]: https://ava-labs.atlassian.net/browse/CP-9984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ