### PR TITLE
Use first png or ico as WC approval logo

### DIFF
--- a/packages/core-mobile/app/screens/rpc/components/v2/SessionProposal/SessionProposal.tsx
+++ b/packages/core-mobile/app/screens/rpc/components/v2/SessionProposal/SessionProposal.tsx
@@ -18,6 +18,7 @@ import { Button, Text } from '@avalabs/k2-mobile'
 import { isSiteScanResponseMalicious } from 'store/rpc/handlers/wc_sessionRequest/utils'
 import { AlertType } from '@avalabs/vm-module-types'
 import { CorePrimaryAccount } from '@avalabs/types'
+import { CoreTypes } from '@walletconnect/types'
 import RpcRequestBottomSheet from '../../shared/RpcRequestBottomSheet'
 import AlertBanner from '../AlertBanner'
 import SelectAccounts from './SelectAccounts'
@@ -84,6 +85,14 @@ const SessionProposal = (): JSX.Element => {
     return <Networks chainIds={chainIdsToDisplay} hasMore={hasMore} />
   }
 
+  const getPngFromMetadata = (
+    metadata: CoreTypes.Metadata
+  ): string | undefined => {
+    return metadata.icons.find(
+      icon => icon.endsWith('.png') || icon.endsWith('.ico')
+    )
+  }
+
   return (
     <RpcRequestBottomSheet onClose={rejectAndClose}>
       <NativeViewGestureHandler>
@@ -114,8 +123,8 @@ const SessionProposal = (): JSX.Element => {
                 backgroundColor: theme.colorBg3
               }}>
               <Avatar.Custom
-                name={'dapp'}
-                logoUri={peerMeta?.icons[1]}
+                name={peerMeta.name}
+                logoUri={getPngFromMetadata(peerMeta)}
                 size={80}
               />
             </OvalTagBg>

--- a/yarn.lock
+++ b/yarn.lock
@@ -25996,7 +25996,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 869028a5bb7a4a8a125d274753b703c2b3579b5efc7bb82db136a186fd88a11c5a4696505ebcd976d20fcdd41111abe229ae0e19c27c50bb30fe4f52bb6383bc
+  checksum: ae658f8c94177d1b419ffb73d26bd70474b6c688af507daaabc11451f983f77a906b2aafcdfdd09c96cab846d9722dcaf26a7c22ee7d19fb4cf70578c8812ac5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- use png or ico as logo on WC approval screen
- if no matching logo found, use fallback icon

## Screenshots/Videos

<img width="1298" alt="Screenshot 2025-03-11 at 5 00 51 PM" src="https://github.com/user-attachments/assets/0c88ad4f-a544-429b-b479-e0691324bd44" />


when no logo is found, use dapp name initial
<img width="1598" alt="Screenshot 2025-03-11 at 5 14 01 PM" src="https://github.com/user-attachments/assets/fbe3c771-4332-4452-9242-c143fecdb408" />



## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
