### PR TITLE
CP-10043: Gas widget update

### DIFF
--- a/packages/core-mobile/app/components/EditFees.tsx
+++ b/packages/core-mobile/app/components/EditFees.tsx
@@ -6,7 +6,6 @@ import FlexSpacer from 'components/FlexSpacer'
 import { Row } from 'components/Row'
 import { calculateGasAndFees, Eip1559Fees, GasAndFees } from 'utils/Utils'
 import { Network } from '@avalabs/core-chains-sdk'
-import { useApplicationContext } from 'contexts/ApplicationContext'
 import { useNativeTokenPriceForNetwork } from 'hooks/networks/useNativeTokenPriceForNetwork'
 import {
   Button,
@@ -24,6 +23,8 @@ import { VsCurrencyType } from '@avalabs/core-coingecko-sdk'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { sanitizeDecimalInput } from 'utils/units/sanitize'
+import { formatCurrency } from 'utils/FormatCurrency'
+import { SubTextNumber } from './SubTextNumber'
 
 type EditFeesProps = {
   network: Network
@@ -42,16 +43,6 @@ const maxPriorityFeeInfoMessage =
 const gasLimitInfoMessage =
   'Total units of gas needed to complete the transaction. Do not edit unless necessary.'
 
-function CurrencyHelperText({ text }: { text: string }): JSX.Element {
-  return (
-    <Row style={{ justifyContent: 'flex-end', paddingHorizontal: 16 }}>
-      <Text variant="caption" sx={{ color: '$neutral300' }}>
-        {text}
-      </Text>
-    </Row>
-  )
-}
-
 const EditFees = ({
   lowMaxFeePerGas,
   maxFeePerGas: initMaxFeePerGas,
@@ -65,10 +56,6 @@ const EditFees = ({
   noGasLimitError
 }: EditFeesProps): JSX.Element => {
   const isBaseUnitRate = feeDecimals === undefined
-
-  const {
-    appHook: { tokenInCurrencyFormatter }
-  } = useApplicationContext()
   const _gasLimitError = noGasLimitError ?? 'Please enter a valid gas limit'
   const {
     theme: { colors }
@@ -122,7 +109,7 @@ const EditFees = ({
         newFees.maxTotalFee,
         network.networkToken.decimals,
         network.networkToken.symbol
-      ).toDisplay(),
+      ).toDisplay({ asNumber: true }),
     [
       network.networkToken.decimals,
       network.networkToken.symbol,
@@ -271,20 +258,29 @@ const EditFees = ({
             </Tooltip>
           )}
           <FlexSpacer />
-          <Text variant="heading5" sx={{ color: '$neutral50' }}>
-            {maxTotalFee}
-          </Text>
+          <SubTextNumber number={maxTotalFee} size="big" />
+
           <Space x={4} />
           <Text variant="heading6" sx={{ color: '$neutral400' }}>
             {network?.networkToken?.symbol?.toUpperCase()}
           </Text>
         </Row>
-
-        <CurrencyHelperText
-          text={`${tokenInCurrencyFormatter(
-            newFees.maxTotalFeeInCurrency
-          )} ${selectedCurrency.toUpperCase()}`}
-        />
+        <Text
+          variant="body2"
+          sx={{
+            color: '$neutral300',
+            lineHeight: 15,
+            alignSelf: 'flex-end',
+            marginTop: 2,
+            marginRight: 14
+          }}>
+          {formatCurrency({
+            amount: newFees.maxTotalFeeInCurrency,
+            currency: selectedCurrency,
+            boostSmallNumberPrecision: false,
+            showLessThanThreshold: true
+          })}
+        </Text>
       </ScrollView>
       <Button
         testID="custom_network_fee_save_btn"

--- a/packages/core-mobile/app/components/NetworkFeeSelector.tsx
+++ b/packages/core-mobile/app/components/NetworkFeeSelector.tsx
@@ -193,13 +193,11 @@ const NetworkFeeSelector = ({
 
   return (
     <>
-      <Space y={4} />
       <View
         sx={{
           backgroundColor: isDark ? '$neutral900' : '$neutral800',
           padding: 16,
-          borderRadius: 8,
-          marginBottom: 16
+          borderRadius: 8
         }}>
         {!networkFee?.isFixedFee && (
           <>

--- a/packages/core-mobile/app/components/NetworkFeeSelector.tsx
+++ b/packages/core-mobile/app/components/NetworkFeeSelector.tsx
@@ -242,7 +242,7 @@ const NetworkFeeSelector = ({
         <>
           <Row
             style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-            <Text variant="caption" sx={{ color: '$neutral400' }}>
+            <Text variant="caption" sx={{ color: '$neutral200' }}>
               Fee Amount
             </Text>
             <View sx={{ flexDirection: 'row' }}>

--- a/packages/core-mobile/app/components/NetworkFeeSelector.tsx
+++ b/packages/core-mobile/app/components/NetworkFeeSelector.tsx
@@ -1,5 +1,4 @@
 import { Row } from 'components/Row'
-import Settings from 'assets/icons/settings.svg'
 import { Space } from 'components/Space'
 import React, {
   FC,
@@ -26,16 +25,14 @@ import {
   useTheme,
   View
 } from '@avalabs/k2-mobile'
-import { useApplicationContext } from 'contexts/ApplicationContext'
 import { NetworkFees } from '@avalabs/vm-module-types'
 import { GAS_LIMIT_FOR_XP_CHAIN } from 'consts/fees'
-import { isBitcoinNetwork } from 'utils/network/isBitcoinNetwork'
 import { isAvmNetwork, isPvmNetwork } from 'utils/network/isAvalancheNetwork'
 import { useNetworks } from 'hooks/networks/useNetworks'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
-import { bigIntToFeeDenomination } from 'utils/units/fees'
-import { Tooltip } from './Tooltip'
+import { formatCurrency } from 'utils/FormatCurrency'
+import { SubTextNumber } from './SubTextNumber'
 
 export enum FeePreset {
   SLOW = 'Slow',
@@ -52,22 +49,19 @@ const NetworkFeeSelector = ({
   chainId,
   gasLimit,
   onFeesChange,
+  isDark = false,
   isGasLimitEditable = true,
   noGasLimitError,
-  supportsAvalancheDynamicFee = false,
-  showOnlyFeeSelection = false
+  supportsAvalancheDynamicFee = false
 }: {
   chainId?: number
   gasLimit: number
   onFeesChange?(fees: Eip1559Fees, feePreset: FeePreset): void
+  isDark?: boolean
   isGasLimitEditable?: boolean
   noGasLimitError?: string
   supportsAvalancheDynamicFee?: boolean
-  showOnlyFeeSelection?: boolean
 }): JSX.Element => {
-  const {
-    appHook: { tokenInCurrencyFormatter }
-  } = useApplicationContext()
   const { activeNetwork, getNetwork } = useNetworks()
   const { networkToken } = activeNetwork
   const { navigate } = useNavigation<NavigationProp>()
@@ -80,19 +74,18 @@ const NetworkFeeSelector = ({
     network,
     selectedCurrency.toLowerCase() as VsCurrencyType
   )
-  const isBtcNetwork = network ? isBitcoinNetwork(network) : false
   const isPVM = isPvmNetwork(network)
   const isAVM = isAvmNetwork(network)
   const [selectedPreset, setSelectedPreset] = useState(FeePreset.SLOW)
   const [calculatedFees, setCalculatedFees] = useState<GasAndFees>()
   const calculatedMaxTotalFeeDisplayed = useMemo(() => {
-    if (!calculatedFees?.maxTotalFee) return UNKNOWN_AMOUNT
+    if (!calculatedFees?.maxTotalFee) return
     const unit = new TokenUnit(
       calculatedFees.maxTotalFee,
       networkToken.decimals,
       networkToken.symbol
     )
-    return unit.toDisplay()
+    return unit.toDisplay({ asNumber: true })
   }, [calculatedFees, networkToken])
   const [customFees, setCustomFees] = useState<GasAndFees>()
 
@@ -180,32 +173,6 @@ const NetworkFeeSelector = ({
     onFeesChange?.(newFees, FeePreset.CUSTOM)
   }
 
-  const displayGasValues = useMemo(() => {
-    if (!networkFee) return undefined
-
-    const customFee = customFees?.maxFeePerGas ?? networkFee.medium.maxFeePerGas
-
-    return {
-      [FeePreset.SLOW]: bigIntToFeeDenomination(
-        networkFee.low.maxFeePerGas,
-        networkFee.displayDecimals
-      ),
-      [FeePreset.NORMAL]: bigIntToFeeDenomination(
-        networkFee.medium.maxFeePerGas,
-        networkFee.displayDecimals
-      ),
-
-      [FeePreset.FAST]: bigIntToFeeDenomination(
-        networkFee.high.maxFeePerGas,
-        networkFee.displayDecimals
-      ),
-      [FeePreset.CUSTOM]: bigIntToFeeDenomination(
-        customFee,
-        networkFee.displayDecimals
-      )
-    }
-  }, [customFees?.maxFeePerGas, networkFee])
-
   const goToEditGasLimit = (n?: Network): void => {
     if (networkFee === undefined || n === undefined) return
     navigate(AppNavigation.Modal.EditGasLimit, {
@@ -226,45 +193,13 @@ const NetworkFeeSelector = ({
 
   return (
     <>
-      {!showOnlyFeeSelection && (
-        <>
-          <Row
-            style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-            {isBtcNetwork || isPVM || isAVM ? (
-              <View sx={{ paddingVertical: 12 }}>
-                <Text variant="body2" sx={{ color: '$neutral50' }}>
-                  Network Fee
-                </Text>
-              </View>
-            ) : (
-              <Tooltip
-                content={
-                  'Core estimates the maximum gas (maxFeePerGas) a transaction could consume based on network conditions. This transaction will likely consume less gas than estimated.'
-                }
-                position={'right'}
-                style={{ width: 200 }}>
-                <Text variant="buttonMedium">Maximum Network Fee</Text>
-              </Tooltip>
-            )}
-            {(!isPVM && supportsAvalancheDynamicFee) ||
-              (!isAVM && (
-                <TouchableOpacity
-                  sx={{ marginTop: 8 }}
-                  onPress={() => goToEditGasLimit(network)}>
-                  <Settings />
-                </TouchableOpacity>
-              ))}
-          </Row>
-        </>
-      )}
       <Space y={4} />
-
       <View
         sx={{
-          backgroundColor: '$neutral900',
+          backgroundColor: isDark ? '$neutral900' : '$neutral800',
           padding: 16,
           borderRadius: 8,
-          marginBottom: showOnlyFeeSelection ? 0 : 16
+          marginBottom: 16
         }}>
         {!networkFee?.isFixedFee && (
           <>
@@ -277,21 +212,18 @@ const NetworkFeeSelector = ({
                 label={FeePreset.SLOW}
                 selected={selectedPreset === FeePreset.SLOW}
                 onSelect={() => handleSelectedPreset(FeePreset.SLOW)}
-                value={displayGasValues?.[FeePreset.SLOW]}
                 testID="slow_base_fee"
               />
               <FeeSelector
                 label={FeePreset.NORMAL}
                 selected={selectedPreset === FeePreset.NORMAL}
                 onSelect={() => handleSelectedPreset(FeePreset.NORMAL)}
-                value={displayGasValues?.[FeePreset.NORMAL]}
                 testID="fast_base_fee"
               />
               <FeeSelector
                 label={FeePreset.FAST}
                 selected={selectedPreset === FeePreset.FAST}
                 onSelect={() => handleSelectedPreset(FeePreset.FAST)}
-                value={displayGasValues?.[FeePreset.FAST]}
                 testID="instant_base_fee"
               />
               <FeeSelector
@@ -301,46 +233,43 @@ const NetworkFeeSelector = ({
                   handleSelectedPreset(FeePreset.CUSTOM)
                   goToEditGasLimit(network)
                 }}
-                value={
-                  selectedPreset !== FeePreset.CUSTOM && !customFees
-                    ? displayGasValues?.[FeePreset.NORMAL]
-                    : displayGasValues?.[FeePreset.CUSTOM]
-                }
                 testID="custom_base_fee"
               />
             </Row>
-            {!showOnlyFeeSelection && <Space y={20} />}
+            <Space y={20} />
           </>
         )}
-        {!showOnlyFeeSelection && (
-          <>
-            <Row
-              style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-              <Text variant="body2" sx={{ color: '$neutral400' }}>
-                Fee Amount
+        <>
+          <Row
+            style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+            <Text variant="caption" sx={{ color: '$neutral400' }}>
+              Fee Amount
+            </Text>
+            <View sx={{ flexDirection: 'row' }}>
+              <SubTextNumber
+                number={calculatedMaxTotalFeeDisplayed}
+                testID="token_gas_fee"
+              />
+              <Text variant="subtitle2" sx={{ color: '$neutral50' }}>
+                {' ' + network?.networkToken?.symbol}
               </Text>
-              <View sx={{ flexDirection: 'row' }}>
-                <Text testID="token_gas_fee" sx={{ color: '$neutral50' }}>
-                  {`${calculatedMaxTotalFeeDisplayed} `}
-                </Text>
-                <Text variant="body1" sx={{ color: '$neutral400' }}>
-                  {network?.networkToken?.symbol}
-                </Text>
-              </View>
-            </Row>
-            <Row style={{ justifyContent: 'flex-end' }}>
-              <Text
-                variant="caption"
-                sx={{ color: '$neutral400', lineHeight: 15 }}>
-                {calculatedFees?.maxTotalFeeInCurrency
-                  ? tokenInCurrencyFormatter(
-                      calculatedFees.maxTotalFeeInCurrency
-                    )
-                  : UNKNOWN_AMOUNT + ' ' + selectedCurrency}
-              </Text>
-            </Row>
-          </>
-        )}
+            </View>
+          </Row>
+          <Row style={{ justifyContent: 'flex-end' }}>
+            <Text
+              variant="caption"
+              sx={{ color: '$neutral400', lineHeight: 15 }}>
+              {calculatedFees?.maxTotalFeeInCurrency
+                ? formatCurrency({
+                    amount: calculatedFees.maxTotalFeeInCurrency,
+                    currency: selectedCurrency,
+                    boostSmallNumberPrecision: false,
+                    showLessThanThreshold: true
+                  })
+                : UNKNOWN_AMOUNT + ' ' + selectedCurrency}
+            </Text>
+          </Row>
+        </>
       </View>
     </>
   )
@@ -348,11 +277,10 @@ const NetworkFeeSelector = ({
 
 export const FeeSelector: FC<{
   label: string
-  value?: string
   selected: boolean
   testID?: string
   onSelect: (value: string) => void
-}> = ({ label, selected, onSelect, value, testID }) => {
+}> = ({ label, selected, onSelect, testID }) => {
   const {
     theme: { colors }
   } = useTheme()
@@ -380,9 +308,8 @@ export const FeeSelector: FC<{
           flexDirection: 'column',
           alignItems: 'center'
         }}>
-        <ButtonText selected={selected}>{label}</ButtonText>
         <ButtonText selected={selected} testID={testID}>
-          {value}
+          {label}
         </ButtonText>
       </View>
     </TouchableOpacity>

--- a/packages/core-mobile/app/components/SubTextNumber.tsx
+++ b/packages/core-mobile/app/components/SubTextNumber.tsx
@@ -1,0 +1,50 @@
+import React, { useMemo } from 'react'
+import { View, Text } from '@avalabs/k2-mobile'
+import { StyleSheet } from 'react-native'
+import { numberToSubscriptFormat } from 'utils/numberToSubscriptFormat/numberToSubscriptFormat'
+
+interface Props {
+  number: number | undefined
+  testID?: string
+}
+
+export const SubTextNumber: React.FC<Props> = ({ number, testID }) => {
+  const { mainTextBefore, subText, mainTextAfter } = useMemo(
+    () => numberToSubscriptFormat(number),
+    [number]
+  )
+
+  return (
+    <View style={styles.container} testID={testID}>
+      <Text variant="subtitle2" sx={{ color: '$neutral50' }}>
+        {mainTextBefore}
+      </Text>
+      {subText && (
+        <Text
+          style={styles.subText}
+          variant="subtitle2"
+          sx={{ color: '$neutral50' }}>
+          {subText}
+        </Text>
+      )}
+      {mainTextAfter && (
+        <Text variant="subtitle2" sx={{ color: '$neutral50' }}>
+          {mainTextAfter}
+        </Text>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  subText: {
+    fontSize: 10,
+    fontWeight: 'bold',
+    position: 'relative',
+    top: 4
+  }
+})

--- a/packages/core-mobile/app/components/SubTextNumber.tsx
+++ b/packages/core-mobile/app/components/SubTextNumber.tsx
@@ -6,29 +6,35 @@ import { numberToSubscriptFormat } from 'utils/numberToSubscriptFormat/numberToS
 interface Props {
   number: number | undefined
   testID?: string
+  size?: 'big' | 'small'
 }
 
-export const SubTextNumber: React.FC<Props> = ({ number, testID }) => {
+export const SubTextNumber: React.FC<Props> = ({
+  number,
+  testID,
+  size = 'small'
+}) => {
   const { mainTextBefore, subText, mainTextAfter } = useMemo(
     () => numberToSubscriptFormat(number),
     [number]
   )
 
+  const textVariant = size === 'big' ? 'heading5' : 'subtitle2'
   return (
     <View style={styles.container} testID={testID}>
-      <Text variant="subtitle2" sx={{ color: '$neutral50' }}>
+      <Text variant={textVariant} sx={{ color: '$neutral50' }}>
         {mainTextBefore}
       </Text>
       {subText && (
         <Text
-          style={styles.subText}
-          variant="subtitle2"
+          style={size === 'big' ? styles.subTextBig : styles.subTextSmall}
+          variant={textVariant}
           sx={{ color: '$neutral50' }}>
           {subText}
         </Text>
       )}
       {mainTextAfter && (
-        <Text variant="subtitle2" sx={{ color: '$neutral50' }}>
+        <Text variant={textVariant} sx={{ color: '$neutral50' }}>
           {mainTextAfter}
         </Text>
       )}
@@ -41,8 +47,14 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center'
   },
-  subText: {
+  subTextSmall: {
     fontSize: 10,
+    fontWeight: 'bold',
+    position: 'relative',
+    top: 4
+  },
+  subTextBig: {
+    fontSize: 15,
     fontWeight: 'bold',
     position: 'relative',
     top: 4

--- a/packages/core-mobile/app/components/TokenAddress.tsx
+++ b/packages/core-mobile/app/components/TokenAddress.tsx
@@ -11,6 +11,9 @@ import BitcoinSVG from 'components/svg/BitcoinSVG'
 import { isBech32Address } from '@avalabs/core-bridge-sdk'
 import { isAddress } from 'ethers'
 import AvaLogoSVG from 'components/svg/AvaLogoSVG'
+import { isBtcAddress as isValidBtcAddress } from 'utils/isBtcAddress'
+import { useSelector } from 'react-redux'
+import { selectActiveNetwork } from 'store/network'
 
 type TextType = 'Heading' | 'ButtonSmall' | 'ButtonMedium' | 'Body1' | 'Body2'
 
@@ -37,7 +40,7 @@ const TokenAddress: FC<Props> = ({
   copyIconEnd
 }): JSX.Element => {
   const theme = useContext(ApplicationContext).theme
-
+  const activeNetwork = useSelector(selectActiveNetwork)
   const tokenAddress = showFullAddress ? address : truncateAddress(address)
   const txtColor = textColor ? textColor : theme.colorText1
 
@@ -48,6 +51,9 @@ const TokenAddress: FC<Props> = ({
     onCopyAddress?.(address)
   }
 
+  const isBtcAddress = (): boolean =>
+    isValidBtcAddress(address, !activeNetwork.isTestnet)
+
   return (
     <AvaButton.Base
       onPress={() => (hideCopy ? noop : copyAddressToClipboard())}
@@ -57,13 +63,13 @@ const TokenAddress: FC<Props> = ({
         marginRight: 0
       }}
       testID="receive_token_address">
-      {showIcon && isBech32Address(address) && (
+      {showIcon && isBtcAddress() && (
         <>
           <BitcoinSVG size={16} />
           <Space x={8} />
         </>
       )}
-      {showIcon && isAddress(address) && (
+      {showIcon && (isBech32Address(address) || isAddress(address)) && (
         <>
           <AvaLogoSVG
             size={16}

--- a/packages/core-mobile/app/hooks/useGasless.ts
+++ b/packages/core-mobile/app/hooks/useGasless.ts
@@ -20,7 +20,7 @@ type Params = {
 type Return = {
   gaslessEnabled: boolean
   setGaslessEnabled: React.Dispatch<React.SetStateAction<boolean>>
-  showGaslessSwitch: boolean
+  shouldShowGaslessSwitch: boolean
   gaslessError: Alert | null
   handleGaslessTx: (addressFrom: string) => Promise<string | undefined>
 }
@@ -38,7 +38,7 @@ export const useGasless = ({
   const isGaslessBlocked = useSelector(selectIsGaslessBlocked)
   const [gaslessError, setGaslessError] = useState<Alert | null>(null)
 
-  const showGaslessSwitch = useMemo(() => {
+  const shouldShowGaslessSwitch = useMemo(() => {
     return !isGaslessBlocked && !gaslessError && isGaslessEligible
   }, [gaslessError, isGaslessBlocked, isGaslessEligible])
 
@@ -130,7 +130,7 @@ export const useGasless = ({
   return {
     gaslessEnabled,
     setGaslessEnabled,
-    showGaslessSwitch,
+    shouldShowGaslessSwitch,
     gaslessError,
     handleGaslessTx
   }

--- a/packages/core-mobile/app/hooks/useGasless.ts
+++ b/packages/core-mobile/app/hooks/useGasless.ts
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Alert, AlertType, SigningData } from '@avalabs/vm-module-types'
+import { useSelector } from 'react-redux'
+import { selectIsGaslessBlocked } from 'store/posthog'
+import { useNetworks } from 'hooks/networks/useNetworks'
+import { getChainIdFromCaip2 } from 'utils/caip2ChainIds'
+import GaslessService from 'services/gasless/GaslessService'
+import Logger from 'utils/Logger'
+import NetworkService from 'services/network/NetworkService'
+import { JsonRpcBatchInternal } from '@avalabs/core-wallets-sdk'
+import { resolve } from '@avalabs/core-utils-sdk'
+import AnalyticsService from 'services/analytics/AnalyticsService'
+
+type Params = {
+  maxFeePerGas: bigint | undefined
+  signingData: SigningData
+  caip2ChainId: string
+}
+
+type Return = {
+  gaslessEnabled: boolean
+  setGaslessEnabled: React.Dispatch<React.SetStateAction<boolean>>
+  showGaslessSwitch: boolean
+  gaslessError: Alert | null
+  handleGaslessTx: (addressFrom: string) => Promise<string | undefined>
+}
+
+export const useGasless = ({
+  signingData,
+  maxFeePerGas,
+  caip2ChainId
+}: Params): Return => {
+  const { getNetwork } = useNetworks()
+  const chainId = getChainIdFromCaip2(caip2ChainId)
+  const network = getNetwork(chainId)
+  const [isGaslessEligible, setIsGaslessEligible] = useState(false)
+  const [gaslessEnabled, setGaslessEnabled] = useState(false)
+  const isGaslessBlocked = useSelector(selectIsGaslessBlocked)
+  const [gaslessError, setGaslessError] = useState<Alert | null>(null)
+
+  const showGaslessSwitch = useMemo(() => {
+    return !isGaslessBlocked && !gaslessError && isGaslessEligible
+  }, [gaslessError, isGaslessBlocked, isGaslessEligible])
+
+  useEffect(() => {
+    const checkGaslessEligibility = async (): Promise<void> => {
+      if (!chainId) {
+        setIsGaslessEligible(false)
+        return
+      }
+      const isEligibleForChain = await GaslessService.isEligibleForChain(
+        chainId.toString()
+      ).catch(err => {
+        Logger.error('Error checking gasless eligibility', err)
+        return false
+      })
+      const isEligibleForTxType =
+        GaslessService.isEligibleForTxType(signingData)
+      const isEligible = isEligibleForTxType && isEligibleForChain
+      Logger.info('ApprovalPopup: Gasless eligibility', isEligible)
+      setIsGaslessEligible(isEligible)
+    }
+    checkGaslessEligibility()
+  }, [chainId, signingData])
+
+  const showGaslessError = useCallback(() => {
+    setGaslessError({
+      type: AlertType.INFO,
+      details: {
+        title: 'Free Gas Error',
+        description:
+          'Core was unable to fund the gas. You will need to pay the gas fee to continue with this transaction. '
+      }
+    })
+  }, [])
+
+  const handleGaslessTx = async (
+    addressFrom: string
+  ): Promise<string | undefined> => {
+    let attempts = 0
+    const MAX_ATTEMPTS = 1
+
+    if (!network) {
+      showGaslessError()
+      return undefined
+    }
+    const provider = await NetworkService.getProviderForNetwork(network)
+    if (!(provider instanceof JsonRpcBatchInternal)) {
+      showGaslessError()
+      return undefined
+    }
+
+    while (attempts <= MAX_ATTEMPTS) {
+      const [result, error] = await resolve(
+        GaslessService.fundTx({
+          signingData,
+          addressFrom,
+          maxFeePerGas,
+          provider
+        })
+      )
+
+      if (result?.txHash) {
+        AnalyticsService.capture('GaslessFundSuccessful', {
+          fundTxHash: result?.txHash
+        })
+        setGaslessError(null)
+        return result.txHash
+      }
+
+      // Show error and stop if we get a DO_NOT_RETRY error or
+      // if we've hit max attempts with a RETRY_WITH_NEW_CHALLENGE error
+      if (
+        error ||
+        result?.error?.category === 'DO_NOT_RETRY' ||
+        (result?.error?.category === 'RETRY_WITH_NEW_CHALLENGE' &&
+          attempts === MAX_ATTEMPTS)
+      ) {
+        AnalyticsService.capture('GaslessFundFailed')
+        Logger.error(`[ApprovalPopup.tsx][handleGaslessTx]${error}`)
+        showGaslessError()
+        return undefined
+      }
+
+      attempts++
+    }
+    return undefined
+  }
+
+  return {
+    gaslessEnabled,
+    setGaslessEnabled,
+    showGaslessSwitch,
+    gaslessError,
+    handleGaslessTx
+  }
+}

--- a/packages/core-mobile/app/screens/rpc/components/v2/ApprovalPopup.tsx
+++ b/packages/core-mobile/app/screens/rpc/components/v2/ApprovalPopup.tsx
@@ -1,19 +1,15 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { ActivityIndicator, StyleSheet, ScrollView } from 'react-native'
-import { Alert, AlertType, TokenType } from '@avalabs/vm-module-types'
+import { TokenType } from '@avalabs/vm-module-types'
 import { Space } from 'components/Space'
 import { Row } from 'components/Row'
-import NetworkFeeSelector from 'components/NetworkFeeSelector'
 import { WalletScreenProps } from 'navigation/types'
 import AppNavigation from 'navigation/AppNavigation'
 import { useNavigation, useRoute } from '@react-navigation/native'
 import { useSelector } from 'react-redux'
 import { NetworkLogo } from 'screens/network/NetworkLogo'
 import { Button, Text, View, useTheme } from '@avalabs/k2-mobile'
-import {
-  selectIsGaslessBlocked,
-  selectIsSeedlessSigningBlocked
-} from 'store/posthog'
+import { selectIsSeedlessSigningBlocked } from 'store/posthog'
 import FeatureBlocked from 'screens/posthog/FeatureBlocked'
 import { Eip1559Fees } from 'utils/Utils'
 import WalletConnectService from 'services/walletconnectv2/WalletConnectService'
@@ -32,23 +28,18 @@ import GlobeSVG from 'components/svg/GlobeSVG'
 import { useSpendLimits } from 'hooks/useSpendLimits'
 import { isHex } from 'viem'
 import { getChainIdFromCaip2 } from 'utils/caip2ChainIds'
-import Switch from 'components/Switch'
-import GaslessService from 'services/gasless/GaslessService'
 import Logger from 'utils/Logger'
 import { SendErrorMessage } from 'screens/send/utils/types'
 import { useNativeTokenWithBalance } from 'screens/send/hooks/useNativeTokenWithBalance'
-import { Tooltip } from 'components/Tooltip'
-import InfoSVG from 'components/svg/InfoSVG'
 import { validateFee } from 'screens/send/utils/evm/validate'
-import NetworkService from 'services/network/NetworkService'
-import { JsonRpcBatchInternal } from '@avalabs/core-wallets-sdk'
-import { resolve } from '@avalabs/core-utils-sdk'
-import AnalyticsService from 'services/analytics/AnalyticsService'
+import { useGasless } from 'hooks/useGasless'
 import RpcRequestBottomSheet from '../shared/RpcRequestBottomSheet'
 import { DetailSectionView } from '../shared/DetailSectionView'
 import BalanceChange from './BalanceChange'
 import { SpendLimits } from './SpendLimits'
 import AlertBanner from './AlertBanner'
+import NetworkFeeSelectorWithGasless from './NetworkFeeSelectorWithGasless'
+
 type ApprovalPopupScreenProps = WalletScreenProps<
   typeof AppNavigation.Modal.ApprovalPopup
 >
@@ -63,36 +54,8 @@ const ApprovalPopup = (): JSX.Element => {
   const caip2ChainId = request.chainId
   const chainId = getChainIdFromCaip2(caip2ChainId)
   const network = getNetwork(chainId)
-  const [isGaslessEligible, setIsGaslessEligible] = useState(false)
-  const [gaslessEnabled, setGaslessEnabled] = useState(false)
-  const isGaslessBlocked = useSelector(selectIsGaslessBlocked)
   const [amountError, setAmountError] = useState<string | undefined>()
   const nativeToken = useNativeTokenWithBalance()
-  const [gaslessError, setGaslessError] = useState<Alert | null>(null)
-  const showGaslessSwitch = useMemo(() => {
-    return !isGaslessBlocked && !gaslessError && isGaslessEligible
-  }, [gaslessError, isGaslessBlocked, isGaslessEligible])
-
-  useEffect(() => {
-    const checkGaslessEligibility = async (): Promise<void> => {
-      if (!chainId) {
-        setIsGaslessEligible(false)
-        return
-      }
-      const isEligibleForChain = await GaslessService.isEligibleForChain(
-        chainId.toString()
-      ).catch(err => {
-        Logger.error('Error checking gasless eligibility', err)
-        return false
-      })
-      const isEligibleForTxType =
-        GaslessService.isEligibleForTxType(signingData)
-      const isEligible = isEligibleForTxType && isEligibleForChain
-      Logger.info('ApprovalPopup: Gasless eligibility', isEligible)
-      setIsGaslessEligible(isEligible)
-    }
-    checkGaslessEligibility()
-  }, [chainId, request.chainId, signingData])
 
   const accountSelector =
     'account' in signingData
@@ -111,7 +74,17 @@ const ApprovalPopup = (): JSX.Element => {
   const [maxPriorityFeePerGas, setMaxPriorityFeePerGas] = useState<
     bigint | undefined
   >()
-
+  const {
+    gaslessEnabled,
+    setGaslessEnabled,
+    showGaslessSwitch,
+    gaslessError,
+    handleGaslessTx
+  } = useGasless({
+    signingData,
+    maxFeePerGas,
+    caip2ChainId
+  })
   const approveDisabled =
     !network ||
     !account ||
@@ -171,75 +144,50 @@ const ApprovalPopup = (): JSX.Element => {
   const { spendLimits, canEdit, updateSpendLimit, hashedCustomSpend } =
     useSpendLimits(displayData.tokenApprovals)
 
+  const validateEthSendTransaction = useCallback(() => {
+    if (
+      !signingData ||
+      !network?.networkToken ||
+      !nativeToken ||
+      signingData.type !== 'eth_sendTransaction'
+    )
+      return
+    const ethSendTx = signingData.data
+
+    try {
+      const gasLimit = ethSendTx.gasLimit ? BigInt(ethSendTx.gasLimit) : 0n
+      const amount = ethSendTx.value ? BigInt(ethSendTx.value) : 0n
+
+      validateFee({
+        gasLimit,
+        maxFee: maxFeePerGas || 0n,
+        amount,
+        nativeToken,
+        token: nativeToken
+      })
+
+      setAmountError(undefined)
+    } catch (err) {
+      if (err instanceof Error) {
+        setAmountError(err.message)
+      } else {
+        setAmountError(SendErrorMessage.UNKNOWN_ERROR)
+      }
+    }
+  }, [signingData, network, maxFeePerGas, nativeToken])
+
+  useEffect(() => {
+    if (gaslessEnabled) {
+      setAmountError(undefined)
+      return
+    }
+    validateEthSendTransaction()
+  }, [validateEthSendTransaction, gaslessEnabled])
+
   const handleFeesChange = useCallback((fees: Eip1559Fees) => {
     setMaxFeePerGas(fees.maxFeePerGas)
     setMaxPriorityFeePerGas(fees.maxPriorityFeePerGas)
   }, [])
-
-  function showGaslessError(): void {
-    setGaslessError({
-      type: AlertType.INFO,
-      details: {
-        title: 'Free Gas Error',
-        description:
-          'Core was unable to fund the gas. You will need to pay the gas fee to continue with this transaction. '
-      }
-    })
-  }
-
-  const handleGaslessTx = async (
-    addressFrom: string
-  ): Promise<string | undefined> => {
-    let attempts = 0
-    const MAX_ATTEMPTS = 1
-
-    if (!network) {
-      showGaslessError()
-      return undefined
-    }
-    const provider = await NetworkService.getProviderForNetwork(network)
-    if (!(provider instanceof JsonRpcBatchInternal)) {
-      showGaslessError()
-      return undefined
-    }
-
-    while (attempts <= MAX_ATTEMPTS) {
-      const [result, error] = await resolve(
-        GaslessService.fundTx({
-          signingData,
-          addressFrom,
-          maxFeePerGas,
-          provider
-        })
-      )
-
-      if (result?.txHash) {
-        AnalyticsService.capture('GaslessFundSuccessful', {
-          fundTxHash: result?.txHash
-        })
-        setGaslessError(null)
-        return result.txHash
-      }
-
-      // Show error and stop if we get a DO_NOT_RETRY error or
-      // if we've hit max attempts with a RETRY_WITH_NEW_CHALLENGE error
-      if (
-        error ||
-        result?.error?.category === 'DO_NOT_RETRY' ||
-        (result?.error?.category === 'RETRY_WITH_NEW_CHALLENGE' &&
-          attempts === MAX_ATTEMPTS)
-      ) {
-        AnalyticsService.capture('GaslessFundFailed')
-        Logger.error(`[ApprovalPopup.tsx][handleGaslessTx]${error}`)
-        showGaslessError()
-        setSubmitting(false)
-        return undefined
-      }
-
-      attempts++
-    }
-    return undefined
-  }
 
   const onHandleApprove = async (): Promise<void> => {
     if (approveDisabled) return
@@ -465,59 +413,6 @@ const ApprovalPopup = (): JSX.Element => {
     return <BalanceChange balanceChange={balanceChange} />
   }
 
-  const renderGasless = (): JSX.Element | null => {
-    if (!showGaslessSwitch) {
-      return null
-    }
-    return (
-      <Row
-        style={{
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          paddingVertical: 8
-        }}>
-        <Row style={{ alignItems: 'center' }}>
-          <Text variant="body2">Get Free Gas</Text>
-          <Space x={4} />
-          <Tooltip
-            content="When toggled Core will pay the network fee for this transaction."
-            position="right"
-            style={{ width: 200 }}
-            icon={<InfoSVG size={14} />}
-          />
-        </Row>
-        <Switch
-          value={gaslessEnabled}
-          onValueChange={() => setGaslessEnabled(prevState => !prevState)}
-        />
-      </Row>
-    )
-  }
-
-  const renderNetworkFeeSelector = (): JSX.Element | null => {
-    if (gaslessEnabled && showGaslessSwitch) return null
-    if (!showNetworkFeeSelector || !chainId) return null
-
-    let gasLimit: number | undefined
-
-    if (
-      typeof signingData.data === 'object' &&
-      'gasLimit' in signingData.data
-    ) {
-      gasLimit = Number(signingData.data.gasLimit || 0)
-    }
-
-    if (!gasLimit) return null
-
-    return (
-      <NetworkFeeSelector
-        chainId={chainId}
-        gasLimit={gasLimit}
-        onFeesChange={handleFeesChange}
-      />
-    )
-  }
-
   const renderDetails = (): JSX.Element => {
     return (
       <>
@@ -532,45 +427,45 @@ const ApprovalPopup = (): JSX.Element => {
     )
   }
 
-  const validateEthSendTransaction = useCallback(() => {
-    if (
-      !signingData ||
-      !network?.networkToken ||
-      !nativeToken ||
-      signingData.type !== 'eth_sendTransaction'
+  const renderAmountError = (): JSX.Element | null => {
+    if (!amountError) return null
+
+    return (
+      <Text
+        variant="body2"
+        sx={{
+          color: '$dangerMain',
+          maxWidth: '55%',
+          marginVertical: 8
+        }}>
+        {amountError}
+      </Text>
     )
-      return
-    const ethSendTx = signingData.data
+  }
 
-    try {
-      const gasLimit = ethSendTx.gasLimit ? BigInt(ethSendTx.gasLimit) : 0n
-      const amount = ethSendTx.value ? BigInt(ethSendTx.value) : 0n
+  const renderNetworkFeeSelectorWithGasless = (): JSX.Element | null => {
+    if (!showNetworkFeeSelector) return null
 
-      validateFee({
-        gasLimit,
-        maxFee: maxFeePerGas || 0n,
-        amount,
-        nativeToken,
-        token: nativeToken
-      })
+    let gasLimit: number | undefined
 
-      setAmountError(undefined)
-    } catch (err) {
-      if (err instanceof Error) {
-        setAmountError(err.message)
-      } else {
-        setAmountError(SendErrorMessage.UNKNOWN_ERROR)
-      }
+    if (
+      typeof signingData.data === 'object' &&
+      'gasLimit' in signingData.data
+    ) {
+      gasLimit = Number(signingData.data.gasLimit || 0)
     }
-  }, [signingData, network, maxFeePerGas, nativeToken])
 
-  useEffect(() => {
-    if (gaslessEnabled) {
-      setAmountError(undefined)
-      return
-    }
-    validateEthSendTransaction()
-  }, [validateEthSendTransaction, gaslessEnabled])
+    return (
+      <NetworkFeeSelectorWithGasless
+        gaslessEnabled={gaslessEnabled}
+        setGaslessEnabled={setGaslessEnabled}
+        gasLimit={gasLimit}
+        caip2ChainId={caip2ChainId}
+        handleFeesChange={handleFeesChange}
+        showGaslessSwitch={showGaslessSwitch}
+      />
+    )
+  }
 
   return (
     <>
@@ -592,19 +487,8 @@ const ApprovalPopup = (): JSX.Element => {
           {renderDetails()}
           {renderSpendLimits()}
           {renderBalanceChange()}
-          {renderGasless()}
-          {amountError && (
-            <Text
-              variant="body2"
-              sx={{
-                color: '$dangerMain',
-                maxWidth: '55%',
-                marginVertical: 8
-              }}>
-              {amountError}
-            </Text>
-          )}
-          {renderNetworkFeeSelector()}
+          {renderAmountError()}
+          {renderNetworkFeeSelectorWithGasless()}
           {renderDisclaimer()}
         </ScrollView>
         {renderApproveRejectButtons()}

--- a/packages/core-mobile/app/screens/rpc/components/v2/ApprovalPopup.tsx
+++ b/packages/core-mobile/app/screens/rpc/components/v2/ApprovalPopup.tsx
@@ -77,7 +77,7 @@ const ApprovalPopup = (): JSX.Element => {
   const {
     gaslessEnabled,
     setGaslessEnabled,
-    showGaslessSwitch,
+    shouldShowGaslessSwitch,
     gaslessError,
     handleGaslessTx
   } = useGasless({
@@ -193,7 +193,7 @@ const ApprovalPopup = (): JSX.Element => {
     if (approveDisabled) return
     setSubmitting(true)
 
-    if (showGaslessSwitch && gaslessEnabled) {
+    if (shouldShowGaslessSwitch && gaslessEnabled) {
       const txHash = await handleGaslessTx(account.addressC)
       if (!txHash) {
         setSubmitting(false)
@@ -462,7 +462,7 @@ const ApprovalPopup = (): JSX.Element => {
         gasLimit={gasLimit}
         caip2ChainId={caip2ChainId}
         handleFeesChange={handleFeesChange}
-        showGaslessSwitch={showGaslessSwitch}
+        shouldShowGaslessSwitch={shouldShowGaslessSwitch}
       />
     )
   }

--- a/packages/core-mobile/app/screens/rpc/components/v2/NetworkFeeSelectorWithGasless.tsx
+++ b/packages/core-mobile/app/screens/rpc/components/v2/NetworkFeeSelectorWithGasless.tsx
@@ -2,12 +2,13 @@ import React from 'react'
 import { Space } from 'components/Space'
 import { Row } from 'components/Row'
 import NetworkFeeSelector from 'components/NetworkFeeSelector'
-import { Text } from '@avalabs/k2-mobile'
+import { Text, useTheme, View } from '@avalabs/k2-mobile'
 import { Eip1559Fees } from 'utils/Utils'
 import { getChainIdFromCaip2 } from 'utils/caip2ChainIds'
 import Switch from 'components/Switch'
 import { Tooltip } from 'components/Tooltip'
 import InfoSVG from 'components/svg/InfoSVG'
+import Separator from 'components/Separator'
 
 type Props = {
   gaslessEnabled: boolean
@@ -26,6 +27,7 @@ const NetworkFeeSelectorWithGasless = ({
   caip2ChainId,
   handleFeesChange
 }: Props): JSX.Element => {
+  const { theme } = useTheme()
   const chainId = getChainIdFromCaip2(caip2ChainId)
 
   const renderGaslessSwitch = (): JSX.Element | null => {
@@ -37,7 +39,8 @@ const NetworkFeeSelectorWithGasless = ({
         style={{
           justifyContent: 'space-between',
           alignItems: 'center',
-          paddingVertical: 8
+          paddingTop: 8,
+          marginBottom: 24
         }}>
         <Row style={{ alignItems: 'center' }}>
           <Text variant="body2">Get Free Gas</Text>
@@ -46,7 +49,7 @@ const NetworkFeeSelectorWithGasless = ({
             content="When toggled Core will pay the network fee for this transaction."
             position="right"
             style={{ width: 200 }}
-            icon={<InfoSVG size={14} />}
+            icon={<InfoSVG size={14} color="white" />}
           />
         </Row>
         <Switch
@@ -57,6 +60,16 @@ const NetworkFeeSelectorWithGasless = ({
     )
   }
 
+  const renderSeparator = (): JSX.Element | null => {
+    if (!showGaslessSwitch || gaslessEnabled) return null
+
+    return (
+      <Separator
+        style={{ marginBottom: 10 }}
+        color={theme.colors.$neutral600}
+      />
+    )
+  }
   const renderNetworkFeeSelector = (): JSX.Element | null => {
     if (gaslessEnabled && showGaslessSwitch) return null
     if (!chainId || !gasLimit) return null
@@ -71,10 +84,21 @@ const NetworkFeeSelectorWithGasless = ({
   }
 
   return (
-    <>
-      {renderGaslessSwitch()}
+    <View
+      sx={{
+        backgroundColor: '$neutral800',
+        borderRadius: 8
+      }}>
+      <View
+        style={{
+          paddingHorizontal: 16,
+          paddingTop: 16
+        }}>
+        {renderGaslessSwitch()}
+        {renderSeparator()}
+      </View>
       {renderNetworkFeeSelector()}
-    </>
+    </View>
   )
 }
 

--- a/packages/core-mobile/app/screens/rpc/components/v2/NetworkFeeSelectorWithGasless.tsx
+++ b/packages/core-mobile/app/screens/rpc/components/v2/NetworkFeeSelectorWithGasless.tsx
@@ -39,7 +39,7 @@ const NetworkFeeSelectorWithGasless = ({
         style={{
           justifyContent: 'space-between',
           alignItems: 'center',
-          paddingTop: 8,
+          paddingTop: 24,
           marginBottom: 24
         }}>
         <Row style={{ alignItems: 'center' }}>
@@ -91,8 +91,7 @@ const NetworkFeeSelectorWithGasless = ({
       }}>
       <View
         style={{
-          paddingHorizontal: 16,
-          paddingTop: 16
+          paddingHorizontal: 16
         }}>
         {renderGaslessSwitch()}
         {renderSeparator()}

--- a/packages/core-mobile/app/screens/rpc/components/v2/NetworkFeeSelectorWithGasless.tsx
+++ b/packages/core-mobile/app/screens/rpc/components/v2/NetworkFeeSelectorWithGasless.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import { Space } from 'components/Space'
+import { Row } from 'components/Row'
+import NetworkFeeSelector from 'components/NetworkFeeSelector'
+import { Text } from '@avalabs/k2-mobile'
+import { Eip1559Fees } from 'utils/Utils'
+import { getChainIdFromCaip2 } from 'utils/caip2ChainIds'
+import Switch from 'components/Switch'
+import { Tooltip } from 'components/Tooltip'
+import InfoSVG from 'components/svg/InfoSVG'
+
+type Props = {
+  gaslessEnabled: boolean
+  setGaslessEnabled: React.Dispatch<React.SetStateAction<boolean>>
+  showGaslessSwitch: boolean
+  gasLimit: number | undefined
+  handleFeesChange: (fees: Eip1559Fees) => void
+  caip2ChainId: string
+}
+
+const NetworkFeeSelectorWithGasless = ({
+  gaslessEnabled,
+  setGaslessEnabled,
+  showGaslessSwitch,
+  gasLimit,
+  caip2ChainId,
+  handleFeesChange
+}: Props): JSX.Element => {
+  const chainId = getChainIdFromCaip2(caip2ChainId)
+
+  const renderGaslessSwitch = (): JSX.Element | null => {
+    if (!showGaslessSwitch) {
+      return null
+    }
+    return (
+      <Row
+        style={{
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          paddingVertical: 8
+        }}>
+        <Row style={{ alignItems: 'center' }}>
+          <Text variant="body2">Get Free Gas</Text>
+          <Space x={4} />
+          <Tooltip
+            content="When toggled Core will pay the network fee for this transaction."
+            position="right"
+            style={{ width: 200 }}
+            icon={<InfoSVG size={14} />}
+          />
+        </Row>
+        <Switch
+          value={gaslessEnabled}
+          onValueChange={() => setGaslessEnabled(prevState => !prevState)}
+        />
+      </Row>
+    )
+  }
+
+  const renderNetworkFeeSelector = (): JSX.Element | null => {
+    if (gaslessEnabled && showGaslessSwitch) return null
+    if (!chainId || !gasLimit) return null
+
+    return (
+      <NetworkFeeSelector
+        chainId={chainId}
+        gasLimit={gasLimit}
+        onFeesChange={handleFeesChange}
+      />
+    )
+  }
+
+  return (
+    <>
+      {renderGaslessSwitch()}
+      {renderNetworkFeeSelector()}
+    </>
+  )
+}
+
+export default NetworkFeeSelectorWithGasless

--- a/packages/core-mobile/app/screens/rpc/components/v2/NetworkFeeSelectorWithGasless.tsx
+++ b/packages/core-mobile/app/screens/rpc/components/v2/NetworkFeeSelectorWithGasless.tsx
@@ -13,7 +13,7 @@ import Separator from 'components/Separator'
 type Props = {
   gaslessEnabled: boolean
   setGaslessEnabled: React.Dispatch<React.SetStateAction<boolean>>
-  showGaslessSwitch: boolean
+  shouldShowGaslessSwitch: boolean
   gasLimit: number | undefined
   handleFeesChange: (fees: Eip1559Fees) => void
   caip2ChainId: string
@@ -22,7 +22,7 @@ type Props = {
 const NetworkFeeSelectorWithGasless = ({
   gaslessEnabled,
   setGaslessEnabled,
-  showGaslessSwitch,
+  shouldShowGaslessSwitch,
   gasLimit,
   caip2ChainId,
   handleFeesChange
@@ -31,7 +31,7 @@ const NetworkFeeSelectorWithGasless = ({
   const chainId = getChainIdFromCaip2(caip2ChainId)
 
   const renderGaslessSwitch = (): JSX.Element | null => {
-    if (!showGaslessSwitch) {
+    if (!shouldShowGaslessSwitch) {
       return null
     }
     return (
@@ -61,7 +61,7 @@ const NetworkFeeSelectorWithGasless = ({
   }
 
   const renderSeparator = (): JSX.Element | null => {
-    if (!showGaslessSwitch || gaslessEnabled) return null
+    if (!shouldShowGaslessSwitch || gaslessEnabled) return null
 
     return (
       <Separator
@@ -71,7 +71,7 @@ const NetworkFeeSelectorWithGasless = ({
     )
   }
   const renderNetworkFeeSelector = (): JSX.Element | null => {
-    if (gaslessEnabled && showGaslessSwitch) return null
+    if (gaslessEnabled && shouldShowGaslessSwitch) return null
     if (!chainId || !gasLimit) return null
 
     return (

--- a/packages/core-mobile/app/screens/send/components/SendTokenForm.tsx
+++ b/packages/core-mobile/app/screens/send/components/SendTokenForm.tsx
@@ -200,12 +200,12 @@ const SendTokenForm = ({
             hideErrorMessage
             error={isAllFieldsTouched && error ? error : undefined}
           />
-
           {supportsAvalancheDynamicFee && estimatedFee !== undefined && (
             <>
               <Space y={20} />
               <View sx={{ marginHorizontal: 16 }}>
                 <NetworkFeeSelector
+                  isDark
                   chainId={network.chainId}
                   gasLimit={Number(estimatedFee)}
                   onFeesChange={handleFeesChange}

--- a/packages/core-mobile/app/utils/FormatCurrency.test.ts
+++ b/packages/core-mobile/app/utils/FormatCurrency.test.ts
@@ -1,93 +1,208 @@
 import { formatCurrency } from 'utils/FormatCurrency'
 
-describe('formatCurrency function', () => {
-  describe('formats normal currency', () => {
-    it('Should display any number with max 2 fraction digits', () => {
-      const result = formatCurrency({
+describe('formats normal numbers', () => {
+  it('should display any number with max 2 fraction digits', () => {
+    expect(
+      formatCurrency({
         amount: 13245125.123424,
         currency: 'USD',
         boostSmallNumberPrecision: false
       })
-      expect(result).toBe('$13,245,125.12')
-    })
+    ).toBe('$13,245,125.12')
 
-    it('Should display any number with max 2 fraction digits and round correctly', () => {
-      const result = formatCurrency({
+    expect(
+      formatCurrency({
         amount: 13245125.126,
         currency: 'USD',
         boostSmallNumberPrecision: false
       })
-      expect(result).toBe('$13,245,125.13')
-    })
+    ).toBe('$13,245,125.13')
 
-    it('Should not duplicate currency symbol if it matches currency code', () => {
-      const result = formatCurrency({
-        amount: 13245125.126,
-        currency: 'CHF',
-        boostSmallNumberPrecision: false
-      })
-      expect(result).toBe('13,245,125.13 CHF')
-    })
-
-    it('Should always have 2 fraction digits', () => {
-      const result = formatCurrency({
+    expect(
+      formatCurrency({
         amount: 0.1,
         currency: 'USD',
         boostSmallNumberPrecision: false
       })
-      expect(result).toBe('$0.10')
+    ).toBe('$0.10')
 
-      const result2 = formatCurrency({
+    expect(
+      formatCurrency({
         amount: 100,
         currency: 'USD',
         boostSmallNumberPrecision: false
       })
-      expect(result2).toBe('$100.00')
-    })
+    ).toBe('$100.00')
   })
 
-  describe('formats token as currency', () => {
-    it('Should display numbers >= 1 with max 2 fraction digits', () => {
-      let result = formatCurrency({
-        amount: 13.123424352342212,
-        currency: 'USD',
-        boostSmallNumberPrecision: true
-      })
-      expect(result).toBe('$13.12')
-
-      result = formatCurrency({
-        amount: 130000.12342,
-        currency: 'USD',
-        boostSmallNumberPrecision: true
-      })
-      expect(result).toBe('$130,000.12')
+  it('should not duplicate currency symbol if it matches currency code', () => {
+    const result = formatCurrency({
+      amount: 13245125.126,
+      currency: 'CHF',
+      boostSmallNumberPrecision: false
     })
+    expect(result).toBe('13,245,125.13 CHF')
+  })
+})
 
-    it('Should display numbers >= 1 with min 2 fraction digits', () => {
-      const result = formatCurrency({
-        amount: 1,
-        currency: 'USD',
-        boostSmallNumberPrecision: true
-      })
-      expect(result).toBe('$1.00')
+describe('formats small numbers with boostSmallNumberPrecision', () => {
+  it('should display numbers >= 1 with max 2 fraction digits', () => {
+    let result = formatCurrency({
+      amount: 13.123424352342212,
+      currency: 'USD',
+      boostSmallNumberPrecision: true
     })
+    expect(result).toBe('$13.12')
 
-    it('Should display numbers < 1 with min 2 fraction digits', () => {
-      const result = formatCurrency({
+    result = formatCurrency({
+      amount: 130000.12342,
+      currency: 'USD',
+      boostSmallNumberPrecision: true
+    })
+    expect(result).toBe('$130,000.12')
+  })
+
+  it('should display numbers >= 1 with min 2 fraction digits', () => {
+    const result = formatCurrency({
+      amount: 1,
+      currency: 'USD',
+      boostSmallNumberPrecision: true
+    })
+    expect(result).toBe('$1.00')
+  })
+
+  it('should display numbers < 1 with min 2 fraction digits', () => {
+    expect(
+      formatCurrency({
         amount: 0.9,
         currency: 'USD',
         boostSmallNumberPrecision: true
       })
-      expect(result).toBe('$0.90')
-    })
+    ).toBe('$0.90')
 
-    it('Should display numbers < 1 with max 8 fraction digits', () => {
-      const result = formatCurrency({
-        amount: 0.9923424352342212,
+    expect(
+      formatCurrency({
+        amount: 0.1,
         currency: 'USD',
         boostSmallNumberPrecision: true
       })
-      expect(result).toBe('$0.99234244')
+    ).toBe('$0.10')
+  })
+
+  it('should display numbers < 1 with max 8 fraction digits', () => {
+    const result = formatCurrency({
+      amount: 0.9923424352342212,
+      currency: 'USD',
+      boostSmallNumberPrecision: true
     })
+    expect(result).toBe('$0.99234244')
+  })
+})
+
+describe('formats small numbers', () => {
+  it('should display amounts between 0.001 and 0.01 with 3 decimal places (tenths of cents)', () => {
+    expect(
+      formatCurrency({
+        amount: 0.005,
+        currency: 'USD',
+        boostSmallNumberPrecision: false
+      })
+    ).toBe('$0.005')
+
+    expect(
+      formatCurrency({
+        amount: 0.009,
+        currency: 'USD',
+        boostSmallNumberPrecision: false
+      })
+    ).toBe('$0.009')
+
+    expect(
+      formatCurrency({
+        amount: 0.001,
+        currency: 'USD',
+        boostSmallNumberPrecision: false
+      })
+    ).toBe('$0.001')
+  })
+
+  it('should handle amounts < 0.001', () => {
+    expect(
+      formatCurrency({
+        amount: 0.0005,
+        currency: 'USD',
+        boostSmallNumberPrecision: false,
+        showLessThanThreshold: true
+      })
+    ).toBe('<$0.001')
+
+    expect(
+      formatCurrency({
+        amount: 0.00001,
+        currency: 'USD',
+        boostSmallNumberPrecision: false,
+        showLessThanThreshold: true
+      })
+    ).toBe('<$0.001')
+
+    expect(
+      formatCurrency({
+        amount: 0.0005,
+        currency: 'USD',
+        boostSmallNumberPrecision: false,
+        showLessThanThreshold: false
+      })
+    ).toBe('$0.001')
+  })
+})
+
+describe('formats negative numbers', () => {
+  it('should format negative numbers correctly with appropriate decimal places', () => {
+    expect(
+      formatCurrency({
+        amount: -5.6789,
+        currency: 'USD',
+        boostSmallNumberPrecision: false
+      })
+    ).toBe('-$5.68')
+
+    expect(
+      formatCurrency({
+        amount: -0.009,
+        currency: 'USD',
+        boostSmallNumberPrecision: false
+      })
+    ).toBe('-$0.009')
+
+    expect(
+      formatCurrency({
+        amount: -0.0005,
+        currency: 'USD',
+        boostSmallNumberPrecision: false,
+        showLessThanThreshold: true
+      })
+    ).toBe('<$0.001')
+  })
+})
+
+describe('handles compact notation', () => {
+  it('should display large numbers in compact notation when specified', () => {
+    expect(
+      formatCurrency({
+        amount: 1234567,
+        currency: 'USD',
+        boostSmallNumberPrecision: false,
+        notation: 'compact'
+      })
+    ).toBe('$1.23M')
+
+    expect(
+      formatCurrency({
+        amount: 987654321,
+        currency: 'USD',
+        boostSmallNumberPrecision: false,
+        notation: 'compact'
+      })
+    ).toBe('$987.65M')
   })
 })

--- a/packages/core-mobile/app/utils/numberToSubscriptFormat/numberToSubscriptFormat.test.ts
+++ b/packages/core-mobile/app/utils/numberToSubscriptFormat/numberToSubscriptFormat.test.ts
@@ -1,0 +1,114 @@
+import { numberToSubscriptFormat } from './numberToSubscriptFormat' // Adjust path as needed
+
+// Small numbers (< 0.00001)
+test('formats small number correctly', () => {
+  expect(numberToSubscriptFormat(8.4509221e-7)).toEqual({
+    mainTextBefore: '0.0',
+    subText: '6', // 6 zeros
+    mainTextAfter: '84'
+  })
+
+  expect(numberToSubscriptFormat(0.00000084509221)).toEqual({
+    mainTextBefore: '0.0',
+    subText: '6', // 6 zeros
+    mainTextAfter: '84'
+  })
+
+  expect(numberToSubscriptFormat(1e-19)).toEqual({
+    mainTextBefore: '0.0',
+    subText: '18', // 19 zeros
+    mainTextAfter: '1'
+  })
+
+  expect(numberToSubscriptFormat(0.0000092)).toEqual({
+    mainTextBefore: '0.0',
+    subText: '5', // 5 zeros
+    mainTextAfter: '92'
+  })
+})
+
+// Regular numbers
+test('formats regular number correctly', () => {
+  expect(numberToSubscriptFormat(0.123)).toEqual({
+    mainTextBefore: '0.123',
+    subText: '',
+    mainTextAfter: ''
+  })
+
+  expect(numberToSubscriptFormat(0.000021)).toEqual({
+    mainTextBefore: '0.0001',
+    subText: '',
+    mainTextAfter: ''
+  })
+
+  expect(numberToSubscriptFormat(0.00005)).toEqual({
+    mainTextBefore: '0.0001',
+    subText: '',
+    mainTextAfter: ''
+  })
+
+  expect(numberToSubscriptFormat(42)).toEqual({
+    mainTextBefore: '42',
+    subText: '',
+    mainTextAfter: ''
+  })
+
+  expect(numberToSubscriptFormat(1.23)).toEqual({
+    mainTextBefore: '1.23',
+    subText: '',
+    mainTextAfter: ''
+  })
+
+  // Numbers exceeding 5 characters
+  expect(numberToSubscriptFormat(12.345678)).toEqual({
+    mainTextBefore: '12.346', // round up
+    subText: '',
+    mainTextAfter: ''
+  })
+
+  expect(numberToSubscriptFormat(1234.567)).toEqual({
+    mainTextBefore: '1234.6',
+    subText: '',
+    mainTextAfter: ''
+  })
+
+  expect(numberToSubscriptFormat(123456)).toEqual({
+    mainTextBefore: '123456', // for integers more than 5 digits, keep as is
+    subText: '',
+    mainTextAfter: ''
+  })
+})
+
+// Edge cases
+test('handles zero correctly', () => {
+  const result = numberToSubscriptFormat(0)
+  expect(result).toEqual({
+    mainTextBefore: '0',
+    subText: '',
+    mainTextAfter: ''
+  })
+})
+
+test('handles negative numbers correctly', () => {
+  const result = numberToSubscriptFormat(-0.0000092)
+  expect(result).toEqual({
+    mainTextBefore: '-',
+    subText: '',
+    mainTextAfter: ''
+  })
+})
+
+test('handles non numbers correctly', () => {
+  // @ts-ignore
+  expect(numberToSubscriptFormat('some string')).toEqual({
+    mainTextBefore: '-',
+    subText: '',
+    mainTextAfter: ''
+  })
+
+  expect(numberToSubscriptFormat(undefined)).toEqual({
+    mainTextBefore: '-',
+    subText: '',
+    mainTextAfter: ''
+  })
+})

--- a/packages/core-mobile/app/utils/numberToSubscriptFormat/numberToSubscriptFormat.ts
+++ b/packages/core-mobile/app/utils/numberToSubscriptFormat/numberToSubscriptFormat.ts
@@ -1,0 +1,109 @@
+import { UNKNOWN_AMOUNT } from 'consts/amount'
+
+const DIGIT_LIMIT = 5
+
+export const numberToSubscriptFormat = (
+  number: number | undefined
+): {
+  mainTextBefore: string
+  subText: string
+  mainTextAfter: string
+} => {
+  if (typeof number !== 'number')
+    return {
+      mainTextBefore: UNKNOWN_AMOUNT,
+      subText: '',
+      mainTextAfter: ''
+    }
+
+  // Handle 0
+  if (number === 0)
+    return {
+      mainTextBefore: '0',
+      subText: '',
+      mainTextAfter: ''
+    }
+
+  // Handle less than 0
+  if (number < 0)
+    return {
+      mainTextBefore: UNKNOWN_AMOUNT,
+      subText: '',
+      mainTextAfter: ''
+    }
+
+  // Handle greater than 0.00001
+  if (number > 0.00001) {
+    // For regular numbers, limit to 5 digits (excluding decimal) and round up
+    const roundedNumber = limitAndRoundNumber(number)
+
+    return {
+      mainTextBefore: roundedNumber.toString(),
+      subText: '',
+      mainTextAfter: ''
+    }
+  }
+
+  // Handle numbers less than 0.00001
+  // Convert to scientific notation string if not already
+  const sciNotation = number.toExponential()
+
+  // Example: "8.4509221e-7" → "8.4509221" and "-7"
+  const [coefficient, exponent] = sciNotation.split('e')
+
+  // If either part is missing, return original number
+  if (!coefficient || !exponent) {
+    return {
+      mainTextBefore: number.toString(),
+      subText: '',
+      mainTextAfter: ''
+    }
+  }
+
+  // Parse exponent, if invalid return original number
+  const expNum = parseInt(exponent, 10)
+
+  if (isNaN(expNum)) {
+    return {
+      mainTextBefore: number.toString(),
+      subText: '',
+      mainTextAfter: ''
+    }
+  }
+
+  const absExpNum = Math.abs(expNum)
+
+  // Split coefficient into parts
+  const coeffParts = coefficient.split('.')
+  const digitsBeforeDecimal = coeffParts?.[0]?.length
+
+  // If digitsBeforeDecimal is undefined, return original number
+  if (digitsBeforeDecimal === undefined) {
+    return {
+      mainTextBefore: number.toString(),
+      subText: '',
+      mainTextAfter: ''
+    }
+  }
+
+  // Count number of 0s
+  const zeroCount = absExpNum - digitsBeforeDecimal // e.g., 7 - 1 = 6
+
+  // Get significant digits (remove decimal, take first 2)
+  const significantDigits = coefficient.replace('.', '').slice(0, 2)
+
+  return {
+    mainTextBefore: '0.0',
+    subText: zeroCount.toString(), // Number of zeros as subscript
+    mainTextAfter: significantDigits
+  }
+}
+
+// https://stackoverflow.com/questions/72630881/limit-and-round-number
+const limitAndRoundNumber = (number: number): number => {
+  const wholeDigits = Math.ceil(number).toString().length
+  const power = wholeDigits <= DIGIT_LIMIT ? DIGIT_LIMIT - wholeDigits : 0
+  const multiplier = 10 ** power
+
+  return Math.ceil(number * multiplier) / multiplier
+}

--- a/packages/core-mobile/storybook/stories/FeeSelector.stories.tsx
+++ b/packages/core-mobile/storybook/stories/FeeSelector.stories.tsx
@@ -13,18 +13,10 @@ export default {
 export const Basic = ({
   label,
   selected,
-  onSelect,
-  value
+  onSelect
 }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
 any): React.JSX.Element => {
-  return (
-    <FeeSelector
-      label={label}
-      selected={selected}
-      value={value}
-      onSelect={onSelect}
-    />
-  )
+  return <FeeSelector label={label} selected={selected} onSelect={onSelect} />
 }
 
 Basic.args = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -26827,7 +26827,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 869028a5bb7a4a8a125d274753b703c2b3579b5efc7bb82db136a186fd88a11c5a4696505ebcd976d20fcdd41111abe229ae0e19c27c50bb30fe4f52bb6383bc
+  checksum: 77324747a8b5df0a5558bb99a9a0804a5575d328e84f480e462c56417af97213f38a9930e4582fb749bec374dc4d1a8910a45b006e77af9b14a8e64057b932bf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: [CP-10043]** 
support subtext notation in gas widget when gas has a lot of 0s

## Screenshots/Videos
<img src="https://github.com/user-attachments/assets/52553c3b-e91c-4900-a8dc-3d57c760438c" width="320"/>
<img src="https://github.com/user-attachments/assets/954ff770-16b3-47ff-88d6-60a07b0927dc" width="320"/>
<img src="https://github.com/user-attachments/assets/ad2ffd63-09cf-48aa-94ca-520b2feb7ea3" width="320"/>
<img src="https://github.com/user-attachments/assets/b8c3e03b-55a2-4871-9ed5-f63ee2aa4092" width="320"/>
<img src="https://github.com/user-attachments/assets/28bd32d5-a559-4fe7-849e-b8c83ad99e62" width="320"/>

## Testing
please retest all transactions (send/swap/bridge) across networks (mainnets/testnets). when there are lots of 0s, it should display with the subtext notation.

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10043]: https://ava-labs.atlassian.net/browse/CP-10043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ