### PR TITLE
Fix crypto.subtle

### DIFF
--- a/packages/core-mobile/docs/patches.md
+++ b/packages/core-mobile/docs/patches.md
@@ -63,3 +63,9 @@ https://github.com/software-mansion/react-native-reanimated/pull/7158
 
 perf improvement
 https://github.com/PedroBern/react-native-collapsible-tab-view/pull/461
+
+### react-native-webview-crypto+0.0.26.patch
+
+with the latest react native, if the webview is not rendered using `display: none`, nothing will work: all the javascript injection, message relaying,...
+
+to fix it, we patched the lib so that the webview is still rendered but won't be visible.

--- a/packages/core-mobile/patches/react-native-webview-crypto+0.0.26.patch
+++ b/packages/core-mobile/patches/react-native-webview-crypto+0.0.26.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/react-native-webview-crypto/index.js b/node_modules/react-native-webview-crypto/index.js
+index ec96971..b52ea51 100644
+--- a/node_modules/react-native-webview-crypto/index.js
++++ b/node_modules/react-native-webview-crypto/index.js
+@@ -5,14 +5,12 @@ const { MainWorker, webViewWorkerString } = require("webview-crypto");
+ 
+ const styles = StyleSheet.create({
+   hide: {
+-    display: "none",
+-    position: "absolute",
+-
+-    width: 0,
+-    height: 0,
+-
+-    flexGrow: 0,
+-    flexShrink: 1
++    position: 'absolute',
++    top: -1000,
++    left: -1000,
++    width: 1,
++    height: 1,
++    opacity: 0
+   }
+ });
+ 

--- a/packages/core-mobile/polyfills/crypto.js
+++ b/packages/core-mobile/polyfills/crypto.js
@@ -3,3 +3,9 @@ import { install } from 'react-native-quick-crypto'
 // this will make both buffer (from @craftzdog/react-native-buffer)
 // and crypto (from react-native-quick-crypto) available globally
 install()
+
+// react-native-quick-crypto only has partial support for subtle
+// we need to delete it from the global object so that
+// react-native-webview-crypto can pollyfill it on demand
+// (for example, when exporting seed phrase)
+delete global.crypto.subtle

--- a/yarn.lock
+++ b/yarn.lock
@@ -26834,7 +26834,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 869028a5bb7a4a8a125d274753b703c2b3579b5efc7bb82db136a186fd88a11c5a4696505ebcd976d20fcdd41111abe229ae0e19c27c50bb30fe4f52bb6383bc
+  checksum: 77324747a8b5df0a5558bb99a9a0804a5575d328e84f480e462c56417af97213f38a9930e4582fb749bec374dc4d1a8910a45b006e77af9b14a8e64057b932bf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

For some reason, with the new react native, if the webview is not rendered, nothing will work (all the javascript injection, message relaying,...). To fix it, I patched the lib so that the webview is still rendered but won't be visible.
