### PR TITLE
CP-10130: seedless session expired handler

### DIFF
--- a/packages/core-mobile/__mocks__/expo-router.js
+++ b/packages/core-mobile/__mocks__/expo-router.js
@@ -1,0 +1,12 @@
+export const router = {
+  push: jest.fn(),
+  back: jest.fn(),
+  replace: jest.fn(),
+  setParams: jest.fn(),
+  _reset: () => {
+    router.push.mockReset()
+    router.back.mockReset()
+    router.replace.mockReset()
+    router.setParams.mockReset()
+  }
+}

--- a/packages/core-mobile/app/new/routes/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/_layout.tsx
@@ -29,6 +29,7 @@ import { LogoModal } from 'common/components/LogoModal'
 import { RecoveryMethodProvider } from 'features/onboarding/contexts/RecoveryMethodProvider'
 import {
   forNoAnimation,
+  modalScreensOptions,
   stackNavigatorScreenOptions
 } from 'common/consts/screenOptions'
 import { useLoadFonts } from 'common/hooks/useLoadFonts'
@@ -152,7 +153,10 @@ export default function RootLayout(): JSX.Element | null {
               <Stack.Screen name="onboarding" />
               <Stack.Screen
                 name="sessionExpired"
-                options={{ gestureEnabled: false }}
+                options={{
+                  ...modalScreensOptions,
+                  gestureEnabled: false
+                }}
               />
             </Stack>
             {enabledPrivacyScreen && <LogoModal />}

--- a/packages/core-mobile/app/new/routes/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/_layout.tsx
@@ -150,6 +150,10 @@ export default function RootLayout(): JSX.Element | null {
               <Stack.Screen name="forgotPin" options={{ headerShown: true }} />
               <Stack.Screen name="+not-found" />
               <Stack.Screen name="onboarding" />
+              <Stack.Screen
+                name="sessionExpired"
+                options={{ gestureEnabled: false }}
+              />
             </Stack>
             {enabledPrivacyScreen && <LogoModal />}
           </RecoveryMethodProvider>

--- a/packages/core-mobile/app/new/routes/sessionExpired.tsx
+++ b/packages/core-mobile/app/new/routes/sessionExpired.tsx
@@ -1,0 +1,110 @@
+import { useFocusEffect, useRouter } from 'expo-router'
+import React, { useCallback } from 'react'
+import { BackHandler } from 'react-native'
+import {
+  Button,
+  Icons,
+  SafeAreaView,
+  showAlert,
+  Text,
+  useTheme,
+  View
+} from '@avalabs/k2-alpine'
+import { Space } from 'components/Space'
+import { startRefreshSeedlessTokenFlow } from 'common/utils/startRefreshSeedlessTokenFlow'
+import SeedlessService from 'seedless/services/SeedlessService'
+import { useDispatch, useSelector } from 'react-redux'
+import { onLogOut, selectWalletState, WalletState } from 'store/app'
+import { initWalletServiceAndUnlock } from 'hooks/useWallet'
+import { SEEDLESS_MNEMONIC_STUB } from 'seedless/consts'
+import { WalletType } from 'services/wallet/types'
+import Logger from 'utils/Logger'
+
+const SessionTimeoutScreen = (): React.JSX.Element => {
+  const router = useRouter()
+  const walletState = useSelector(selectWalletState)
+  const dispatch = useDispatch()
+  const {
+    theme: { colors }
+  } = useTheme()
+  useFocusEffect(
+    useCallback(() => {
+      const onBackPress = (): boolean => true
+      BackHandler.addEventListener('hardwareBackPress', onBackPress)
+
+      return () =>
+        BackHandler.removeEventListener('hardwareBackPress', onBackPress)
+    }, [])
+  )
+
+  const onRetry = useCallback((): void => {
+    startRefreshSeedlessTokenFlow(SeedlessService.session)
+      .then(result => {
+        if (result.success) {
+          router.canDismiss() && router.dismiss()
+          if (walletState === WalletState.INACTIVE) {
+            initWalletServiceAndUnlock({
+              dispatch,
+              mnemonic: SEEDLESS_MNEMONIC_STUB,
+              walletType: WalletType.SEEDLESS,
+              isLoggingIn: true
+            }).catch(Logger.error)
+          }
+          return
+        }
+        switch (result.error.name) {
+          case 'USER_ID_MISMATCH':
+            showAlert({
+              title: 'Wrong email address',
+              description:
+                'Please log in with the email address you used when you created your wallet.',
+              buttons: [
+                {
+                  text: 'OK',
+                  style: 'cancel'
+                }
+              ]
+            })
+            break
+          case 'USER_CANCELED':
+          case 'UNSUPPORTED_OIDC_PROVIDER':
+          case 'NOT_REGISTERED':
+          case 'UNEXPECTED_ERROR':
+            throw new Error(result.error.name)
+        }
+      })
+      .catch(e => {
+        Logger.error('startRefreshSeedlessTokenFlow error', e)
+        router.canDismiss() && router.dismiss()
+        dispatch(onLogOut)
+      })
+  }, [dispatch, router, walletState])
+
+  return (
+    <SafeAreaView
+      style={{
+        flex: 1,
+        justifyContent: 'space-between',
+        marginHorizontal: 16
+      }}>
+      <View style={{ alignItems: 'center', justifyContent: 'center', flex: 1 }}>
+        <Icons.Action.Info color={colors.$textPrimary} width={36} height={36} />
+        <Space y={24} />
+        <Text variant={'heading5'}>Your Session has Timed Out</Text>
+        <Space y={8} />
+        <Text variant={'body2'} style={{ textAlign: 'center' }}>
+          The session has expired, press Retry to continue.
+        </Text>
+      </View>
+      <Button
+        size={'large'}
+        type={'primary'}
+        onPress={onRetry}
+        style={{ width: '100%', marginBottom: 16 }}>
+        Retry
+      </Button>
+    </SafeAreaView>
+  )
+}
+
+export default SessionTimeoutScreen

--- a/packages/core-mobile/app/seedless/store/listeners.ts
+++ b/packages/core-mobile/app/seedless/store/listeners.ts
@@ -15,6 +15,7 @@ import { Action } from '@reduxjs/toolkit'
 import { AppListenerEffectAPI } from 'store'
 import { onTokenExpired } from 'seedless/store/slice'
 import { setAccountTitle } from 'store/account/slice'
+import { router } from 'expo-router'
 
 const refreshSeedlessToken = async (): Promise<void> => {
   if (WalletService.walletType !== WalletType.SEEDLESS) {


### PR DESCRIPTION
## Description

**Ticket: [CP-10130]** 

- add sessionExpired screen to ask user to re-authenticate 
- show native alert when user uses wrong social account
- 
## Screenshots/Videos

https://github.com/user-attachments/assets/51cf9e02-e9c5-4d1c-b885-8aad2f08546c

updated modal presentation

https://github.com/user-attachments/assets/69cd16ae-85df-4a86-8301-b85b7290ad86

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10130]: https://ava-labs.atlassian.net/browse/CP-10130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ