### PR TITLE
Cp 10230

### DIFF
--- a/packages/core-mobile/app/new/common/components/DropdownSelections.tsx
+++ b/packages/core-mobile/app/new/common/components/DropdownSelections.tsx
@@ -3,6 +3,7 @@ import {
   IndexPath,
   SimpleDropdown,
   SxProp,
+  Text,
   usePopoverAnchor,
   View
 } from '@avalabs/k2-alpine'
@@ -60,6 +61,7 @@ export const DropdownSelections = ({
             onDeselect={filter.onDeselect}
           />
         )}
+
         {sort && (
           <Sorts
             useAnchorRect={sort.useAnchorRect}

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsContent.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsContent.tsx
@@ -12,7 +12,6 @@ import React, { ReactNode, useCallback, useMemo } from 'react'
 import { NftItem } from 'services/nft/types'
 
 import { noop } from '@avalabs/core-utils-sdk'
-import { useNavigation } from '@react-navigation/native'
 import { LinearGradientBottomWrapper } from 'common/components/LinearGradientBottomWrapper'
 import { showSnackbar } from 'common/utils/toast'
 import { LinearGradient } from 'expo-linear-gradient'
@@ -23,13 +22,7 @@ import {
 import { ActionButtonTitle } from 'features/portfolio/assets/consts'
 import { useNetworks } from 'hooks/networks/useNetworks'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { useDispatch, useSelector } from 'react-redux'
 import { isAvalancheCChainId } from 'services/network/utils/isAvalancheNetwork'
-import { isCollectibleVisible } from 'store/nft/utils'
-import {
-  selectCollectibleVisibility,
-  toggleCollectibleVisibility
-} from 'store/portfolio'
 import { truncateAddress } from 'utils/Utils'
 import { isAddress } from 'viem'
 import { useCollectiblesContext } from '../CollectiblesContext'
@@ -37,24 +30,19 @@ import { HORIZONTAL_MARGIN } from '../consts'
 
 export const CollectibleDetailsContent = ({
   collectible,
-  collectibles
+  isVisible,
+  onHide
 }: {
   collectible: NftItem | undefined
-  collectibles: NftItem[]
+  isVisible: boolean
+  onHide: () => void
 }): ReactNode => {
-  const dispatch = useDispatch()
   const {
     theme: { colors }
   } = useTheme()
   const insets = useSafeAreaInsets()
   const networks = useNetworks()
-  const { goBack } = useNavigation()
   const { refreshMetadata, isCollectibleRefreshing } = useCollectiblesContext()
-
-  const collectibleVisibility = useSelector(selectCollectibleVisibility)
-  const isVisible = collectible
-    ? isCollectibleVisible(collectibleVisibility, collectible)
-    : false
 
   const attributes: GroupListItem[] = useMemo(
     () =>
@@ -102,33 +90,18 @@ export const CollectibleDetailsContent = ({
     await refreshMetadata(collectible, collectible.chainId)
   }, [canRefreshMetadata, collectible, refreshMetadata])
 
-  const toggleHidden = useCallback((): void => {
-    if (collectible?.localId) {
-      dispatch(toggleCollectibleVisibility({ uid: collectible.localId }))
-
-      if (isVisible) {
-        if (collectibles.length === 1) {
-          goBack()
-        }
-        showSnackbar('Collectible hidden')
-      } else {
-        showSnackbar('Collectible unhidden')
-      }
-    }
-  }, [collectible?.localId, collectibles.length, dispatch, isVisible, goBack])
-
   const ACTION_BUTTONS: ActionButton[] = useMemo(() => {
     const visibilityAction: ActionButton = {
       title: isVisible ? ActionButtonTitle.Hide : ActionButtonTitle.Unhide,
       icon: isVisible ? 'hide' : 'show',
-      onPress: toggleHidden
+      onPress: onHide
     }
 
     return [
       { title: ActionButtonTitle.Send, icon: 'send', onPress: noop },
       visibilityAction
     ]
-  }, [isVisible, toggleHidden])
+  }, [isVisible, onHide])
 
   return (
     <View

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsContent.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsContent.tsx
@@ -48,7 +48,6 @@ export const CollectibleDetailsContent = ({
   } = useTheme()
   const insets = useSafeAreaInsets()
   const networks = useNetworks()
-  const { theme } = useTheme()
   const { goBack } = useNavigation()
   const { refreshMetadata, isCollectibleRefreshing } = useCollectiblesContext()
 

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsContent.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsContent.tsx
@@ -48,6 +48,7 @@ export const CollectibleDetailsContent = ({
   } = useTheme()
   const insets = useSafeAreaInsets()
   const networks = useNetworks()
+  const { theme } = useTheme()
   const { goBack } = useNavigation()
   const { refreshMetadata, isCollectibleRefreshing } = useCollectiblesContext()
 
@@ -184,6 +185,9 @@ export const CollectibleDetailsContent = ({
                 value: createdBy
               }
             ]}
+            valueSx={{
+              fontFamily: 'DejaVuSansMono'
+            }}
           />
 
           <GroupList

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsHero.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsHero.tsx
@@ -6,9 +6,8 @@ import {
   useTheme,
   View
 } from '@avalabs/k2-alpine'
-import { GlowRef } from 'common/components/Glow'
 import { LinearGradient } from 'expo-linear-gradient'
-import React, { ReactNode, useRef } from 'react'
+import React, { ReactNode } from 'react'
 import Animated, {
   Extrapolation,
   interpolate,
@@ -176,6 +175,7 @@ export const CollectibleDetailsHero = ({
               paddingBottom: 50,
               paddingTop: 20
             }}
+            nestedScrollEnabled
             showsVerticalScrollIndicator={false}>
             <View
               style={{

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsHero.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsHero.tsx
@@ -6,7 +6,7 @@ import {
   useTheme,
   View
 } from '@avalabs/k2-alpine'
-import { Glow, GlowRef } from 'common/components/Glow'
+import { GlowRef } from 'common/components/Glow'
 import { LinearGradient } from 'expo-linear-gradient'
 import React, { ReactNode, useRef } from 'react'
 import Animated, {
@@ -39,10 +39,11 @@ export const CollectibleDetailsHero = ({
   const {
     theme: { colors }
   } = useTheme()
-  const glowRef = useRef<GlowRef>(null)
+  // TODO: add lottie animation instead of custom glow
+  // const glowRef = useRef<GlowRef>(null)
 
   const animateGlow = (): void => {
-    glowRef.current?.startAnimation()
+    // glowRef.current?.startAnimation()
   }
 
   const opacityStyle = useAnimatedStyle(() => {
@@ -72,18 +73,18 @@ export const CollectibleDetailsHero = ({
     }
   })
 
-  const glowStyle = useAnimatedStyle(() => {
-    const scale = interpolate(
-      scrollY.value,
-      [0, SNAP_DISTANCE],
-      [1, 0.365],
-      Extrapolation.CLAMP
-    )
+  // const glowStyle = useAnimatedStyle(() => {
+  //   const scale = interpolate(
+  //     scrollY.value,
+  //     [0, SNAP_DISTANCE],
+  //     [1, 0.365],
+  //     Extrapolation.CLAMP
+  //   )
 
-    return {
-      transform: [{ scale }]
-    }
-  })
+  //   return {
+  //     transform: [{ scale }]
+  //   }
+  // })
 
   return (
     <View
@@ -118,7 +119,8 @@ export const CollectibleDetailsHero = ({
               collectible.status !== NftLocalStatus.Processed ||
               collectible.imageData?.type === NftContentType.MP4
             }>
-            <Animated.View
+            {/* TODO: add lottie instead of custom glow animation */}
+            {/* <Animated.View
               style={[
                 glowStyle,
                 {
@@ -132,8 +134,8 @@ export const CollectibleDetailsHero = ({
                   zIndex: -1
                 }
               ]}>
-              <Glow ref={glowRef} size={CARD_SIZE * 1.7} />
-            </Animated.View>
+              <Glow ref={glowRef} size={CARD_SIZE * 1.6} />
+            </Animated.View> */}
 
             <CollectibleGridItem
               collectible={collectible}

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsScreen.tsx
@@ -114,7 +114,13 @@ export const CollectibleDetailsScreen = ({
     if (collectible?.localId) {
       dispatch(toggleCollectibleVisibility({ uid: collectible.localId }))
 
-      if (isVisible && !isHiddenVisible) {
+      if (isVisible) {
+        showSnackbar('Collectible hidden')
+      } else {
+        showSnackbar('Collectible unhidden')
+      }
+
+      if (isHiddenVisible) {
         if (currentIndex > 0) {
           setCurrentIndex(currentIndex - 1)
         }
@@ -122,10 +128,6 @@ export const CollectibleDetailsScreen = ({
         if (filteredAndSorted.length === 1) {
           navigation.goBack()
         }
-
-        showSnackbar('Collectible hidden')
-      } else {
-        showSnackbar('Collectible unhidden')
       }
     }
   }, [

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsScreen.tsx
@@ -61,7 +61,8 @@ export const CollectibleDetailsScreen = ({
   const headerHeight = useHeaderHeight()
   const frame = useSafeAreaFrame()
 
-  const { filteredAndSorted } = useCollectiblesFilterAndSort(initial)
+  const { filteredAndSorted, isHiddenVisible } =
+    useCollectiblesFilterAndSort(initial)
 
   const [currentIndex, setCurrentIndex] = useState(
     filteredAndSorted?.findIndex(
@@ -113,7 +114,7 @@ export const CollectibleDetailsScreen = ({
     if (collectible?.localId) {
       dispatch(toggleCollectibleVisibility({ uid: collectible.localId }))
 
-      if (isVisible) {
+      if (isVisible && !isHiddenVisible) {
         if (currentIndex > 0) {
           setCurrentIndex(currentIndex - 1)
         }
@@ -132,6 +133,7 @@ export const CollectibleDetailsScreen = ({
     currentIndex,
     dispatch,
     filteredAndSorted.length,
+    isHiddenVisible,
     isVisible,
     navigation
   ])

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsScreen.tsx
@@ -1,10 +1,4 @@
-import {
-  ANIMATED,
-  Icons,
-  SCREEN_HEIGHT,
-  useTheme,
-  View
-} from '@avalabs/k2-alpine'
+import { ANIMATED, Icons, useTheme, View } from '@avalabs/k2-alpine'
 import { useHeaderHeight } from '@react-navigation/elements'
 import { useNavigation } from '@react-navigation/native'
 import { ErrorState } from 'common/components/ErrorState'
@@ -27,7 +21,10 @@ import Animated, {
   withSequence,
   withTiming
 } from 'react-native-reanimated'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import {
+  useSafeAreaFrame,
+  useSafeAreaInsets
+} from 'react-native-safe-area-context'
 import {
   CollectibleFilterAndSortInitialState,
   useCollectiblesFilterAndSort
@@ -54,6 +51,7 @@ export const CollectibleDetailsScreen = ({
   const navigation = useNavigation()
   const insets = useSafeAreaInsets()
   const headerHeight = useHeaderHeight()
+  const frame = useSafeAreaFrame()
 
   const { filteredAndSorted } = useCollectiblesFilterAndSort(initial)
 
@@ -174,7 +172,7 @@ export const CollectibleDetailsScreen = ({
   const renderEmpty = useMemo((): ReactNode => {
     return (
       <ErrorState
-        sx={{ height: SCREEN_HEIGHT - headerHeight, paddingTop: headerHeight }}
+        sx={{ height: frame.height - headerHeight, paddingTop: headerHeight }}
         title={`Oops\nThis collectible could not be loaded`}
         description="Please hit refresh or try again later"
         button={{
@@ -183,7 +181,7 @@ export const CollectibleDetailsScreen = ({
         }}
       />
     )
-  }, [headerHeight, onBack])
+  }, [frame.height, headerHeight, onBack])
 
   const heroStyle = useAnimatedStyle(() => {
     const translateY = interpolate(
@@ -196,7 +194,7 @@ export const CollectibleDetailsScreen = ({
     const height = interpolate(
       scrollY.value,
       [0, SNAP_DISTANCE],
-      [SCREEN_HEIGHT, CARD_SIZE_SMALL],
+      [frame.height, CARD_SIZE_SMALL],
       Extrapolation.CLAMP
     )
 
@@ -214,15 +212,15 @@ export const CollectibleDetailsScreen = ({
     const translateY = interpolate(
       scrollY.value,
       [0, SNAP_DISTANCE],
-      [0, -SCREEN_HEIGHT + headerHeight + SNAP_DISTANCE * 2],
+      [0, -frame.height + headerHeight + SNAP_DISTANCE * 2],
       Extrapolation.CLAMP
     )
 
     return {
-      top: SCREEN_HEIGHT,
+      top: frame.height,
       left: 0,
       right: 0,
-      height: SCREEN_HEIGHT - headerHeight - SNAP_DISTANCE,
+      height: frame.height - headerHeight - SNAP_DISTANCE,
       transform: [
         {
           translateY
@@ -268,7 +266,7 @@ export const CollectibleDetailsScreen = ({
           }}
           contentContainerStyle={{
             paddingBottom: insets.bottom,
-            minHeight: SCREEN_HEIGHT + SNAP_DISTANCE
+            minHeight: frame.height + SNAP_DISTANCE
           }}
           bounces={false}
           showsVerticalScrollIndicator={false}

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsScreen.tsx
@@ -333,7 +333,6 @@ export const CollectibleDetailsScreen = ({
                   <Icons.Custom.ArrowDownHandleBar
                     color={colors.$textSecondary}
                     width={40}
-                    height={10}
                   />
                 </Pressable>
               </Animated.View>

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleItem.tsx
@@ -116,7 +116,12 @@ export const CollectibleListItem = memo(
               width: 48,
               borderRadius: 12
             }}>
-            <CollectibleRenderer collectible={collectible} />
+            <CollectibleRenderer
+              videoProps={{
+                hideControls: true
+              }}
+              collectible={collectible}
+            />
           </CardContainer>
           <View
             sx={{

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleItem.tsx
@@ -1,11 +1,12 @@
 import {
+  alpha,
   AnimatedPressable,
+  AnimatedPressableProps,
   Chip,
   Icons,
   Text,
   useTheme,
-  View,
-  AnimatedPressableProps
+  View
 } from '@avalabs/k2-alpine'
 import { getListItemEnteringAnimation } from 'common/utils/animations'
 import React, { memo, ReactNode } from 'react'
@@ -90,9 +91,7 @@ export const CollectibleListItem = memo(
     index: number
     onPress?: () => void
   }): ReactNode => {
-    const {
-      theme: { colors }
-    } = useTheme()
+    const { theme } = useTheme()
     const height = getGridCardHeight(CollectibleView.ListView, index)
 
     const collectibleName = getCollectibleName(collectible)
@@ -156,19 +155,31 @@ export const CollectibleListItem = memo(
               </View>
               <View>
                 {collectible.balance ? (
-                  <Chip
-                    size="small"
-                    variant="dark"
+                  <View
                     style={{
                       maxWidth: 100,
-                      minWidth: 30
+                      minWidth: 30,
+                      backgroundColor: alpha(theme.colors.$textPrimary, 0.3),
+                      borderRadius: 100,
+                      height: 20,
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                      paddingHorizontal: 10
                     }}>
-                    {collectible.balance.toString()}
-                  </Chip>
+                    <Text
+                      variant="buttonSmall"
+                      style={{
+                        color: theme.colors?.$textSecondary
+                      }}>
+                      {collectible.balance.toString()}
+                    </Text>
+                  </View>
                 ) : null}
               </View>
             </View>
-            <Icons.Navigation.ChevronRightV2 color={colors.$textPrimary} />
+            <Icons.Navigation.ChevronRightV2
+              color={theme.colors.$textPrimary}
+            />
           </View>
         </Pressable>
       </Animated.View>

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleManagementItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleManagementItem.tsx
@@ -3,10 +3,11 @@ import { alpha } from '@avalabs/k2-mobile'
 import React, { ReactNode } from 'react'
 import { Pressable } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
-import { NftItem } from 'services/nft/types'
+import { NftItem, NftLocalStatus } from 'services/nft/types'
 import { CollectibleView } from 'store/balance'
 import { isCollectibleVisible } from 'store/nft/utils'
 import {
+  selectCollectibleUnprocessableVisibility,
   selectCollectibleVisibility,
   toggleCollectibleVisibility
 } from 'store/portfolio'
@@ -35,6 +36,12 @@ export const CollectibleManagementItem = ({
 
   const collectibleVisibility = useSelector(selectCollectibleVisibility)
   const isToggledOn = isCollectibleVisible(collectibleVisibility, collectible)
+  const collectibleUnprocessableVisibility = useSelector(
+    selectCollectibleUnprocessableVisibility
+  )
+  const isDisabled =
+    collectibleUnprocessableVisibility &&
+    collectible.status === NftLocalStatus.Unprocessable
 
   function handleChange(): void {
     dispatch(toggleCollectibleVisibility({ uid: collectible.localId }))
@@ -109,6 +116,7 @@ export const CollectibleManagementItem = ({
             }
             value={isToggledOn}
             onValueChange={handleChange}
+            disabled={isDisabled}
           />
         </View>
       </View>

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleManagementItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleManagementItem.tsx
@@ -65,7 +65,12 @@ export const CollectibleManagementItem = ({
           width: 48,
           borderRadius: 12
         }}>
-        <CollectibleRenderer collectible={collectible} />
+        <CollectibleRenderer
+          collectible={collectible}
+          videoProps={{
+            hideControls: true
+          }}
+        />
       </CardContainer>
       <View
         sx={{

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleManagementScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleManagementScreen.tsx
@@ -1,4 +1,5 @@
 import { SearchBar, Text, Toggle, View } from '@avalabs/k2-alpine'
+import { ErrorState } from 'common/components/ErrorState'
 import { LoadingState } from 'common/components/LoadingState'
 import { portfolioTabContentHeight } from 'features/portfolio/utils'
 import React, { ReactNode, useMemo, useState } from 'react'
@@ -27,9 +28,6 @@ export const CollectibleManagementScreen = (): ReactNode => {
       return collectibles?.filter(
         collectible =>
           collectible?.name?.toLowerCase().includes(searchText.toLowerCase()) ||
-          collectible?.description
-            ?.toLowerCase()
-            .includes(searchText.toLowerCase()) ||
           collectible?.collectionName
             ?.toLowerCase()
             .includes(searchText.toLowerCase())
@@ -50,7 +48,13 @@ export const CollectibleManagementScreen = (): ReactNode => {
 
   const renderEmpty = useMemo(() => {
     if (isLoading || isRefetching) return <LoadingState />
-    return <LoadingState sx={{ height: portfolioTabContentHeight }} />
+    return (
+      <ErrorState
+        title="No collectibles found"
+        description="Try searching for a different collectible"
+        sx={{ height: portfolioTabContentHeight }}
+      />
+    )
   }, [isLoading, isRefetching])
 
   return (

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleManagementScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleManagementScreen.tsx
@@ -1,16 +1,8 @@
-import {
-  alpha,
-  SearchBar,
-  Text,
-  Toggle,
-  useTheme,
-  View
-} from '@avalabs/k2-alpine'
-import { ListRenderItem } from 'react-native'
+import { SearchBar, Text, Toggle, View } from '@avalabs/k2-alpine'
 import { LoadingState } from 'common/components/LoadingState'
-import { LinearGradient } from 'expo-linear-gradient'
 import { portfolioTabContentHeight } from 'features/portfolio/utils'
 import React, { ReactNode, useMemo, useState } from 'react'
+import { ListRenderItem } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
@@ -25,7 +17,6 @@ import { CollectibleManagementItem } from './CollectibleManagementItem'
 
 export const CollectibleManagementScreen = (): ReactNode => {
   const insets = useSafeAreaInsets()
-  const { theme } = useTheme()
   const { collectibles, isLoading, isRefetching, refetch } =
     useCollectiblesContext()
 
@@ -72,51 +63,31 @@ export const CollectibleManagementScreen = (): ReactNode => {
           flexDirection: 'row',
           justifyContent: 'space-between',
           alignItems: 'center',
-          paddingHorizontal: HORIZONTAL_MARGIN
+          paddingHorizontal: HORIZONTAL_MARGIN,
+          paddingBottom: HORIZONTAL_MARGIN
         }}>
         <Text variant="heading2">Manage list</Text>
       </View>
 
       <SearchBar onTextChanged={handleSearch} searchText={searchText} />
 
-      <View
-        style={{
-          flex: 1
-        }}>
-        <LinearGradient
-          colors={[
-            alpha(theme.colors.$surfacePrimary, 1),
-            alpha(theme.colors.$surfacePrimary, 0)
-          ]}
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            height: 30,
-            zIndex: 10
-          }}
-          start={{ x: 0, y: 0 }}
-          end={{ x: 0, y: 1 }}
-          pointerEvents="none"
-        />
-        <FlatList
-          keyExtractor={item => `collectibles-manage-${item.localId}`}
-          data={filteredCollectibles}
-          renderItem={renderItem}
-          ListEmptyComponent={renderEmpty}
-          onRefresh={refetch}
-          refreshing={isRefetching}
-          keyboardDismissMode="interactive"
-          showsVerticalScrollIndicator={false}
-          keyboardShouldPersistTaps="handled"
-          nestedScrollEnabled
-          ListHeaderComponent={<CollectibleManagementOptions />}
-          contentContainerStyle={{
-            paddingBottom: insets.bottom
-          }}
-        />
-      </View>
+      <FlatList
+        keyExtractor={item => `collectibles-manage-${item.localId}`}
+        data={filteredCollectibles}
+        renderItem={renderItem}
+        ListEmptyComponent={renderEmpty}
+        onRefresh={refetch}
+        refreshing={isRefetching}
+        keyboardDismissMode="interactive"
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+        nestedScrollEnabled
+        ListHeaderComponent={<CollectibleManagementOptions />}
+        contentContainerStyle={{
+          paddingBottom: insets.bottom,
+          paddingTop: HORIZONTAL_MARGIN / 2
+        }}
+      />
     </View>
   )
 }

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectiblesScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectiblesScreen.tsx
@@ -139,15 +139,15 @@ export const CollectiblesScreen = ({
       )
     }
 
-    if (hasFilters && filteredAndSorted.length === 0) {
+    if (filteredAndSorted.length === 0 && hasFilters) {
       return (
         <ErrorState
           sx={{
-            height: portfolioTabContentHeight - 100
+            height: portfolioTabContentHeight
           }}
           title="No Collectibles found"
           description="
-            Try changing the filter settings or reset the filter to see all assets."
+              Try changing the filter settings or reset the filter to see all assets."
           button={{
             title: 'Reset filter',
             onPress: onResetFilter
@@ -156,11 +156,11 @@ export const CollectiblesScreen = ({
       )
     }
 
-    if (isEveryCollectibleHidden && filteredAndSorted.length === 0) {
+    if (filteredAndSorted.length === 0 && isEveryCollectibleHidden) {
       return (
         <ErrorState
           sx={{
-            height: portfolioTabContentHeight - 100
+            height: portfolioTabContentHeight
           }}
           title="All collectibles hidden"
           description="You have hidden all your collectibles"
@@ -234,8 +234,8 @@ export const CollectiblesScreen = ({
     isEnabled,
     error,
     isSuccess,
-    hasFilters,
     filteredAndSorted.length,
+    hasFilters,
     isEveryCollectibleHidden,
     colors.$textPrimary,
     refetch,

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectiblesScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectiblesScreen.tsx
@@ -2,6 +2,7 @@ import {
   AnimatedPressable,
   Icons,
   IndexPath,
+  SCREEN_WIDTH,
   useTheme,
   View
 } from '@avalabs/k2-alpine'
@@ -178,7 +179,7 @@ export const CollectiblesScreen = ({
           flexDirection: 'row',
           gap: HORIZONTAL_MARGIN,
           marginHorizontal: HORIZONTAL_MARGIN,
-          paddingTop: HORIZONTAL_MARGIN + 10
+          paddingTop: HORIZONTAL_MARGIN / 2
         }}>
         <View
           style={{
@@ -242,19 +243,19 @@ export const CollectiblesScreen = ({
     onShowHidden
   ])
 
-  const renderHeader = useMemo((): JSX.Element | undefined => {
-    if (collectibles.length === 0 && (!isEnabled || isLoading)) return
+  const renderHeader = useMemo((): JSX.Element | null => {
+    if (collectibles.length === 0 && (!isEnabled || isLoading)) return null
+    if (collectibles.length === 0) return null
 
     return (
       <View
         style={[
           {
             alignSelf: 'center',
-            width: '100%',
-            paddingHorizontal: HORIZONTAL_MARGIN,
+            width: SCREEN_WIDTH - HORIZONTAL_MARGIN * 2,
             zIndex: 10,
             marginTop: 4,
-            marginBottom: CollectibleView.ListView === listType ? 8 : 16
+            marginBottom: CollectibleView.ListView === listType ? 8 : 10
           }
         ]}>
         <DropdownSelections

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectiblesScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectiblesScreen.tsx
@@ -10,7 +10,7 @@ import { CollapsibleTabs } from 'common/components/CollapsibleTabs'
 import { ErrorState } from 'common/components/ErrorState'
 import { portfolioTabContentHeight } from 'features/portfolio/utils'
 import React, { ReactNode, useCallback, useEffect, useMemo } from 'react'
-import { Platform, useWindowDimensions } from 'react-native'
+import { Platform } from 'react-native'
 
 import { DropdownSelections } from 'common/components/DropdownSelections'
 import { LoadingState } from 'common/components/LoadingState'
@@ -48,7 +48,6 @@ export const CollectiblesScreen = ({
   const {
     theme: { colors }
   } = useTheme()
-  const dimensions = useWindowDimensions()
   const {
     isLoading,
     isEnabled,
@@ -251,7 +250,8 @@ export const CollectiblesScreen = ({
         style={[
           {
             alignSelf: 'center',
-            width: dimensions.width - HORIZONTAL_MARGIN * 2,
+            width: '100%',
+            paddingHorizontal: HORIZONTAL_MARGIN,
             zIndex: 10,
             marginTop: 4,
             marginBottom: CollectibleView.ListView === listType ? 8 : 16
@@ -268,7 +268,6 @@ export const CollectiblesScreen = ({
     collectibles.length,
     isEnabled,
     isLoading,
-    dimensions.width,
     listType,
     filter,
     sort,

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectiblesScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectiblesScreen.tsx
@@ -129,7 +129,7 @@ export const CollectiblesScreen = ({
     if (error || !isSuccess) {
       return (
         <ErrorState
-          sx={{ height: portfolioTabContentHeight }}
+          sx={{ height: portfolioTabContentHeight - 100 }}
           description="Please hit refresh or try again later"
           button={{
             title: 'Refresh',
@@ -143,7 +143,7 @@ export const CollectiblesScreen = ({
       return (
         <ErrorState
           sx={{
-            height: portfolioTabContentHeight
+            height: portfolioTabContentHeight - 100
           }}
           title="No Collectibles found"
           description="
@@ -160,7 +160,7 @@ export const CollectiblesScreen = ({
       return (
         <ErrorState
           sx={{
-            height: portfolioTabContentHeight
+            height: portfolioTabContentHeight - 100
           }}
           title="All collectibles hidden"
           description="You have hidden all your collectibles"

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/hooks/useCollectiblesFilterAndSort.ts
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/hooks/useCollectiblesFilterAndSort.ts
@@ -41,6 +41,7 @@ export const useCollectiblesFilterAndSort = (
   view: DropdownSelection
   isEveryCollectibleHidden: boolean
   isUnprocessableHidden: boolean
+  isHiddenVisible: boolean
   onResetFilter: () => void
   onShowHidden: () => void
 } => {
@@ -72,6 +73,7 @@ export const useCollectiblesFilterAndSort = (
     section: 0,
     row: 0
   })
+
 
   const filterOption = useMemo(() => {
     return [
@@ -252,11 +254,14 @@ export const useCollectiblesFilterAndSort = (
     [collectibles?.length, collectiblesVisibility, filteredAndSorted]
   )
 
+  const isHiddenVisible = filter.selected[1]?.row !== 3
+
   return {
     filteredAndSorted,
     filter: filter as DropdownSelection & { selected: IndexPath[] },
     sort,
     view,
+    isHiddenVisible,
     isEveryCollectibleHidden,
     isUnprocessableHidden,
     onResetFilter,

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/hooks/useCollectiblesFilterAndSort.ts
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/hooks/useCollectiblesFilterAndSort.ts
@@ -40,6 +40,7 @@ export const useCollectiblesFilterAndSort = (
   sort: DropdownSelection
   view: DropdownSelection
   isEveryCollectibleHidden: boolean
+  isUnprocessableHidden: boolean
   onResetFilter: () => void
   onShowHidden: () => void
 } => {
@@ -161,7 +162,7 @@ export const useCollectiblesFilterAndSort = (
 
       if (isUnprocessableHidden)
         nfts = nfts.filter((nft: NftItem) => {
-          return nft.status !== NftLocalStatus.Unprocessable
+          return nft.status === NftLocalStatus.Processed
         })
 
       if (contentType !== CollectibleStatus.Hidden)
@@ -257,6 +258,7 @@ export const useCollectiblesFilterAndSort = (
     sort,
     view,
     isEveryCollectibleHidden,
+    isUnprocessableHidden,
     onResetFilter,
     onShowHidden
   }

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/hooks/useCollectiblesFilterAndSort.ts
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/hooks/useCollectiblesFilterAndSort.ts
@@ -123,10 +123,12 @@ export const useCollectiblesFilterAndSort = (
       title: 'Sort',
       data: COLLECTIBLE_SORTS,
       selected: selectedSort,
-      onSelected: setSelectedSort
+      onSelected: setSelectedSort,
+      useAnchorRect: true
     }),
     [selectedSort]
   )
+
   const view = useMemo(
     () => ({
       title: 'View',

--- a/packages/core-mobile/app/store/nft/utils.ts
+++ b/packages/core-mobile/app/store/nft/utils.ts
@@ -11,5 +11,5 @@ export function isCollectibleVisible(
 ): boolean {
   const collectibleVisible =
     collectibleVisibility?.[collectible?.localId?.toLowerCase()]
-  return collectibleVisible !== undefined ? collectibleVisible : true
+  return collectibleVisible != null ? collectibleVisible : true
 }

--- a/packages/core-mobile/app/store/portfolio/slice.ts
+++ b/packages/core-mobile/app/store/portfolio/slice.ts
@@ -13,8 +13,13 @@ export const portfolioSlice = createSlice({
       action: PayloadAction<{ tokenId: string }>
     ) => {
       const { tokenId } = action.payload
-      state.tokenVisibility[tokenId.toLowerCase()] =
-        !state.tokenVisibility[tokenId.toLowerCase()]
+
+      if (state.tokenVisibility?.[tokenId.toLowerCase()] != null) {
+        state.tokenVisibility[tokenId.toLowerCase()] =
+          !state.tokenVisibility[tokenId.toLowerCase()]
+      } else {
+        state.tokenVisibility[tokenId.toLowerCase()] = false
+      }
     },
     toggleCollectibleVisibility: (
       state,
@@ -22,8 +27,12 @@ export const portfolioSlice = createSlice({
     ) => {
       const { uid } = action.payload
 
-      state.collectibleVisibility[uid.toLowerCase()] =
-        !state.collectibleVisibility?.[uid.toLowerCase()] || false
+      if (state.collectibleVisibility?.[uid.toLowerCase()] != null) {
+        state.collectibleVisibility[uid.toLowerCase()] =
+          !state.collectibleVisibility?.[uid.toLowerCase()]
+      } else {
+        state.collectibleVisibility[uid.toLowerCase()] = false
+      }
     },
     toggleCollectibleUnprocessableVisibility: state => {
       state.collectibleUnprocessableVisibility =

--- a/packages/k2-alpine/src/components/Toast/Snackbar.tsx
+++ b/packages/k2-alpine/src/components/Toast/Snackbar.tsx
@@ -3,6 +3,7 @@ import { TouchableWithoutFeedback, ViewStyle } from 'react-native'
 import { darkModeColors, lightModeColors } from '../../theme/tokens/colors'
 import { Text, View } from '../Primitives'
 import { useTheme } from '../../hooks'
+import { SCREEN_WIDTH } from '../../const'
 
 export const Snackbar = ({
   message,
@@ -34,20 +35,27 @@ export const Snackbar = ({
       testID={testID}
       onPress={onPress}>
       <View
-        sx={{
-          backgroundColor,
-          paddingHorizontal: 20,
-          paddingVertical: 10,
-          borderRadius: 1000
+        style={{
+          width: SCREEN_WIDTH,
+          justifyContent: 'center',
+          alignItems: 'center'
         }}>
-        <Text
-          variant="subtitle2"
-          sx={{
-            fontFamily: 'Inter-SemiBold',
-            color: textColor
+        <View
+          style={{
+            backgroundColor,
+            paddingHorizontal: 20,
+            paddingVertical: 10,
+            borderRadius: 1000
           }}>
-          {message}
-        </Text>
+          <Text
+            variant="subtitle2"
+            sx={{
+              fontFamily: 'Inter-SemiBold',
+              color: textColor
+            }}>
+            {message}
+          </Text>
+        </View>
       </View>
     </TouchableWithoutFeedback>
   )


### PR DESCRIPTION
## Description

**Ticket: [CP-10230]** 

### NFT Detail Screen

**FIXED** - **High** - After hiding all, I land on Oops screen. We should navigate back instead of showing oops screen. Do not show oops screen when everything is hidden
**FIXED** - **Low** - [design QA] slight gradient shouldn't be visible on the top & bottom of the list
**FIXED** - **Medium** -  ANDROID ONLY: when I just want to scroll the nft data section (created by standard chain…), the whole screen moves and I can’t scroll the nft data section only. always the nft full screen follows and I can’t scroll up and down the data list. However, I can scroll the data section only fine on iOS. It’s just android having the issue. please see the video below, the device on the left is iOS and the other is Android.

**FIXED** - **High** - Hide button is not responding with one tap. I had to hit twice to finally hide it. 
**Also fixed it for assets management screen. Both had double toggle for hiding bug** 
**FIXED** - **High** - When the ‘collectible hidden’ toast msg is displayed the other elements at the top of the screen cannot be tapped, i.e. the back button
**I made the whole area dismissable now but you have to press once to dismiss and once to go back or prev/next**


### NFT Image full screen

**FIXED** - Cannot scroll nft description text on android
**FIXED** - remove glow when launch
**FIXED** - make the bottom arrow button bigger [(design QA)]


### NFT grid/list View 

**FIXED** - **High** hide filter and view button when it’s empty state 
**FIXED** - manage list is not updated after being shown. they are still toggled OFF 
**FIXED** - **Low** ListView: number button bg looks darker than design
**FIXED** **High** Sort button is missing. 
**FIXED** **High** Sort Bug when we have sort button on the screen: sort a-z or sort z-a seems to be not working. When I select name z to a, I see they are not sorted correctly. I can’t verify date added sort

**Both of these have the same issue which is the way we process collectibles => tech debt**
**High** when I hit show hidden button, two bugs are visible
- show unreachable nfts placeholder appears for a moment before displaying data
- when we first load data, the screen flickers to load different networks nft and sort. 


**NFT Manage list Screen**

**FIXED** - when hide unreachable button is ON, we should gray out the toggle of the unreachable nfts
**FIXED** - no padding between manage list, searhc bar, and hide button
**FIXED** - I had to hit toggle twice to disable it sometimes

## Screenshots/Videos


https://github.com/user-attachments/assets/c8e182e2-b140-4ba3-aba7-33bab798b405

https://github.com/user-attachments/assets/e8688dfc-6a4a-41ce-98c3-5c0e9c08b4c0

<img width="441" alt="Screenshot 2025-04-05 at 03 08 28" src="https://github.com/user-attachments/assets/0f960a15-4750-4b3e-a65e-6fa4135e3c99" />

## Testing


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
