### PR TITLE
Stake fetching improvements.

### DIFF
--- a/packages/core-mobile/app/services/earn/types.ts
+++ b/packages/core-mobile/app/services/earn/types.ts
@@ -28,11 +28,6 @@ export type CollectTokensForStakingParams = {
   feeState?: pvm.FeeState
 }
 
-export type GetAllStakesParams = {
-  isTestnet: boolean
-  addresses: string[]
-}
-
 export enum StakeTypeEnum {
   Available = 'Available',
   Staked = 'Staked',

--- a/packages/core-mobile/app/services/earn/utils.ts
+++ b/packages/core-mobile/app/services/earn/utils.ts
@@ -338,14 +338,16 @@ export const getSortedValidatorsByEndTime = (
 
 export const getTransformedTransactions = async (
   addresses: string[],
-  isTestnet: boolean
+  isTestnet: boolean,
+  startTimestamp?: number
 ): Promise<
   (PChainTransaction & { index: number; isDeveloperMode: boolean })[]
 > => {
   try {
     const stakes = await EarnService.getAllStakes({
       isTestnet,
-      addresses
+      addresses,
+      startTimestamp
     })
 
     return stakes.map(transaction => {

--- a/packages/core-mobile/app/utils/network/glacier.ts
+++ b/packages/core-mobile/app/utils/network/glacier.ts
@@ -31,6 +31,10 @@ export const glacierApi = GLACIER_URL
   ? createApiClient(GLACIER_URL, {
       axiosConfig: {
         headers: CORE_HEADERS,
+        // Use query-string's stringify with arrayFormat 'comma'
+        // so that array parameters are serialized as comma-separated values,
+        // e.g. txTypes=AddPermissionlessDelegatorTx,AddDelegatorTx,
+        // instead of the default repeated keys (txTypes[]=...).
         paramsSerializer: params =>
           queryString.stringify(params, { arrayFormat: 'comma' })
       }

--- a/packages/core-mobile/app/utils/network/glacier.ts
+++ b/packages/core-mobile/app/utils/network/glacier.ts
@@ -1,5 +1,6 @@
 import Config from 'react-native-config'
 import Logger from 'utils/Logger'
+import queryString from 'query-string'
 import { createApiClient, api as noOpApiClient } from './glacierApi.client'
 import { CORE_HEADERS } from './constants'
 
@@ -27,5 +28,11 @@ export function addGlacierAPIKeyIfNeeded(url: string): string {
 }
 
 export const glacierApi = GLACIER_URL
-  ? createApiClient(GLACIER_URL, { axiosConfig: { headers: CORE_HEADERS } })
+  ? createApiClient(GLACIER_URL, {
+      axiosConfig: {
+        headers: CORE_HEADERS,
+        paramsSerializer: params =>
+          queryString.stringify(params, { arrayFormat: 'comma' })
+      }
+    })
   : noOpApiClient


### PR DESCRIPTION
## Description

* Fetch staking transactions using backend filters(`AddDelegatorTx`, `AddPermissionlessDelegatorTx`)
* When fetching stakes for scheduling completion notifications, only include stakes from within the past year, since earlier ones can't be active