### PR TITLE
Fix: no token breakdown for p/x chain on Android

### DIFF
--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenDetail.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenDetail.tsx
@@ -194,8 +194,10 @@ const TokenDetail: FC<Props> = ({ token }): React.JSX.Element => {
 
   return (
     <CollapsibleTabs.FlatList
+      style={{
+        paddingTop: 4
+      }}
       contentContainerStyle={{
-        paddingTop: 4,
         paddingHorizontal: 16,
         paddingBottom: 16
       }}


### PR DESCRIPTION
## Description

**Ticket: [CP-10436]** 

* Fix bug where content is not shown when using paddingTop in contentContainerStyle with CollapsibleTabs.

[CP-10436]: https://ava-labs.atlassian.net/browse/CP-10436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ