### PR TITLE
CP-10343: Prevent tapping back on the pin screen

### DIFF
--- a/packages/core-mobile/app/new/routes/loginWithPinOrBiometry.tsx
+++ b/packages/core-mobile/app/new/routes/loginWithPinOrBiometry.tsx
@@ -34,8 +34,12 @@ import { BiometricType } from 'services/deviceInfo/DeviceInfoService'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { useSelector } from 'react-redux'
 import { selectSelectedAvatar } from 'store/settings/avatar'
+import { usePreventScreenRemoval } from 'common/hooks/usePreventScreenRemoval'
+import { selectWalletState, WalletState } from 'store/app'
 
 const LoginWithPinOrBiometry = (): JSX.Element => {
+  const walletState = useSelector(selectWalletState)
+  usePreventScreenRemoval(walletState === WalletState.INACTIVE)
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const avatar = useSelector(selectSelectedAvatar)
   const { theme } = useTheme()


### PR DESCRIPTION
## Description

**Ticket: [CP-10343]** 

This pr prevents users from being able to press the back button on the Pin screen to unlock the wallet. Also adds logic to show "Are you sure you want to exit?" alert when users try to quit the app. 

## Screenshots/Videos
when users are already logged in

https://github.com/user-attachments/assets/9e79b02f-b12c-418f-886b-56acb123dd29

when users just completed onboarding

https://github.com/user-attachments/assets/6712ddd1-cdfb-4088-b7ae-91ae70949d6d

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10343]: https://ava-labs.atlassian.net/browse/CP-10343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ