### PR TITLE
fix bottom padding after top offset fix

### DIFF
--- a/packages/core-mobile/app/new/common/components/ListScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ListScreen.tsx
@@ -208,7 +208,10 @@ export const ListScreen = <T,>({
 
   const paddingBottom = useMemo(() => {
     if (Platform.OS === 'android' && isSecondaryModal) {
-      return topMarginOffset + insets.bottom + insets.top + 24
+      // Dev mode needs the top offset
+      // React Natives's hot reloading might be breaking the top offset
+      const topOffset = __DEV__ ? topMarginOffset : 0
+      return topOffset + insets.bottom + insets.top + 24
     }
 
     return insets.bottom

--- a/packages/core-mobile/app/new/common/components/ListScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ListScreen.tsx
@@ -92,6 +92,7 @@ export const ListScreen = <T,>({
   const headerRef = useRef<View>(null)
   const contentHeaderHeight = useSharedValue<number>(0)
   const { topMarginOffset } = useModalScreenOptions()
+  const isAndroidWithBottomBar = useIsAndroidWithBottomBar()
 
   const { onScroll, scrollY, targetHiddenProgress } = useFadingHeaderNavigation(
     {
@@ -235,8 +236,6 @@ export const ListScreen = <T,>({
       }
     ] as StyleProp<ViewStyle>[]
   }, [props?.contentContainerStyle, data.length, paddingBottom])
-
-  const isAndroidWithBottomBar = useIsAndroidWithBottomBar()
 
   const keyboardVerticalOffset = useMemo(() => {
     if (isSecondaryModal) {

--- a/packages/core-mobile/app/new/common/components/ListScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ListScreen.tsx
@@ -207,11 +207,15 @@ export const ListScreen = <T,>({
   }, [renderEmpty])
 
   const paddingBottom = useMemo(() => {
-    if (Platform.OS === 'android' && isSecondaryModal) {
-      // Dev mode needs the top offset
-      // React Natives's hot reloading might be breaking the top offset
-      const topOffset = __DEV__ ? topMarginOffset : 0
-      return topOffset + insets.bottom + insets.top + 24
+    if (isSecondaryModal) {
+      if (Platform.OS === 'android') {
+        // Dev mode needs the top offset
+        // React Natives's hot reloading might be breaking the top offset
+        const topOffset = __DEV__ ? topMarginOffset : 0
+        return topOffset + insets.bottom + insets.top + 24
+      }
+
+      return insets.bottom + topMarginOffset
     }
 
     return insets.bottom
@@ -235,13 +239,16 @@ export const ListScreen = <T,>({
   const isAndroidWithBottomBar = useIsAndroidWithBottomBar()
 
   const keyboardVerticalOffset = useMemo(() => {
-    if (Platform.OS === 'android' && isSecondaryModal) {
-      return -insets.bottom + 8
+    if (isSecondaryModal) {
+      if (Platform.OS === 'android') {
+        return -insets.bottom + 8
+      }
+      return insets.bottom
     }
     if (isAndroidWithBottomBar) {
       return 16
     }
-    return insets.bottom
+    return insets.bottom + 16
   }, [insets.bottom, isAndroidWithBottomBar, isSecondaryModal])
 
   return (

--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -134,11 +134,14 @@ export const ScrollScreen = ({
 
   const paddingBottom = useMemo(() => {
     if (Platform.OS === 'android' && isSecondaryModal) {
+      const topOffset = __DEV__ ? topMarginOffset : 0
+      // Dev mode needs the top offset
+      // React Natives's hot reloading might be breaking the top offset
       if (isAndroidWithBottomBar) {
-        return topMarginOffset + insets.bottom
+        return topOffset + insets.bottom
       }
 
-      return topMarginOffset + insets.top + insets.bottom
+      return topOffset + insets.top + insets.bottom
     }
     return insets.bottom + 16
   }, [


### PR DESCRIPTION
## Description

After the fix for the margin top offset on modals for Android, the bottom padding on modals and secondary modals broke.
I think it's because of react-native's metro bundler status bar 

Made the fix for production and kept the dev mode values otherwise dev mode looks broken on android


## Testing


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
