### PR TITLE
Adjust swap slippage and token price granularity

### DIFF
--- a/packages/core-mobile/app/new/common/components/TokenInputWidget.tsx
+++ b/packages/core-mobile/app/new/common/components/TokenInputWidget.tsx
@@ -171,7 +171,7 @@ export const TokenInputWidget = ({
                 }}>
                 <TouchableOpacity
                   onPress={onSelectToken}
-                  disabled={!isTokenSelectable}>
+                  disabled={!isTokenSelectable || disabled}>
                   <View sx={{ gap: 1 }}>
                     {token && <Text variant="subtitle2">{title}</Text>}
                     <View sx={{ flexDirection: 'row', alignItems: 'center' }}>

--- a/packages/core-mobile/app/new/features/swap/components.tsx/SlippageInput.tsx
+++ b/packages/core-mobile/app/new/features/swap/components.tsx/SlippageInput.tsx
@@ -10,10 +10,12 @@ const inputKey = 'slippage'
 
 export const SlippageInput = ({
   slippage,
-  setSlippage
+  setSlippage,
+  disabled
 }: {
   slippage: number
   setSlippage: (slippage: number) => void
+  disabled?: boolean
 }): JSX.Element => {
   const { theme } = useTheme()
 
@@ -26,7 +28,8 @@ export const SlippageInput = ({
 
   const handlePress = useCallback(() => {
     showAlertWithTextInput({
-      title: 'Edit slippage',
+      title: 'Custom slippage',
+      description: 'Allowed range: 0.1% - 100%',
       inputs: [
         {
           key: inputKey,
@@ -43,6 +46,7 @@ export const SlippageInput = ({
         },
         {
           text: 'Save',
+          style: 'default',
           shouldDisable: (values: Record<string, string>) => {
             const isEmpty = values[inputKey]?.length === 0
             const isInvalid = Boolean(
@@ -66,7 +70,7 @@ export const SlippageInput = ({
         alignItems: 'center',
         gap: 4
       }}>
-      <Pressable onPress={handlePress} hitSlop={20}>
+      <Pressable onPress={handlePress} hitSlop={20} disabled={disabled}>
         <Text
           variant="mono"
           sx={{

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -271,6 +271,8 @@ export const SwapScreen = (): JSX.Element => {
           paddingBottom: 4
         }}>
         <TokenInputWidget
+          disabled={swapInProcess}
+          editable={!swapInProcess}
           autoFocus={true}
           amount={fromTokenValue}
           balance={fromToken?.balance}
@@ -304,7 +306,8 @@ export const SwapScreen = (): JSX.Element => {
     cChainNetwork,
     fromToken,
     localError,
-    fromTokenValue
+    fromTokenValue,
+    swapInProcess
   ])
 
   const renderToSection = useCallback((): JSX.Element => {
@@ -318,6 +321,8 @@ export const SwapScreen = (): JSX.Element => {
           backgroundColor: theme.colors.$surfaceSecondary
         }}>
         <TokenInputWidget
+          disabled={swapInProcess}
+          editable={!swapInProcess}
           amount={toTokenValue}
           balance={toToken?.balance}
           shouldShowBalance={true}
@@ -349,7 +354,8 @@ export const SwapScreen = (): JSX.Element => {
     cChainNetwork,
     toTokenValue,
     isFetchingOptimalRate,
-    handleSelectToToken
+    handleSelectToToken,
+    swapInProcess
   ])
 
   const data = useMemo(() => {
@@ -368,7 +374,13 @@ export const SwapScreen = (): JSX.Element => {
 
     items.push({
       title: 'Slippage tolerance',
-      accessory: <SlippageInput slippage={slippage} setSlippage={setSlippage} />
+      accessory: (
+        <SlippageInput
+          slippage={slippage}
+          setSlippage={setSlippage}
+          disabled={swapInProcess}
+        />
+      )
     })
 
     return items
@@ -378,6 +390,7 @@ export const SwapScreen = (): JSX.Element => {
     optimalRate,
     slippage,
     setSlippage,
+    swapInProcess,
     isFetchingOptimalRate
   ])
 
@@ -489,6 +502,7 @@ export const SwapScreen = (): JSX.Element => {
                   height: 40,
                   alignSelf: 'center'
                 }}
+                disabled={swapInProcess}
                 onPress={handleToggleTokens}>
                 <Icons.Custom.SwapVertical />
               </CircularButton>

--- a/packages/core-mobile/app/new/features/swap/utils.ts
+++ b/packages/core-mobile/app/new/features/swap/utils.ts
@@ -1,6 +1,6 @@
 export const isSlippageValid = (value: string): boolean => {
   return Boolean(
-    (parseFloat(value) >= 0 &&
+    (parseFloat(value) >= 0.1 &&
       parseFloat(value) <= 100 &&
       value?.length <= 4) ||
       !value

--- a/packages/core-mobile/app/new/features/track/market/components/MarketGridView.tsx
+++ b/packages/core-mobile/app/new/features/track/market/components/MarketGridView.tsx
@@ -38,7 +38,7 @@ export const MarketGridView = memo(
     index: number
     onPress: () => void
     formattedPrice: string
-    formattedPriceChange: string
+    formattedPriceChange?: string
     formattedPercentChange?: string
     status: PriceChangeStatus
     isFavorite?: boolean

--- a/packages/core-mobile/app/new/features/track/market/components/MarketListItem.tsx
+++ b/packages/core-mobile/app/new/features/track/market/components/MarketListItem.tsx
@@ -10,6 +10,7 @@ import { selectSelectedCurrency } from 'store/settings/currency'
 import { formatCurrency } from 'utils/FormatCurrency'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { PriceChangeStatus } from '@avalabs/k2-alpine'
+import { isEffectivelyZero } from 'features/track/utils'
 import { MarketGridView } from './MarketGridView'
 import { MarketListView } from './MarketListView'
 
@@ -42,15 +43,21 @@ export const MarketListItem = ({
 
   const priceChange = token.priceChange24h ?? 0
 
-  const formattedPriceChange = useMemo(
-    () =>
-      formatCurrency({
-        amount: Math.abs(priceChange),
-        currency,
-        boostSmallNumberPrecision: true
-      }),
-    [currency, priceChange]
-  )
+  const formattedPriceChange = useMemo(() => {
+    const absPriceChange = Math.abs(priceChange)
+
+    // for effectively zero price changes, return undefined
+    // this is to avoid displaying "0.00" in the price change column
+    if (isEffectivelyZero(absPriceChange)) {
+      return undefined
+    }
+
+    return formatCurrency({
+      amount: Math.abs(priceChange),
+      currency,
+      boostSmallNumberPrecision: true
+    })
+  }, [currency, priceChange])
 
   const formattedPercent = useMemo(
     () =>

--- a/packages/core-mobile/app/new/features/track/market/components/MarketListView.tsx
+++ b/packages/core-mobile/app/new/features/track/market/components/MarketListView.tsx
@@ -29,7 +29,7 @@ export const MarketListView = memo(
     isFavorite?: boolean
     index: number
     formattedPrice: string
-    formattedPriceChange: string
+    formattedPriceChange?: string
     formattedPercentChange?: string
     status: PriceChangeStatus
     onPress: () => void

--- a/packages/core-mobile/app/new/features/track/utils.ts
+++ b/packages/core-mobile/app/new/features/track/utils.ts
@@ -9,3 +9,9 @@ export const compareTokenPriceChangePercentage24h = (
 
   return percentChange1 - percentChange2
 }
+
+const zeroThreshold = 0.000001
+
+export const isEffectivelyZero = (value: number): boolean => {
+  return Math.abs(value) < zeroThreshold
+}

--- a/packages/core-mobile/app/utils/FormatCurrency.test.ts
+++ b/packages/core-mobile/app/utils/FormatCurrency.test.ts
@@ -46,7 +46,7 @@ describe('formats normal numbers', () => {
 })
 
 describe('formats small numbers with boostSmallNumberPrecision', () => {
-  it('should display numbers >= 1 with max 2 fraction digits', () => {
+  it('should display numbers >= 0.1 with max 2 fraction digits', () => {
     let result = formatCurrency({
       amount: 13.123424352342212,
       currency: 'USD',
@@ -62,7 +62,7 @@ describe('formats small numbers with boostSmallNumberPrecision', () => {
     expect(result).toBe('$130,000.12')
   })
 
-  it('should display numbers >= 1 with min 2 fraction digits', () => {
+  it('should display numbers >= 0.1 with min 2 fraction digits', () => {
     const result = formatCurrency({
       amount: 1,
       currency: 'USD',
@@ -71,14 +71,14 @@ describe('formats small numbers with boostSmallNumberPrecision', () => {
     expect(result).toBe('$1.00')
   })
 
-  it('should display numbers < 1 with min 2 fraction digits', () => {
+  it('should display numbers < 0.1 with min 2 fraction digits', () => {
     expect(
       formatCurrency({
-        amount: 0.9,
+        amount: 0.09,
         currency: 'USD',
         boostSmallNumberPrecision: true
       })
-    ).toBe('$0.90')
+    ).toBe('$0.09')
 
     expect(
       formatCurrency({
@@ -89,13 +89,13 @@ describe('formats small numbers with boostSmallNumberPrecision', () => {
     ).toBe('$0.10')
   })
 
-  it('should display numbers < 1 with max 8 fraction digits', () => {
+  it('should display numbers < 0.1 with max 6 fraction digits', () => {
     const result = formatCurrency({
-      amount: 0.9923424352342212,
+      amount: 0.09923424352342212,
       currency: 'USD',
       boostSmallNumberPrecision: true
     })
-    expect(result).toBe('$0.99234244')
+    expect(result).toBe('$0.099234')
   })
 })
 

--- a/packages/core-mobile/app/utils/FormatCurrency.ts
+++ b/packages/core-mobile/app/utils/FormatCurrency.ts
@@ -67,7 +67,7 @@ const selectCurrencyFormat = ({
 
   const absAmount = Math.abs(amount)
 
-  if (boostSmallNumberPrecision && absAmount < 1) {
+  if (boostSmallNumberPrecision && absAmount < 0.1) {
     return getHighPrecisionFormat(currency)
   }
 
@@ -104,7 +104,8 @@ const getHighPrecisionFormat = memoize(
   (currency: string) =>
     new Intl.NumberFormat('en-US', {
       ...commonNumberFormat(currency),
-      maximumFractionDigits: 8
+      maximumFractionDigits: 6,
+      roundingMode: 'floor'
     })
 )
 

--- a/packages/k2-alpine/src/components/PriceChangeIndicator/types.ts
+++ b/packages/k2-alpine/src/components/PriceChangeIndicator/types.ts
@@ -1,5 +1,5 @@
 export type PriceChange = {
-  formattedPrice: string
+  formattedPrice?: string
   status: PriceChangeStatus
   formattedPercent?: string
 }


### PR DESCRIPTION
## Description
for swap:
- allow slippage value from 0.1 to 100
- when a swap is in progress, disable all the buttons

for track:
- reduce granularity for small price changes
- hide 0.00 price changes

## Screenshots/Videos
swap slippage and disabled state
https://github.com/user-attachments/assets/a9ce3d44-c5e5-4e1e-b768-1f969a589cd5

track token details
<img src="https://github.com/user-attachments/assets/8e47c6fe-c641-47bc-bd20-0aae49ba41ef" width="300"/>
<img src="https://github.com/user-attachments/assets/2fa8f4c8-d668-4e9c-a7b9-42e4a8a44f61" width="300"/>
<img src="https://github.com/user-attachments/assets/1761b7e8-0676-498c-bfcd-ebe1cd62fe65" width="300"/>
<img src="https://github.com/user-attachments/assets/58c23ee5-ebad-4ad0-9d94-fb673fe3bf4d" width="300"/>


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
