### PR TITLE
CP-10495: only use ethers isAddress to check evm address

### DIFF
--- a/packages/core-mobile/app/new/features/accountSettings/utils/isValidAddress.ts
+++ b/packages/core-mobile/app/new/features/accountSettings/utils/isValidAddress.ts
@@ -1,5 +1,4 @@
 import { isAddress } from 'ethers'
-import { isBech32Address } from '@avalabs/core-bridge-sdk'
 import { Avalanche } from '@avalabs/core-wallets-sdk'
 import { isBtcAddress } from 'utils/isBtcAddress'
 import { AddressType } from '../consts'
@@ -18,7 +17,6 @@ export const isValidAddress = ({
   if (addressType === undefined) {
     return (
       isAddress(address) ||
-      isBech32Address(address) ||
       isBtcAddress(address, !isDeveloperMode) ||
       (Avalanche.isBech32Address(addressWithoutPrefix, false) &&
         ((isDeveloperMode && addressWithoutPrefix.includes('fuji')) ||
@@ -29,7 +27,7 @@ export const isValidAddress = ({
   switch (addressType) {
     case AddressType.EVM:
     case AddressType.EVM_TESTNET:
-      return isAddress(address) || isBech32Address(address)
+      return isAddress(address)
     case AddressType.XP:
     case AddressType.XP_TESTNET: {
       return (


### PR DESCRIPTION
## Description

**Ticket: [CP-10495]** 

Please include a summary of the changes. Please also include relevant motivation and context. List any dependencies that are required for this change. If this is a breaking change, please also include steps to migrate.

## Screenshots/Videos


## Testing


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10495]: https://ava-labs.atlassian.net/browse/CP-10495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ