### PR TITLE
CP-10536: Fix tokenDetail

### DIFF
--- a/packages/core-mobile/app/new/features/track/components/ShareChart.tsx
+++ b/packages/core-mobile/app/new/features/track/components/ShareChart.tsx
@@ -9,7 +9,6 @@ import {
   useTheme,
   View
 } from '@avalabs/k2-alpine'
-import { useWatchlist } from 'hooks/watchlist/useWatchlist'
 import React, { useMemo } from 'react'
 import { useTokenDetails } from 'common/hooks/useTokenDetails'
 import { formatLargeCurrency } from 'utils/Utils'
@@ -19,12 +18,19 @@ import { UNKNOWN_AMOUNT } from 'consts/amount'
 import SparklineChart from 'features/track/components/SparklineChart'
 import { isEffectivelyZero } from '../utils'
 
-export const ShareChart = ({ tokenId }: { tokenId: string }): JSX.Element => {
+export const ShareChart = ({
+  tokenId,
+  searchText
+}: {
+  tokenId: string
+  searchText?: string
+}): JSX.Element => {
   const { theme } = useTheme()
   const { theme: inversedTheme } = useInversedTheme({ isDark: theme.isDark })
-  const { chartData, ranges } = useTokenDetails(tokenId ?? '')
-  const { getMarketTokenById } = useWatchlist()
-  const token = tokenId ? getMarketTokenById(tokenId) : undefined
+  const { chartData, ranges, tokenInfo } = useTokenDetails({
+    tokenId: tokenId ?? '',
+    searchText
+  })
 
   return (
     <View
@@ -32,7 +38,7 @@ export const ShareChart = ({ tokenId }: { tokenId: string }): JSX.Element => {
         width: CHART_IMAGE_SIZE,
         height: CHART_IMAGE_SIZE
       }}>
-      {!token || (chartData ?? []).length === 0 ? (
+      {!tokenInfo || (chartData ?? []).length === 0 ? (
         <View
           sx={{
             backgroundColor: theme.colors.$surfaceSecondary,
@@ -54,9 +60,9 @@ export const ShareChart = ({ tokenId }: { tokenId: string }): JSX.Element => {
               paddingBottom: 4
             }}>
             <TokenHeader
-              logoUri={token.logoUri}
-              symbol={token.symbol}
-              currentPrice={token.currentPrice}
+              logoUri={tokenInfo.logoUri}
+              symbol={tokenInfo.symbol}
+              currentPrice={tokenInfo.currentPrice}
               ranges={
                 ranges.minDate === 0 && ranges.maxDate === 0
                   ? undefined

--- a/packages/core-mobile/app/new/features/track/screens/TrackShareScreen.tsx
+++ b/packages/core-mobile/app/new/features/track/screens/TrackShareScreen.tsx
@@ -1,7 +1,6 @@
 import { Text, useTheme, View } from '@avalabs/k2-alpine'
 import { LoadingState } from 'common/components/LoadingState'
 import { useLocalSearchParams } from 'expo-router'
-import { useWatchlist } from 'hooks/watchlist/useWatchlist'
 import React, { useCallback, useRef, useState } from 'react'
 import { LayoutChangeEvent, PixelRatio, Platform } from 'react-native'
 import {
@@ -24,12 +23,13 @@ import { ScrollScreen } from 'common/components/ScrollScreen'
 
 const ShareMarketTokenScreen = (): JSX.Element => {
   const { theme } = useTheme()
-  const { tokenId } = useLocalSearchParams<{ tokenId: string }>()
-  const { getMarketTokenById } = useWatchlist()
-  const token = tokenId ? getMarketTokenById(tokenId) : undefined
+  const { tokenId, searchText } = useLocalSearchParams<{
+    tokenId: string
+    searchText: string
+  }>()
   const [viewWidth, setViewWidth] = useState<number>()
   const viewShotRef = useRef<ViewShot>(null)
-  const { tokenInfo } = useTokenDetails(tokenId ?? '')
+  const { tokenInfo } = useTokenDetails({ tokenId: tokenId ?? '', searchText })
 
   const handleLayout = (event: LayoutChangeEvent): void => {
     setViewWidth(event.nativeEvent.layout.width)
@@ -123,7 +123,7 @@ const ShareMarketTokenScreen = (): JSX.Element => {
     [urlToShare, handleSendMessage, handleMore, handleCopyLink, handleShare]
   )
 
-  if (!tokenId || !token) {
+  if (!tokenId || !tokenInfo) {
     return <LoadingState sx={{ flex: 1 }} />
   }
 
@@ -148,7 +148,7 @@ const ShareMarketTokenScreen = (): JSX.Element => {
                 overflow: 'hidden'
               }}>
               <ViewShot ref={viewShotRef}>
-                <ShareChart tokenId={tokenId} />
+                <ShareChart tokenId={tokenId} searchText={searchText} />
               </ViewShot>
             </View>
           </View>

--- a/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
+++ b/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
@@ -46,7 +46,10 @@ import { useTokenDetails } from 'common/hooks/useTokenDetails'
 
 const TrackTokenDetailScreen = (): JSX.Element => {
   const { theme } = useTheme()
-  const { tokenId } = useLocalSearchParams<{ tokenId: string }>()
+  const { tokenId, searchText } = useLocalSearchParams<{
+    tokenId: string
+    searchText: string
+  }>()
   const [isChartInteracting, setIsChartInteracting] = useState(false)
   const { navigate } = useRouter()
   const { navigateToSwap } = useNavigateToSwap()
@@ -69,7 +72,7 @@ const TrackTokenDetailScreen = (): JSX.Element => {
     isFavorite,
     handleFavorite,
     openUrl
-  } = useTokenDetails(tokenId ?? '')
+  } = useTokenDetails({ tokenId: tokenId ?? '', searchText })
 
   const selectedSegmentIndex = useSharedValue(0)
 
@@ -166,9 +169,12 @@ const TrackTokenDetailScreen = (): JSX.Element => {
   )
 
   const handleShare = useCallback(() => {
-    // @ts-ignore TODO: make routes typesafe
-    navigate({ pathname: '/trackTokenDetail/share', params: { tokenId } })
-  }, [navigate, tokenId])
+    navigate({
+      // @ts-ignore TODO: make routes typesafe
+      pathname: '/trackTokenDetail/share',
+      params: { tokenId, searchText }
+    })
+  }, [navigate, searchText, tokenId])
 
   const marketData = useMemo(() => {
     const data: GroupListItem[] = []

--- a/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/track/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/track/index.tsx
@@ -183,10 +183,10 @@ const TrackHomeScreen = (): JSX.Element => {
       navigate({
         // @ts-ignore TODO: make routes typesafe
         pathname: '/trackTokenDetail',
-        params: { tokenId }
+        params: { tokenId, searchText }
       })
     },
-    [navigate]
+    [navigate, searchText]
   )
 
   const renderEmptyTabBar = useCallback((): JSX.Element => <></>, [])


### PR DESCRIPTION
## Description

**Ticket: [CP-10536]** 

- fix incorrect share route
- pass searchText into TrackTokenDetail and TrackShareShare, to fetch the token from react query cache, then get the token by token id

## Screenshots/Videos

https://github.com/user-attachments/assets/58d1a9b1-ffdb-4dee-a701-a32dcb564298



## Testing


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10536]: https://ava-labs.atlassian.net/browse/CP-10536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ