### PR TITLE
Scrollable separator animation + modal top margin fix

### DIFF
--- a/packages/core-mobile/app/new/common/components/ListScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ListScreen.tsx
@@ -1,6 +1,7 @@
 import {
   ANIMATED,
   NavigationTitleHeader,
+  Separator,
   SPRING_LINEAR_TRANSITION,
   Text
 } from '@avalabs/k2-alpine'
@@ -157,6 +158,13 @@ export const ListScreen = <T,>({
     }
   })
 
+  const animatedBorderStyle = useAnimatedStyle(() => {
+    const opacity = interpolate(scrollY.value, [0, headerHeight], [0, 1])
+    return {
+      opacity
+    }
+  })
+
   const ListHeaderComponent = useMemo(() => {
     return (
       <Animated.View style={[animatedHeaderContainerStyle, { gap: 12 }]}>
@@ -186,10 +194,23 @@ export const ListScreen = <T,>({
           <View style={{ paddingBottom: renderHeader ? 12 : 0 }}>
             {renderHeader?.()}
           </View>
+          <Animated.View
+            style={[
+              animatedBorderStyle,
+              {
+                position: 'absolute',
+                bottom: 0,
+                left: 0,
+                right: 0
+              }
+            ]}>
+            <Separator />
+          </Animated.View>
         </BlurViewWithFallback>
       </Animated.View>
     )
   }, [
+    animatedBorderStyle,
     animatedHeaderContainerStyle,
     animatedHeaderStyle,
     headerHeight,

--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -1,4 +1,9 @@
-import { NavigationTitleHeader, SxProp, Text } from '@avalabs/k2-alpine'
+import {
+  NavigationTitleHeader,
+  Separator,
+  SxProp,
+  Text
+} from '@avalabs/k2-alpine'
 import { useHeaderHeight } from '@react-navigation/elements'
 import { useFadingHeaderNavigation } from 'common/hooks/useFadingHeaderNavigation'
 import React, { useCallback, useLayoutEffect, useRef, useState } from 'react'
@@ -117,6 +122,13 @@ export const ScrollScreen = ({
     }
   }, [contentHeaderHeight])
 
+  const animatedBorderStyle = useAnimatedStyle(() => {
+    const opacity = interpolate(scrollY.value, [0, headerHeight], [0, 1])
+    return {
+      opacity
+    }
+  })
+
   const renderContent = useCallback(() => {
     return (
       <>
@@ -188,7 +200,7 @@ export const ScrollScreen = ({
           </KeyboardStickyView>
         ) : null}
 
-        <BlurViewWithFallback
+        <View
           style={{
             position: 'absolute',
             top: 0,
@@ -196,8 +208,25 @@ export const ScrollScreen = ({
             right: 0,
             bottom: 0,
             height: headerHeight
-          }}
-        />
+          }}>
+          <BlurViewWithFallback
+            style={{
+              flex: 1
+            }}
+          />
+          <Animated.View
+            style={[
+              animatedBorderStyle,
+              {
+                position: 'absolute',
+                bottom: 0,
+                left: 0,
+                right: 0
+              }
+            ]}>
+            <Separator />
+          </Animated.View>
+        </View>
       </View>
     )
   }
@@ -223,7 +252,7 @@ export const ScrollScreen = ({
         {renderContent()}
       </ScrollView>
 
-      <BlurViewWithFallback
+      <View
         style={{
           position: 'absolute',
           top: 0,
@@ -231,8 +260,25 @@ export const ScrollScreen = ({
           right: 0,
           bottom: 0,
           height: headerHeight
-        }}
-      />
+        }}>
+        <BlurViewWithFallback
+          style={{
+            flex: 1
+          }}
+        />
+        <Animated.View
+          style={[
+            animatedBorderStyle,
+            {
+              position: 'absolute',
+              bottom: 0,
+              left: 0,
+              right: 0
+            }
+          ]}>
+          <Separator />
+        </Animated.View>
+      </View>
 
       {renderFooter ? (
         <LinearGradientBottomWrapper>

--- a/packages/core-mobile/app/new/common/consts/screenOptions.tsx
+++ b/packages/core-mobile/app/new/common/consts/screenOptions.tsx
@@ -9,7 +9,7 @@ import { Platform } from 'react-native'
 //import { NotificationBarButton } from 'common/components/NotificationBarButton'
 import BlurredBackgroundView from 'common/components/BlurredBackgroundView'
 
-export const MODAL_TOP_MARGIN = Platform.OS === 'ios' ? 24 : 35
+export const MODAL_TOP_MARGIN = 28
 export const MODAL_BORDER_RADIUS = 40
 export const MODAL_HEADER_HEIGHT = 62
 

--- a/packages/core-mobile/app/new/common/hooks/useModalScreenOptions.tsx
+++ b/packages/core-mobile/app/new/common/hooks/useModalScreenOptions.tsx
@@ -55,7 +55,7 @@ export function useModalScreenOptions(): {
   const formSheetScreensOptions: StackNavigationOptions = {
     ...modalOptions,
     cardStyle: {
-      marginTop: Platform.OS === 'ios' ? topMarginOffset : MODAL_TOP_MARGIN,
+      marginTop: Platform.OS === 'ios' ? topMarginOffset - 4 : MODAL_TOP_MARGIN,
       borderTopLeftRadius: MODAL_BORDER_RADIUS,
       borderTopRightRadius: MODAL_BORDER_RADIUS
     },

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleManagementScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleManagementScreen.tsx
@@ -70,6 +70,7 @@ export const CollectibleManagementScreen = (): ReactNode => {
   return (
     <ListScreen
       title="Manage list"
+      isModal
       keyExtractor={item => `collectibles-manage-${item.localId}`}
       data={filteredCollectibles}
       renderItem={renderItem}

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/index.tsx
@@ -124,7 +124,7 @@ const AccountSettingsScreen = (): JSX.Element => {
       contentContainerStyle={{
         paddingTop: 16
       }}>
-      <View sx={{ gap: 48 }}>
+      <View sx={{ gap: 48, marginTop: 16 }}>
         <View
           sx={{
             alignItems: 'center'


### PR DESCRIPTION
## Description


Fixes
- CollectibleManagementScreen didn't needed isModal prop
- scrollable screens border separator animation when scrolling
- modal top margin offset fix for all devices (was broken because header height was not consistent before)

## Screenshots/Videos

https://github.com/user-attachments/assets/7ed04815-00d5-4a9b-a058-ab342bbde22f



Broken and fixed modal top margin
![Screenshot 2025-05-08 at 00 02 13](https://github.com/user-attachments/assets/594f82b5-1eca-4f2b-831b-0a33037786a7)
![Screenshot 2025-05-08 at 00 00 33](https://github.com/user-attachments/assets/11ec09cc-fa66-4346-b324-b536c41eda6e)




## Testing


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
