### PR TITLE
allow all traffic for android debug builds

### DIFF
--- a/packages/core-mobile/android/app/src/debug/AndroidManifest.xml
+++ b/packages/core-mobile/android/app/src/debug/AndroidManifest.xml
@@ -6,7 +6,6 @@
 
     <application
         android:usesCleartextTraffic="true"
-        tools:targetApi="28"
         tools:ignore="GoogleAppIndexingWarning"
         android:networkSecurityConfig="@xml/network_security_config"
         android:largeHeap="true"/>

--- a/packages/core-mobile/android/app/src/debug/res/xml/network_security_config.xml
+++ b/packages/core-mobile/android/app/src/debug/res/xml/network_security_config.xml
@@ -6,8 +6,6 @@
             <certificates src="user" overridePins="true" />
         </trust-anchors>
     </debug-overrides>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">10.0.2.2</domain>
-        <domain includeSubdomains="true">localhost</domain>
-    </domain-config>
+    <!-- Allow cleartext traffic for all domains (ONLY in debug builds) -->
+    <base-config cleartextTrafficPermitted="true" />
 </network-security-config>


### PR DESCRIPTION
## Description

This allows building and running debug builds on real Android devices. iOS is already possible. When being asked for a url, just specify your computer's ip address. you can use this command `ipconfig getifaddr en0` to grab the ip address.


## Screenshots/Videos
<img src="https://github.com/user-attachments/assets/876da76d-8281-4ccb-a1a5-76346986a552" width=350/>



## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
