### PR TITLE
Fix layout of Balance Change section on the approval screen

### DIFF
--- a/packages/core-mobile/app/new/common/components/Logo.tsx
+++ b/packages/core-mobile/app/new/common/components/Logo.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Image } from '@avalabs/k2-alpine'
+import { Image } from 'expo-image'
 import { FC, useState } from 'react'
 import { formatUriImageToPng, isContentfulImageUri } from 'utils/Contentful'
 import { SvgUri } from 'react-native-svg'

--- a/packages/core-mobile/app/new/features/approval/components/BalanceChange/BalanceChange.tsx
+++ b/packages/core-mobile/app/new/features/approval/components/BalanceChange/BalanceChange.tsx
@@ -11,7 +11,6 @@ const BalanceChangeComponent = ({
   return (
     <View
       sx={{
-        paddingVertical: 16,
         justifyContent: 'space-between',
         alignItems: 'center',
         flexDirection: 'row',
@@ -23,21 +22,17 @@ const BalanceChangeComponent = ({
           flexDirection: 'column'
         }}>
         {balanceChange.outs.map((outTokenDiff, index) => (
-          <TokenDiffGroup
-            key={index.toString()}
-            tokenDiff={outTokenDiff}
-            isOut={true}
-          />
+          <View key={index.toString()} sx={{ paddingVertical: 16 }}>
+            <TokenDiffGroup tokenDiff={outTokenDiff} isOut={true} />
+          </View>
         ))}
-        {balanceChange.ins.length > 0 && (
-          <Separator sx={{ marginVertical: 16, marginHorizontal: 16 }} />
+        {balanceChange.outs.length > 0 && balanceChange.ins.length > 0 && (
+          <Separator sx={{ marginHorizontal: 16 }} />
         )}
         {balanceChange.ins.map((inTokenDiff, index) => (
-          <TokenDiffGroup
-            key={index.toString()}
-            tokenDiff={inTokenDiff}
-            isOut={false}
-          />
+          <View key={index.toString()} sx={{ paddingVertical: 16 }}>
+            <TokenDiffGroup tokenDiff={inTokenDiff} isOut={false} />
+          </View>
         ))}
       </View>
     </View>

--- a/packages/core-mobile/app/new/features/approval/components/BalanceChange/TokenDiffGroup.tsx
+++ b/packages/core-mobile/app/new/features/approval/components/BalanceChange/TokenDiffGroup.tsx
@@ -136,19 +136,15 @@ const TokenDiffItemComponent = ({
   }, [diffItem.displayValue, isOut, colors.$textDanger, colors.$textPrimary])
 
   const renderTokenLogo = useCallback((): JSX.Element | null => {
-    if (token.name !== undefined && token.symbol !== undefined) {
-      return (
-        <TokenLogo
-          symbol={token.symbol}
-          logoUri={token.logoUri}
-          size={42}
-          isNft={isNft}
-        />
-      )
-    }
-
-    return null
-  }, [token.name, token.symbol, token.logoUri, isNft])
+    return (
+      <TokenLogo
+        symbol={token.symbol}
+        logoUri={token.logoUri}
+        size={42}
+        isNft={isNft}
+      />
+    )
+  }, [token.symbol, token.logoUri, isNft])
 
   return (
     <View


### PR DESCRIPTION
## Description

* Show logos for tokens that don’t have a symbol or name.
* use expo-image to handle cases where logoUri redirects to another url
* Fix layout issue when Balance Change only has an “in” value

## Screenshots
| before | after |
| --- | --- |
| <img src=https://github.com/user-attachments/assets/6769869e-e042-42b0-bb49-da23eab24817 width=320 /> | <img src=https://github.com/user-attachments/assets/8e82eace-009e-4161-a6eb-4f0fa4fd7b56 width=320 /> |
