### PR TITLE
adjust not enough AVAX alert and fix send UI bug

### DIFF
--- a/packages/core-mobile/app/new/features/send/components/SendToken.tsx
+++ b/packages/core-mobile/app/new/features/send/components/SendToken.tsx
@@ -215,6 +215,7 @@ export const SendToken = ({ onSend }: { onSend: () => void }): JSX.Element => {
             {addressToSend && (
               <Text
                 variant="mono"
+                numberOfLines={1}
                 sx={{
                   fontSize: 13,
                   color: colors.$textSecondary

--- a/packages/core-mobile/app/new/features/send/components/SendToken.tsx
+++ b/packages/core-mobile/app/new/features/send/components/SendToken.tsx
@@ -10,6 +10,7 @@ import {
   Card,
   Icons,
   Pressable,
+  SCREEN_WIDTH,
   SendTokenUnitInputWidget,
   Text,
   useTheme,
@@ -180,7 +181,8 @@ export const SendToken = ({ onSend }: { onSend: () => void }): JSX.Element => {
           flexDirection: 'row',
           alignItems: 'center',
           borderRadius: 12,
-          justifyContent: 'space-between'
+          justifyContent: 'space-between',
+          width: '100%'
         }}>
         <Text variant="body1" sx={{ fontSize: 16, lineHeight: 22 }}>
           Send to
@@ -189,12 +191,19 @@ export const SendToken = ({ onSend }: { onSend: () => void }): JSX.Element => {
           sx={{
             flexDirection: 'row',
             alignItems: 'center',
-            gap: 8
+            justifyContent: 'flex-end',
+            gap: 8,
+            flex: 1
           }}>
-          <View sx={{ alignItems: 'flex-end' }}>
+          <View
+            sx={{
+              alignItems: 'flex-end',
+              width: SCREEN_WIDTH * 0.5
+            }}>
             {recipient?.name && (
               <Text
                 variant="body1"
+                numberOfLines={1}
                 sx={{
                   fontSize: 16,
                   lineHeight: 22,

--- a/packages/core-mobile/app/new/features/stake/hooks/useAddStake.ts
+++ b/packages/core-mobile/app/new/features/stake/hooks/useAddStake.ts
@@ -22,7 +22,7 @@ export const useAddStake = (): {
 
   const showNotEnoughAvaxAlert = useCallback((): void => {
     showAlert({
-      title: `${minStakeAmount} AVAX required`,
+      title: `${minStakeAmount} available AVAX required`,
       description:
         'Staking your AVAX in the Avalanche Network allows you to earn up to 10% APY.',
       buttons: [


### PR DESCRIPTION
## Description

- make "not enough AVAX" alert clearer
- fix send to not being able to handle long text

## Screenshots/Videos
<img src="https://github.com/user-attachments/assets/dd4faafc-1c8f-46cb-85cc-c95a3c268a3f" width=350/>
<img src="https://github.com/user-attachments/assets/8c531cd2-806e-4a58-8d8b-5ef5644aa1f4" width=350/>


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
