### PR TITLE
Fix DeFi Details not scrollable and adjust alerts 

### DIFF
--- a/packages/core-mobile/app/new/common/components/NavigationRedirect.tsx
+++ b/packages/core-mobile/app/new/common/components/NavigationRedirect.tsx
@@ -92,7 +92,7 @@ export const NavigationRedirect = (): null => {
             title: 'Are you sure?',
             description: 'You will exit the app',
             buttons: [
-              { text: 'Cancel', style: 'cancel' },
+              { text: 'Cancel' },
               {
                 text: 'Got it',
                 onPress: () => {

--- a/packages/core-mobile/app/new/common/components/SelectAvatar.tsx
+++ b/packages/core-mobile/app/new/common/components/SelectAvatar.tsx
@@ -61,8 +61,7 @@ export const SelectAvatar = memo(
         subtitle={description}
         renderFooter={renderFooter}
         contentContainerStyle={{
-          padding: 16,
-          flex: 1
+          padding: 16
         }}>
         <View
           style={{

--- a/packages/core-mobile/app/new/common/components/SelectAvatar.tsx
+++ b/packages/core-mobile/app/new/common/components/SelectAvatar.tsx
@@ -61,7 +61,8 @@ export const SelectAvatar = memo(
         subtitle={description}
         renderFooter={renderFooter}
         contentContainerStyle={{
-          padding: 16
+          padding: 16,
+          flex: 1
         }}>
         <View
           style={{

--- a/packages/core-mobile/app/new/features/accountSettings/components/AccountButtons.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/components/AccountButtons.tsx
@@ -24,7 +24,6 @@ export const AccountButtons = ({
       buttons: [
         {
           text: 'Cancel',
-          style: 'cancel',
           onPress: dismissAlertWithTextInput
         },
         {

--- a/packages/core-mobile/app/new/features/accountSettings/components/AdvancedField.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/components/AdvancedField.tsx
@@ -49,11 +49,11 @@ export const AdvancedField = ({
       description: 'This action can’t be undone',
       buttons: [
         {
-          text: 'Cancel',
-          style: 'cancel'
+          text: 'Cancel'
         },
         {
           text: 'Delete',
+          style: 'destructive',
           onPress: () => onUpdate(id, undefined)
         }
       ]

--- a/packages/core-mobile/app/new/features/accountSettings/components/ContactForm.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/components/ContactForm.tsx
@@ -43,7 +43,6 @@ export const ContactForm = ({
       buttons: [
         {
           text: 'Cancel',
-          style: 'cancel',
           onPress: dismissAlertWithTextInput
         },
         {
@@ -80,11 +79,11 @@ export const ContactForm = ({
           description: 'This action can’t be undone',
           buttons: [
             {
-              text: 'Cancel',
-              style: 'cancel'
+              text: 'Cancel'
             },
             {
               text: 'Delete',
+              style: 'destructive',
               onPress: () => onUpdate(updatedContact)
             }
           ]

--- a/packages/core-mobile/app/new/features/accountSettings/components/SeedlessExportMnemonicPhrase.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/components/SeedlessExportMnemonicPhrase.tsx
@@ -58,13 +58,12 @@ export const SeedlessExportMnemonicPhrase = ({
         'Copying your phrase can expose it to other apps on your device. It is best to write down your phrase instead.',
       buttons: [
         {
+          text: 'Cancel'
+        },
+        {
           text: 'Copy Anyway',
           style: 'default',
           onPress: () => onCopyPhrase(mnemonic)
-        },
-        {
-          text: 'Cancel',
-          style: 'cancel'
         }
       ]
     })

--- a/packages/core-mobile/app/new/features/accountSettings/screens/manageNetworks/AddEditNetworkScreen.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/screens/manageNetworks/AddEditNetworkScreen.tsx
@@ -374,8 +374,7 @@ export const AddEditNetworkScreen = (): JSX.Element => {
         renderFooter={renderFooter}
         contentContainerStyle={{
           padding: 16,
-          gap: 40,
-          flex: 1
+          gap: 40
         }}>
         <View sx={{ alignItems: 'center', gap: 24 }}>
           {formState.logoUri ? (

--- a/packages/core-mobile/app/new/features/accountSettings/screens/manageNetworks/AddEditNetworkScreen.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/screens/manageNetworks/AddEditNetworkScreen.tsx
@@ -114,7 +114,6 @@ export const AddEditNetworkScreen = (): JSX.Element => {
       buttons: [
         {
           text: 'Cancel',
-          style: 'cancel',
           onPress: dismissAlertWithTextInput
         },
         {
@@ -185,7 +184,6 @@ export const AddEditNetworkScreen = (): JSX.Element => {
       buttons: [
         {
           text: 'Cancel',
-          style: 'cancel',
           onPress: dismissAlertWithTextInput
         },
         {

--- a/packages/core-mobile/app/new/features/approval/components/Details.tsx
+++ b/packages/core-mobile/app/new/features/approval/components/Details.tsx
@@ -212,8 +212,7 @@ export const Details = ({
             description: data,
             buttons: [
               {
-                text: 'Got it',
-                style: 'cancel'
+                text: 'Got it'
               }
             ]
           })

--- a/packages/core-mobile/app/new/features/approval/components/SpendLimits/SpendLimitOptions.tsx
+++ b/packages/core-mobile/app/new/features/approval/components/SpendLimits/SpendLimitOptions.tsx
@@ -83,8 +83,7 @@ export const SpendLimitOptions = ({
             ],
             buttons: [
               {
-                text: 'Cancel',
-                style: 'cancel'
+                text: 'Cancel'
               },
               {
                 text: 'Save',

--- a/packages/core-mobile/app/new/features/approval/hooks/useNetworkFeeSelector.ts
+++ b/packages/core-mobile/app/new/features/approval/hooks/useNetworkFeeSelector.ts
@@ -233,7 +233,6 @@ export const useNetworkFeeSelector = ({
         buttons: [
           {
             text: 'Cancel',
-            style: 'cancel',
             onPress: dismissAlertWithTextInput
           },
           {

--- a/packages/core-mobile/app/new/features/bridge/screens/BridgeScreen.tsx
+++ b/packages/core-mobile/app/new/features/bridge/screens/BridgeScreen.tsx
@@ -244,7 +244,7 @@ export const BridgeScreen = (): JSX.Element => {
         showAlert({
           title: 'Error',
           description: getJsonRpcErrorMessage(transferError),
-          buttons: [{ text: 'OK', style: 'cancel' }]
+          buttons: [{ text: 'Got it' }]
         })
         Logger.error('[Bridge error]', transferError)
         AnalyticsService.capture('BridgeTransferRequestError', {
@@ -269,7 +269,7 @@ export const BridgeScreen = (): JSX.Element => {
       showAlert({
         title: 'Error Bridging',
         description: errorMessage,
-        buttons: [{ text: 'OK', style: 'cancel' }]
+        buttons: [{ text: 'Got it' }]
       })
       AnalyticsService.capture('BridgeTokenSelectError', {
         errorMessage

--- a/packages/core-mobile/app/new/features/browser/components/FavoritesList.tsx
+++ b/packages/core-mobile/app/new/features/browser/components/FavoritesList.tsx
@@ -172,7 +172,6 @@ const FavoriteItem = ({
       buttons: [
         {
           text: 'Cancel',
-          style: 'cancel',
           onPress: handleHideFavoriteAlert
         },
         {

--- a/packages/core-mobile/app/new/features/onboarding/components/EnterRecoveryPhrase.tsx
+++ b/packages/core-mobile/app/new/features/onboarding/components/EnterRecoveryPhrase.tsx
@@ -32,8 +32,7 @@ export const EnterRecoveryPhrase = ({
           'The recovery phrase you entered is invalid. Please double check for spelling mistakes or the order of each word.',
         buttons: [
           {
-            text: 'Dismiss',
-            style: 'cancel'
+            text: 'Dismiss'
           }
         ]
       })

--- a/packages/core-mobile/app/new/features/onboarding/components/RecoveryPhrase.tsx
+++ b/packages/core-mobile/app/new/features/onboarding/components/RecoveryPhrase.tsx
@@ -29,7 +29,6 @@ export const RecoveryPhrase = ({
       buttons: [
         {
           text: 'Dismiss',
-          style: 'cancel',
           onPress: onNext
         }
       ]

--- a/packages/core-mobile/app/new/features/onboarding/components/VerifyRecoveryPhrase.tsx
+++ b/packages/core-mobile/app/new/features/onboarding/components/VerifyRecoveryPhrase.tsx
@@ -61,7 +61,7 @@ export const VerifyRecoveryPhrase = ({
         title: 'Invalid phrase',
         description:
           "The words you selected don't match the recovery phrase. The exact order of each word matters. Please try again.",
-        buttons: [{ text: 'Dismiss', style: 'cancel' }]
+        buttons: [{ text: 'Dismiss' }]
       })
     }
   }, [

--- a/packages/core-mobile/app/new/features/portfolio/defi/components/DeFiGridView.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/defi/components/DeFiGridView.tsx
@@ -59,8 +59,8 @@ export const DeFiGridView = ({
                 numberOfLines={1}>
                 {formattedPrice}
               </Text>
-              <View onTouchStart={e => e.stopPropagation()} hitSlop={20}>
-                <TouchableOpacity onPress={onPressArrow} hitSlop={20}>
+              <View onTouchStart={e => e.stopPropagation()} hitSlop={50}>
+                <TouchableOpacity onPress={onPressArrow} hitSlop={50}>
                   <Icons.Custom.Outbound color={theme.colors.$textPrimary} />
                 </TouchableOpacity>
               </View>

--- a/packages/core-mobile/app/new/features/send/components/RecentContacts.tsx
+++ b/packages/core-mobile/app/new/features/send/components/RecentContacts.tsx
@@ -69,8 +69,7 @@ export const RecentContacts = ({
           description: 'Please enter a valid address',
           buttons: [
             {
-              text: 'Dismiss',
-              style: 'cancel'
+              text: 'Dismiss'
             }
           ]
         })

--- a/packages/core-mobile/app/new/features/swap/components.tsx/SlippageInput.tsx
+++ b/packages/core-mobile/app/new/features/swap/components.tsx/SlippageInput.tsx
@@ -41,7 +41,6 @@ export const SlippageInput = ({
       buttons: [
         {
           text: 'Cancel',
-          style: 'cancel',
           onPress: dismissAlertWithTextInput
         },
         {

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addRecoveryMethods/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addRecoveryMethods/index.tsx
@@ -35,12 +35,12 @@ const ManageRecoveryMethodsScreen = (): JSX.Element => {
         'You will no longer be able to use this authenticator once your switch. You can always re-add an authenticator app.',
       buttons: [
         {
+          text: 'Cancel'
+        },
+
+        {
           text: 'Change',
           onPress: totpResetInit
-        },
-        {
-          text: 'Cancel',
-          style: 'cancel'
         }
       ]
     })
@@ -55,8 +55,7 @@ const ManageRecoveryMethodsScreen = (): JSX.Element => {
             'You need at least one recovery method to be able to recover your account.',
           buttons: [
             {
-              text: 'OK',
-              style: 'cancel'
+              text: 'Got it'
             }
           ]
         })
@@ -67,14 +66,15 @@ const ManageRecoveryMethodsScreen = (): JSX.Element => {
         description: 'Are you sure you want to remove this recovery method?',
         buttons: [
           {
+            text: 'Cancel'
+          },
+
+          {
             text: 'Remove',
+            style: 'destructive',
             onPress: () => {
               fidoDelete(mfaId)
             }
-          },
-          {
-            text: 'Cancel',
-            style: 'cancel'
           }
         ]
       })

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addressBook/contactDetail.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addressBook/contactDetail.tsx
@@ -27,11 +27,11 @@ const ContactDetailScreen = (): React.JSX.Element => {
         description,
         buttons: [
           {
-            text: 'Cancel',
-            style: 'cancel'
+            text: 'Cancel'
           },
           {
             text: buttonText,
+            style: 'destructive',
             onPress: () => {
               dispatch(removeContact(contactId))
               canGoBack() && back()

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addressBook/editContactAvatar.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addressBook/editContactAvatar.tsx
@@ -2,7 +2,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router'
 import { SelectAvatar } from 'common/components/SelectAvatar'
 import { useRandomAvatar } from 'features/onboarding/hooks/useRandomAvatar'
 import { useRandomizedAvatars } from 'features/onboarding/hooks/useRandomizedAvatars'
-import React, { useMemo, useState } from 'react'
+import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { editContact, selectContact } from 'store/addressBook'
 
@@ -33,16 +33,9 @@ const EditContactAvatarScreen = (): JSX.Element => {
     )
   }
 
-  const title = useMemo(() => {
-    if (contact?.name) {
-      return `Select ${contact.name}'s avatar`
-    }
-    return 'Select contact avatar'
-  }, [contact?.name])
-
   return (
     <SelectAvatar
-      title={title}
+      title={'Select\ncontact avatar'}
       avatars={randomizedAvatars}
       selectedAvatar={selectedAvatar}
       onSubmit={onSubmit}

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addressBook/selectContactAvatar.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addressBook/selectContactAvatar.tsx
@@ -1,14 +1,13 @@
-import { useLocalSearchParams, useRouter } from 'expo-router'
+import { useRouter } from 'expo-router'
 import { useNewContactAvatar } from 'features/accountSettings/store'
 import { SelectAvatar } from 'common/components/SelectAvatar'
 import { useRandomAvatar } from 'features/onboarding/hooks/useRandomAvatar'
 import { useRandomizedAvatars } from 'features/onboarding/hooks/useRandomizedAvatars'
-import React, { useMemo, useState } from 'react'
+import React, { useState } from 'react'
 
 const SelectContactAvatarScreen = (): JSX.Element => {
   const { back } = useRouter()
   const [newContactAvatar, setNewContactAvatar] = useNewContactAvatar()
-  const { name } = useLocalSearchParams<{ name: string }>()
 
   const randomizedAvatars = useRandomizedAvatars()
   const randomAvatar = useRandomAvatar(randomizedAvatars)
@@ -24,16 +23,9 @@ const SelectContactAvatarScreen = (): JSX.Element => {
     }
   }
 
-  const title = useMemo(() => {
-    if (name) {
-      return `Select ${name}'s avatar`
-    }
-    return `Select contact\navatar`
-  }, [name])
-
   return (
     <SelectAvatar
-      title={title}
+      title={'Select\ncontact avatar'}
       avatars={randomizedAvatars}
       selectedAvatar={selectedAvatar}
       onSubmit={onSubmit}

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/connectedSites.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/connectedSites.tsx
@@ -39,7 +39,7 @@ const ConnectedSitesScreen = (): JSX.Element => {
       title: 'Disconnect all sites',
       description: 'Are you sure you want to disconnect all sites?',
       buttons: [
-        { text: 'Cancel', style: 'cancel' },
+        { text: 'Cancel' },
         {
           text: 'Disconnect',
           style: 'destructive',

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/index.tsx
@@ -72,8 +72,7 @@ const AccountSettingsScreen = (): JSX.Element => {
           'Change appearance is not available in testnet mode. Please turn off testnet mode to change appearance.',
         buttons: [
           {
-            text: 'OK',
-            style: 'cancel'
+            text: 'Got it'
           }
         ]
       })
@@ -243,12 +242,12 @@ const AccountSettingsScreen = (): JSX.Element => {
                   'Removing the account will delete all local information stored on this device. Your assets will remain on chain.',
                 buttons: [
                   {
-                    text: 'I understand, continue',
-                    onPress: deleteWallet
+                    text: 'Cancel'
                   },
                   {
-                    text: 'Cancel',
-                    style: 'cancel'
+                    text: 'I understand, continue',
+                    style: 'destructive',
+                    onPress: deleteWallet
                   }
                 ]
               })

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/seedlessExportPhrase/notInitiated.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/seedlessExportPhrase/notInitiated.tsx
@@ -16,13 +16,12 @@ const SeedlessExportNotInitiatedScreen = (): JSX.Element => {
       description: getWaitingPeriodDescription(),
       buttons: [
         {
+          text: 'Cancel'
+        },
+        {
           text: 'Next',
           style: 'default',
           onPress: () => initExport().catch(Logger.error)
-        },
-        {
-          text: 'Cancel',
-          style: 'cancel'
         }
       ]
     })

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/seedlessExportPhrase/pending.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/seedlessExportPhrase/pending.tsx
@@ -23,16 +23,15 @@ const SeedlessExportPendingScreen = (): JSX.Element => {
         description,
         buttons: [
           {
+            text: 'Cancel'
+          },
+          {
             text: 'Next',
             style: 'default',
             onPress: async () => {
               await deleteExport()
               canGoBack() && back()
             }
-          },
-          {
-            text: 'Cancel',
-            style: 'cancel'
           }
         ]
       })

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/seedlessExportPhrase/readyToExport.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/seedlessExportPhrase/readyToExport.tsx
@@ -31,16 +31,15 @@ const SeedlessExportReadyScreen = (): JSX.Element => {
         description,
         buttons: [
           {
+            text: 'Cancel'
+          },
+          {
             text: 'Next',
             style: 'default',
             onPress: async () => {
               canGoBack() && back()
               await deleteExport()
             }
-          },
-          {
-            text: 'Cancel',
-            style: 'cancel'
           }
         ]
       })

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStake/confirm.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStake/confirm.tsx
@@ -208,14 +208,14 @@ const StakeConfirmScreen = (): JSX.Element => {
       description: 'Your staking setup will not go through if you close now',
       buttons: [
         {
+          text: 'Back'
+        },
+        {
           text: 'Cancel',
+          style: 'destructive',
           onPress: () => {
             handleDismiss()
           }
-        },
-        {
-          text: 'Back',
-          style: 'cancel'
         }
       ]
     })
@@ -263,15 +263,15 @@ const StakeConfirmScreen = (): JSX.Element => {
         'Your stake failed due to network issues. Would you like to keep trying to stake your funds?',
       buttons: [
         {
-          text: 'Try again',
-          onPress: () => {
-            issueDelegation(true)
-          }
-        },
-        {
           text: 'Cancel stake',
           onPress: () => {
             handleDismiss()
+          }
+        },
+        {
+          text: 'Try again',
+          onPress: () => {
+            issueDelegation(true)
           }
         }
       ]
@@ -298,12 +298,12 @@ const StakeConfirmScreen = (): JSX.Element => {
           'Core was unable to find a node that matches your requirements. Please start over or try again later',
         buttons: [
           {
-            text: 'Start over',
-            onPress: handleStartOver
-          },
-          {
             text: 'Cancel',
             onPress: handleDismiss
+          },
+          {
+            text: 'Start over',
+            onPress: handleStartOver
           }
         ]
       })

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/claimStakeReward/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/claimStakeReward/index.tsx
@@ -62,12 +62,12 @@ const ClaimStakeRewardScreen = (): JSX.Element => {
         'Your transaction failed due to network issues. Would you like to try again?',
       buttons: [
         {
-          text: 'Try again',
-          onPress: issueClaimRewards
-        },
-        {
           text: 'Cancel',
           onPress: back
+        },
+        {
+          text: 'Try again',
+          onPress: issueClaimRewards
         }
       ]
     })
@@ -168,7 +168,7 @@ const ClaimStakeRewardScreen = (): JSX.Element => {
       showAlert({
         title: 'No claimable balance',
         description: 'You have no balance available for claiming.',
-        buttons: [{ text: 'Go back', style: 'cancel', onPress: back }]
+        buttons: [{ text: 'Go back', onPress: back }]
       })
     }
   }, [data, back])

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/defiDetail/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/defiDetail/index.tsx
@@ -105,8 +105,8 @@ const DeFiDetailScreen = (): JSX.Element => {
     <ScrollScreen
       navigationTitle={data.name}
       renderFooter={renderFooter}
-      contentContainerStyle={{ padding: 16, flex: 1 }}>
-      <View sx={{ gap: 10 }}>
+      contentContainerStyle={{ padding: 16 }}>
+      <View sx={{ gap: 10, marginTop: 5 }}>
         <LogoWithNetwork size="medium" item={data} chain={memoizedChain} />
         <View>
           <Text variant="heading2" sx={{ color: '$textSecondary' }}>

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/stakeDetail/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/stakeDetail/index.tsx
@@ -184,7 +184,7 @@ const StakeDetailScreen = (): React.JSX.Element => {
     <ScrollScreen
       title={title}
       navigationTitle="Stake detail"
-      contentContainerStyle={{ padding: 16, flex: 1 }}>
+      contentContainerStyle={{ padding: 16 }}>
       <View sx={{ marginTop: 24, gap: 12 }}>
         {groupListSections.map((section, index) => (
           <GroupList

--- a/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/browser/history.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/browser/history.tsx
@@ -51,11 +51,11 @@ const HistoryScreen = (): JSX.Element => {
       description: 'You will permanently delete your historical browsing data',
       buttons: [
         {
-          text: 'Cancel',
-          style: 'cancel'
+          text: 'Cancel'
         },
         {
           text: 'Yes',
+          style: 'destructive',
           onPress: handleConfirmClearAll
         }
       ]

--- a/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/browser/tabs.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/browser/tabs.tsx
@@ -130,11 +130,11 @@ const TabsScreen = (): JSX.Element => {
       description: 'This will remove all of your active tabs',
       buttons: [
         {
-          text: 'Cancel',
-          style: 'cancel'
+          text: 'Cancel'
         },
         {
           text: 'Yes',
+          style: 'destructive',
           onPress: handleConfirmCloseAll
         }
       ]

--- a/packages/core-mobile/app/new/routes/sessionExpired/index.tsx
+++ b/packages/core-mobile/app/new/routes/sessionExpired/index.tsx
@@ -88,8 +88,7 @@ const SessionExpiredScreen = (): React.JSX.Element => {
                 'Please log in with the email address you used when you created your wallet.',
               buttons: [
                 {
-                  text: 'OK',
-                  style: 'cancel'
+                  text: 'Got it'
                 }
               ]
             })

--- a/packages/core-mobile/app/store/notifications/listeners/handlePromptNotifications.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/handlePromptNotifications.ts
@@ -57,7 +57,6 @@ export const handlePromptNotifications = async (
       },
       {
         text: 'Turn on',
-        style: 'cancel',
         onPress: async () => {
           const { permission } = await NotificationsService.getAllPermissions(
             false

--- a/packages/k2-alpine/src/components/Alert/Alert.stories.tsx
+++ b/packages/k2-alpine/src/components/Alert/Alert.stories.tsx
@@ -19,8 +19,7 @@ export const All = (): JSX.Element => {
       description: 'Are you sure you want to delete your wallet?',
       buttons: [
         {
-          text: 'Cancel',
-          style: 'cancel'
+          text: 'Cancel'
         },
         {
           text: 'Delete',
@@ -38,7 +37,6 @@ export const All = (): JSX.Element => {
       buttons: [
         {
           text: 'Cancel',
-          style: 'cancel',
           onPress: () => {
             alert.current?.hide()
           }

--- a/packages/k2-alpine/src/components/Alert/Alert.tsx
+++ b/packages/k2-alpine/src/components/Alert/Alert.tsx
@@ -78,7 +78,6 @@ export const AlertWithTextInputs = forwardRef<
         ))}
         {buttons.map((button, index) => {
           const disabled = button.shouldDisable?.(values)
-          const bold = button.style === 'cancel'
 
           return (
             <Dialog.Button
@@ -91,7 +90,6 @@ export const AlertWithTextInputs = forwardRef<
                   ? 'red'
                   : undefined
               }
-              bold={bold}
               onPress={() => {
                 button.onPress?.(values)
                 setVisible(false)

--- a/packages/k2-alpine/src/components/Alert/types.ts
+++ b/packages/k2-alpine/src/components/Alert/types.ts
@@ -2,7 +2,7 @@ import { AlertOptions, KeyboardTypeOptions } from 'react-native'
 
 export type AlertButton<T> = {
   text: string
-  style?: 'default' | 'cancel' | 'destructive'
+  style?: 'default' | 'destructive'
   onPress?: (values: T) => void
   shouldDisable?: (values: T) => boolean
 }

--- a/packages/k2-alpine/src/components/Tooltip/Tooltip.tsx
+++ b/packages/k2-alpine/src/components/Tooltip/Tooltip.tsx
@@ -8,7 +8,7 @@ import { TouchableOpacity } from '../Primitives'
 interface TooltipProps {
   title: string
   description: string
-  button?: AlertButton
+  button?: Omit<AlertButton, 'style'> & { style?: 'default' | 'destructive' }
   options?: AlertOptions
   size?: number
   hitSlop?: Insets


### PR DESCRIPTION
## Description

**Ticket: [CP-10589]** 
**Ticket: [CP-10590]** 

make DeFi Details, Select Avatar, Edit Network and Stake Details scrollable
adjust alerts to not have cancel style



## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10589]: https://ava-labs.atlassian.net/browse/CP-10589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-10590]: https://ava-labs.atlassian.net/browse/CP-10590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ