### PR TITLE
Fix bottom sheet flickering on Android

### DIFF
--- a/packages/core-mobile/app/new/common/consts/screenOptions.tsx
+++ b/packages/core-mobile/app/new/common/consts/screenOptions.tsx
@@ -1,13 +1,14 @@
 import {
   StackCardInterpolatedStyle,
   StackNavigationOptions,
-  TransitionPresets
+  TransitionPresets,
+  TransitionSpecs
 } from '@react-navigation/stack'
 import BackBarButton from 'common/components/BackBarButton'
 import React from 'react'
 import { Platform } from 'react-native'
-//import { NotificationBarButton } from 'common/components/NotificationBarButton'
 import BlurredBackgroundView from 'common/components/BlurredBackgroundView'
+import { TransitionSpec } from '@react-navigation/stack/lib/typescript/commonjs/src/types'
 
 export const MODAL_TOP_MARGIN = 28
 export const MODAL_BORDER_RADIUS = 40
@@ -46,4 +47,12 @@ export const modalScreenOptionsWithHeaderBack: StackNavigationOptions = {
 
 export function forNoAnimation(): StackCardInterpolatedStyle {
   return {}
+}
+
+export const androidModalTransitionSpec = {
+  open: TransitionSpecs.BottomSheetSlideInSpec,
+  close: {
+    animation: 'timing',
+    config: { duration: 0 }
+  } as TransitionSpec
 }

--- a/packages/core-mobile/app/new/common/hooks/useModalScreenOptions.tsx
+++ b/packages/core-mobile/app/new/common/hooks/useModalScreenOptions.tsx
@@ -2,7 +2,8 @@ import {
   CardStyleInterpolators,
   StackCardInterpolatedStyle,
   StackCardInterpolationProps,
-  StackNavigationOptions
+  StackNavigationOptions,
+  TransitionSpecs
 } from '@react-navigation/stack'
 import {
   MODAL_BORDER_RADIUS,
@@ -41,6 +42,15 @@ export function useModalScreenOptions(): {
       borderTopRightRadius: MODAL_BORDER_RADIUS,
       zIndex: 1000
     },
+    ...(Platform.OS === 'android' && {
+      transitionSpec: {
+        open: TransitionSpecs.BottomSheetSlideInSpec,
+        close: {
+          animation: 'timing',
+          config: { duration: 0 }
+        }
+      }
+    }),
     gestureEnabled: true,
     // Make the whole screen gestureable for dismissing the modal
     // This breaks keyboard open interaction on Android
@@ -78,6 +88,13 @@ export function useModalScreenOptions(): {
           cardStyle: {
             marginTop: 0,
             paddingTop: insets.top
+          },
+          transitionSpec: {
+            open: TransitionSpecs.BottomSheetSlideInSpec,
+            close: {
+              animation: 'timing',
+              config: { duration: 0 }
+            }
           },
           cardStyleInterpolator: stackModalInterpolator.forModalPresentationIOS
         }

--- a/packages/core-mobile/app/new/common/hooks/useModalScreenOptions.tsx
+++ b/packages/core-mobile/app/new/common/hooks/useModalScreenOptions.tsx
@@ -2,10 +2,10 @@ import {
   CardStyleInterpolators,
   StackCardInterpolatedStyle,
   StackCardInterpolationProps,
-  StackNavigationOptions,
-  TransitionSpecs
+  StackNavigationOptions
 } from '@react-navigation/stack'
 import {
+  androidModalTransitionSpec,
   MODAL_BORDER_RADIUS,
   MODAL_HEADER_HEIGHT,
   MODAL_TOP_MARGIN,
@@ -39,17 +39,10 @@ export function useModalScreenOptions(): {
     cardStyle: {
       marginTop: topMarginOffset,
       borderTopLeftRadius: MODAL_BORDER_RADIUS,
-      borderTopRightRadius: MODAL_BORDER_RADIUS,
-      zIndex: 1000
+      borderTopRightRadius: MODAL_BORDER_RADIUS
     },
     ...(Platform.OS === 'android' && {
-      transitionSpec: {
-        open: TransitionSpecs.BottomSheetSlideInSpec,
-        close: {
-          animation: 'timing',
-          config: { duration: 0 }
-        }
-      }
+      transitionSpec: androidModalTransitionSpec
     }),
     gestureEnabled: true,
     // Make the whole screen gestureable for dismissing the modal
@@ -89,13 +82,7 @@ export function useModalScreenOptions(): {
             marginTop: 0,
             paddingTop: insets.top
           },
-          transitionSpec: {
-            open: TransitionSpecs.BottomSheetSlideInSpec,
-            close: {
-              animation: 'timing',
-              config: { duration: 0 }
-            }
-          },
+          transitionSpec: androidModalTransitionSpec,
           cardStyleInterpolator: stackModalInterpolator.forModalPresentationIOS
         }
       : {


### PR DESCRIPTION
## Description

dismissing a modal via gesture for some reason results in some flickering on Android. for now, looks like the best solution is just to use 0 duration transition on Android to prevent the flickering. the drawback is that it also affects the transition when pressing physical back button.

## Screenshots/Videos
**before**
https://github.com/user-attachments/assets/bbeb7d85-e0e4-436c-8b1d-44b8f375510a

**after**
https://github.com/user-attachments/assets/ab56d2e6-07ad-42e0-bcac-b5f8cc393570

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
