### PR TITLE
CP-10537: Fix price change indicator layout + mask additional balances when privacy mode is on

### DIFF
--- a/packages/core-mobile/app/new/common/components/BalanceText.tsx
+++ b/packages/core-mobile/app/new/common/components/BalanceText.tsx
@@ -1,0 +1,25 @@
+import { SxProp, Text, TextVariant } from '@avalabs/k2-alpine'
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { selectIsPrivacyModeEnabled } from 'store/settings/securityPrivacy'
+import { TextProps } from 'react-native'
+import { HiddenBalanceText } from './HiddenBalanceText'
+
+export const BalanceText = ({
+  variant,
+  sx,
+  isCurrency = true,
+  ...rest
+}: {
+  variant: TextVariant
+  sx?: SxProp
+  isCurrency?: boolean
+} & TextProps): JSX.Element => {
+  const isPrivacyModeEnabled = useSelector(selectIsPrivacyModeEnabled)
+
+  return isPrivacyModeEnabled ? (
+    <HiddenBalanceText variant={variant} sx={sx} isCurrency={isCurrency} />
+  ) : (
+    <Text variant={variant} sx={sx} {...rest} />
+  )
+}

--- a/packages/core-mobile/app/new/common/components/BalanceText.tsx
+++ b/packages/core-mobile/app/new/common/components/BalanceText.tsx
@@ -1,4 +1,4 @@
-import { SxProp, Text, TextVariant } from '@avalabs/k2-alpine'
+import { MaskedText, SxProp, Text, TextVariant } from '@avalabs/k2-alpine'
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { selectIsPrivacyModeEnabled } from 'store/settings/securityPrivacy'
@@ -9,16 +9,22 @@ export const BalanceText = ({
   variant,
   sx,
   isCurrency = true,
+  maskType = 'dots',
   ...rest
 }: {
   variant: TextVariant
   sx?: SxProp
   isCurrency?: boolean
+  maskType?: 'dots' | 'covered'
 } & TextProps): JSX.Element => {
   const isPrivacyModeEnabled = useSelector(selectIsPrivacyModeEnabled)
 
   return isPrivacyModeEnabled ? (
-    <HiddenBalanceText variant={variant} sx={sx} isCurrency={isCurrency} />
+    maskType === 'dots' ? (
+      <HiddenBalanceText variant={variant} sx={sx} isCurrency={isCurrency} />
+    ) : (
+      <MaskedText shouldMask={isPrivacyModeEnabled} sx={sx} {...rest} />
+    )
   ) : (
     <Text variant={variant} sx={sx} {...rest} />
   )

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/ActivityListItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/ActivityListItem.tsx
@@ -7,6 +7,7 @@ import {
   useTheme,
   View
 } from '@avalabs/k2-alpine'
+import { BalanceText } from 'common/components/BalanceText'
 
 type Props = {
   title: ReactNode
@@ -15,6 +16,7 @@ type Props = {
   status?: PriceChangeStatus
   accessoryType?: 'outbound' | 'chevron'
   onPress?: () => void
+  subtitleType: 'amountInCurrency' | 'amountInToken' | 'text'
 }
 
 const ActivityListItem: FC<Props> = ({
@@ -23,7 +25,8 @@ const ActivityListItem: FC<Props> = ({
   icon,
   onPress,
   accessoryType = 'outbound',
-  status = PriceChangeStatus.Neutral
+  status = PriceChangeStatus.Neutral,
+  subtitleType
 }) => {
   const {
     theme: { colors }
@@ -69,16 +72,28 @@ const ActivityListItem: FC<Props> = ({
               ellipsizeMode="tail">
               {title}
             </Text>
-            <Text
-              variant="body2"
-              sx={{
-                color: textColor,
-                lineHeight: 16
-              }}
-              numberOfLines={1}
-              ellipsizeMode="tail">
-              {subtitle}
-            </Text>
+            {subtitleType === 'text' ? (
+              <Text
+                variant="body2"
+                sx={{
+                  color: textColor,
+                  lineHeight: 16
+                }}
+                numberOfLines={1}
+                ellipsizeMode="tail">
+                {subtitle}
+              </Text>
+            ) : (
+              <BalanceText
+                variant="body2"
+                sx={{ color: textColor, lineHeight: 16 }}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+                isCurrency={subtitleType === 'amountInCurrency'}
+                maskType="covered">
+                {subtitle}
+              </BalanceText>
+            )}
           </View>
           {accessoryType === 'outbound' && (
             <Icons.Custom.Outbound color={colors.$textPrimary} />

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/PendingBridgeTransactionItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/PendingBridgeTransactionItem.tsx
@@ -49,6 +49,7 @@ export const PendingBridgeTransactionItem: FC<
       }
       title={`Bridging in progress` + (amount ? `: ${amount} ${symbol}` : '')}
       subtitle="Tap for more details"
+      subtitleType="text"
       accessoryType="chevron"
       onPress={onPress}
     />

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
@@ -32,7 +32,7 @@ export const TokenActivityListItem: FC<Props> = ({ tx, onPress }) => {
     }
   }, [tx.txType])
 
-  const subtitle = useMemo(() => {
+  const formattedAmountInCurrency = useMemo(() => {
     if (!currentPrice || isNaN(Number(tx.tokens[0]?.amount))) {
       return UNKNOWN_AMOUNT
     }
@@ -53,7 +53,8 @@ export const TokenActivityListItem: FC<Props> = ({ tx, onPress }) => {
   return (
     <ActivityListItem
       title={<TokenActivityListItemTitle tx={tx} />}
-      subtitle={subtitle}
+      subtitle={formattedAmountInCurrency}
+      subtitleType="amountInCurrency"
       icon={
         <View
           sx={{

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
@@ -4,6 +4,9 @@ import { useTheme, View, Text } from '@avalabs/k2-alpine'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { useBlockchainNames } from 'common/utils/useBlockchainNames'
 import { SubTextNumber } from 'common/components/SubTextNumber'
+import { useSelector } from 'react-redux'
+import { selectIsPrivacyModeEnabled } from 'store/settings/securityPrivacy'
+import { HiddenBalanceText } from 'common/components/HiddenBalanceText'
 import { TokenActivityTransaction } from './TokenActivityListItem'
 
 export const TokenActivityListItemTitle = ({
@@ -15,9 +18,15 @@ export const TokenActivityListItemTitle = ({
     theme: { colors }
   } = useTheme()
   const { sourceBlockchain, targetBlockchain } = useBlockchainNames(tx)
+  const isPrivacyModeEnabled = useSelector(selectIsPrivacyModeEnabled)
+  const textVariant = 'body1'
 
   const renderAmount = useCallback(
     (amount?: string): ReactNode => {
+      if (isPrivacyModeEnabled) {
+        return <HiddenBalanceText variant={textVariant} isCurrency={false} />
+      }
+
       const num = Number(amount)
       if (!isNaN(num)) {
         return (
@@ -30,7 +39,7 @@ export const TokenActivityListItemTitle = ({
       }
       return amount ?? UNKNOWN_AMOUNT
     },
-    [colors]
+    [colors, isPrivacyModeEnabled]
   )
 
   // Build an array of nodes: strings and React elements
@@ -93,7 +102,7 @@ export const TokenActivityListItemTitle = ({
         typeof node === 'string' ? (
           <Text
             key={`txt-${i}`}
-            variant="body1"
+            variant={textVariant}
             sx={{ color: colors.$textPrimary }}>
             {node}
           </Text>

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenDetail.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenDetail.tsx
@@ -22,6 +22,7 @@ import {
   LocalTokenWithBalance
 } from 'store/balance'
 import { xpChainToken } from 'utils/units/knownTokens'
+import { BalanceText } from 'common/components/BalanceText'
 import { LogoWithNetwork } from './LogoWithNetwork'
 
 type PChainBalanceType = keyof PChainBalance
@@ -146,21 +147,23 @@ const TokenDetail: FC<Props> = ({ token }): React.JSX.Element => {
               <Text variant="buttonMedium" numberOfLines={1} sx={{ flex: 1 }}>
                 {assetName}
               </Text>
-              <Text
+              <BalanceText
                 variant="body2"
                 sx={{ lineHeight: 16, flex: 1 }}
                 ellipsizeMode="tail"
+                isCurrency={false}
+                maskType="covered"
                 numberOfLines={1}>
                 {balanceInAvax?.toDisplay()} {xpChainToken.symbol}
-              </Text>
+              </BalanceText>
             </View>
             <View sx={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-              <Text
+              <BalanceText
                 variant="buttonMedium"
                 numberOfLines={1}
                 sx={{ lineHeight: 18, marginBottom: 1 }}>
                 {formattedBalance}
-              </Text>
+              </BalanceText>
             </View>
           </View>
         </View>

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/XpActivityListItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/XpActivityListItem.tsx
@@ -63,7 +63,7 @@ export const XpActivityListItem: FC<Props> = ({ tx, onPress }) => {
     }
   }, [tx.txType])
 
-  const subtitle = useMemo(() => {
+  const formattedTokenAmount = useMemo(() => {
     const amount = isNaN(Number(tx.tokens[0]?.amount))
       ? UNKNOWN_AMOUNT
       : tx.tokens[0]?.amount
@@ -94,7 +94,8 @@ export const XpActivityListItem: FC<Props> = ({ tx, onPress }) => {
   return (
     <ActivityListItem
       title={title}
-      subtitle={subtitle}
+      subtitle={formattedTokenAmount}
+      subtitleType="amountInToken"
       icon={transactionTypeIcon}
       onPress={onPress}
       status={PriceChangeStatus.Neutral}

--- a/packages/core-mobile/app/new/features/portfolio/defi/components/DeFiCommonRow.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/defi/components/DeFiCommonRow.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Separator, Text, useTheme, View } from '@avalabs/k2-alpine'
 import { DeFiToken } from 'services/defi/types'
 import { useExchangedAmount } from 'new/common/hooks/useExchangedAmount'
+import { BalanceText } from 'common/components/BalanceText'
 import { StackedImages } from './StackedImages'
 
 export const DeFiCommonRow = ({
@@ -71,13 +72,13 @@ export const DeFiCommonRow = ({
                   sx={{ color: '$textSecondary' }}>
                   {symbols}
                 </Text>
-                <Text
+                <BalanceText
                   variant="body1"
                   sx={{ color: '$textSecondary' }}
                   numberOfLines={1}
                   ellipsizeMode="tail">
                   {getAmount(suppliedValue, 'compact')}
-                </Text>
+                </BalanceText>
               </View>
             </View>
           </View>

--- a/packages/core-mobile/app/new/features/portfolio/defi/components/DeFiLendingSection.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/defi/components/DeFiLendingSection.tsx
@@ -3,6 +3,7 @@ import { DeFiToken } from 'services/defi/types'
 import React from 'react'
 import { useExchangedAmount } from 'new/common/hooks/useExchangedAmount'
 import { Separator, Text, useTheme, View } from '@avalabs/k2-alpine'
+import { BalanceText } from 'common/components/BalanceText'
 import { IMAGE_SIZE } from '../consts'
 import { DeFiRowItem } from './DeFiRowItem'
 
@@ -52,10 +53,10 @@ export const DeFiLendingSection = ({
                 {token.symbol}
               </Text>
             </View>
-            <Text variant="body1" sx={{ color: amountTextColor }}>
+            <BalanceText variant="body1" sx={{ color: amountTextColor }}>
               {numberSign}
               {getAmount(token.amount * token.price, 'compact')}
-            </Text>
+            </BalanceText>
           </DeFiRowItem>
           {index !== tokens.length - 1 && (
             <Separator sx={{ marginHorizontal: 16 }} />

--- a/packages/core-mobile/app/new/features/portfolio/defi/components/DeFiPortfolioInsuranceBuyer.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/defi/components/DeFiPortfolioInsuranceBuyer.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { useExchangedAmount } from 'new/common/hooks/useExchangedAmount'
 import { getDateInMmmDdYyyyHhMmA } from 'utils/date/getDateInMmmDdYyyyHhMmA'
 import { Card, Separator, Text, View } from '@avalabs/k2-alpine'
+import { BalanceText } from 'common/components/BalanceText'
 import { DeFiRowItem } from './DeFiRowItem'
 
 interface Props {
@@ -39,13 +40,13 @@ export const DeFiPortfolioInsuranceBuyer: FC<Props> = ({ items }) => {
                 }}>
                 {description}
               </Text>
-              <Text
+              <BalanceText
                 variant="body2"
                 sx={{
                   color: '$textSecondary'
                 }}>
                 {getAmount(item.netUsdValue)}
-              </Text>
+              </BalanceText>
             </DeFiRowItem>
             <Separator sx={{ marginHorizontal: 16 }} />
             <DeFiRowItem>

--- a/packages/core-mobile/app/new/features/portfolio/defi/components/DeFiPortfolioPerpetual.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/defi/components/DeFiPortfolioPerpetual.tsx
@@ -2,6 +2,7 @@ import { DeFiPerpetualItem } from 'services/defi/types'
 import React from 'react'
 import { useExchangedAmount } from 'new/common/hooks/useExchangedAmount'
 import { Card, Separator, Text, useTheme, View } from '@avalabs/k2-alpine'
+import { BalanceText } from 'common/components/BalanceText'
 import { IMAGE_SIZE } from '../consts'
 import { DeFiRowItem } from './DeFiRowItem'
 import { StackedImages } from './StackedImages'
@@ -61,9 +62,9 @@ export const DeFiPortfolioPerpetual = ({
                     {positionToken.symbol}/{marginToken.symbol}
                   </Text>
                 </View>
-                <Text variant="body1" sx={{ color: '$textSecondary' }}>
+                <BalanceText variant="body1" sx={{ color: '$textSecondary' }}>
                   {getAmount(netUsdValue, 'compact')}
-                </Text>
+                </BalanceText>
               </DeFiRowItem>
               <Separator sx={{ marginHorizontal: 16 }} />
               <DeFiRowItem>

--- a/packages/core-mobile/app/new/features/portfolio/defi/components/DeFiPortfolioReward.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/defi/components/DeFiPortfolioReward.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { DeFiRewardItem } from 'services/defi/types'
 import { useExchangedAmount } from 'new/common/hooks/useExchangedAmount'
 import { Card, Separator, Text, useTheme, View } from '@avalabs/k2-alpine'
+import { BalanceText } from 'common/components/BalanceText'
 import { IMAGE_SIZE, MAX_TOKEN_COUNT } from '../consts'
 import { DeFiRowItem } from './DeFiRowItem'
 import { StackedImages } from './StackedImages'
@@ -69,9 +70,9 @@ export const DeFiPortfolioReward = ({
                   flexDirection: 'row',
                   justifyContent: 'flex-end'
                 }}>
-                <Text variant="body1" sx={{ color: '$textSecondary' }}>
+                <BalanceText variant="body1" sx={{ color: '$textSecondary' }}>
                   {getAmount(netUsdValue)}
-                </Text>
+                </BalanceText>
               </View>
             </DeFiRowItem>
           </Card>

--- a/packages/core-mobile/app/new/features/portfolio/defi/components/DeFiPortfolioVesting.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/defi/components/DeFiPortfolioVesting.tsx
@@ -3,6 +3,7 @@ import { Card, Image, Separator, Text, View } from '@avalabs/k2-alpine'
 import { DeFiVestingItem } from 'services/defi/types'
 import { useExchangedAmount } from 'new/common/hooks/useExchangedAmount'
 import { getDateInMmmDdYyyyHhMmA } from 'utils/date/getDateInMmmDdYyyyHhMmA'
+import { BalanceText } from 'common/components/BalanceText'
 import { IMAGE_SIZE } from '../consts'
 import { DeFiRowItem } from './DeFiRowItem'
 
@@ -50,13 +51,13 @@ export const DeFiPortfolioVesting = ({ items }: Props): JSX.Element => {
                   flexDirection: 'row',
                   justifyContent: 'flex-end'
                 }}>
-                <Text
+                <BalanceText
                   variant="body1"
                   numberOfLines={1}
                   ellipsizeMode="tail"
                   sx={{ color: '$textSecondary' }}>
                   {getAmount(netUsdValue, 'compact')}
-                </Text>
+                </BalanceText>
               </View>
             </DeFiRowItem>
             {endDate && (

--- a/packages/k2-alpine/package.json
+++ b/packages/k2-alpine/package.json
@@ -41,7 +41,7 @@
     "react-native-gesture-handler": "2.20.0",
     "react-native-modal-datetime-picker": "18.0.0",
     "react-native-popover-view": "6.1.0",
-    "react-native-reanimated": "3.16.7",
+    "react-native-reanimated": "3.17.1",
     "react-native-reanimated-carousel": "v4.0.2",
     "react-native-safe-area-context": "5.3.0",
     "react-native-svg": "15.8.0"
@@ -57,7 +57,7 @@
     "react-native": "0.76.9",
     "react-native-gesture-handler": "2.20.0",
     "react-native-modal-datetime-picker": "18.0.0",
-    "react-native-reanimated": "3.16.7",
+    "react-native-reanimated": "3.17.1",
     "react-native-safe-area-context": "5.3.0",
     "react-native-svg": "15.8.0"
   },

--- a/packages/k2-alpine/src/components/Animated/AnimatedText.tsx
+++ b/packages/k2-alpine/src/components/Animated/AnimatedText.tsx
@@ -1,11 +1,10 @@
 import React, { useMemo } from 'react'
 import { SxProp } from 'dripsy'
-import Animated, { LinearTransition } from 'react-native-reanimated'
+import Animated from 'react-native-reanimated'
 import { TextVariant } from '../../theme/tokens/text'
 import { Text } from '../Primitives'
 import { AnimateFadeScale } from '../AnimatedFadeScale/AnimatedFadeScale'
-
-const springTransition = LinearTransition.springify()
+import { SPRING_LINEAR_TRANSITION } from '../../utils'
 
 export const AnimatedText = ({
   variant = 'heading2',
@@ -33,7 +32,7 @@ export const AnimatedText = ({
 
   return (
     <Animated.View
-      layout={springTransition}
+      layout={SPRING_LINEAR_TRANSITION}
       style={{
         flexDirection: 'row',
         alignItems: 'flex-end',

--- a/packages/k2-alpine/src/components/PriceChangeIndicator/PriceChangeIndicator.tsx
+++ b/packages/k2-alpine/src/components/PriceChangeIndicator/PriceChangeIndicator.tsx
@@ -1,9 +1,4 @@
 import React from 'react'
-import Animated, {
-  FadeIn,
-  FadeOut,
-  LinearTransition
-} from 'react-native-reanimated'
 import { StyleSheet } from 'react-native'
 import { SxProp } from 'dripsy'
 import { useTheme } from '../../hooks'
@@ -13,6 +8,7 @@ import { AnimatedText } from '../Animated/AnimatedText'
 import { View, Text } from '../Primitives'
 import { K2AlpineTheme } from '../../theme/theme'
 import { MaskedView } from '../MaskedView/MaskedView'
+import { AnimateFadeScale } from '../AnimatedFadeScale/AnimatedFadeScale'
 import { PriceChangeStatus } from './types'
 
 export const PriceChangeIndicator = ({
@@ -110,7 +106,7 @@ const AnimatedComponent = ({
   const showArrow =
     status === PriceChangeStatus.Down || status === PriceChangeStatus.Up
   return (
-    <Animated.View exiting={FadeOut} entering={FadeIn} style={styles.container}>
+    <View style={styles.container}>
       {formattedPrice && (
         <AnimatedText
           variant={textVariant}
@@ -120,10 +116,12 @@ const AnimatedComponent = ({
           }}
         />
       )}
-      <Animated.View
-        layout={LinearTransition.springify().damping(100)}
-        style={styles.innerWrapper}>
-        {showArrow && <Arrow sx={arrowSx} status={status} size={arrowSize} />}
+      <View style={styles.innerWrapper}>
+        {showArrow && (
+          <AnimateFadeScale>
+            <Arrow sx={arrowSx} status={status} size={arrowSize} />
+          </AnimateFadeScale>
+        )}
         {formattedPercent !== undefined && (
           <AnimatedText
             variant={textVariant}
@@ -133,8 +131,8 @@ const AnimatedComponent = ({
             }}
           />
         )}
-      </Animated.View>
-    </Animated.View>
+      </View>
+    </View>
   )
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -594,7 +594,7 @@ __metadata:
     react-native-gesture-handler: 2.20.0
     react-native-modal-datetime-picker: 18.0.0
     react-native-popover-view: 6.1.0
-    react-native-reanimated: 3.16.7
+    react-native-reanimated: 3.17.1
     react-native-reanimated-carousel: v4.0.2
     react-native-safe-area-context: 5.3.0
     react-native-svg: 15.8.0
@@ -613,7 +613,7 @@ __metadata:
     react-native: 0.76.9
     react-native-gesture-handler: 2.20.0
     react-native-modal-datetime-picker: 18.0.0
-    react-native-reanimated: 3.16.7
+    react-native-reanimated: 3.17.1
     react-native-safe-area-context: 5.3.0
     react-native-svg: 15.8.0
   languageName: unknown
@@ -27293,29 +27293,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-reanimated@npm:3.16.7":
-  version: 3.16.7
-  resolution: "react-native-reanimated@npm:3.16.7"
-  dependencies:
-    "@babel/plugin-transform-arrow-functions": ^7.0.0-0
-    "@babel/plugin-transform-class-properties": ^7.0.0-0
-    "@babel/plugin-transform-classes": ^7.0.0-0
-    "@babel/plugin-transform-nullish-coalescing-operator": ^7.0.0-0
-    "@babel/plugin-transform-optional-chaining": ^7.0.0-0
-    "@babel/plugin-transform-shorthand-properties": ^7.0.0-0
-    "@babel/plugin-transform-template-literals": ^7.0.0-0
-    "@babel/plugin-transform-unicode-regex": ^7.0.0-0
-    "@babel/preset-typescript": ^7.16.7
-    convert-source-map: ^2.0.0
-    invariant: ^2.2.4
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-    react: "*"
-    react-native: "*"
-  checksum: 108095709cd7a3effc5b5d276d94e161b399bd2d06e32140834168a0051545401bb09228071447e5925571da3f86f335d2a82c76751cdae07f66faf50b25c97f
-  languageName: node
-  linkType: hard
-
 "react-native-reanimated@npm:3.17.1":
   version: 3.17.1
   resolution: "react-native-reanimated@npm:3.17.1"
@@ -27540,7 +27517,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 77324747a8b5df0a5558bb99a9a0804a5575d328e84f480e462c56417af97213f38a9930e4582fb749bec374dc4d1a8910a45b006e77af9b14a8e64057b932bf
+  checksum: 869028a5bb7a4a8a125d274753b703c2b3579b5efc7bb82db136a186fd88a11c5a4696505ebcd976d20fcdd41111abe229ae0e19c27c50bb30fe4f52bb6383bc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

* https://ava-labs.atlassian.net/browse/CP-10537
* https://ava-labs.atlassian.net/browse/CP-10534

## Screenshots/Videos
| | Privacy mode is on |
| --- | --- | 
| Defi detail | <img src=https://github.com/user-attachments/assets/0e9ff202-dcbc-4170-b011-3177c0b44362 width=320 /> | 
| Portfolio token detail | <img src=https://github.com/user-attachments/assets/c4202d80-57de-4aaa-a201-11dc6803f992 width=320 /> | 
| Portfolio token detail - p/x chain | <img src=https://github.com/user-attachments/assets/7c2b9260-ead8-400b-930a-a28d164dd9de width=320 /> |