### PR TITLE
CP-10668: do not show network fee section when balance is not sufficient

### DIFF
--- a/packages/core-mobile/app/new/features/stake/screens/ClaimStakeRewardScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/screens/ClaimStakeRewardScreen.tsx
@@ -135,8 +135,12 @@ export const ClaimStakeRewardScreen = (): JSX.Element => {
     [avaxPrice, formatTokenInCurrency]
   )
 
-  const feeData: GroupListItem[] = useMemo(
-    () => [
+  const feeData: GroupListItem[] = useMemo(() => {
+    if (insufficientBalanceForFee) {
+      return []
+    }
+
+    return [
       {
         title: 'Network fee',
         rightIcon: (
@@ -145,16 +149,15 @@ export const ClaimStakeRewardScreen = (): JSX.Element => {
             description="Fees paid to execute the transaction"
           />
         ),
-        value: insufficientBalanceForFee ? undefined : totalFees ===
-          undefined ? (
-          <ActivityIndicator />
-        ) : (
-          <StakeTokenUnitValue value={totalFees} />
-        )
+        value:
+          totalFees === undefined ? (
+            <ActivityIndicator />
+          ) : (
+            <StakeTokenUnitValue value={totalFees} />
+          )
       }
-    ],
-    [totalFees, insufficientBalanceForFee]
-  )
+    ]
+  }, [totalFees, insufficientBalanceForFee])
 
   usePreventScreenRemoval(claimRewardsMutation.isPending)
 


### PR DESCRIPTION
## Description

**Ticket: [CP-10668]** 

* do not show network fee section when balance is not sufficient 

## Screenshots/Videos
<img src=https://github.com/user-attachments/assets/7a7f0403-e932-42e7-a2e5-42e1d724d872 width=320 />

[CP-10668]: https://ava-labs.atlassian.net/browse/CP-10668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ