### PR TITLE
CP-10465: Fix to show logo placeholder when logo is not available

### DIFF
--- a/packages/core-mobile/app/new/features/track/components/TokenHeader.tsx
+++ b/packages/core-mobile/app/new/features/track/components/TokenHeader.tsx
@@ -62,9 +62,7 @@ export const TokenHeader = ({
 
   return (
     <View onLayout={onLayout}>
-      {logoUri !== undefined && (
-        <TokenLogo symbol={symbol} logoUri={logoUri} size={42} />
-      )}
+      <TokenLogo symbol={symbol} logoUri={logoUri} size={42} />
       <View
         sx={{
           marginTop: 15,


### PR DESCRIPTION
## Description

**Ticket: [CP-10465]** 

* Fix to show logo placeholder when logo is not available in token detail screen

## Screenshot
<img src=https://github.com/user-attachments/assets/f9af8ab6-c1eb-4711-995b-698a27a3c7c5 width=320 />

[CP-10465]: https://ava-labs.atlassian.net/browse/CP-10465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ