### PR TITLE
CP-10464: reset hasEnoughAvax state whenever active account changes

### DIFF
--- a/packages/core-mobile/app/hooks/earn/useHasEnoughAvaxToStake.ts
+++ b/packages/core-mobile/app/hooks/earn/useHasEnoughAvaxToStake.ts
@@ -5,10 +5,13 @@ import { useGetClaimableBalance } from 'hooks/earn/useGetClaimableBalance'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import useCChainNetwork from 'hooks/earn/useCChainNetwork'
 import { useGetStuckBalance } from 'hooks/earn/useGetStuckBalance'
+import { selectActiveAccount } from 'store/account/slice'
+import { useSelector } from 'react-redux'
 
 export const useHasEnoughAvaxToStake = (): {
   hasEnoughAvax: boolean | undefined
 } => {
+  const activeAccount = useSelector(selectActiveAccount)
   const { minStakeAmount } = useStakingParams()
   const cChainBalance = useCChainBalance()
   const claimableBalance = useGetClaimableBalance()
@@ -18,6 +21,11 @@ export const useHasEnoughAvaxToStake = (): {
   const [hasEnoughAvax, setHasEnoughAvax] = useState<boolean | undefined>(
     undefined
   )
+
+  // reset hasEnoughAvax when the active account changes to avoid stale state
+  useEffect(() => {
+    setHasEnoughAvax(undefined)
+  }, [activeAccount])
 
   useEffect(() => {
     if (cChainBalance.data?.balance !== undefined && cChainNetworkToken) {


### PR DESCRIPTION
## Description

**Ticket: [CP-10464]** 
we weren't resetting the hasEnoughAvax when switching active account and it can take a bit of time to fetch balance for the new active account (we only update hasEnoughAvax when the balance is done fetching)

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
