### PR TITLE
CP-10681: fetch balance on account detail 

### DIFF
--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -33,7 +33,7 @@ import { useSelector } from 'react-redux'
 import AnalyticsService from 'services/analytics/AnalyticsService'
 import {
   LocalTokenWithBalance,
-  selectTokensWithZeroBalance
+  selectTokensWithZeroBalanceByNetwork
 } from 'store/balance'
 import { getTokenAddress } from 'swap/getSwapRate'
 import { calculateRate } from 'swap/utils'
@@ -54,7 +54,6 @@ export const SwapScreen = (): JSX.Element => {
   const { formatCurrency } = useFormatCurrency()
 
   const swapList = useSwapList()
-  const tokensWithZeroBalance = useSelector(selectTokensWithZeroBalance)
 
   const {
     swap,
@@ -77,6 +76,10 @@ export const SwapScreen = (): JSX.Element => {
   const [toTokenValue, setToTokenValue] = useState<bigint>()
   const [localError, setLocalError] = useState<string>('')
   const cChainNetwork = useCChainNetwork()
+  const tokensWithZeroBalance = useSelector(
+    selectTokensWithZeroBalanceByNetwork(cChainNetwork?.chainId)
+  )
+
   const [isInputFocused, setIsInputFocused] = useState<boolean>(false)
   const swapButtonBackgroundColor = useMemo(
     () => getButtonBackgroundColor('secondary', theme, false),

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/account.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/account.tsx
@@ -1,8 +1,9 @@
 import { BalanceHeader, View } from '@avalabs/k2-alpine'
 import { ScrollScreen } from 'common/components/ScrollScreen'
+import { useBalanceForAccount } from 'common/contexts/useBalanceForAccount'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
-import { useLocalSearchParams } from 'expo-router'
+import { useFocusEffect, useLocalSearchParams } from 'expo-router'
 import { AccountAddresses } from 'features/accountSettings/components/accountAddresses'
 import { AccountButtons } from 'features/accountSettings/components/AccountButtons'
 import React, { useCallback, useMemo } from 'react'
@@ -49,6 +50,14 @@ const AccountScreen = (): JSX.Element => {
           withoutCurrencySuffix: true
         })
   }, [balanceAccurate, balanceTotalInCurrency, formatCurrency])
+
+  const { fetchBalance } = useBalanceForAccount(accountIndexNumber)
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchBalance()
+    }, [fetchBalance])
+  )
 
   const renderHeader = useCallback((): JSX.Element => {
     return (

--- a/packages/core-mobile/app/store/balance/slice.ts
+++ b/packages/core-mobile/app/store/balance/slice.ts
@@ -9,7 +9,6 @@ import { selectActiveAccount } from 'store/account'
 import {
   selectAllNetworks,
   selectEnabledChainIds,
-  selectEnabledNetworks,
   selectNetworks
 } from 'store/network'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
@@ -103,19 +102,19 @@ export const selectTokensWithBalanceByNetwork = (
     }
   )
 
-export const selectTokensWithZeroBalance = createSelector(
-  [selectEnabledNetworks, selectActiveAccount, _selectAllBalances],
-  (enabledNetworks, activeAccount, allBalances): LocalTokenWithBalance[] => {
-    if (!activeAccount) return []
+export const selectTokensWithZeroBalanceByNetwork = (
+  chainId?: number
+): ((state: RootState) => LocalTokenWithBalance[]) =>
+  createSelector(
+    [selectActiveAccount, _selectAllBalances],
+    (activeAccount, allBalances): LocalTokenWithBalance[] => {
+      if (!activeAccount || !chainId) return []
 
-    return enabledNetworks.reduce((acc, network) => {
-      const key = getKey(network.chainId, activeAccount.index)
+      const key = getKey(chainId, activeAccount.index)
       const tokens = allBalances[key]?.tokens ?? []
-      const zeroBalanceTokens = tokens.filter(token => token.balance === 0n)
-      return acc.concat(zeroBalanceTokens)
-    }, [] as LocalTokenWithBalance[])
-  }
-)
+      return tokens.filter(token => token.balance === 0n)
+    }
+  )
 
 export const selectAvaxPrice = (state: RootState): number => {
   const balances = Object.values(state.balance.balances)

--- a/packages/core-mobile/app/store/index.ts
+++ b/packages/core-mobile/app/store/index.ts
@@ -30,7 +30,7 @@ import { combinedReducer as browser } from './browser'
 import { snapshotsReducer as snapshots } from './snapshots/slice'
 import { reduxStorage } from './reduxStorage'
 
-const VERSION = 18
+const VERSION = 19
 
 // list of reducers that don't need to be persisted
 // for nested/partial blacklist, please use transform

--- a/packages/core-mobile/app/store/migrations.ts
+++ b/packages/core-mobile/app/store/migrations.ts
@@ -11,10 +11,7 @@ import { AddressBookState } from 'store/addressBook'
 import { uuid } from 'utils/uuid'
 import { CORE_MOBILE_WALLET_ID } from 'services/walletconnectv2/types'
 import { ChannelId } from 'services/notifications/channels'
-import {
-  AVALANCHE_MAINNET_NETWORK,
-  AVALANCHE_TESTNET_NETWORK
-} from 'services/network/consts'
+import { AVALANCHE_MAINNET_NETWORK } from 'services/network/consts'
 import { initialState as watchlistInitialState } from './watchlist'
 import {
   DefaultFeatureFlagConfig,
@@ -308,7 +305,6 @@ export const migrations = {
     }
   },
   19: (state: any) => {
-    const isDeveloperMode = state.settings.advanced.developerMode
     // in the mobile next-gen app, we don't have the concept of active network anymore,
     // we will default active network to avalanche c-chain until we remove active network
     // everywhere in the app
@@ -316,9 +312,14 @@ export const migrations = {
       ...state,
       network: {
         ...state.network,
-        active: isDeveloperMode
-          ? AVALANCHE_TESTNET_NETWORK
-          : AVALANCHE_MAINNET_NETWORK
+        active: AVALANCHE_MAINNET_NETWORK
+      },
+      settings: {
+        ...state.settings,
+        advanced: {
+          ...state.settings.advanced,
+          developerMode: false
+        }
       }
     }
   }

--- a/packages/core-mobile/app/store/migrations.ts
+++ b/packages/core-mobile/app/store/migrations.ts
@@ -11,7 +11,6 @@ import { AddressBookState } from 'store/addressBook'
 import { uuid } from 'utils/uuid'
 import { CORE_MOBILE_WALLET_ID } from 'services/walletconnectv2/types'
 import { ChannelId } from 'services/notifications/channels'
-import { AVALANCHE_MAINNET_NETWORK } from 'services/network/consts'
 import { initialState as watchlistInitialState } from './watchlist'
 import {
   DefaultFeatureFlagConfig,
@@ -312,7 +311,7 @@ export const migrations = {
       ...state,
       network: {
         ...state.network,
-        active: AVALANCHE_MAINNET_NETWORK
+        active: ChainId.AVALANCHE_MAINNET_ID
       },
       settings: {
         ...state.settings,

--- a/packages/core-mobile/app/store/migrations.ts
+++ b/packages/core-mobile/app/store/migrations.ts
@@ -11,6 +11,10 @@ import { AddressBookState } from 'store/addressBook'
 import { uuid } from 'utils/uuid'
 import { CORE_MOBILE_WALLET_ID } from 'services/walletconnectv2/types'
 import { ChannelId } from 'services/notifications/channels'
+import {
+  AVALANCHE_MAINNET_NETWORK,
+  AVALANCHE_TESTNET_NETWORK
+} from 'services/network/consts'
 import { initialState as watchlistInitialState } from './watchlist'
 import {
   DefaultFeatureFlagConfig,
@@ -300,6 +304,21 @@ export const migrations = {
         ...state.network,
         enabledChainIds,
         disabledLastTransactedChainIds: []
+      }
+    }
+  },
+  19: (state: any) => {
+    const isDeveloperMode = state.settings.advanced.developerMode
+    // in the mobile next-gen app, we don't have the concept of active network anymore,
+    // we will default active network to avalanche c-chain until we remove active network
+    // everywhere in the app
+    return {
+      ...state,
+      network: {
+        ...state.network,
+        active: isDeveloperMode
+          ? AVALANCHE_TESTNET_NETWORK
+          : AVALANCHE_MAINNET_NETWORK
       }
     }
   }


### PR DESCRIPTION
## Description

**Ticket: [CP-10681]** 

- add migration to default activeNetwork to avalanche c-chain
- update selectTokensWithZeroBalance to selectTokensWithZeroBalanceByNetwork, since we only need to get the zero balance tokens for avalanche c-chain network on swap screen
- fetch account balance when account detail screen is focused

## Screenshots/Videos


https://github.com/user-attachments/assets/aed39459-45cd-4311-8b41-faa8b9df3bcc



## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10681]: https://ava-labs.atlassian.net/browse/CP-10681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ