### PR TITLE
CP-10621: Fix Android Alert Button Color

### DIFF
--- a/packages/core-mobile/android/app/src/main/res/values-night/colors.xml
+++ b/packages/core-mobile/android/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="dialogTextColor">#000000</color>
+</resources>

--- a/packages/core-mobile/android/app/src/main/res/values-night/colors.xml
+++ b/packages/core-mobile/android/app/src/main/res/values-night/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="dialogTextColor">#000000</color>
+    <color name="dialogTextColor">#FFFFFF</color>
 </resources>

--- a/packages/core-mobile/android/app/src/main/res/values/colors.xml
+++ b/packages/core-mobile/android/app/src/main/res/values/colors.xml
@@ -4,6 +4,7 @@
     <color name="textPrimary">#000000</color>
     <color name="neutral400">#B4B4B7</color>
     <color name="neutral50">#F8F8FB</color>
+    <color name="dialogTextColor">#FFFFFF</color>
     <color name="neutral900">#1A1A1C</color>
     <color name="neutral850">#2A2A2D</color>
     <color name="bootsplash_background">#000000</color>

--- a/packages/core-mobile/android/app/src/main/res/values/colors.xml
+++ b/packages/core-mobile/android/app/src/main/res/values/colors.xml
@@ -4,7 +4,7 @@
     <color name="textPrimary">#000000</color>
     <color name="neutral400">#B4B4B7</color>
     <color name="neutral50">#F8F8FB</color>
-    <color name="dialogTextColor">#FFFFFF</color>
+    <color name="dialogTextColor">#000000</color>
     <color name="neutral900">#1A1A1C</color>
     <color name="neutral850">#2A2A2D</color>
     <color name="bootsplash_background">#000000</color>

--- a/packages/core-mobile/android/app/src/main/res/values/styles.xml
+++ b/packages/core-mobile/android/app/src/main/res/values/styles.xml
@@ -17,8 +17,8 @@
         <item name="enforceNavigationBarContrast">false</item>
 
         <!-- default tint color for dialog button text -->
-        <item name="android:colorPrimary">@color/neutral50</item>
-        <item name="colorPrimary">@color/neutral50</item>
+        <item name="android:colorPrimary">@color/dialogTextColor</item>
+        <item name="colorPrimary">@color/dialogTextColor</item>
     </style>
 
     <style name="CustomBottomNavigationStyle" parent="Widget.Material3.BottomNavigationView">


### PR DESCRIPTION
## Description

**Ticket: [CP-10621]** 

We were using the same color for both dark and light themes. This pr adds `values-night` folder which contains colors to be used in dark mode.

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10621]: https://ava-labs.atlassian.net/browse/CP-10621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ