### PR TITLE
make track screens wait for swap list to load before rendering

### DIFF
--- a/packages/core-mobile/app/new/common/hooks/useIsSwapListLoaded.ts
+++ b/packages/core-mobile/app/new/common/hooks/useIsSwapListLoaded.ts
@@ -1,0 +1,10 @@
+import { useMemo } from 'react'
+import { useSwapList } from './useSwapList'
+
+export const useIsSwapListLoaded = (): boolean => {
+  const swapList = useSwapList()
+
+  return useMemo(() => {
+    return swapList.length > 0
+  }, [swapList.length])
+}

--- a/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
+++ b/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
@@ -47,6 +47,7 @@ import { useGetPrices } from 'hooks/watchlist/useGetPrices'
 import { useIsFocused } from '@react-navigation/native'
 import { MarketType } from 'store/watchlist'
 import { AVAX_COINGECKO_ID } from 'consts/coingecko'
+import { useIsSwapListLoaded } from 'common/hooks/useIsSwapListLoaded'
 
 const TrackTokenDetailScreen = (): JSX.Element => {
   const { theme } = useTheme()
@@ -89,6 +90,8 @@ const TrackTokenDetailScreen = (): JSX.Element => {
       tokenInfo.currentPrice === undefined &&
       coingeckoId.length > 0
   })
+
+  const isSwapListLoaded = useIsSwapListLoaded()
 
   const selectedSegmentIndex = useSharedValue(0)
 
@@ -352,7 +355,15 @@ const TrackTokenDetailScreen = (): JSX.Element => {
     )
   }, [tokenInfo, prices, ranges, coingeckoId])
 
-  if (!tokenId || !tokenInfo) {
+  const showLoading =
+    !tokenId ||
+    !tokenInfo ||
+    // the token's swapability depends on the swap list
+    // thus, we need to wait for the swap list to load
+    // so that we can display the swap button accordingly
+    !isSwapListLoaded
+
+  if (showLoading) {
     return <LoadingState sx={styles.container} />
   }
 

--- a/packages/core-mobile/app/new/features/track/trending/components/TrendingScreen.tsx
+++ b/packages/core-mobile/app/new/features/track/trending/components/TrendingScreen.tsx
@@ -8,6 +8,7 @@ import React, { useMemo } from 'react'
 import { Dimensions } from 'react-native'
 import Animated from 'react-native-reanimated'
 import { MarketType } from 'store/watchlist/types'
+import { useIsSwapListLoaded } from 'common/hooks/useIsSwapListLoaded'
 import TrendingTokensScreen from './TrendingTokensScreen'
 
 export const TrendingScreen = ({
@@ -21,6 +22,8 @@ export const TrendingScreen = ({
     isRefetchingTrendingTokens,
     refetchTrendingTokens
   } = useWatchlist()
+
+  const isSwapListLoaded = useIsSwapListLoaded()
 
   const emptyComponent = useMemo(() => {
     if (isRefetchingTrendingTokens) {
@@ -38,7 +41,14 @@ export const TrendingScreen = ({
     )
   }, [isRefetchingTrendingTokens, refetchTrendingTokens])
 
-  if (isLoadingTrendingTokens) {
+  const showLoading =
+    isLoadingTrendingTokens ||
+    // each token's swapability depends on the swap list
+    // thus, we need to wait for the swap list to load
+    // so that we can display the buy button accordingly
+    !isSwapListLoaded
+
+  if (showLoading) {
     return <LoadingState sx={{ height: portfolioTabContentHeight * 1.5 }} />
   }
 


### PR DESCRIPTION
## Description

this is to make sure we render the buy/swap button correctly. currently if users go to track screens too quickly and the swap list is not loaded, we will render view button since we have no data yet.
