### PR TITLE
CP-10719: Enable send only for primary networks

### DIFF
--- a/packages/core-mobile/app/new/common/hooks/useMergedNetworks.ts
+++ b/packages/core-mobile/app/new/common/hooks/useMergedNetworks.ts
@@ -1,0 +1,26 @@
+import { Network } from '@avalabs/core-chains-sdk'
+import { useMemo } from 'react'
+import { useSelector } from 'react-redux'
+import {
+  MAIN_MERGED_NETWORKS,
+  TEST_MERGED_NETWORKS
+} from 'services/network/consts'
+import { selectIsDeveloperMode } from 'store/settings/advanced'
+
+/**
+ * Hook to get the merged networks (networks are merged together with same address)
+ * based on the developer mode.
+ * @returns {Object} An object containing the networks.
+ */
+export function useMergedNetworks(): {
+  networks: Network[]
+} {
+  const isDeveloperMode = useSelector(selectIsDeveloperMode)
+
+  const networks = useMemo(() => {
+    if (isDeveloperMode) return TEST_MERGED_NETWORKS as Network[]
+    return MAIN_MERGED_NETWORKS as Network[]
+  }, [isDeveloperMode])
+
+  return { networks }
+}

--- a/packages/core-mobile/app/new/common/hooks/usePrimaryNetworks.ts
+++ b/packages/core-mobile/app/new/common/hooks/usePrimaryNetworks.ts
@@ -2,17 +2,27 @@ import { Network } from '@avalabs/core-chains-sdk'
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { MAIN_NETWORKS, TEST_NETWORKS } from 'services/network/consts'
+import { getEthereumNetwork } from 'services/network/utils/providerUtils'
+import { selectNetworks } from 'store/network'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 
+/**
+ * Hook to get the primary networks based on the developer mode.
+ * @returns {Object} An object containing the networks.
+ */
 export function usePrimaryNetworks(): {
   networks: Network[]
 } {
+  const allNetworks = useSelector(selectNetworks)
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
+  const ethereumNetwork = getEthereumNetwork(allNetworks, isDeveloperMode)
 
   const networks = useMemo(() => {
-    if (isDeveloperMode) return TEST_NETWORKS as Network[]
-    return MAIN_NETWORKS as Network[]
-  }, [isDeveloperMode])
+    if (isDeveloperMode) {
+      return [...TEST_NETWORKS, ethereumNetwork] as Network[]
+    }
+    return [...MAIN_NETWORKS, ethereumNetwork] as Network[]
+  }, [ethereumNetwork, isDeveloperMode])
 
   return { networks }
 }

--- a/packages/core-mobile/app/new/features/accountSettings/components/ContactForm.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/components/ContactForm.tsx
@@ -8,7 +8,7 @@ import {
   View
 } from '@avalabs/k2-alpine'
 import { NetworkVMType } from '@avalabs/vm-module-types'
-import { usePrimaryNetworks } from 'common/hooks/usePrimaryNetworks'
+import { useMergedNetworks } from 'common/hooks/useMergedNetworks'
 import {
   dismissAlertWithTextInput,
   showAlertWithTextInput
@@ -38,7 +38,7 @@ export const ContactForm = ({
   onUpdate: (contact: Contact) => void
   onSelectAvatar: () => void
 }): React.JSX.Element => {
-  const { networks } = usePrimaryNetworks()
+  const { networks } = useMergedNetworks()
 
   const avatar = useMemo(() => {
     return loadAvatar(contact.avatar)

--- a/packages/core-mobile/app/new/features/accountSettings/components/accountAddresses.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/components/accountAddresses.tsx
@@ -10,11 +10,11 @@ import {
 import { Account } from 'store/account'
 import { copyToClipboard } from 'common/utils/clipboard'
 import { truncateAddress } from '@avalabs/core-utils-sdk'
-import { usePrimaryNetworks } from 'common/hooks/usePrimaryNetworks'
 import { NetworkLogoWithChain } from 'common/components/NetworkLogoWithChain'
 import { isXPChain } from 'utils/network/isAvalancheNetwork'
 import { NetworkVMType } from '@avalabs/vm-module-types'
 import { TRUNCATE_ADDRESS_LENGTH } from 'common/consts/text'
+import { useMergedNetworks } from 'common/hooks/useMergedNetworks'
 
 export const AccountAddresses = ({
   account
@@ -24,7 +24,7 @@ export const AccountAddresses = ({
   const {
     theme: { colors }
   } = useTheme()
-  const { networks } = usePrimaryNetworks()
+  const { networks } = useMergedNetworks()
 
   const onCopyAddress = (value: string, message: string): void => {
     copyToClipboard(value, message)

--- a/packages/core-mobile/app/new/features/receive/screens/ReceiveScreen.tsx
+++ b/packages/core-mobile/app/new/features/receive/screens/ReceiveScreen.tsx
@@ -1,8 +1,7 @@
 import { NetworkVMType } from '@avalabs/core-chains-sdk'
 import { Icons, Text, TouchableOpacity, useTheme } from '@avalabs/k2-alpine'
 import { ScrollScreen } from 'common/components/ScrollScreen'
-import { TokenLogo } from 'common/components/TokenLogo'
-import { usePrimaryNetworks } from 'common/hooks/usePrimaryNetworks'
+import { useMergedNetworks } from 'common/hooks/useMergedNetworks'
 import { router } from 'expo-router'
 import React, { ReactNode, useCallback, useEffect, useMemo } from 'react'
 import { View } from 'react-native'
@@ -10,13 +9,14 @@ import { useSelector } from 'react-redux'
 import AnalyticsService from 'services/analytics/AnalyticsService'
 import { selectActiveAccount } from 'store/account'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
+import { TokenLogo } from 'common/components/TokenLogo'
 import { AccountAddresses } from '../components/AccountAddresses'
 import { QRCode } from '../components/QRCode'
 import { useReceiveSelectedNetwork } from '../store'
 
 export const ReceiveScreen = (): ReactNode => {
   const { theme } = useTheme()
-  const { networks } = usePrimaryNetworks()
+  const { networks } = useMergedNetworks()
 
   const [selectedNetwork, setSelectedNetwork] = useReceiveSelectedNetwork()
 

--- a/packages/core-mobile/app/new/features/receive/screens/SelectReceiveNetworkScreen.tsx
+++ b/packages/core-mobile/app/new/features/receive/screens/SelectReceiveNetworkScreen.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { SelectNetworkScreen } from 'common/screens/SelectNetworkScreen'
-import { usePrimaryNetworks } from 'common/hooks/usePrimaryNetworks'
+import { useMergedNetworks } from 'common/hooks/useMergedNetworks'
 import { useReceiveSelectedNetwork } from '../store'
 
 export const SelectReceiveNetworkScreen = (): JSX.Element => {
-  const { networks } = usePrimaryNetworks()
+  const { networks } = useMergedNetworks()
   const [selectedNetwork, setSelectedNetwork] = useReceiveSelectedNetwork()
 
   return (

--- a/packages/core-mobile/app/services/network/consts.ts
+++ b/packages/core-mobile/app/services/network/consts.ts
@@ -15,6 +15,8 @@ export enum ChainName {
   AVALANCHE_X_TESTNET = 'Avalanche X-Chain Testnet',
   AVALANCHE_P_TESTNET = 'Avalanche P-Chain Testnet',
   AVALANCHE_XP_TESTNET = 'Avalanche X/P-Chain Testnet',
+  AVALANCHE_C = 'Avalanche C-Chain',
+  AVALANCHE_C_TESTNET = 'Avalanche C-Chain Testnet',
   AVALANCHE_C_EVM = 'Avalanche C-Chain/EVM',
   AVALANCHE_C_EVM_TESTNET = 'Avalanche C-Chain/EVM Testnet',
   BITCOIN = 'Bitcoin',
@@ -23,7 +25,7 @@ export enum ChainName {
 
 export const AVALANCHE_MAINNET_NETWORK = {
   chainId: ChainId.AVALANCHE_MAINNET_ID,
-  chainName: ChainName.AVALANCHE_C_EVM,
+  chainName: ChainName.AVALANCHE_C,
   isTestnet: false,
   logoUri:
     'https://images.ctfassets.net/gcj8jwzm6086/5VHupNKwnDYJvqMENeV7iJ/3e4b8ff10b69bfa31e70080a4b142cd0/avalanche-avax-logo.svg',
@@ -38,7 +40,7 @@ export const AVALANCHE_MAINNET_NETWORK = {
 
 export const AVALANCHE_TESTNET_NETWORK = {
   chainId: ChainId.AVALANCHE_TESTNET_ID,
-  chainName: ChainName.AVALANCHE_C_EVM_TESTNET,
+  chainName: ChainName.AVALANCHE_C_TESTNET,
   isTestnet: true,
   logoUri:
     'https://images.ctfassets.net/gcj8jwzm6086/5VHupNKwnDYJvqMENeV7iJ/3e4b8ff10b69bfa31e70080a4b142cd0/avalanche-avax-logo.svg',
@@ -102,17 +104,34 @@ export const NETWORK_X_TEST = {
   explorerUrl: 'https://subnets-test.avax.network/x-chain'
 } as Network
 
+export const MAIN_MERGED_NETWORKS = [
+  { ...AVALANCHE_MAINNET_NETWORK, chainName: ChainName.AVALANCHE_C_EVM },
+  { ...AVALANCHE_XP_NETWORK, chainName: ChainName.AVALANCHE_XP },
+  { ...BITCOIN_NETWORK, chainName: ChainName.BITCOIN }
+]
+
+export const TEST_MERGED_NETWORKS = [
+  {
+    ...AVALANCHE_TESTNET_NETWORK,
+    chainName: ChainName.AVALANCHE_C_EVM_TESTNET
+  },
+  {
+    ...AVALANCHE_XP_TEST_NETWORK,
+    chainName: ChainName.AVALANCHE_XP_TESTNET
+  },
+  { ...BITCOIN_TEST_NETWORK, chainName: ChainName.BITCOIN_TESTNET }
+]
+
 export const MAIN_NETWORKS = [
   AVALANCHE_MAINNET_NETWORK,
-  { ...AVALANCHE_XP_NETWORK, chainName: ChainName.AVALANCHE_XP },
+  NETWORK_P,
+  NETWORK_X,
   { ...BITCOIN_NETWORK, chainName: ChainName.BITCOIN }
 ]
 
 export const TEST_NETWORKS = [
   AVALANCHE_TESTNET_NETWORK,
-  {
-    ...AVALANCHE_XP_TEST_NETWORK,
-    chainName: ChainName.AVALANCHE_XP_TESTNET
-  },
+  NETWORK_P_TEST,
+  NETWORK_X_TEST,
   { ...BITCOIN_TEST_NETWORK, chainName: ChainName.BITCOIN_TESTNET }
 ]


### PR DESCRIPTION
## Description

**Ticket: [CP-10719]** 

- only enable send for primary networks
- rename usePrimaryNetworks to useMergedNetworks for places we show merged row for network with same address
- usePrimaryNetworks includes C/X/P chains, Ethereum and Bitcoin

## Screenshots/Videos



## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
