### PR TITLE
[NFT] Android - Add gap between the nft preview and send/hide buttons

### DIFF
--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsFooter.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleDetailsFooter.tsx
@@ -35,7 +35,8 @@ export const CollectibleDetailsFooter = ({
         style={{
           gap: 10,
           padding: HORIZONTAL_MARGIN,
-          paddingBottom: insets.bottom + HORIZONTAL_MARGIN
+          paddingTop: 0,
+          paddingBottom: insets.bottom + HORIZONTAL_MARGIN / 2
         }}>
         {collectible?.networkChainId &&
         isAvalancheCChainId(collectible?.networkChainId) ? (

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/screens/CollectibleDetailsScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/screens/CollectibleDetailsScreen.tsx
@@ -90,10 +90,11 @@ export const CollectibleDetailsScreen = ({
   const bounceValue = useSharedValue(0)
   const scrollViewRef = useRef<Animated.ScrollView>(null)
 
-  const scrollViewHandler = useAnimatedScrollHandler(event => {
+  const onScroll = useAnimatedScrollHandler(event => {
     'worklet'
     scrollY.value = event.contentOffset.y
   })
+
   const onScrollEndDrag = useCallback((): void => {
     'worklet'
     if (scrollY.value > SNAP_DISTANCE / 2) {
@@ -314,7 +315,7 @@ export const CollectibleDetailsScreen = ({
       {collectible ? (
         <Animated.ScrollView
           ref={scrollViewRef}
-          onScroll={scrollViewHandler}
+          onScroll={onScroll}
           style={{
             flex: 1,
             position: 'relative'

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/screens/CollectibleDetailsScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/screens/CollectibleDetailsScreen.tsx
@@ -18,6 +18,7 @@ import React, {
   useRef,
   useState
 } from 'react'
+import { Platform } from 'react-native'
 import { Pressable } from 'react-native-gesture-handler'
 import Animated, {
   Extrapolation,
@@ -45,7 +46,6 @@ import {
   CollectibleFilterAndSortInitialState,
   useCollectiblesFilterAndSort
 } from '../hooks/useCollectiblesFilterAndSort'
-import { Platform } from 'react-native'
 
 type CollectibleDetailsScreenRouteParams = {
   localId?: string

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/screens/CollectibleDetailsScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/screens/CollectibleDetailsScreen.tsx
@@ -94,6 +94,16 @@ export const CollectibleDetailsScreen = ({
     'worklet'
     scrollY.value = event.contentOffset.y
   })
+  const onScrollEndDrag = useCallback((): void => {
+    'worklet'
+    if (scrollY.value > SNAP_DISTANCE / 2) {
+      scrollViewRef.current?.scrollToEnd()
+    } else {
+      scrollViewRef.current?.scrollTo({
+        y: 0
+      })
+    }
+  }, [scrollY])
 
   const onSeeMore = (): void => {
     'worklet'
@@ -313,6 +323,7 @@ export const CollectibleDetailsScreen = ({
             paddingBottom: insets.bottom,
             minHeight: SCREEN_HEIGHT + SNAP_DISTANCE
           }}
+          onScrollEndDrag={onScrollEndDrag}
           nestedScrollEnabled
           bounces={false}
           showsVerticalScrollIndicator={false}

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/screens/CollectibleDetailsScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/screens/CollectibleDetailsScreen.tsx
@@ -1,4 +1,10 @@
-import { ANIMATED, Icons, useTheme, View } from '@avalabs/k2-alpine'
+import {
+  ANIMATED,
+  Icons,
+  SCREEN_HEIGHT,
+  useTheme,
+  View
+} from '@avalabs/k2-alpine'
 import { useHeaderHeight } from '@react-navigation/elements'
 import { useNavigation } from '@react-navigation/native'
 import { ErrorState } from 'common/components/ErrorState'
@@ -22,10 +28,7 @@ import Animated, {
   withSequence,
   withTiming
 } from 'react-native-reanimated'
-import {
-  useSafeAreaFrame,
-  useSafeAreaInsets
-} from 'react-native-safe-area-context'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
 import { isCollectibleVisible } from 'store/nft/utils'
 import {
@@ -42,6 +45,7 @@ import {
   CollectibleFilterAndSortInitialState,
   useCollectiblesFilterAndSort
 } from '../hooks/useCollectiblesFilterAndSort'
+import { Platform } from 'react-native'
 
 type CollectibleDetailsScreenRouteParams = {
   localId?: string
@@ -59,7 +63,6 @@ export const CollectibleDetailsScreen = ({
   const navigation = useNavigation()
   const insets = useSafeAreaInsets()
   const headerHeight = useHeaderHeight()
-  const frame = useSafeAreaFrame()
 
   const { filteredAndSorted, isHiddenVisible } =
     useCollectiblesFilterAndSort(initial)
@@ -201,12 +204,7 @@ export const CollectibleDetailsScreen = ({
 
   useEffect(() => {
     navigation.setOptions({
-      headerRight,
-      headerTransparent: true,
-      headerStyle: {
-        elevation: 0,
-        shadowOpacity: 0
-      }
+      headerRight
     })
   }, [navigation, currentIndex, filteredAndSorted, headerRight])
 
@@ -217,7 +215,7 @@ export const CollectibleDetailsScreen = ({
   const renderEmpty = useMemo((): ReactNode => {
     return (
       <ErrorState
-        sx={{ height: frame.height - headerHeight, paddingTop: headerHeight }}
+        sx={{ height: SCREEN_HEIGHT - headerHeight, paddingTop: headerHeight }}
         title={`Oops\nThis collectible could not be loaded`}
         description="Please hit refresh or try again later"
         button={{
@@ -226,20 +224,20 @@ export const CollectibleDetailsScreen = ({
         }}
       />
     )
-  }, [frame.height, headerHeight, onBack])
+  }, [headerHeight, onBack])
 
   const heroStyle = useAnimatedStyle(() => {
     const translateY = interpolate(
       scrollY.value,
       [0, SNAP_DISTANCE],
-      [0, headerHeight + 70],
+      [0, headerHeight + 80],
       Extrapolation.CLAMP
     )
 
     const height = interpolate(
       scrollY.value,
       [0, SNAP_DISTANCE],
-      [frame.height, CARD_SIZE_SMALL],
+      [SCREEN_HEIGHT, CARD_SIZE_SMALL],
       Extrapolation.CLAMP
     )
 
@@ -257,15 +255,15 @@ export const CollectibleDetailsScreen = ({
     const translateY = interpolate(
       scrollY.value,
       [0, SNAP_DISTANCE],
-      [0, -frame.height + headerHeight + SNAP_DISTANCE * 2],
+      [0, -SCREEN_HEIGHT + headerHeight + SNAP_DISTANCE * 2],
       Extrapolation.CLAMP
     )
 
     return {
-      top: frame.height,
+      top: SCREEN_HEIGHT,
       left: 0,
       right: 0,
-      height: frame.height - headerHeight - SNAP_DISTANCE,
+      height: SCREEN_HEIGHT - headerHeight - SNAP_DISTANCE,
       transform: [
         {
           translateY
@@ -297,7 +295,12 @@ export const CollectibleDetailsScreen = ({
   })
 
   return (
-    <View style={{ flex: 1 }}>
+    <View
+      style={{
+        flex: 1,
+        // Android needs to have a negative margin to account for the status bar
+        marginTop: Platform.OS === 'ios' ? 0 : -insets.top
+      }}>
       {collectible ? (
         <Animated.ScrollView
           ref={scrollViewRef}
@@ -308,7 +311,7 @@ export const CollectibleDetailsScreen = ({
           }}
           contentContainerStyle={{
             paddingBottom: insets.bottom,
-            minHeight: frame.height + SNAP_DISTANCE
+            minHeight: SCREEN_HEIGHT + SNAP_DISTANCE
           }}
           nestedScrollEnabled
           bounces={false}


### PR DESCRIPTION
## Description

**Ticket: [CP-10564]** 

Fixes
- Replaced frame.insets with SCREEN_HEIGHT and adjusted position.
- Added snapping when scrolling when user ends gesture


To note:
There are positioning inconsistencies between Android and iOS. 
- Android moves the screen's view under the status bar and pushes the calculations by 24px whenever we're using headerHeight
- iOS works perfectly


## Testing


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
