### PR TITLE
CP-10763 Unable to move forward from name your wallet screen

### DIFF
--- a/packages/core-mobile/app/new/features/onboarding/components/SetWalletName.tsx
+++ b/packages/core-mobile/app/new/features/onboarding/components/SetWalletName.tsx
@@ -27,6 +27,7 @@ export const SetWalletName = ({
   return (
     <ScrollScreen
       shouldAvoidKeyboard
+      disableStickyFooter
       showNavigationHeaderTitle={false}
       title="Add a name for your wallet"
       renderFooter={renderFooter}


### PR DESCRIPTION
## Description

**Ticket: [CP-10763]** 

Disable sticky footer on setWalletName

## Testing


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10763]: https://ava-labs.atlassian.net/browse/CP-10763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ