### PR TITLE
Fix: app crashes when hitting percentage buttons on staking flow

### DIFF
--- a/packages/k2-alpine/src/components/TokenUnitInput/TokenUnitInputWidget.tsx
+++ b/packages/k2-alpine/src/components/TokenUnitInput/TokenUnitInputWidget.tsx
@@ -62,7 +62,7 @@ export const TokenUnitInputWidget = ({
 
     onChange?.(
       new TokenUnit(
-        Number(value.toDisplay()) * 10 ** token.maxDecimals,
+        Number(value.toDisplay({ asNumber: true })) * 10 ** token.maxDecimals,
         token.maxDecimals,
         token.symbol
       )


### PR DESCRIPTION
## Description

* This fixes the crash when hitting percentage buttons on staking flow, when the resulting amount is greater than 1000