### PR TITLE
CP-10860: Remove x/p address prefix

### DIFF
--- a/packages/core-mobile/app/new/features/send/components/SendToken.tsx
+++ b/packages/core-mobile/app/new/features/send/components/SendToken.tsx
@@ -25,6 +25,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { selectSelectedCurrency } from 'store/settings/currency'
 import { TRUNCATE_ADDRESS_LENGTH } from 'common/consts/text'
+import { xpAddressWithoutPrefix } from 'common/utils/xpAddressWIthoutPrefix'
 import { useSendContext } from '../context/sendContext'
 import { useSendSelectedToken } from '../store'
 
@@ -97,6 +98,20 @@ export const SendToken = ({ onSend }: { onSend: () => void }): JSX.Element => {
       selectedToken?.symbol ?? ''
     )
   }, [network.networkToken.decimals, selectedToken])
+
+  const addressToSendWithoutPrefix = useMemo(() => {
+    if (selectedToken === undefined) {
+      return undefined
+    }
+    if (
+      addressToSend &&
+      (isTokenWithBalancePVM(selectedToken) ||
+        isTokenWithBalanceAVM(selectedToken))
+    ) {
+      return xpAddressWithoutPrefix(addressToSend)
+    }
+    return addressToSend
+  }, [addressToSend, selectedToken])
 
   const canSubmit =
     !isSending &&
@@ -201,7 +216,7 @@ export const SendToken = ({ onSend }: { onSend: () => void }): JSX.Element => {
                 {recipient.name}
               </Text>
             )}
-            {addressToSend && (
+            {addressToSendWithoutPrefix && (
               <Text
                 variant="mono"
                 numberOfLines={1}
@@ -209,7 +224,10 @@ export const SendToken = ({ onSend }: { onSend: () => void }): JSX.Element => {
                   fontSize: 13,
                   color: colors.$textSecondary
                 }}>
-                {truncateAddress(addressToSend, TRUNCATE_ADDRESS_LENGTH)}
+                {truncateAddress(
+                  addressToSendWithoutPrefix,
+                  TRUNCATE_ADDRESS_LENGTH
+                )}
               </Text>
             )}
           </View>


### PR DESCRIPTION
## Description

**Ticket: [CP-10860]** 

- in the old app, xp address can be saved to contact with P- or X- prefix.  this should be removed since we merge these two fields and show address without prefix.

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10860]: https://ava-labs.atlassian.net/browse/CP-10860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ