### PR TITLE
CP-10878: use channel name instead of subtitle for notification body

### DIFF
--- a/packages/core-mobile/app/services/notifications/NotificationsService.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationsService.ts
@@ -138,7 +138,7 @@ class NotificationsService {
       {
         id: txHash, // use to look up if the stake notification already exists
         title: channel.title,
-        body: channel.subtitle,
+        body: channel.name,
         data: {
           url: STAKE_COMPELETE_DEEPLINK_URL,
           isDeveloperMode: isDeveloperMode.toString(),


### PR DESCRIPTION
## Description

**Ticket: [CP-10878]** 

we adjusted the subtitle from "Stake Complete" to "Stake complete alerts" so that we could display it in Notification Preferences screen. however we were still using subtitle in the notification, which causes the bug. this pr adjusts it to use the channel name instead.


## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10878]: https://ava-labs.atlassian.net/browse/CP-10878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ