### PR TITLE
CP-10881: Fix unable to view token detail via price alert push notification 

### DIFF
--- a/packages/core-mobile/app/contexts/DeeplinkContext/utils/handleDeeplink.ts
+++ b/packages/core-mobile/app/contexts/DeeplinkContext/utils/handleDeeplink.ts
@@ -8,6 +8,7 @@ import { showSnackbar } from 'new/common/utils/toast'
 import { router } from 'expo-router'
 import { History } from 'store/browser'
 import { navigateFromDeeplinkUrl } from 'utils/navigateFromDeeplink'
+import { MarketType } from 'store/watchlist'
 import { ACTIONS, DeepLink, PROTOCOLS } from '../types'
 
 export const handleDeeplink = ({
@@ -66,7 +67,9 @@ export const handleDeeplink = ({
         navigateFromDeeplinkUrl('/claimStakeReward')
       } else if (action === ACTIONS.WatchList) {
         const coingeckoId = pathname.split('/')[1]
-        navigateFromDeeplinkUrl(`/trackTokenDetail?tokenId=${coingeckoId}`)
+        navigateFromDeeplinkUrl(
+          `/trackTokenDetail?tokenId=${coingeckoId}&marketType=${MarketType.SEARCH}`
+        )
       } else {
         const path = deeplink.url.split(':/')[1]
         path && navigateFromDeeplinkUrl(path)

--- a/packages/core-mobile/app/new/common/screens/SelectNetworkScreen.tsx
+++ b/packages/core-mobile/app/new/common/screens/SelectNetworkScreen.tsx
@@ -13,11 +13,13 @@ import { isPChain, isXChain, isXPChain } from 'utils/network/isAvalancheNetwork'
 export const SelectNetworkScreen = ({
   networks,
   selected,
-  onSelect
+  onSelect,
+  isReceiveScreen = false
 }: {
   networks: Network[]
   selected?: Network
   onSelect: (network: Network) => void
+  isReceiveScreen?: boolean
 }): JSX.Element => {
   const { theme } = useTheme()
   const { back } = useRouter()
@@ -70,7 +72,7 @@ export const SelectNetworkScreen = ({
               variant="buttonMedium">
               {item.chainName}
             </Text>
-            {isAvalancheCChain && (
+            {isAvalancheCChain && isReceiveScreen && (
               <View
                 sx={{
                   flex: 1,

--- a/packages/core-mobile/app/new/features/bridge/screens/SelectBridgeTokenScreen.tsx
+++ b/packages/core-mobile/app/new/features/bridge/screens/SelectBridgeTokenScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react'
 import {
   Icons,
+  SCREEN_WIDTH,
   Separator,
   Text,
   TouchableOpacity,
@@ -94,7 +95,12 @@ export const SelectBridgeTokenScreen = (): JSX.Element => {
               />
             )}
             <View>
-              <Text variant="buttonMedium">{item.asset.name}</Text>
+              <Text
+                variant="buttonMedium"
+                numberOfLines={1}
+                sx={{ width: SCREEN_WIDTH * 0.65 }}>
+                {item.asset.name}
+              </Text>
               <Text variant="subtitle2">
                 {item.balance !== undefined
                   ? formatTokenAmount(

--- a/packages/core-mobile/app/new/features/receive/screens/SelectReceiveNetworkScreen.tsx
+++ b/packages/core-mobile/app/new/features/receive/screens/SelectReceiveNetworkScreen.tsx
@@ -12,6 +12,7 @@ export const SelectReceiveNetworkScreen = (): JSX.Element => {
       networks={networks}
       selected={selectedNetwork}
       onSelect={setSelectedNetwork}
+      isReceiveScreen
     />
   )
 }

--- a/packages/core-mobile/app/new/features/send/screens/SelectSendTokenScreen.tsx
+++ b/packages/core-mobile/app/new/features/send/screens/SelectSendTokenScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react'
 import {
   Icons,
+  SCREEN_WIDTH,
   Separator,
   Text,
   TouchableOpacity,
@@ -121,7 +122,12 @@ export const SelectSendTokenScreen = (): JSX.Element => {
               outerBorderColor={colors.$surfaceSecondary}
             />
             <View>
-              <Text variant="buttonMedium">{item.name}</Text>
+              <Text
+                variant="buttonMedium"
+                numberOfLines={1}
+                sx={{ width: SCREEN_WIDTH * 0.65 }}>
+                {item.name}
+              </Text>
               <Text variant="subtitle2">{balance + ' ' + item.symbol}</Text>
             </View>
           </View>

--- a/packages/core-mobile/app/new/features/swap/screens/SelectSwapTokenScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SelectSwapTokenScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react'
 import {
   Icons,
+  SCREEN_WIDTH,
   Separator,
   Text,
   TouchableOpacity,
@@ -81,7 +82,12 @@ export const SelectSwapTokenScreen = ({
               outerBorderColor={colors.$surfaceSecondary}
             />
             <View>
-              <Text variant="buttonMedium">{item.name}</Text>
+              <Text
+                variant="buttonMedium"
+                numberOfLines={1}
+                sx={{ width: SCREEN_WIDTH * 0.65 }}>
+                {item.name}
+              </Text>
               <Text variant="subtitle2">
                 {item.balanceDisplayValue} {item.symbol}
               </Text>

--- a/packages/core-mobile/app/new/features/track/utils/utils.ts
+++ b/packages/core-mobile/app/new/features/track/utils/utils.ts
@@ -17,7 +17,11 @@ export const isEffectivelyZero = (value: number): boolean => {
   return Math.abs(value) < zeroThreshold
 }
 
-export const getTokenAddress = (token: MarketToken): string | undefined => {
+export const getTokenAddress = (
+  token: MarketToken | undefined
+): string | undefined => {
+  if (!token) return undefined
+
   return 'platforms' in token
     ? token.platforms[SUPPORTED_PLATFORM_ID]
     : undefined


### PR DESCRIPTION
## Description

**Ticket: [CP-10881]** 

there are actually 2 issues that cause the infinite loading screen
1/ the track token details screen requires both a coingecko id and market type SEARCH to function correctly. we were passing only coingecko id from the deeplink
2/ we weren't handling undefined token in `getTokenAddress`, which makes `useTokenDetails` hook throw an error when it tries to calll `setTokenInfo`

this pr also fixes these issues:
- select token screen (in swap/send/bridge) doesn't handle long token name correctly
- select network screen in bridge shows "also supporting" evm networks

## Screenshots/Videos
https://github.com/user-attachments/assets/5f296108-35b2-4b43-940c-c1ade2751e8a

<img src="https://github.com/user-attachments/assets/45400c5b-8168-4240-98fe-7026d4505aa5" width=300/>

<img src="https://github.com/user-attachments/assets/9ebd0ce7-ad9d-4caf-9732-085a46a5bfdb" width=300/>


## Testing
please retest price alert push notification as well as checking all the select token/network screens

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10881]: https://ava-labs.atlassian.net/browse/CP-10881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ