### PR TITLE
CP-10897: Deduplicate tokens in select a token screen 

### DIFF
--- a/packages/core-mobile/app/new/common/hooks/useSearchableTokenList.ts
+++ b/packages/core-mobile/app/new/common/hooks/useSearchableTokenList.ts
@@ -105,10 +105,11 @@ export function useSearchableTokenList({
   const mergedTokens = useMemo(() => {
     const tokensWithBalanceIDs: Record<LocalTokenId, boolean> = {}
     tokensWithBalance.forEach(token => {
-      tokensWithBalanceIDs[token.localId] = true
+      tokensWithBalanceIDs[token.localId.toLowerCase()] = true
     })
+
     const remainingNetworkTokens = allNetworkTokens.filter(
-      token => !tokensWithBalanceIDs[token.localId]
+      token => !tokensWithBalanceIDs[token.localId.toLowerCase()]
     )
     return [...tokensWithBalance, ...remainingNetworkTokens]
   }, [allNetworkTokens, tokensWithBalance])


### PR DESCRIPTION
## Description

**Ticket: [CP-10897]** 

the merging of Glacier tokens with https://proxy-api.avax.network/tokens?evmChainId=43114 wasn't working because the addresses have different casing. this PR fixes it by converting all addresses to lowercase.

```
tokensWithBalanceIDs {
  "avalancheavax": true,
  "0x0c7d9adcd4bab7783a477c76f9492da0e1ce00ca": true,
  "0x152b9d0fdc40c096757f570a51e494bd4b943e50": true,
  "0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab": true,
  "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7": true,
  "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e": true,
  "avax-p": true,
  "bitcoinbtc": true,
  "etheth": true,
 ...
 }
```



## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10897]: https://ava-labs.atlassian.net/browse/CP-10897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ