### PR TITLE
CP-10911: show manually entered address by default in send flow

### DIFF
--- a/packages/core-mobile/app/new/features/send/components/SendToken.tsx
+++ b/packages/core-mobile/app/new/features/send/components/SendToken.tsx
@@ -100,10 +100,11 @@ export const SendToken = ({ onSend }: { onSend: () => void }): JSX.Element => {
   }, [network.networkToken.decimals, selectedToken])
 
   const addressToSendWithoutPrefix = useMemo(() => {
-    if (selectedToken === undefined) {
+    if (selectedToken === undefined && toAddress?.recipientType !== 'address') {
       return undefined
     }
     if (
+      selectedToken &&
       addressToSend &&
       (isTokenWithBalancePVM(selectedToken) ||
         isTokenWithBalanceAVM(selectedToken))
@@ -111,7 +112,7 @@ export const SendToken = ({ onSend }: { onSend: () => void }): JSX.Element => {
       return xpAddressWithoutPrefix(addressToSend)
     }
     return addressToSend
-  }, [addressToSend, selectedToken])
+  }, [addressToSend, selectedToken, toAddress?.recipientType])
 
   const canSubmit =
     !isSending &&


### PR DESCRIPTION
## Description

**Ticket: [CP-10911]** 

Please include a summary of the changes. Please also include relevant motivation and context. List any dependencies that are required for this change. If this is a breaking change, please also include steps to migrate.

## Screenshots/Videos

https://github.com/user-attachments/assets/5cc4cdbd-3645-4f0f-9af4-8950ee810993

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10911]: https://ava-labs.atlassian.net/browse/CP-10911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ