### PR TITLE
Fix Crash caused by solana dev-net const missing properties 

### DIFF
--- a/packages/core-mobile/app/services/network/consts.ts
+++ b/packages/core-mobile/app/services/network/consts.ts
@@ -127,10 +127,21 @@ export const NETWORK_SOLANA = {
 
 export const NETWORK_SOLANA_DEVNET = {
   chainId: ChainId.SOLANA_DEVNET_ID,
+  chainName: 'Solana Devnet',
   isTestnet: true,
   vmName: NetworkVMType.SVM,
   rpcUrl: 'https://api.devnet.solana.com',
-  wsUrl: 'wss://api.devnet.solana.com'
+  wsUrl: 'wss://api.devnet.solana.com',
+  networkToken: {
+    name: 'Solana',
+    symbol: 'SOL',
+    decimals: 9,
+    logoUri:
+      'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/solana/info/logo.png'
+  },
+  logoUri:
+    'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/solana/info/logo.png',
+  explorerUrl: 'https://explorer.solana.com/?cluster=devnet'
 } as Network
 
 // Primary networks are the ones that are always enabled in the app


### PR DESCRIPTION
## Description

**Ticket: []** 

Please include a summary of the changes. Please also include relevant motivation and context. List any dependencies that are required for this change. If this is a breaking change, please also include steps to migrate.

- Added missing properties to const var for solana dev net used in `useCombinedNetworks`
- This fixes a crash in the account screen when on test net with the `solana-support` feature flag enabled 

## Screenshots/Videos

https://github.com/user-attachments/assets/05712cd6-6fda-4e10-8f19-d98a21372615



## Testing


## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
