### PR TITLE
CP-10404 [Testnet] too slow to switch testnet and mainnet

### DIFF
--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/index.tsx
@@ -85,11 +85,13 @@ const AccountSettingsScreen = (): JSX.Element => {
   }, [navigate])
 
   const onTestnetChange = (value: boolean): void => {
+    showSnackbar('Testnet mode is now ' + (value ? 'on' : 'off'))
+
     AnalyticsService.capture(
       value ? 'DeveloperModeEnabled' : 'DeveloperModeDisabled'
     )
+
     dispatch(toggleDeveloperMode())
-    showSnackbar('Testnet mode is now ' + (value ? 'on' : 'off'))
   }
 
   const handlePressAboutItem = useCallback(


### PR DESCRIPTION
## Description

**Ticket: [CP-10404]** 

Moved the toast triggering before switching isDeveloperMode redux state

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10404]: https://ava-labs.atlassian.net/browse/CP-10404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ