### PR TITLE
CP-11104: Migrate stake complete notification to use accountId 

### DIFF
--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStake/confirm.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStake/confirm.tsx
@@ -235,14 +235,14 @@ const StakeConfirmScreen = (): JSX.Element => {
           {
             txHash,
             endTimestamp: getUnixTime(validatedStakingEndTime),
-            accountIndex: activeAccount?.index,
+            accountId: activeAccount?.id,
             isDeveloperMode
           }
         ])
       )
     },
     [
-      activeAccount?.index,
+      activeAccount?.id,
       dispatch,
       isDeveloperMode,
       validatedStakingEndTime,

--- a/packages/core-mobile/app/services/earn/EarnService.ts
+++ b/packages/core-mobile/app/services/earn/EarnService.ts
@@ -362,7 +362,7 @@ class EarnService {
     | {
         txHash: string
         endTimestamp: number | undefined
-        accountIndex: number
+        accountId: string | undefined
         isDeveloperMode: boolean
         isOnGoing: boolean
       }[]
@@ -403,10 +403,15 @@ class EarnService {
       return currentNetworkTransactions
         .concat(oppositeNetworkTransactions)
         .map(transaction => {
+          // find account that matches the transaction's index
+          const account = accountsArray.find(
+            acc => acc.index === transaction.index
+          )
+
           return {
             txHash: transaction.txHash,
             endTimestamp: transaction.endTimestamp,
-            accountIndex: Number(transaction.index),
+            accountId: account?.id,
             isDeveloperMode: transaction.isDeveloperMode,
             isOnGoing: isOnGoing(transaction, now)
           }

--- a/packages/core-mobile/app/services/earn/EarnService.ts
+++ b/packages/core-mobile/app/services/earn/EarnService.ts
@@ -362,7 +362,7 @@ class EarnService {
     | {
         txHash: string
         endTimestamp: number | undefined
-        accountId: string | undefined
+        accountId: string
         isDeveloperMode: boolean
         isOnGoing: boolean
       }[]
@@ -408,10 +408,14 @@ class EarnService {
             acc => acc.index === transaction.index
           )
 
+          if (!account) {
+            throw new Error('Account not found')
+          }
+
           return {
             txHash: transaction.txHash,
             endTimestamp: transaction.endTimestamp,
-            accountId: account?.id,
+            accountId: account.id,
             isDeveloperMode: transaction.isDeveloperMode,
             isOnGoing: isOnGoing(transaction, now)
           }

--- a/packages/core-mobile/app/services/earn/EarnService.ts
+++ b/packages/core-mobile/app/services/earn/EarnService.ts
@@ -402,15 +402,14 @@ class EarnService {
       const now = new Date()
       return currentNetworkTransactions
         .concat(oppositeNetworkTransactions)
-        .map(transaction => {
+        .flatMap(transaction => {
           // find account that matches the transaction's index
           const account = accountsArray.find(
             acc => acc.index === transaction.index
           )
 
-          if (!account) {
-            throw new Error('Account not found')
-          }
+          // flat map will remove this
+          if (!account) return []
 
           return {
             txHash: transaction.txHash,

--- a/packages/core-mobile/app/services/notifications/NotificationService.test.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationService.test.ts
@@ -7,7 +7,8 @@ describe('scheduleNotification', () => {
     const mockNotification = {
       txHash: 'testNodeId',
       timestamp: 123456789,
-      channelId: ChannelId.STAKING_COMPLETE
+      channelId: ChannelId.STAKING_COMPLETE,
+      accountId: '3824cbfb-6016-4731-a1dd-8e3a2b202d6f'
     }
     await NotificationsService.scheduleNotification(mockNotification)
     expect(notifee.createTriggerNotification).toHaveBeenCalled()
@@ -16,7 +17,8 @@ describe('scheduleNotification', () => {
     const mockNotification = {
       txHash: 'testNodeId',
       timestamp: 123456789,
-      channelId: 'testChannelId' as ChannelId
+      channelId: 'testChannelId' as ChannelId,
+      accountId: '3824cbfb-6016-4731-a1dd-8e3a2b202d6f'
     }
     await NotificationsService.scheduleNotification(mockNotification)
     expect(notifee.createTriggerNotification).not.toHaveBeenCalled()

--- a/packages/core-mobile/app/services/notifications/NotificationsService.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationsService.ts
@@ -111,13 +111,13 @@ class NotificationsService {
     txHash,
     timestamp: unixTimestamp,
     channelId,
-    accountIndex,
+    accountId,
     isDeveloperMode = false
   }: {
     txHash: string
     timestamp: number // unix timestamp in milliseconds
     channelId: ChannelId
-    accountIndex?: number
+    accountId: string
     isDeveloperMode?: boolean
   }): Promise<void> => {
     const timestamp = fromUnixTime(unixTimestamp).getTime()
@@ -142,7 +142,7 @@ class NotificationsService {
         data: {
           url: STAKE_COMPELETE_DEEPLINK_URL,
           isDeveloperMode: isDeveloperMode.toString(),
-          accountIndex: accountIndex ?? 0
+          accountId: accountId
         },
         ios: {
           badgeCount: 1
@@ -186,7 +186,7 @@ class NotificationsService {
             )
             await this.scheduleNotification({
               txHash: data.txHash,
-              accountIndex: data.accountIndex,
+              accountId: data.accountId ?? '',
               timestamp: data.endTimestamp,
               channelId: ChannelId.STAKING_COMPLETE,
               isDeveloperMode: data.isDeveloperMode

--- a/packages/core-mobile/app/store/notifications/listeners/handleProcessNotificationData.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/handleProcessNotificationData.ts
@@ -26,13 +26,16 @@ export const handleProcessNotificationData = async (
     }
   }
 
-  //maybe set account
-  if ('accountAddress' in data && typeof data.accountAddress === 'string') {
+  // prioritize new approach of using accountId over accountAddress
+  if ('accountId' in data && typeof data.accountId === 'string') {
+    dispatch(setActiveAccount(data.accountId))
+  } else if (
+    'accountAddress' in data &&
+    typeof data.accountAddress === 'string'
+  ) {
     const account = selectAccountByAddress(data.accountAddress)(state)
     if (account) {
       dispatch(setActiveAccount(account.id))
     }
-  } else if ('accountId' in data && typeof data.accountId === 'string') {
-    dispatch(setActiveAccount(data.accountId))
   }
 }

--- a/packages/core-mobile/app/store/notifications/types.ts
+++ b/packages/core-mobile/app/store/notifications/types.ts
@@ -9,6 +9,6 @@ export type StakeCompleteNotification = Pick<
   PChainTransaction,
   'endTimestamp' | 'txHash'
 > & {
-  accountIndex?: number
+  accountId?: string
   isDeveloperMode?: boolean
 }


### PR DESCRIPTION
## Description

**Ticket: [CP-11104](https://ava-labs.atlassian.net/browse/CP-11104)** 

Please include a summary of the changes. Please also include relevant motivation and context. List any dependencies that are required for this change. If this is a breaking change, please also include steps to migrate.

## Overview
This PR updates the stake complete notification system to use account IDs instead of account indices, making the account selection process more reliable and deterministic.

## Changes
- Modified `EarnService` to use account IDs instead of indices when tracking stake transactions
- Updated `NotificationsService` to handle account IDs in notification data
- Enhanced notification data processing to prioritize account ID over legacy account address
- Updated type definitions to reflect the account ID-based approach

## Screenshots/Videos
In my video i created a fake stake transaction and fed it into our notification service to confirm that we successfully change accounts and were grabbing stake data for the correct account 

https://github.com/user-attachments/assets/3ea714a0-f7ae-4000-87c2-68e2895cacaf


## Testing
- Manual Testing as seen above in the video 


## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11104]: https://ava-labs.atlassian.net/browse/CP-11104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ