### PR TITLE
CP-10837 Fail to fetch the full balance after the first login

### DIFF
--- a/packages/core-mobile/app/seedless/services/transformKeyInfosToPubkeys.ts
+++ b/packages/core-mobile/app/seedless/services/transformKeyInfosToPubkeys.ts
@@ -52,7 +52,9 @@ export const transformKeyInfosToPubKeys = (
 
   // We only look for key sets that contain all of the required key types.
   const validKeySets = allDerivedKeySets.filter(keySet => {
-    return keySet.every(key => requiredKeyTypes.every(type => key[type]))
+    return keySet
+      .filter(key => Boolean(key))
+      .every(key => requiredKeyTypes.every(type => key[type]))
   })
 
   if (!validKeySets[0]) {


### PR DESCRIPTION
## Description

**Ticket: [CP-10837]** 

On my seedless account there was null key sets on indexes 2 and 3 but existing key set on index 4. This made `transformKeyInfosToPubKeys` fail and thus never initialized Seedless wallet after onboarding.
This fixes it

## Screenshots/Videos

https://github.com/user-attachments/assets/e95e97e9-c703-4f58-9d76-3a2b8588ce89



## Testing


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10837]: https://ava-labs.atlassian.net/browse/CP-10837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ