### PR TITLE
CP-10837: Call refreshPublicKeys in the initAccounts listener

### DIFF
--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/manageAccounts.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/manageAccounts.tsx
@@ -18,7 +18,6 @@ import { HiddenBalanceText } from 'common/components/HiddenBalanceText'
 import NavigationBarButton from 'common/components/NavigationBarButton'
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import { TRUNCATE_ADDRESS_LENGTH } from 'common/consts/text'
-import { useActiveAccount } from 'common/hooks/useActiveAccount'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { useRouter } from 'expo-router'
@@ -26,6 +25,7 @@ import { useBalanceForAccount } from 'new/common/contexts/useBalanceForAccount'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Account, selectAccounts, setActiveAccount } from 'store/account'
+import { selectActiveAccount } from 'store/account'
 import { selectIsPrivacyModeEnabled } from 'store/settings/securityPrivacy'
 import { selectActiveWalletId, selectWallets } from 'store/wallet/slice'
 
@@ -41,7 +41,7 @@ const ManageAccountsScreen = (): React.JSX.Element => {
   const accountCollection = useSelector(selectAccounts)
   const allWallets = useSelector(selectWallets)
   const activeWalletId = useSelector(selectActiveWalletId)
-  const activeAccount = useActiveAccount()
+  const activeAccount = useSelector(selectActiveAccount)
 
   const [expandedWallets, setExpandedWallets] = useState<
     Record<string, boolean>
@@ -147,7 +147,7 @@ const ManageAccountsScreen = (): React.JSX.Element => {
             </Text>
           ),
           leftIcon:
-            account.id === activeAccount.id ? (
+            account.id === activeAccount?.id ? (
               <Icons.Custom.CheckSmall
                 color={colors.$textPrimary}
                 width={24}
@@ -159,7 +159,7 @@ const ManageAccountsScreen = (): React.JSX.Element => {
           value: (
             <AccountBalance
               accountId={account.id}
-              isActive={account.id === activeAccount.id}
+              isActive={account.id === activeAccount?.id}
             />
           ),
           onPress: () => handleSetActiveAccount(account.id),
@@ -188,7 +188,7 @@ const ManageAccountsScreen = (): React.JSX.Element => {
     searchText,
     colors.$textPrimary,
     colors.$textSecondary,
-    activeAccount.id,
+    activeAccount?.id,
     handleSetActiveAccount,
     gotoAccountDetails
   ])

--- a/packages/core-mobile/app/seedless/store/listeners.ts
+++ b/packages/core-mobile/app/seedless/store/listeners.ts
@@ -13,11 +13,7 @@ import { AppStartListening, AppListenerEffectAPI } from 'store/types'
 import { onTokenExpired } from 'seedless/store/slice'
 import { selectAccountById, setAccountTitle } from 'store/account/slice'
 import { router } from 'expo-router'
-import {
-  selectActiveWallet,
-  selectWalletById,
-  setActiveWallet
-} from 'store/wallet/slice'
+import { selectActiveWallet } from 'store/wallet/slice'
 import { SeedlessPubKeysStorage } from 'seedless/services/storage/SeedlessPubKeysStorage'
 
 const refreshSeedlessToken = async (
@@ -89,32 +85,6 @@ const signOutSocial = async (_: Action): Promise<void> => {
   await GoogleSigninService.signOut()
 }
 
-const handleActiveWalletChange = async (
-  action: ReturnType<typeof setActiveWallet>,
-  listenerApi: AppListenerEffectAPI
-): Promise<void> => {
-  const { getState } = listenerApi
-  const state = getState()
-  const activeWalletId = action.payload
-  const activeWallet = selectWalletById(activeWalletId)(state)
-
-  if (!activeWallet || activeWallet.type !== WalletType.SEEDLESS) {
-    Logger.trace('No Seedless wallet to initialize')
-    return
-  }
-
-  try {
-    Logger.trace('Initializing Seedless wallet after setActiveWallet')
-    const storedPubKeys = await SeedlessPubKeysStorage.retrieve()
-    if (storedPubKeys.length === 0) {
-      await SeedlessService.refreshPublicKeys()
-    }
-    Logger.trace('Seedless wallet initialized successfully')
-  } catch (error) {
-    Logger.error('Failed to initialize Seedless wallet', error)
-  }
-}
-
 export const addSeedlessListeners = (
   startListening: AppStartListening
 ): void => {
@@ -153,10 +123,5 @@ export const addSeedlessListeners = (
         listenerApi
       })
     }
-  })
-
-  startListening({
-    actionCreator: setActiveWallet,
-    effect: handleActiveWalletChange
   })
 }

--- a/packages/core-mobile/app/store/account/listeners.ts
+++ b/packages/core-mobile/app/store/account/listeners.ts
@@ -19,6 +19,7 @@ import BiometricsSDK from 'utils/BiometricsSDK'
 import WalletFactory from 'services/wallet/WalletFactory'
 import SeedlessWallet from 'seedless/services/wallet/SeedlessWallet'
 import { transactionSnackbar } from 'common/utils/toast'
+import Logger from 'utils/Logger'
 import {
   selectAccounts,
   setAccounts,
@@ -45,6 +46,17 @@ const initAccounts = async (
   const walletSecret = await BiometricsSDK.loadWalletSecret(activeWallet.id)
   if (!walletSecret.success) {
     throw new Error('Failed to load wallet secret')
+  }
+
+  if (activeWallet.type === WalletType.SEEDLESS) {
+    try {
+      await SeedlessService.refreshPublicKeys()
+    } catch (error) {
+      Logger.error(
+        'Failed to fetch and save public keys for Seedless wallet',
+        error
+      )
+    }
   }
 
   const acc = await accountService.createNextAccount({


### PR DESCRIPTION
## Description

**Ticket: [CP-10837]** 

* Fixed it to call `refreshPublicKeys` in the `initAccounts` listener to ensure the Seedless wallet has public keys before creating accounts. We don’t need to call `refreshPublicKeys` every time the active Seedless wallet changes, since we support only one Seedless wallet and its keys should already be available from storage.

[CP-10837]: https://ava-labs.atlassian.net/browse/CP-10837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ