### PR TITLE
CP-10839 - [Import key feature] Should not add "no accounts in this wallet" section if it's empty

### DIFF
--- a/packages/core-mobile/app/new/common/hooks/useDeriveAddresses.test.ts
+++ b/packages/core-mobile/app/new/common/hooks/useDeriveAddresses.test.ts
@@ -218,7 +218,7 @@ describe('useDeriveAddresses', () => {
 
       expect(result.current.derivedAddresses).toEqual([])
       expect(result.current.tempAccountDetails).toBeNull()
-      expect(result.current.showDerivedInfo).toBe(true) // Still true because privateKey is not empty
+      expect(result.current.showDerivedInfo).toBe(false)
     })
 
     it('should handle derivation errors gracefully', async () => {
@@ -246,7 +246,7 @@ describe('useDeriveAddresses', () => {
       )
       expect(result.current.derivedAddresses).toEqual([])
       expect(result.current.tempAccountDetails).toBeNull()
-      expect(result.current.showDerivedInfo).toBe(true)
+      expect(result.current.showDerivedInfo).toBe(false)
     })
   })
 

--- a/packages/core-mobile/app/new/common/hooks/useDeriveAddresses.ts
+++ b/packages/core-mobile/app/new/common/hooks/useDeriveAddresses.ts
@@ -78,17 +78,18 @@ export const useDeriveAddresses = (
           symbol: 'BTC'
         }
       ])
+      setShowDerivedInfo(true)
     } catch (error) {
       Logger.info('error deriving addresses:', error)
       setDerivedAddresses([])
       setTempAccountDetails(null)
+      setShowDerivedInfo(false)
     }
   }, [isTestnet, privateKey, accounts])
 
   useEffect(() => {
     if (privateKey.trim() !== '') {
       deriveAddresses()
-      setShowDerivedInfo(true)
     } else {
       setShowDerivedInfo(false)
       setDerivedAddresses([])

--- a/packages/core-mobile/app/new/common/hooks/usePrivateKeyImportHandler.ts
+++ b/packages/core-mobile/app/new/common/hooks/usePrivateKeyImportHandler.ts
@@ -9,13 +9,14 @@ export const usePrivateKeyImportHandler = (
   tempAccountDetails: ImportedAccount | null,
   privateKey: string
 ): {
+  isImporting: boolean
   handleImport: () => Promise<void>
   isCheckingMigration: boolean
 } => {
   const [isCheckingMigration, setIsCheckingMigration] = useState(false)
   const { navigate } = useRouter()
   const activeWallet = useActiveWallet()
-  const { importWallet } = useImportPrivateKey()
+  const { importWallet, isImporting } = useImportPrivateKey()
 
   const handleImport = useCallback(async (): Promise<void> => {
     if (!tempAccountDetails) return
@@ -41,6 +42,7 @@ export const usePrivateKeyImportHandler = (
 
   return {
     handleImport,
+    isImporting,
     isCheckingMigration
   }
 }

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/importPrivateKey.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/importPrivateKey.tsx
@@ -41,7 +41,8 @@ const ImportPrivateKeyScreen = (): JSX.Element => {
           privateKey.trim() === '' ||
           isAwaitingOurBalance ||
           isCheckingMigration ||
-          isImporting
+          isImporting ||
+          !showDerivedInfo
         }>
         {isImporting ? <ActivityIndicator size="small" /> : 'Import'}
       </Button>
@@ -51,7 +52,8 @@ const ImportPrivateKeyScreen = (): JSX.Element => {
     isAwaitingOurBalance,
     isCheckingMigration,
     isImporting,
-    privateKey
+    privateKey,
+    showDerivedInfo
   ])
 
   return (

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/importPrivateKey.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/importPrivateKey.tsx
@@ -11,7 +11,6 @@ import { TokenLogo } from 'common/components/TokenLogo'
 import { usePrivateKeyBalance } from 'common/hooks/usePrivateKeyBalance'
 import { SimpleTextInput } from 'new/common/components/SimpleTextInput'
 import { useDeriveAddresses } from 'new/common/hooks/useDeriveAddresses'
-import { useImportPrivateKey } from 'new/common/hooks/useImportPrivateKey'
 import { usePrivateKeyImportHandler } from 'new/common/hooks/usePrivateKeyImportHandler'
 import React, { useCallback, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -21,7 +20,6 @@ const ImportPrivateKeyScreen = (): JSX.Element => {
   const [privateKey, setPrivateKey] = useState('')
 
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
-  const { isImporting } = useImportPrivateKey()
 
   const { derivedAddresses, tempAccountDetails, showDerivedInfo } =
     useDeriveAddresses(privateKey, isDeveloperMode)
@@ -30,10 +28,8 @@ const ImportPrivateKeyScreen = (): JSX.Element => {
     usePrivateKeyBalance(tempAccountDetails)
 
   // Extract import handler logic
-  const { handleImport, isCheckingMigration } = usePrivateKeyImportHandler(
-    tempAccountDetails,
-    privateKey
-  )
+  const { handleImport, isImporting, isCheckingMigration } =
+    usePrivateKeyImportHandler(tempAccountDetails, privateKey)
 
   const renderFooter = useCallback(() => {
     return (
@@ -47,7 +43,7 @@ const ImportPrivateKeyScreen = (): JSX.Element => {
           isCheckingMigration ||
           isImporting
         }>
-        Import
+        {isImporting ? <ActivityIndicator size="small" /> : 'Import'}
       </Button>
     )
   }, [


### PR DESCRIPTION
## Description

**Ticket: [CP-10839]** 

- added spinner while importing
- display total Balance and derived addresses only when private key is valid
- disable button while private key is invalid
- disable button when isImporting is true


## Testing


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10839]: https://ava-labs.atlassian.net/browse/CP-10839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ