### PR TITLE
CP-11189: Implement Remove Seedless wallet public keys 

### DIFF
--- a/packages/core-mobile/app/new/features/accountSettings/components/AccountButtons.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/components/AccountButtons.tsx
@@ -115,17 +115,19 @@ export const AccountButtons = ({
         onPress={handleShowAlertWithTextInput}>
         Rename account
       </Button>
-      <Button
-        style={{ borderRadius: 12 }}
-        size="large"
-        textStyle={{
-          color: theme.colors.$textDanger
-        }}
-        type="secondary"
-        disabled={!isRemoveEnabled}
-        onPress={handleRemoveAccount}>
-        Remove account
-      </Button>
+      {walletType !== WalletType.SEEDLESS && (
+        <Button
+          style={{ borderRadius: 12 }}
+          size="large"
+          textStyle={{
+            color: theme.colors.$textDanger
+          }}
+          type="secondary"
+          disabled={!isRemoveEnabled}
+          onPress={handleRemoveAccount}>
+          Remove account
+        </Button>
+      )}
       {!isRemoveEnabled && (
         <Text variant="caption" sx={{ color: theme.colors.$textSecondary }}>
           Only the most recently added account may be removed

--- a/packages/core-mobile/app/seedless/services/storage/SeedlessPubKeysStorage.ts
+++ b/packages/core-mobile/app/seedless/services/storage/SeedlessPubKeysStorage.ts
@@ -30,6 +30,23 @@ export class SeedlessPubKeysStorage {
     return pubKeys
   }
 
+  static async removePublicKeysByIndex(accountIndex: number): Promise<void> {
+    const pubKeys = await this.retrieve()
+
+    // Filter out all public keys for this account index across all paths
+    const filteredKeys = pubKeys.filter(key => {
+      // Parse the derivation path to get the account index
+      const pathParts = key.derivationPath.split('/')
+      const lastPart = pathParts[pathParts.length - 1]
+      if (!lastPart) return true // Keep keys with invalid paths
+      const lastIndex = parseInt(lastPart, 10)
+      return lastIndex !== accountIndex
+    })
+
+    // Save the updated list
+    await this.save(filteredKeys)
+  }
+
   static clearCache(): void {
     this.cache = undefined
   }

--- a/packages/core-mobile/app/seedless/services/storage/SeedlessPubKeysStorage.ts
+++ b/packages/core-mobile/app/seedless/services/storage/SeedlessPubKeysStorage.ts
@@ -30,23 +30,6 @@ export class SeedlessPubKeysStorage {
     return pubKeys
   }
 
-  static async removePublicKeysByIndex(accountIndex: number): Promise<void> {
-    const pubKeys = await this.retrieve()
-
-    // Filter out all public keys for this account index across all paths
-    const filteredKeys = pubKeys.filter(key => {
-      // Parse the derivation path to get the account index
-      const pathParts = key.derivationPath.split('/')
-      const lastPart = pathParts[pathParts.length - 1]
-      if (!lastPart) return true // Keep keys with invalid paths
-      const lastIndex = parseInt(lastPart, 10)
-      return lastIndex !== accountIndex
-    })
-
-    // Save the updated list
-    await this.save(filteredKeys)
-  }
-
   static clearCache(): void {
     this.cache = undefined
   }

--- a/packages/core-mobile/app/store/account/thunks.ts
+++ b/packages/core-mobile/app/store/account/thunks.ts
@@ -8,6 +8,8 @@ import {
   selectWalletById,
   setActiveWallet
 } from 'store/wallet/slice'
+import { WalletType } from 'services/wallet/types'
+import { SeedlessPubKeysStorage } from 'seedless/services/storage/SeedlessPubKeysStorage'
 import {
   reducerName,
   selectAccountById,
@@ -72,6 +74,7 @@ export const removeAccountWithActiveCheck = createAsyncThunk<
     const state = thunkApi.getState()
     const accountToRemove = selectAccountById(accountId)(state)
     const activeAccount = selectActiveAccount(state)
+    const wallet = selectWalletById(accountToRemove?.walletId ?? '')(state)
 
     if (!accountToRemove) {
       throw new Error(`Account with ID "${accountId}" not found`)
@@ -97,6 +100,12 @@ export const removeAccountWithActiveCheck = createAsyncThunk<
       if (previousAccount) {
         thunkApi.dispatch(setActiveAccountId(previousAccount.id))
       }
+    }
+
+    if (wallet?.type === WalletType.SEEDLESS) {
+      await SeedlessPubKeysStorage.removePublicKeysByIndex(
+        accountToRemove.index
+      )
     }
 
     // Remove the account


### PR DESCRIPTION
…in account thunk

## Description

**Ticket: [CP-11189](https://ava-labs.atlassian.net/browse/CP-11189)** 

- Hid the `remove account` button on the account buttons if wallet type is `SEEDLESS`
- Added extra safe guard to `removeAccountWithActiveCheck` to prevent the deletion of `SEEDLESS` wallets 

## Screenshots/Videos


| Wallet Type | Delete Account Behavior |
|-------------|------------------------|
| Mnemonic Wallet | <video src="https://user-images.githubusercontent.com/14a8bf4a-3fbb-4d30-a895-629e99efaa71" controls></video> |
| Seedless Wallet | <video src="https://user-images.githubusercontent.com/339637d7-3ce9-46a3-b017-31da35f950d8" controls></video> |


## Testing
- Manually created a few accounts on a seedless wallet, viewed account details, proved you can no longer delete 
- Manually created a few accounts on a mnemonic wallet, viewed account details, proved you can still delete accounts 

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11189]: https://ava-labs.atlassian.net/browse/CP-11189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ