### PR TITLE
CP-11060 - Swap - Can't update slippage tolereance 

### DIFF
--- a/packages/core-mobile/app/errors/swapError.ts
+++ b/packages/core-mobile/app/errors/swapError.ts
@@ -12,6 +12,18 @@ enum SwapErrorCode {
   SWAP_TX_FAILED = 'SWAP_TX_FAILED'
 }
 
+export enum ParaswapErrorCode {
+  ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT = 'ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT',
+  INTERNAL_ERROR_WHILE_COMPUTING_PRICE = 'Internal Error while computing the price'
+}
+
+export const ParaswapError = {
+  [ParaswapErrorCode.ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT]:
+    'Slippage tolerance exceeded, increase the slippage and try again.',
+  [ParaswapErrorCode.INTERNAL_ERROR_WHILE_COMPUTING_PRICE]:
+    'An error occurred while computing the price'
+}
+
 type ObjWithError = { error: string }
 
 const isObjWithError = (error: unknown): error is ObjWithError =>
@@ -64,10 +76,14 @@ export const swapError = {
 
 export const humanizeParaswapRateError = (errorMsg: string): string => {
   switch (errorMsg) {
-    case 'ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT':
-      return 'Slippage tolerance exceeded, increase the slippage and try again.'
-    case 'Internal Error while computing the price':
-      return 'An error occurred while computing the price'
+    case ParaswapErrorCode.ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT:
+      return ParaswapError[
+        ParaswapErrorCode.ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT
+      ]
+    case ParaswapErrorCode.INTERNAL_ERROR_WHILE_COMPUTING_PRICE:
+      return ParaswapError[
+        ParaswapErrorCode.INTERNAL_ERROR_WHILE_COMPUTING_PRICE
+      ]
     default:
       return errorMsg
   }

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -235,17 +235,17 @@ export const SwapScreen = (): JSX.Element => {
   ])
 
   const showFeesAndSlippage = useMemo(() => {
-    return quote && isParaswapQuote(quote)
-  }, [quote])
+    return (quote && isParaswapQuote(quote)) || errorMessage.length
+  }, [errorMessage, quote])
 
   const handleSwap = useCallback(() => {
     AnalyticsService.capture('SwapReviewOrder', {
       destinationInputField: destination,
-      slippageTolerance: showFeesAndSlippage ? slippage : undefined
+      slippageTolerance: slippage
     })
 
     swap()
-  }, [swap, destination, slippage, showFeesAndSlippage])
+  }, [swap, destination, slippage])
 
   const handleFromAmountChange = useCallback(
     (amount: bigint): void => {
@@ -410,7 +410,7 @@ export const SwapScreen = (): JSX.Element => {
       })
     }
 
-    showFeesAndSlippage &&
+    if (showFeesAndSlippage) {
       items.push({
         title: 'Slippage tolerance',
         accessory: (
@@ -421,13 +421,14 @@ export const SwapScreen = (): JSX.Element => {
           />
         )
       })
+    }
 
     return items
   }, [
-    toToken,
     fromToken,
-    showFeesAndSlippage,
+    toToken,
     rate,
+    showFeesAndSlippage,
     slippage,
     setSlippage,
     swapInProcess

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -47,6 +47,7 @@ import {
   SwapType
 } from '../types'
 import { calculateRate as calculateEvmRate } from '../utils/evm/calculateRate'
+import { ParaswapError, ParaswapErrorCode } from 'errors/swapError'
 
 export const SwapScreen = (): JSX.Element => {
   const { theme } = useTheme()
@@ -235,8 +236,8 @@ export const SwapScreen = (): JSX.Element => {
   ])
 
   const showFeesAndSlippage = useMemo(() => {
-    return (quote && isParaswapQuote(quote)) || errorMessage.length
-  }, [errorMessage, quote])
+    return quote && isParaswapQuote(quote)
+  }, [quote])
 
   const handleSwap = useCallback(() => {
     AnalyticsService.capture('SwapReviewOrder', {
@@ -410,7 +411,12 @@ export const SwapScreen = (): JSX.Element => {
       })
     }
 
-    if (showFeesAndSlippage) {
+    if (
+      showFeesAndSlippage ||
+      // display slippage field if slippage tolerance is exceeded
+      errorMessage ===
+        ParaswapError[ParaswapErrorCode.ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT]
+    ) {
       items.push({
         title: 'Slippage tolerance',
         accessory: (
@@ -428,6 +434,7 @@ export const SwapScreen = (): JSX.Element => {
     fromToken,
     toToken,
     rate,
+    errorMessage,
     showFeesAndSlippage,
     slippage,
     setSlippage,

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -21,6 +21,7 @@ import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import { usePreventScreenRemoval } from 'common/hooks/usePreventScreenRemoval'
 import { useSwapList } from 'common/hooks/useSwapList'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
+import { ParaswapError, ParaswapErrorCode } from 'errors/swapError'
 import { useGlobalSearchParams, useRouter } from 'expo-router'
 import useCChainNetwork from 'hooks/earn/useCChainNetwork'
 import { useWatchlist } from 'hooks/watchlist/useWatchlist'
@@ -47,7 +48,6 @@ import {
   SwapType
 } from '../types'
 import { calculateRate as calculateEvmRate } from '../utils/evm/calculateRate'
-import { ParaswapError, ParaswapErrorCode } from 'errors/swapError'
 
 export const SwapScreen = (): JSX.Element => {
   const { theme } = useTheme()

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/manageAccounts.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/manageAccounts.tsx
@@ -89,12 +89,12 @@ const ManageAccountsScreen = (): React.JSX.Element => {
       return (
         walletName.includes(searchText.toLowerCase()) ||
         account.name.toLowerCase().includes(searchText.toLowerCase()) ||
-        account.addressC.toLowerCase().includes(searchText.toLowerCase()) ||
-        account.addressBTC.toLowerCase().includes(searchText.toLowerCase()) ||
-        account.addressAVM.toLowerCase().includes(searchText.toLowerCase()) ||
-        account.addressPVM.toLowerCase().includes(searchText.toLowerCase()) ||
-        account.addressSVM.toLowerCase().includes(searchText.toLowerCase()) ||
-        account.addressCoreEth.toLowerCase().includes(searchText.toLowerCase())
+        account.addressC?.toLowerCase().includes(searchText.toLowerCase()) ||
+        account.addressBTC?.toLowerCase().includes(searchText.toLowerCase()) ||
+        account.addressAVM?.toLowerCase().includes(searchText.toLowerCase()) ||
+        account.addressPVM?.toLowerCase().includes(searchText.toLowerCase()) ||
+        account.addressSVM?.toLowerCase().includes(searchText.toLowerCase()) ||
+        account.addressCoreEth?.toLowerCase().includes(searchText.toLowerCase())
       )
     })
   }, [allAccountsArray, allWallets, searchText])


### PR DESCRIPTION
## Description

**Ticket: [CP-11060]** 

- Display slippage field in case there is error
- small fix for manageAccounts searching 

![simulator_screenshot_BFF7F41D-F86F-45F6-A4B8-DAF29872D4F4](https://github.com/user-attachments/assets/85dd92f4-5604-4955-92a6-abde7a65ce3a)


Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11060]: https://ava-labs.atlassian.net/browse/CP-11060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ