### PR TITLE
CP-11118: Portfolio Event Tracking

### DIFF
--- a/packages/core-mobile/app/new/features/portfolio/assets/components/AssetsScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/AssetsScreen.tsx
@@ -30,6 +30,7 @@ import {
 } from 'store/balance'
 import { selectEnabledNetworks } from 'store/network'
 import { selectActiveAccount } from 'store/account'
+import AnalyticsService from 'services/analytics/AnalyticsService'
 import errorIcon from '../../../../assets/icons/rocket.png'
 import { useAssetsFilterAndSort } from '../hooks/useAssetsFilterAndSort'
 import { TokenListItem } from './TokenListItem'
@@ -67,6 +68,7 @@ const AssetsScreen: FC<Props> = ({
       const manageList =
         ASSET_MANAGE_VIEWS?.[indexPath.section]?.[indexPath.row]
       if (manageList === AssetManageView.ManageList) {
+        AnalyticsService.capture('PortfolioManageTokenListClicked')
         goToTokenManagement()
         return
       }

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/AssetsScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/AssetsScreen.tsx
@@ -37,7 +37,7 @@ import { TokenListItem } from './TokenListItem'
 
 interface Props {
   containerStyle: ViewStyle
-  goToTokenDetail: (localId: string, chainId: number) => void
+  goToTokenDetail: (token: LocalTokenWithBalance) => void
   goToTokenManagement: () => void
   goToBuy: () => void
   onScrollResync: () => void
@@ -104,7 +104,7 @@ const AssetsScreen: FC<Props> = ({
           <TokenListItem
             token={item}
             index={index}
-            onPress={() => goToTokenDetail(item.localId, item.networkChainId)}
+            onPress={() => goToTokenDetail(item)}
             isGridView={isGridView}
           />
         </View>

--- a/packages/core-mobile/app/new/features/portfolio/assets/screens/TokenDetailScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/screens/TokenDetailScreen.tsx
@@ -254,7 +254,7 @@ export const TokenDetailScreen = (): React.JSX.Element => {
 
   const handleExplorerLink = useCallback(
     (explorerLink: string): void => {
-      AnalyticsService.capture('ActivityCardLinkClicked')
+      AnalyticsService.capture('ExplorerLinkClicked')
       back()
       openUrl({ url: explorerLink, title: '' })
     },

--- a/packages/core-mobile/app/new/features/portfolio/screens/PortfolioScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/screens/PortfolioScreen.tsx
@@ -55,6 +55,7 @@ import AnalyticsService from 'services/analytics/AnalyticsService'
 import { AnalyticsEventName } from 'services/analytics/types'
 import { selectActiveAccount } from 'store/account'
 import {
+  LocalTokenWithBalance,
   selectBalanceForAccountIsAccurate,
   selectBalanceTotalInCurrencyForAccount,
   selectIsLoadingBalances,
@@ -367,13 +368,18 @@ const PortfolioHomeScreen = (): JSX.Element => {
   )
 
   const handleGoToTokenDetail = useCallback(
-    (localId: string, chainId: number): void => {
+    (token: LocalTokenWithBalance): void => {
+      const { name, symbol, localId, networkChainId } = token
       AnalyticsService.capture('PortfolioTokenSelected', {
-        selectedToken: localId,
-        chainId: chainId
+        name,
+        symbol,
+        chainId: networkChainId
       })
-      // @ts-ignore TODO: make routes typesafe
-      push({ pathname: '/tokenDetail', params: { localId, chainId } })
+      push({
+        // @ts-ignore TODO: make routes typesafe
+        pathname: '/tokenDetail',
+        params: { localId, chainId: networkChainId }
+      })
     },
     [push]
   )

--- a/packages/core-mobile/app/new/features/portfolio/screens/PortfolioScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/screens/PortfolioScreen.tsx
@@ -51,6 +51,8 @@ import {
   useSafeAreaInsets
 } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
+import AnalyticsService from 'services/analytics/AnalyticsService'
+import { AnalyticsEventName } from 'services/analytics/types'
 import { selectActiveAccount } from 'store/account'
 import {
   selectBalanceForAccountIsAccurate,
@@ -68,6 +70,12 @@ import { RootState } from 'store/types'
 import { useFocusedSelector } from 'utils/performance/useFocusedSelector'
 
 const SEGMENT_ITEMS = ['Assets', 'Collectibles', 'DeFi']
+
+const SEGMENT_EVENT_MAP: Record<number, AnalyticsEventName> = {
+  0: 'PortfolioAssetsClicked',
+  1: 'PortfolioCollectiblesClicked',
+  2: 'PortfolioDeFiClicked'
+}
 
 const PortfolioHomeScreen = (): JSX.Element => {
   const tabBarHeight = useBottomTabBarHeight()
@@ -332,6 +340,12 @@ const PortfolioHomeScreen = (): JSX.Element => {
 
   const handleSelectSegment = useCallback(
     (index: number): void => {
+      const eventName = SEGMENT_EVENT_MAP[index]
+
+      if (eventName) {
+        AnalyticsService.capture(eventName)
+      }
+
       selectedSegmentIndex.value = index
 
       InteractionManager.runAfterInteractions(() => {
@@ -354,6 +368,10 @@ const PortfolioHomeScreen = (): JSX.Element => {
 
   const handleGoToTokenDetail = useCallback(
     (localId: string, chainId: number): void => {
+      AnalyticsService.capture('PortfolioTokenSelected', {
+        selectedToken: localId,
+        chainId: chainId
+      })
       // @ts-ignore TODO: make routes typesafe
       push({ pathname: '/tokenDetail', params: { localId, chainId } })
     },
@@ -513,11 +531,5 @@ const PortfolioHomeScreen = (): JSX.Element => {
 const styles = StyleSheet.create({
   segmentedControl: { marginHorizontal: 16, marginBottom: 16 }
 })
-
-export enum PortfolioHomeScreenTab {
-  Assets = 0,
-  Collectibles = 1,
-  DeFi = 2
-}
 
 export default PortfolioHomeScreen

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -4,8 +4,7 @@ export type AnalyticsEvents = {
   AccountSelectorAddAccount: { accountNumber: number }
   AccountSelectorBtcAddressCopied: undefined
   AccountSelectorEthAddressCopied: undefined
-  ActivityCardDetailShown: undefined
-  ActivityCardLinkClicked: undefined
+  ExplorerLinkClicked: undefined
   AddContactClicked: undefined
   AddContactFailed: undefined
   AddContactSucceeded: undefined
@@ -45,8 +44,6 @@ export type AnalyticsEvents = {
   ChangePasswordFailed: undefined
   HallidayBuyClicked: undefined
   CoinbasePayBuyClicked: undefined
-  CollectibleItemClicked: { chainId: string }
-  CollectibleSendClicked: { chainId: string }
   ConnectedSitesClicked: undefined
   ConnectedSiteRemoved: {
     walletConnectVersion: string
@@ -93,13 +90,11 @@ export type AnalyticsEvents = {
   OnboardingPasswordSet: undefined
   OnboardingSubmitSucceeded: { walletType: string }
   OnboardingSubmitFailed: { walletType: string }
-  PortfolioActivityClicked: undefined
+  PortfolioManageTokenListClicked: undefined
   PortfolioAssetsClicked: undefined
   PortfolioCollectiblesClicked: undefined
   PortfolioDeFiClicked: undefined
-  PortfolioPrimaryNetworkClicked: { chainId: number }
-  PortfolioSecondaryNetworkClicked: { chainId: number }
-  PortfolioTokenSelected: { selectedToken: string }
+  PortfolioTokenSelected: { selectedToken: string; chainId: number }
   PrivacyPolicyClicked: undefined
   ReceivePageVisited: undefined
   RecoveryPhraseClicked: undefined
@@ -154,11 +149,6 @@ export type AnalyticsEvents = {
   Swap_TokenSelected: undefined
   TermsAndConditionsAccepted: undefined
   TermsOfUseClicked: undefined
-  TokenListTokenSelected: { selectedToken: string }
-  TokenReceiveClicked: { chainId: number }
-  TokenSendClicked: { chainId: number }
-  TokenSwapClicked: { chainId: number }
-  TokenBridgeClicked: { chainId: number }
   TotpValidationFailed: { error: string }
   TotpValidationSuccess: undefined
   WalletConnectSessionApprovedV2: {

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -94,7 +94,7 @@ export type AnalyticsEvents = {
   PortfolioAssetsClicked: undefined
   PortfolioCollectiblesClicked: undefined
   PortfolioDeFiClicked: undefined
-  PortfolioTokenSelected: { selectedToken: string; chainId: number }
+  PortfolioTokenSelected: { name: string; symbol: string; chainId: number }
   PrivacyPolicyClicked: undefined
   ReceivePageVisited: undefined
   RecoveryPhraseClicked: undefined


### PR DESCRIPTION
**Ticket: [CP-11118]** 

**New Analytics Events Added**:
  - Added `PortfolioManageTokenListClicked` to track clicks on the token management list.
  - Added `PortfolioAssetsClicked`, `PortfolioCollectiblesClicked`, and `PortfolioDeFiClicked` for segment selection tracking in the portfolio screen.
  - Updated `PortfolioTokenSelected` parameters (`name`, `symbol` and `chainId`) for tracking token selection.
  - Updated `ExplorerLinkClicked` to replace `ActivityCardLinkClicked` for tracking explorer link interactions.

**Unused Analytics Events Removed**:
  - Removed events `PortfolioPrimaryNetworkClicked`, `PortfolioSecondaryNetworkClicked`, `TokenListTokenSelected`, `TokenReceiveClicked`, `TokenSendClicked`, `TokenSwapClicked`, `TokenBridgeClicked`, `CollectibleItemClicked`, `CollectibleSendClicked`, `ActivityCardDetailShown`

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [x] I have updated the documentation


[CP-11118]: https://ava-labs.atlassian.net/browse/CP-11118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ