### PR TITLE
CP-11154 Data is not encrypted correctly error

### DIFF
--- a/packages/core-mobile/app/new/common/hooks/usePinOrBiometryLogin.ts
+++ b/packages/core-mobile/app/new/common/hooks/usePinOrBiometryLogin.ts
@@ -156,13 +156,12 @@ export function usePinOrBiometryLogin({
         const accessType = BiometricsSDK.getAccessType()
 
         if (accessType === 'BIO') {
-          // Check if migration is needed first
-          const migrator = new KeychainMigrator(activeWalletId)
-          await migrator.migrateIfNeeded('BIO')
-
           const isSuccess = await BiometricsSDK.loadEncryptionKeyWithBiometry()
 
           if (isSuccess) {
+            // Check if migration is needed first
+            const migrator = new KeychainMigrator(activeWalletId)
+            await migrator.migrateIfNeeded('BIO')
             setVerified(true)
             resetRateLimiter()
             return new NothingToLoad()


### PR DESCRIPTION
## Description

**Ticket: [CP-11154]** 

In case that users with enabled biometry login upgrade to new version but provide invalid biometry data (non-matching face or fingerprint, can happen on iOS that face recognition fails at first but succeeds on second try) KeychainMigrator would fail and trigger app reset.
This is fixed by checking if biometry data is valid before trying to migrate.


## Screenshots/Videos
![Screenshot 2025-06-27 at 10 29 13](https://github.com/user-attachments/assets/fa582e20-8f4e-40ea-a855-1a5fa62186cb)

![Screenshot 2025-06-27 at 10 30 56](https://github.com/user-attachments/assets/7469e8bd-a0dd-47fe-a91c-146312e6065b)


## Testing
### Testing fail case
- have v0.0.0.5523 or prior installed and onboarded with enabled biometry
- upgrade app to v0.0.0.5588 
- run app and provide invalid Biometry data 
- observe "Data is not encrypted correctly error"

### Test fixed case
- have v0.0.0.5523 or prior installed and onboarded with enabled biometry
- upgrade app to this version
- run app and provide invalid Biometry data 
- observe that login screen stays on waiting for user to provide valid PIN or biometry data

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
