### PR TITLE
CP-10882 - Remove PIN/Bio requirement when app is open and backgrounded

### DIFF
--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/securityAndPrivacy.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/securityAndPrivacy.tsx
@@ -15,7 +15,9 @@ import AnalyticsService from 'services/analytics/AnalyticsService'
 import { WalletType } from 'services/wallet/types'
 import {
   selectCoreAnalyticsConsent,
-  setCoreAnalytics
+  selectLockWalletWithPIN,
+  setCoreAnalytics,
+  setLockWalletWithPIN
 } from 'store/settings/securityPrivacy'
 import { useStoredBiometrics } from 'common/hooks/useStoredBiometrics'
 import BiometricsSDK from 'utils/BiometricsSDK'
@@ -28,6 +30,7 @@ const SecurityAndPrivacyScreen = (): JSX.Element => {
   } = useTheme()
   const dispatch = useDispatch()
   const coreAnalyticsConsent = useSelector(selectCoreAnalyticsConsent)
+  const lockWalletWithPIN = useSelector(selectLockWalletWithPIN)
   const { allApprovedDapps } = useConnectedDapps()
   const wallet = useActiveWallet()
   const {
@@ -149,6 +152,30 @@ const SecurityAndPrivacyScreen = (): JSX.Element => {
     ]
   }, [coreAnalyticsConsent, handleToggleCoreAnalyticsConsent])
 
+  const handleToggleLockWalletWithPIN = useCallback(
+    (value: boolean): void => {
+      dispatch(setLockWalletWithPIN(value))
+    },
+    [dispatch]
+  )
+
+  const lockWalletWithPINData = useMemo(() => {
+    return [
+      {
+        title: 'Lock wallet with PIN',
+        value: (
+          <Toggle
+            onValueChange={() =>
+              handleToggleLockWalletWithPIN(!lockWalletWithPIN)
+            }
+            testID={lockWalletWithPIN ? 'pin_enabled' : 'pin_disabled'}
+            value={lockWalletWithPIN}
+          />
+        )
+      }
+    ]
+  }, [lockWalletWithPIN, handleToggleLockWalletWithPIN])
+
   return (
     <ScrollScreen
       title={`Security\n& privacy`}
@@ -166,6 +193,16 @@ const SecurityAndPrivacyScreen = (): JSX.Element => {
         valueSx={{ fontSize: 16, lineHeight: 22 }}
       />
       <Space y={24} />
+      <GroupList
+        data={lockWalletWithPINData}
+        titleSx={{
+          fontSize: 16,
+          lineHeight: 22,
+          fontFamily: 'Inter-Regular'
+        }}
+        separatorMarginRight={16}
+      />
+      <Space y={12} />
       <GroupList
         data={pinAndBiometricData}
         titleSx={{

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/securityAndPrivacy.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/securityAndPrivacy.tsx
@@ -155,7 +155,7 @@ const SecurityAndPrivacyScreen = (): JSX.Element => {
 
   const handleToggleLockWalletWithPIN = useCallback(
     (value: boolean): void => {
-      if (!value) {
+      if (value === false) {
         showAlert({
           title: 'Do you really want to disable the PIN code?',
           description:

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/securityAndPrivacy.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/securityAndPrivacy.tsx
@@ -1,6 +1,7 @@
 import {
   GroupList,
   GroupListItem,
+  showAlert,
   Text,
   Toggle,
   useTheme
@@ -154,7 +155,26 @@ const SecurityAndPrivacyScreen = (): JSX.Element => {
 
   const handleToggleLockWalletWithPIN = useCallback(
     (value: boolean): void => {
-      dispatch(setLockWalletWithPIN(value))
+      if (!value) {
+        showAlert({
+          title: 'Do you really want to disable the PIN code?',
+          description:
+            'I understand that removing the need of a PIN code to unlock my wallet will lorem ipsum lorem ipsum dolor sit amet.',
+          buttons: [
+            {
+              text: 'Cancel'
+            },
+            {
+              text: 'Disable',
+              onPress: () => {
+                dispatch(setLockWalletWithPIN(value))
+              }
+            }
+          ]
+        })
+      } else {
+        dispatch(setLockWalletWithPIN(value))
+      }
     },
     [dispatch]
   )
@@ -162,7 +182,7 @@ const SecurityAndPrivacyScreen = (): JSX.Element => {
   const lockWalletWithPINData = useMemo(() => {
     return [
       {
-        title: 'Lock wallet with PIN',
+        title: 'Lock wallet with a PIN',
         value: (
           <Toggle
             onValueChange={() =>

--- a/packages/core-mobile/app/store/settings/securityPrivacy/slice.ts
+++ b/packages/core-mobile/app/store/settings/securityPrivacy/slice.ts
@@ -11,6 +11,9 @@ export const securityPrivacySlice = createSlice({
     setCoreAnalytics: (state, action: PayloadAction<boolean | undefined>) => {
       state.coreAnalytics = action.payload
     },
+    setLockWalletWithPIN: (state, action: PayloadAction<boolean>) => {
+      state.lockWalletWithPIN = action.payload
+    },
     /**
      * Set Terms of use and Privacy policy consent
      */
@@ -28,6 +31,11 @@ export const selectCoreAnalyticsConsent = (
   state: RootState
 ): boolean | undefined => state.settings.securityPrivacy.coreAnalytics
 
+// selectors
+export const selectLockWalletWithPIN = (
+  state: RootState
+): boolean | undefined => state.settings.securityPrivacy.coreAnalytics
+
 /**
  * Select Terms of use and Privacy policy consent
  * @param state
@@ -39,7 +47,11 @@ export const selectIsPrivacyModeEnabled = (state: RootState): boolean =>
   state.settings.securityPrivacy.privacyModeEnabled
 
 // actions
-export const { setCoreAnalytics, setTouAndPpConsent, togglePrivacyMode } =
-  securityPrivacySlice.actions
+export const {
+  setCoreAnalytics,
+  setTouAndPpConsent,
+  togglePrivacyMode,
+  setLockWalletWithPIN
+} = securityPrivacySlice.actions
 
 export const securityPrivacyReducer = securityPrivacySlice.reducer

--- a/packages/core-mobile/app/store/settings/securityPrivacy/slice.ts
+++ b/packages/core-mobile/app/store/settings/securityPrivacy/slice.ts
@@ -32,9 +32,8 @@ export const selectCoreAnalyticsConsent = (
 ): boolean | undefined => state.settings.securityPrivacy.coreAnalytics
 
 // selectors
-export const selectLockWalletWithPIN = (
-  state: RootState
-): boolean | undefined => state.settings.securityPrivacy.coreAnalytics
+export const selectLockWalletWithPIN = (state: RootState): boolean =>
+  state.settings.securityPrivacy.lockWalletWithPIN
 
 /**
  * Select Terms of use and Privacy policy consent

--- a/packages/core-mobile/app/store/settings/securityPrivacy/types.ts
+++ b/packages/core-mobile/app/store/settings/securityPrivacy/types.ts
@@ -1,11 +1,13 @@
 export const initialState: SecurityNPrivacyState = {
   coreAnalytics: undefined,
   consentToTOUnPP: false,
-  privacyModeEnabled: false
+  privacyModeEnabled: false,
+  lockWalletWithPIN: true
 }
 
 export type SecurityNPrivacyState = {
   coreAnalytics: boolean | undefined
   consentToTOUnPP: boolean
   privacyModeEnabled: boolean
+  lockWalletWithPIN: boolean
 }


### PR DESCRIPTION
## Description

**Ticket: [CP-10882]** 

- Added new field with toggle in security & privacy
- Added in redux lockWalletWithPIN
- Added alert before disabling
- Added check in app listener to skip verification if lockWalletWithPIN is false

## Screenshots/Videos

https://github.com/user-attachments/assets/18e9a90c-bfde-460f-8bf5-d35c4f539fd9


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10882]: https://ava-labs.atlassian.net/browse/CP-10882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ