### PR TITLE
CP-10892 - If touch id is disabled then the pin pad is not auto populated on lock screen

### DIFF
--- a/packages/core-mobile/app/new/routes/loginWithPinOrBiometry.tsx
+++ b/packages/core-mobile/app/new/routes/loginWithPinOrBiometry.tsx
@@ -15,6 +15,7 @@ import { LoadingState } from 'common/components/LoadingState'
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import { usePinOrBiometryLogin } from 'common/hooks/usePinOrBiometryLogin'
 import { usePreventScreenRemoval } from 'common/hooks/usePreventScreenRemoval'
+import { useStoredBiometrics } from 'common/hooks/useStoredBiometrics'
 import { useFocusEffect, useRouter } from 'expo-router'
 import { useWallet } from 'hooks/useWallet'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
@@ -105,6 +106,8 @@ const LoginWithPinOrBiometry = (): JSX.Element => {
     onStartLoading: handleStartLoading,
     onStopLoading: handleStopLoading
   })
+
+  const { useBiometrics } = useStoredBiometrics()
 
   const [isEnteringPin, setIsEnteringPin] = useState(false)
 
@@ -203,7 +206,7 @@ const LoginWithPinOrBiometry = (): JSX.Element => {
       InteractionManager.runAfterInteractions(() => {
         if (bioType !== BiometricType.NONE) {
           handlePromptBioLogin()
-        } else if (!isBiometricAvailable) {
+        } else if (!isBiometricAvailable || !useBiometrics) {
           focusPinInput()
         }
       })
@@ -211,7 +214,13 @@ const LoginWithPinOrBiometry = (): JSX.Element => {
       return () => {
         blurPinInput()
       }
-    }, [bioType, isBiometricAvailable, handlePromptBioLogin, focusPinInput])
+    }, [
+      bioType,
+      isBiometricAvailable,
+      useBiometrics,
+      handlePromptBioLogin,
+      focusPinInput
+    ])
   )
 
   useEffect(() => {


### PR DESCRIPTION
## Description

**Ticket: [CP-10892]** 

Check if Use touch Id is disabled and trigger a focus for PIN input

https://github.com/user-attachments/assets/de04acf7-2eae-47e0-af15-07c01cdde8e1


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-10892]: https://ava-labs.atlassian.net/browse/CP-10892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ