### PR TITLE
CP-11241: Use the wallet from the wallet id param instead of the active wallet

### DIFF
--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/account.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/account.tsx
@@ -77,6 +77,7 @@ const AccountScreen = (): JSX.Element => {
       // @ts-ignore TODO: make routes typesafe
       pathname: '/accountSettings/verifyPinForPrivateKey',
       params: {
+        walletId: account.walletId,
         accountIndex: account.index.toString()
       }
     })

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/verifyPinForPrivateKey.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/verifyPinForPrivateKey.tsx
@@ -5,14 +5,15 @@ import { useSelector } from 'react-redux'
 import { selectActiveNetwork } from 'store/network'
 import Logger from 'utils/Logger'
 import BiometricsSDK from 'utils/BiometricsSDK'
-import { useActiveWallet } from 'common/hooks/useActiveWallet'
 import WalletService from 'services/wallet/WalletService'
 
 const VerifyPinForPrivateKeyScreen = (): JSX.Element => {
   const { replace } = useRouter()
-  const { accountIndex } = useLocalSearchParams<{ accountIndex: string }>()
+  const { walletId, accountIndex } = useLocalSearchParams<{
+    walletId: string
+    accountIndex: string
+  }>()
   const activeNetwork = useSelector(selectActiveNetwork)
-  const activeWallet = useActiveWallet()
 
   const getPrivateKeyFromMnemonic = async (
     mnemonic: string
@@ -25,9 +26,7 @@ const VerifyPinForPrivateKeyScreen = (): JSX.Element => {
   }
 
   const handleLoginSuccess = async (): Promise<void> => {
-    const walletSecretResult = await BiometricsSDK.loadWalletSecret(
-      activeWallet.id
-    )
+    const walletSecretResult = await BiometricsSDK.loadWalletSecret(walletId)
     if (!walletSecretResult.success) {
       Logger.error('Failed to load wallet secret', walletSecretResult.error)
       return


### PR DESCRIPTION
## Description

**Ticket: [CP-11241]** 

* Use the wallet corresponding to the provided wallet id instead of relying on the active wallet, to generate the private key for the wallet and account selected by the user

[CP-11241]: https://ava-labs.atlassian.net/browse/CP-11241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ