### PR TITLE
CP-11154 Fix double bio prompt

### DIFF
--- a/packages/core-mobile/app/hooks/useAppBackgroundTracker.ts
+++ b/packages/core-mobile/app/hooks/useAppBackgroundTracker.ts
@@ -87,7 +87,7 @@ async function isForegroundAndLoggedIn(
   return (
     appState.current.match(/background/) &&
     nextAppState === 'active' &&
-    (await BiometricsSDK.getAccessType())
+    BiometricsSDK.getAccessType()
   )
 }
 

--- a/packages/core-mobile/app/new/common/hooks/usePinOrBiometryLogin.ts
+++ b/packages/core-mobile/app/new/common/hooks/usePinOrBiometryLogin.ts
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useState } from 'react'
-import BiometricsSDK from 'utils/BiometricsSDK'
+import BiometricsSDK, { BiometricType } from 'utils/BiometricsSDK'
 import { Alert } from 'react-native'
 import { InvalidVersionError, NoSaltError } from 'utils/EncryptionHelper'
 import Logger from 'utils/Logger'
 import { formatTimer } from 'utils/Utils'
-import { BiometricType } from 'utils/BiometricsSDK'
 import KeychainMigrator, {
   BadPinError,
-  MigrationFailedError
+  MigrationFailedError,
+  MigrationStatus
 } from 'utils/KeychainMigrator'
 import { useSelector } from 'react-redux'
 import { selectActiveWalletId } from 'store/wallet/slice'
@@ -156,12 +156,27 @@ export function usePinOrBiometryLogin({
         const accessType = BiometricsSDK.getAccessType()
 
         if (accessType === 'BIO') {
+          // Check if migration is needed first
+          const migrator = new KeychainMigrator(activeWalletId)
+          const result = await migrator.migrateIfNeeded('BIO')
+          if (
+            result.success &&
+            result.value === MigrationStatus.RunBiometricMigration
+          ) {
+            //already prompted user for bio, assume verified
+            setVerified(true)
+            resetRateLimiter()
+            return new NothingToLoad()
+          }
+          if (result.success) {
+            throw new Error(
+              'Invalid state: migration status is not RunBiometricMigration'
+            )
+          }
+          //already migrated
           const isSuccess = await BiometricsSDK.loadEncryptionKeyWithBiometry()
 
           if (isSuccess) {
-            // Check if migration is needed first
-            const migrator = new KeychainMigrator(activeWalletId)
-            await migrator.migrateIfNeeded('BIO')
             setVerified(true)
             resetRateLimiter()
             return new NothingToLoad()

--- a/packages/core-mobile/app/new/common/hooks/usePrivateKeyImportHandler.ts
+++ b/packages/core-mobile/app/new/common/hooks/usePrivateKeyImportHandler.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react'
 import { useRouter } from 'expo-router'
 import { ImportedAccount } from 'store/account/types'
-import KeychainMigrator from 'utils/KeychainMigrator'
+import KeychainMigrator, { MigrationStatus } from 'utils/KeychainMigrator'
 import { useActiveWallet } from 'common/hooks/useActiveWallet'
 import { useImportPrivateKey } from './useImportPrivateKey'
 
@@ -23,10 +23,10 @@ export const usePrivateKeyImportHandler = (
 
     setIsCheckingMigration(true)
     const migrator = new KeychainMigrator(activeWallet.id)
-    const migrationNeeded = await migrator.getMigrationStatus('PIN')
+    const migrationStatus = await migrator.getMigrationStatus('PIN')
     setIsCheckingMigration(false)
 
-    if (migrationNeeded) {
+    if (migrationStatus !== MigrationStatus.NoMigrationNeeded) {
       navigate({
         // @ts-ignore TODO: make routes typesafe
         pathname: '/accountSettings/verifyPinForImportPrivateKey',

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/importSeedWallet.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/importSeedWallet.tsx
@@ -5,14 +5,14 @@ import React, { useCallback, useState, useEffect } from 'react'
 import RecoveryPhraseInput from 'new/features/onboarding/components/RecoveryPhraseInput'
 import Logger from 'utils/Logger'
 import {
-  getWalletFromMnemonic,
-  DerivationPath
+  DerivationPath,
+  getWalletFromMnemonic
 } from '@avalabs/core-wallets-sdk'
 import { truncateAddress } from '@avalabs/core-utils-sdk'
 import { useRouter } from 'expo-router'
 import { useImportMnemonic } from 'new/common/hooks/useImportMnemonic'
 import { useActiveWallet } from 'common/hooks/useActiveWallet'
-import KeychainMigrator from 'utils/KeychainMigrator'
+import KeychainMigrator, { MigrationStatus } from 'utils/KeychainMigrator'
 import { MINIMUM_MNEMONIC_WORDS } from 'common/consts'
 import { useCheckIfAccountExists } from 'common/hooks/useCheckIfAccountExists'
 
@@ -93,10 +93,10 @@ const ImportSeedWallet = (): React.JSX.Element => {
 
     setIsCheckingMigration(true)
     const migrator = new KeychainMigrator(activeWallet.id)
-    const migrationNeeded = await migrator.getMigrationStatus('PIN')
+    const migrationStatus = await migrator.getMigrationStatus('PIN')
     setIsCheckingMigration(false)
 
-    if (migrationNeeded) {
+    if (migrationStatus !== MigrationStatus.NoMigrationNeeded) {
       router.navigate({
         // @ts-ignore TODO: make routes typesafe
         pathname: '/accountSettings/verifyPin',

--- a/packages/core-mobile/app/new/routes/loginWithPinOrBiometry.tsx
+++ b/packages/core-mobile/app/new/routes/loginWithPinOrBiometry.tsx
@@ -48,6 +48,7 @@ const LoginWithPinOrBiometry = (): JSX.Element => {
   const { unlock } = useWallet()
   const router = useRouter()
   const walletId = useSelector(selectActiveWalletId)
+  const [isHandledBioPrompt, setIsHandledBioPrompt] = useState(false)
 
   const isProcessing = useSharedValue(false)
   const [hasNoRecentInput, setHasNoRecentInput] = useState(false)
@@ -205,7 +206,8 @@ const LoginWithPinOrBiometry = (): JSX.Element => {
     useCallback(() => {
       InteractionManager.runAfterInteractions(() => {
         const accessType = BiometricsSDK.getAccessType()
-        if (accessType === 'BIO') {
+        if (accessType === 'BIO' && !isHandledBioPrompt) {
+          setIsHandledBioPrompt(true)
           handlePromptBioLogin()
         } else if (!isBiometricAvailable || !useBiometrics) {
           focusPinInput()
@@ -216,6 +218,7 @@ const LoginWithPinOrBiometry = (): JSX.Element => {
         blurPinInput()
       }
     }, [
+      isHandledBioPrompt,
       isBiometricAvailable,
       useBiometrics,
       handlePromptBioLogin,

--- a/packages/core-mobile/app/new/routes/loginWithPinOrBiometry.tsx
+++ b/packages/core-mobile/app/new/routes/loginWithPinOrBiometry.tsx
@@ -204,7 +204,8 @@ const LoginWithPinOrBiometry = (): JSX.Element => {
   useFocusEffect(
     useCallback(() => {
       InteractionManager.runAfterInteractions(() => {
-        if (bioType !== BiometricType.NONE) {
+        const accessType = BiometricsSDK.getAccessType()
+        if (accessType === 'BIO') {
           handlePromptBioLogin()
         } else if (!isBiometricAvailable || !useBiometrics) {
           focusPinInput()

--- a/packages/core-mobile/app/new/routes/loginWithPinOrBiometry.tsx
+++ b/packages/core-mobile/app/new/routes/loginWithPinOrBiometry.tsx
@@ -216,7 +216,6 @@ const LoginWithPinOrBiometry = (): JSX.Element => {
         blurPinInput()
       }
     }, [
-      bioType,
       isBiometricAvailable,
       useBiometrics,
       handlePromptBioLogin,

--- a/packages/core-mobile/app/store/migrations.ts
+++ b/packages/core-mobile/app/store/migrations.ts
@@ -121,7 +121,7 @@ export const migrations = {
   9: async (state: any) => {
     // for people upgrading from < 9, if they have set biometrics or pin,
     // it means they have created a mnemonic wallet
-    const isLoggedIn = await BiometricsSDK.getAccessType()
+    const isLoggedIn = BiometricsSDK.getAccessType()
 
     return {
       ...state,

--- a/packages/core-mobile/app/utils/BiometricsSDK.ts
+++ b/packages/core-mobile/app/utils/BiometricsSDK.ts
@@ -71,11 +71,8 @@ class BiometricsSDK {
     await Keychain.getAllGenericPasswordServices()
   }
 
-  //FIXME: changed in
-  // https://github.com/ava-labs/core-mobile/commit/1644856c46b4567a5e6ece947ce69b81c09a4da0.
-  // This should return null as a sign that user never made login. This is also important for migration #9 (in migrations.ts)
-  getAccessType(): string {
-    return commonStorage.getString(StorageKey.SECURE_ACCESS_SET) ?? 'PIN'
+  getAccessType(): string | undefined {
+    return commonStorage.getString(StorageKey.SECURE_ACCESS_SET)
   }
 
   // Generate a new encryption key

--- a/packages/core-mobile/app/utils/KeychainMigrator.test.ts
+++ b/packages/core-mobile/app/utils/KeychainMigrator.test.ts
@@ -24,7 +24,7 @@ describe('KeychainMigrator', () => {
     it('should return false if fully migrated', async () => {
       mockBiometricsSDK.hasEncryptionKeyWithPin.mockResolvedValue(true)
       const status = await keychainMigrator.getMigrationStatus('PIN')
-      expect(status).toBe(false)
+      expect(status).toBe('noMigrationNeeded')
     })
 
     it('should return "completePartialMigration" if bio key exists but pin key does not', async () => {
@@ -269,7 +269,7 @@ describe('KeychainMigrator', () => {
     })
 
     it('should throw error if loading legacy wallet fails', async () => {
-      const error = new Error('Could not load legacy wallet with biometrics.')
+      const error = new Error('Invalid biometric data. Please try again.')
       mockBiometricsSDK.loadLegacyWalletWithBiometry.mockResolvedValue({
         success: false,
         error

--- a/packages/core-mobile/app/utils/KeychainMigrator.ts
+++ b/packages/core-mobile/app/utils/KeychainMigrator.ts
@@ -1,5 +1,6 @@
 import { ErrorBase } from 'errors/ErrorBase'
 import { Result } from 'types/result'
+import { SecureAccessSet } from 'resources/Constants'
 import BiometricsSDK from './BiometricsSDK'
 import Logger from './Logger'
 import { assertNotUndefined } from './assertions'
@@ -35,6 +36,11 @@ class KeychainMigrator {
       return MigrationStatus.NoMigrationNeeded
     }
 
+    //new bio exists, but accessType is bio so no need to migrate
+    if (newBioKeyExists && accessType === 'BIO') {
+      return MigrationStatus.NoMigrationNeeded
+    }
+
     // no pin key, but bio key exists
     if (newBioKeyExists) {
       return MigrationStatus.CompletePartialMigration
@@ -52,7 +58,7 @@ class KeychainMigrator {
   ): Promise<Result<MigrationStatus>> {
     const migrationStatus = await this.getMigrationStatus(accessType)
     if (migrationStatus === MigrationStatus.NoMigrationNeeded) {
-      return { success: false, error: new Error('No migration needed') }
+      return { success: true, value: migrationStatus }
     }
 
     try {

--- a/packages/core-mobile/app/utils/KeychainMigrator.ts
+++ b/packages/core-mobile/app/utils/KeychainMigrator.ts
@@ -1,10 +1,19 @@
 import { ErrorBase } from 'errors/ErrorBase'
+import { Result } from 'types/result'
 import BiometricsSDK from './BiometricsSDK'
 import Logger from './Logger'
 import { assertNotUndefined } from './assertions'
 
 export class MigrationFailedError extends ErrorBase<'MigrationFailedError'> {}
 export class BadPinError extends ErrorBase<'BadPinError'> {}
+export class BadBioError extends ErrorBase<'BadBioError'> {}
+
+export enum MigrationStatus {
+  RunPinMigration = 'runPinMigration',
+  RunBiometricMigration = 'runBiometricMigration',
+  CompletePartialMigration = 'completePartialMigration',
+  NoMigrationNeeded = 'noMigrationNeeded'
+}
 
 class KeychainMigrator {
   private activeWalletId: string
@@ -16,37 +25,34 @@ class KeychainMigrator {
 
   public async getMigrationStatus(
     accessType: 'PIN' | 'BIO'
-  ): Promise<
-    | 'runPinMigration'
-    | 'runBiometricMigration'
-    | 'completePartialMigration'
-    | false
-  > {
+  ): Promise<MigrationStatus> {
     // Check for legacy wallet data with both PIN and biometrics
     const newPinKeyExists = await BiometricsSDK.hasEncryptionKeyWithPin()
     const newBioKeyExists = await BiometricsSDK.hasEncryptionKeyWithBiometry()
 
     //fully migrated
     if (newPinKeyExists) {
-      return false
+      return MigrationStatus.NoMigrationNeeded
     }
 
     // no pin key, but bio key exists
     if (newBioKeyExists) {
-      return 'completePartialMigration'
+      return MigrationStatus.CompletePartialMigration
     }
 
     //no keys exist
-    return accessType === 'PIN' ? 'runPinMigration' : 'runBiometricMigration'
+    return accessType === 'PIN'
+      ? MigrationStatus.RunPinMigration
+      : MigrationStatus.RunBiometricMigration
   }
 
   public async migrateIfNeeded(
     accessType: 'PIN' | 'BIO',
     pin?: string
-  ): Promise<void> {
+  ): Promise<Result<MigrationStatus>> {
     const migrationStatus = await this.getMigrationStatus(accessType)
-    if (migrationStatus === false) {
-      return
+    if (migrationStatus === MigrationStatus.NoMigrationNeeded) {
+      return { success: false, error: new Error('No migration needed') }
     }
 
     try {
@@ -79,11 +85,9 @@ class KeychainMigrator {
           })
         }
       }
+      return { success: true, value: migrationStatus }
     } catch (error) {
-      if (
-        error instanceof BadPinError ||
-        error instanceof MigrationFailedError
-      ) {
+      if (error instanceof BadPinError || error instanceof BadBioError) {
         throw error
       }
       throw new MigrationFailedError({
@@ -149,7 +153,9 @@ class KeychainMigrator {
     Logger.info('Starting biometric-based keychain migration.')
     const mnemonicResult = await BiometricsSDK.loadLegacyWalletWithBiometry()
     if (!mnemonicResult.success) {
-      throw mnemonicResult.error
+      throw new BadBioError({
+        message: 'Invalid biometric data. Please try again.'
+      })
     }
 
     const newEncryptionKey = await BiometricsSDK.generateEncryptionKey()


### PR DESCRIPTION
## Description

**Ticket: [CP-11154]** 

verifyBiometric now takes into account that if biometric migration happened and is successful that means that user has already provided valid bio data.

## Screenshots/Videos


## Testing


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11154]: https://ava-labs.atlassian.net/browse/CP-11154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ