### PR TITLE
CP-11305: Fix to display the private key without a leading 0x

### DIFF
--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/verifyPinForPrivateKey.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/verifyPinForPrivateKey.tsx
@@ -1,11 +1,14 @@
 import React from 'react'
 import { VerifyWithPinOrBiometry } from 'common/components/VerifyWithPinOrBiometry'
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import { useSelector } from 'react-redux'
-import { selectActiveNetwork } from 'store/network'
 import Logger from 'utils/Logger'
 import BiometricsSDK from 'utils/BiometricsSDK'
 import WalletService from 'services/wallet/WalletService'
+import useCChainNetwork from 'hooks/earn/useCChainNetwork'
+import { Network } from '@avalabs/core-chains-sdk'
+import { useSelector } from 'react-redux'
+import { selectWalletById } from 'store/wallet/slice'
+import { WalletType } from 'services/wallet/types'
 
 const VerifyPinForPrivateKeyScreen = (): JSX.Element => {
   const { replace } = useRouter()
@@ -13,34 +16,46 @@ const VerifyPinForPrivateKeyScreen = (): JSX.Element => {
     walletId: string
     accountIndex: string
   }>()
-  const activeNetwork = useSelector(selectActiveNetwork)
+  const cChainNetwork = useCChainNetwork()
+  const wallet = useSelector(selectWalletById(walletId))
 
   const getPrivateKeyFromMnemonic = async (
-    mnemonic: string
+    mnemonic: string,
+    network: Network
   ): Promise<string> => {
     return WalletService.getPrivateKeyFromMnemonic(
       mnemonic,
-      activeNetwork,
+      network,
       parseInt(accountIndex)
     )
   }
 
   const handleLoginSuccess = async (): Promise<void> => {
-    const walletSecretResult = await BiometricsSDK.loadWalletSecret(walletId)
+    if (!wallet) {
+      Logger.error('Wallet not found for ID:', walletId)
+      return
+    }
+
+    const walletSecretResult = await BiometricsSDK.loadWalletSecret(wallet.id)
     if (!walletSecretResult.success) {
       Logger.error('Failed to load wallet secret', walletSecretResult.error)
       return
     }
     const walletSecret = walletSecretResult.value
     Logger.info('walletSecret', walletSecret)
-    if (walletSecret.startsWith('0x')) {
+    if (wallet.type === WalletType.PRIVATE_KEY) {
       replace({
         // @ts-ignore TODO: make routes typesafe
         pathname: '/accountSettings/viewPrivateKey',
         params: { privateKey: walletSecret }
       })
-    } else {
-      getPrivateKeyFromMnemonic(walletSecret)
+    } else if (wallet.type === WalletType.MNEMONIC) {
+      if (!cChainNetwork) {
+        Logger.error('CChain network is not available')
+        return
+      }
+      // Todo: support private key for x/p network later
+      getPrivateKeyFromMnemonic(walletSecret, cChainNetwork)
         .then(privateKey => {
           replace({
             // @ts-ignore TODO: make routes typesafe


### PR DESCRIPTION
## Description

**Ticket: [CP-11305]** 

* Wallets like Metamask sometimes provide private keys that don’t start with 0x. This fixes an issue where such private keys wouldn’t be displayed properly after being imported.

[CP-11305]: https://ava-labs.atlassian.net/browse/CP-11305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ