### PR TITLE
CP-11357 Show private keys as collection of single wallet in Manage accounts screen

### DIFF
--- a/packages/core-mobile/app/new/common/components/WalletCard.tsx
+++ b/packages/core-mobile/app/new/common/components/WalletCard.tsx
@@ -17,12 +17,14 @@ const WalletCard = ({
   wallet,
   isExpanded,
   searchText,
-  onToggleExpansion
+  onToggleExpansion,
+  showMoreButton = true
 }: {
   wallet: WalletDisplayData
   isExpanded: boolean
   searchText: string
   onToggleExpansion: () => void
+  showMoreButton?: boolean
 }): React.JSX.Element => {
   const {
     theme: { colors }
@@ -65,7 +67,8 @@ const WalletCard = ({
           sx={{
             flexDirection: 'row',
             alignItems: 'center',
-            justifyContent: 'space-between'
+            justifyContent: 'space-between',
+            minHeight: 48
           }}>
           <View
             sx={{
@@ -90,37 +93,39 @@ const WalletCard = ({
             </Text>
           </View>
 
-          <DropdownMenu
-            groups={[
-              {
-                key: 'wallet-actions',
-                items: dropdownItems
-              }
-            ]}
-            onPressAction={(event: { nativeEvent: { event: string } }) =>
-              handleDropdownSelect(
-                event.nativeEvent.event,
-                wallet.id,
-                wallet.name
-              )
-            }>
-            <TouchableOpacity
-              hitSlop={8}
-              style={{
-                minHeight: 48,
-                paddingRight: 24,
-                paddingLeft: 12,
-                justifyContent: 'center',
-                alignItems: 'center'
-              }}
-              onPress={handleMorePress}>
-              <Icons.Navigation.MoreHoriz
-                color={colors.$textSecondary}
-                width={20}
-                height={20}
-              />
-            </TouchableOpacity>
-          </DropdownMenu>
+          {showMoreButton && (
+            <DropdownMenu
+              groups={[
+                {
+                  key: 'wallet-actions',
+                  items: dropdownItems
+                }
+              ]}
+              onPressAction={(event: { nativeEvent: { event: string } }) =>
+                handleDropdownSelect(
+                  event.nativeEvent.event,
+                  wallet.id,
+                  wallet.name
+                )
+              }>
+              <TouchableOpacity
+                hitSlop={8}
+                style={{
+                  minHeight: 48,
+                  paddingRight: 24,
+                  paddingLeft: 12,
+                  justifyContent: 'center',
+                  alignItems: 'center'
+                }}
+                onPress={handleMorePress}>
+                <Icons.Navigation.MoreHoriz
+                  color={colors.$textSecondary}
+                  width={20}
+                  height={20}
+                />
+              </TouchableOpacity>
+            </DropdownMenu>
+          )}
         </TouchableOpacity>
 
         {isExpanded && (

--- a/packages/core-mobile/app/new/features/accountSettings/components/AccountButtons.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/components/AccountButtons.tsx
@@ -25,8 +25,8 @@ export const AccountButtons = ({
   const router = useRouter()
   const { theme } = useTheme()
   const account = useSelector(selectAccountById(accountId))
-  const siblingAccounts = useSelector(
-    selectAccountsByWalletId(account?.walletId ?? '')
+  const siblingAccounts = useSelector((state: RootState) =>
+    selectAccountsByWalletId(state, account?.walletId ?? '')
   )
 
   const isRemoveEnabled = useMemo(() => {

--- a/packages/core-mobile/app/new/features/accountSettings/components/AccountButtons.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/components/AccountButtons.tsx
@@ -13,6 +13,7 @@ import {
   setAccountTitle
 } from 'store/account'
 import { WalletType } from 'services/wallet/types'
+import { RootState } from 'store/types'
 
 export const AccountButtons = ({
   accountId,
@@ -32,13 +33,20 @@ export const AccountButtons = ({
   const isRemoveEnabled = useMemo(() => {
     if (!account) return false
 
+    // For PRIVATE_KEY wallets, always allow removal
+    if (walletType === WalletType.PRIVATE_KEY) {
+      return true
+    }
+
+    // For SEEDLESS and MNEMONIC wallets, only allow removal if there are multiple accounts
+    // and this is the highest index account
     if (siblingAccounts.length <= 1) return false
 
     const highestIndexInWallet = Math.max(
       ...siblingAccounts.map(acc => acc.index)
     )
     return account.index === highestIndexInWallet
-  }, [account, siblingAccounts])
+  }, [account, siblingAccounts, walletType])
 
   const handleShowAlertWithTextInput = (): void => {
     showAlertWithTextInput({

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/manageAccounts.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/manageAccounts.tsx
@@ -132,14 +132,14 @@ const ManageAccountsScreen = (): React.JSX.Element => {
     )
   }, [allWallets])
 
-  const otherWallets = useMemo(() => {
+  const primaryWallets = useMemo(() => {
     return Object.values(allWallets).filter(
       wallet => wallet.type !== WalletType.PRIVATE_KEY
     )
   }, [allWallets])
 
-  const otherWalletsDisplayData = useMemo(() => {
-    return otherWallets.map(wallet => {
+  const primaryWalletsDisplayData = useMemo(() => {
+    return primaryWallets.map(wallet => {
       const accountsForWallet = accountSearchResults.filter(
         account => account.walletId === wallet.id
       )
@@ -220,7 +220,7 @@ const ManageAccountsScreen = (): React.JSX.Element => {
       }
     })
   }, [
-    otherWallets,
+    primaryWallets,
     accountSearchResults,
     activeAccount?.id,
     colors.$textPrimary,
@@ -329,10 +329,10 @@ const ManageAccountsScreen = (): React.JSX.Element => {
   ])
 
   const walletsDisplayData: (WalletDisplayData | null)[] = useMemo(() => {
-    return [...otherWalletsDisplayData, importedWalletsDisplayData].filter(
+    return [...primaryWalletsDisplayData, importedWalletsDisplayData].filter(
       Boolean
     ) as WalletDisplayData[]
-  }, [otherWalletsDisplayData, importedWalletsDisplayData])
+  }, [primaryWalletsDisplayData, importedWalletsDisplayData])
 
   const toggleWalletExpansion = useCallback((walletId: string) => {
     setExpandedWallets(prev => ({

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/manageAccounts.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/manageAccounts.tsx
@@ -29,6 +29,10 @@ import { Account, selectAccounts, setActiveAccount } from 'store/account'
 import { selectActiveAccount } from 'store/account'
 import { selectIsPrivacyModeEnabled } from 'store/settings/securityPrivacy'
 import { selectActiveWalletId, selectWallets } from 'store/wallet/slice'
+import { WalletType } from 'services/wallet/types'
+import { CoreAccountType } from '@avalabs/types'
+
+const VIRTUAL_WALLET_ID = 'private-key-accounts'
 
 const ManageAccountsScreen = (): React.JSX.Element => {
   const {
@@ -48,15 +52,18 @@ const ManageAccountsScreen = (): React.JSX.Element => {
 
   useMemo(() => {
     const initialExpansionState: Record<string, boolean> = {}
-    const walletIds = Object.keys(allWallets)
+    const walletIds = [...Object.keys(allWallets), VIRTUAL_WALLET_ID]
     if (walletIds.length > 0) {
       // Expand only the active wallet by default
       walletIds.forEach(id => {
-        initialExpansionState[id] = id === activeWalletId
+        initialExpansionState[id] =
+          id === activeWalletId ||
+          (id === VIRTUAL_WALLET_ID &&
+            activeAccount?.type === CoreAccountType.IMPORTED)
       })
     }
     setExpandedWallets(initialExpansionState)
-  }, [allWallets, activeWalletId])
+  }, [allWallets, activeWalletId, activeAccount?.type])
 
   const allAccountsArray: Account[] = useMemo(
     () => Object.values(accountCollection),
@@ -105,103 +112,213 @@ const ManageAccountsScreen = (): React.JSX.Element => {
     [dispatch]
   )
 
-  const walletsDisplayData: (WalletDisplayData | null)[] = useMemo(() => {
-    const walletArray = Object.values(allWallets)
-    return walletArray
-      .map(wallet => {
-        const accountsForWallet = accountSearchResults.filter(
-          account => account.walletId === wallet.id
-        )
+  const privateKeyWallets = useMemo(() => {
+    return Object.values(allWallets).filter(
+      wallet => wallet.type === WalletType.PRIVATE_KEY
+    )
+  }, [allWallets])
 
-        if (accountsForWallet.length === 0 && searchText) {
-          return null
-        }
+  const otherWallets = useMemo(() => {
+    return Object.values(allWallets).filter(
+      wallet => wallet.type !== WalletType.PRIVATE_KEY
+    )
+  }, [allWallets])
 
-        const accountDataForWallet = accountsForWallet.map((account, index) => {
-          const isActive = account.id === activeAccount?.id
+  const otherWalletsDisplayData = useMemo(() => {
+    return otherWallets.map(wallet => {
+      const accountsForWallet = accountSearchResults.filter(
+        account => account.walletId === wallet.id
+      )
 
-          const nextAccount = accountsForWallet[index + 1]
-          const hideSeparator =
-            isActive || nextAccount?.id === activeAccount?.id
+      if (accountsForWallet.length === 0) {
+        return null
+      }
 
-          return {
-            hideSeparator,
-            containerSx: {
-              backgroundColor: isActive
-                ? alpha(colors.$textPrimary, 0.1)
-                : 'transparent',
-              borderRadius: 8
-            },
-            title: (
-              <Text
-                testID={`manage_accounts_list__${account.name}`}
-                variant="body1"
-                numberOfLines={2}
-                sx={{
-                  color: colors.$textPrimary,
-                  fontSize: 14,
-                  lineHeight: 16,
-                  fontWeight: '500',
-                  width: SCREEN_WIDTH * 0.3
-                }}>
-                {account.name}
-              </Text>
-            ),
-            subtitle: (
-              <Text
-                variant="mono"
-                sx={{
-                  color: alpha(colors.$textPrimary, 0.6),
-                  fontSize: 13,
-                  lineHeight: 16,
-                  fontWeight: '500'
-                }}>
-                {truncateAddress(account.addressC, TRUNCATE_ADDRESS_LENGTH)}
-              </Text>
-            ),
-            leftIcon: isActive ? (
-              <Icons.Custom.CheckSmall
-                color={colors.$textPrimary}
-                width={24}
-                height={24}
-              />
-            ) : (
-              <View sx={{ width: 24 }} />
-            ),
-            value: (
-              <AccountBalance accountId={account.id} isActive={isActive} />
-            ),
-            onPress: () => handleSetActiveAccount(account.id),
-            accessory: (
-              <TouchableOpacity
-                hitSlop={16}
-                sx={{ marginLeft: 4 }}
-                onPress={() => gotoAccountDetails(account.id)}>
-                <Icons.Alert.AlertCircle
-                  color={colors.$textSecondary}
-                  width={18}
-                  height={18}
-                />
-              </TouchableOpacity>
-            )
-          }
-        })
+      const accountDataForWallet = accountsForWallet.map((account, index) => {
+        const isActive = account.id === activeAccount?.id
+        const nextAccount = accountsForWallet[index + 1]
+        const hideSeparator = isActive || nextAccount?.id === activeAccount?.id
+
         return {
-          ...wallet,
-          accounts: accountDataForWallet
+          hideSeparator,
+          containerSx: {
+            backgroundColor: isActive
+              ? alpha(colors.$textPrimary, 0.1)
+              : 'transparent',
+            borderRadius: 8
+          },
+          title: (
+            <Text
+              testID={`manage_accounts_list__${account.name}`}
+              variant="body1"
+              numberOfLines={2}
+              sx={{
+                color: colors.$textPrimary,
+                fontSize: 14,
+                lineHeight: 16,
+                fontWeight: '500',
+                width: SCREEN_WIDTH * 0.3
+              }}>
+              {account.name}
+            </Text>
+          ),
+          subtitle: (
+            <Text
+              variant="mono"
+              sx={{
+                color: alpha(colors.$textPrimary, 0.6),
+                fontSize: 13,
+                lineHeight: 16,
+                fontWeight: '500'
+              }}>
+              {truncateAddress(account.addressC, TRUNCATE_ADDRESS_LENGTH)}
+            </Text>
+          ),
+          leftIcon: isActive ? (
+            <Icons.Custom.CheckSmall
+              color={colors.$textPrimary}
+              width={24}
+              height={24}
+            />
+          ) : (
+            <View sx={{ width: 24 }} />
+          ),
+          value: <AccountBalance accountId={account.id} isActive={isActive} />,
+          onPress: () => handleSetActiveAccount(account.id),
+          accessory: (
+            <TouchableOpacity
+              hitSlop={16}
+              sx={{ marginLeft: 4 }}
+              onPress={() => gotoAccountDetails(account.id)}>
+              <Icons.Alert.AlertCircle
+                color={colors.$textSecondary}
+                width={18}
+                height={18}
+              />
+            </TouchableOpacity>
+          )
         }
       })
-      .filter(Boolean) // Remove nulls (wallets with no matching search results)
+
+      return {
+        ...wallet,
+        accounts: accountDataForWallet
+      }
+    })
   }, [
-    allWallets,
+    otherWallets,
     accountSearchResults,
-    searchText,
+    activeAccount?.id,
     colors.$textPrimary,
     colors.$textSecondary,
-    activeAccount?.id,
     handleSetActiveAccount,
     gotoAccountDetails
   ])
+
+  const privateKeyWalletsDisplayData = useMemo(() => {
+    // Get all accounts from private key wallets
+    const allPrivateKeyAccounts = privateKeyWallets.flatMap(wallet => {
+      return accountSearchResults.filter(
+        account => account.walletId === wallet.id
+      )
+    })
+
+    if (allPrivateKeyAccounts.length === 0) {
+      return null
+    }
+
+    // Create virtual "Private Key Accounts" wallet if there are any private key wallets
+    // Only add the virtual wallet if there are matching accounts (respects search)
+    const privateKeyAccountData = allPrivateKeyAccounts.map(
+      (account, index) => {
+        const isActive = account.id === activeAccount?.id
+        const nextAccount = allPrivateKeyAccounts[index + 1]
+        const hideSeparator = isActive || nextAccount?.id === activeAccount?.id
+
+        return {
+          hideSeparator,
+          containerSx: {
+            backgroundColor: isActive
+              ? alpha(colors.$textPrimary, 0.1)
+              : 'transparent',
+            borderRadius: 8
+          },
+          title: (
+            <Text
+              testID={`manage_accounts_list__${account.name}`}
+              variant="body1"
+              numberOfLines={2}
+              sx={{
+                color: colors.$textPrimary,
+                fontSize: 14,
+                lineHeight: 16,
+                fontWeight: '500',
+                width: SCREEN_WIDTH * 0.3
+              }}>
+              {account.name}
+            </Text>
+          ),
+          subtitle: (
+            <Text
+              variant="mono"
+              sx={{
+                color: alpha(colors.$textPrimary, 0.6),
+                fontSize: 13,
+                lineHeight: 16,
+                fontWeight: '500'
+              }}>
+              {truncateAddress(account.addressC, TRUNCATE_ADDRESS_LENGTH)}
+            </Text>
+          ),
+          leftIcon: isActive ? (
+            <Icons.Custom.CheckSmall
+              color={colors.$textPrimary}
+              width={24}
+              height={24}
+            />
+          ) : (
+            <View sx={{ width: 24 }} />
+          ),
+          value: <AccountBalance accountId={account.id} isActive={isActive} />,
+          onPress: () => handleSetActiveAccount(account.id),
+          accessory: (
+            <TouchableOpacity
+              hitSlop={16}
+              sx={{ marginLeft: 4 }}
+              onPress={() => gotoAccountDetails(account.id)}>
+              <Icons.Alert.AlertCircle
+                color={colors.$textSecondary}
+                width={18}
+                height={18}
+              />
+            </TouchableOpacity>
+          )
+        }
+      }
+    )
+
+    // Create virtual wallet for private key accounts
+    return {
+      id: VIRTUAL_WALLET_ID, // Virtual ID
+      name: 'Imported',
+      type: WalletType.PRIVATE_KEY,
+      accounts: privateKeyAccountData
+    }
+  }, [
+    privateKeyWallets,
+    accountSearchResults,
+    activeAccount?.id,
+    colors.$textPrimary,
+    colors.$textSecondary,
+    handleSetActiveAccount,
+    gotoAccountDetails
+  ])
+
+  const walletsDisplayData: (WalletDisplayData | null)[] = useMemo(() => {
+    return [...otherWalletsDisplayData, privateKeyWalletsDisplayData].filter(
+      Boolean
+    ) as WalletDisplayData[]
+  }, [otherWalletsDisplayData, privateKeyWalletsDisplayData])
 
   const toggleWalletExpansion = useCallback((walletId: string) => {
     setExpandedWallets(prev => ({
@@ -282,6 +399,7 @@ const ManageAccountsScreen = (): React.JSX.Element => {
               isExpanded={isExpanded}
               searchText={searchText}
               onToggleExpansion={() => toggleWalletExpansion(wallet.id)}
+              showMoreButton={wallet.id !== VIRTUAL_WALLET_ID}
             />
           )
         })

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/manageAccounts.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/manageAccounts.tsx
@@ -33,6 +33,7 @@ import { WalletType } from 'services/wallet/types'
 import { CoreAccountType } from '@avalabs/types'
 
 const VIRTUAL_WALLET_ID = 'private-key-accounts'
+const VIRTUAL_WALLET_NAME = 'Imported'
 
 const ManageAccountsScreen = (): React.JSX.Element => {
   const {
@@ -92,8 +93,16 @@ const ManageAccountsScreen = (): React.JSX.Element => {
       }
       const walletName = wallet.name.toLowerCase()
 
+      const isPrivateKeyAccount = wallet.type === WalletType.PRIVATE_KEY
+      const virtualWalletMatches =
+        isPrivateKeyAccount &&
+        VIRTUAL_WALLET_NAME.toLowerCase().includes(searchText.toLowerCase())
+      const walletNameMatches =
+        !isPrivateKeyAccount && walletName.includes(searchText.toLowerCase())
+
       return (
-        walletName.includes(searchText.toLowerCase()) ||
+        virtualWalletMatches ||
+        walletNameMatches ||
         account.name.toLowerCase().includes(searchText.toLowerCase()) ||
         account.addressC?.toLowerCase().includes(searchText.toLowerCase()) ||
         account.addressBTC?.toLowerCase().includes(searchText.toLowerCase()) ||
@@ -300,7 +309,7 @@ const ManageAccountsScreen = (): React.JSX.Element => {
     // Create virtual wallet for private key accounts
     return {
       id: VIRTUAL_WALLET_ID, // Virtual ID
-      name: 'Imported',
+      name: VIRTUAL_WALLET_NAME,
       type: WalletType.PRIVATE_KEY,
       accounts: privateKeyAccountData
     }
@@ -346,13 +355,7 @@ const ManageAccountsScreen = (): React.JSX.Element => {
   }, [colors.$textPrimary, handleAddAccount])
 
   const renderHeader = useCallback(() => {
-    return (
-      <SearchBar
-        onTextChanged={setSearchText}
-        searchText={searchText}
-        useDebounce={true}
-      />
-    )
+    return <SearchBar onTextChanged={setSearchText} searchText={searchText} />
   }, [searchText])
 
   useEffect(() => {

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/manageAccounts.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/manageAccounts.tsx
@@ -32,8 +32,8 @@ import { selectActiveWalletId, selectWallets } from 'store/wallet/slice'
 import { WalletType } from 'services/wallet/types'
 import { CoreAccountType } from '@avalabs/types'
 
-const VIRTUAL_WALLET_ID = 'private-key-accounts'
-const VIRTUAL_WALLET_NAME = 'Imported'
+const IMPORTED_ACCOUNTS_VIRTUAL_WALLET_ID = 'imported-accounts-wallet-id'
+const IMPORTED_ACCOUNTS_VIRTUAL_WALLET_NAME = 'Imported'
 
 const ManageAccountsScreen = (): React.JSX.Element => {
   const {
@@ -53,13 +53,16 @@ const ManageAccountsScreen = (): React.JSX.Element => {
 
   useMemo(() => {
     const initialExpansionState: Record<string, boolean> = {}
-    const walletIds = [...Object.keys(allWallets), VIRTUAL_WALLET_ID]
+    const walletIds = [
+      ...Object.keys(allWallets),
+      IMPORTED_ACCOUNTS_VIRTUAL_WALLET_ID
+    ]
     if (walletIds.length > 0) {
       // Expand only the active wallet by default
       walletIds.forEach(id => {
         initialExpansionState[id] =
           id === activeWalletId ||
-          (id === VIRTUAL_WALLET_ID &&
+          (id === IMPORTED_ACCOUNTS_VIRTUAL_WALLET_ID &&
             activeAccount?.type === CoreAccountType.IMPORTED)
       })
     }
@@ -96,7 +99,9 @@ const ManageAccountsScreen = (): React.JSX.Element => {
       const isPrivateKeyAccount = wallet.type === WalletType.PRIVATE_KEY
       const virtualWalletMatches =
         isPrivateKeyAccount &&
-        VIRTUAL_WALLET_NAME.toLowerCase().includes(searchText.toLowerCase())
+        IMPORTED_ACCOUNTS_VIRTUAL_WALLET_NAME.toLowerCase().includes(
+          searchText.toLowerCase()
+        )
       const walletNameMatches =
         !isPrivateKeyAccount && walletName.includes(searchText.toLowerCase())
 
@@ -308,8 +313,8 @@ const ManageAccountsScreen = (): React.JSX.Element => {
 
     // Create virtual wallet for private key accounts
     return {
-      id: VIRTUAL_WALLET_ID, // Virtual ID
-      name: VIRTUAL_WALLET_NAME,
+      id: IMPORTED_ACCOUNTS_VIRTUAL_WALLET_ID, // Virtual ID
+      name: IMPORTED_ACCOUNTS_VIRTUAL_WALLET_NAME,
       type: WalletType.PRIVATE_KEY,
       accounts: privateKeyAccountData
     }
@@ -402,7 +407,7 @@ const ManageAccountsScreen = (): React.JSX.Element => {
               isExpanded={isExpanded}
               searchText={searchText}
               onToggleExpansion={() => toggleWalletExpansion(wallet.id)}
-              showMoreButton={wallet.id !== VIRTUAL_WALLET_ID}
+              showMoreButton={wallet.id !== IMPORTED_ACCOUNTS_VIRTUAL_WALLET_ID}
             />
           )
         })

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/manageAccounts.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/manageAccounts.tsx
@@ -126,7 +126,7 @@ const ManageAccountsScreen = (): React.JSX.Element => {
     [dispatch]
   )
 
-  const privateKeyWallets = useMemo(() => {
+  const importedWallets = useMemo(() => {
     return Object.values(allWallets).filter(
       wallet => wallet.type === WalletType.PRIVATE_KEY
     )
@@ -229,9 +229,9 @@ const ManageAccountsScreen = (): React.JSX.Element => {
     gotoAccountDetails
   ])
 
-  const privateKeyWalletsDisplayData = useMemo(() => {
+  const importedWalletsDisplayData = useMemo(() => {
     // Get all accounts from private key wallets
-    const allPrivateKeyAccounts = privateKeyWallets.flatMap(wallet => {
+    const allPrivateKeyAccounts = importedWallets.flatMap(wallet => {
       return accountSearchResults.filter(
         account => account.walletId === wallet.id
       )
@@ -241,7 +241,7 @@ const ManageAccountsScreen = (): React.JSX.Element => {
       return null
     }
 
-    // Create virtual "Private Key Accounts" wallet if there are any private key wallets
+    // Create virtual "Private Key Accounts" wallet if there are any imported wallets
     // Only add the virtual wallet if there are matching accounts (respects search)
     const privateKeyAccountData = allPrivateKeyAccounts.map(
       (account, index) => {
@@ -319,7 +319,7 @@ const ManageAccountsScreen = (): React.JSX.Element => {
       accounts: privateKeyAccountData
     }
   }, [
-    privateKeyWallets,
+    importedWallets,
     accountSearchResults,
     activeAccount?.id,
     colors.$textPrimary,
@@ -329,10 +329,10 @@ const ManageAccountsScreen = (): React.JSX.Element => {
   ])
 
   const walletsDisplayData: (WalletDisplayData | null)[] = useMemo(() => {
-    return [...otherWalletsDisplayData, privateKeyWalletsDisplayData].filter(
+    return [...otherWalletsDisplayData, importedWalletsDisplayData].filter(
       Boolean
     ) as WalletDisplayData[]
-  }, [otherWalletsDisplayData, privateKeyWalletsDisplayData])
+  }, [otherWalletsDisplayData, importedWalletsDisplayData])
 
   const toggleWalletExpansion = useCallback((walletId: string) => {
     setExpandedWallets(prev => ({

--- a/packages/core-mobile/app/store/account/slice.ts
+++ b/packages/core-mobile/app/store/account/slice.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { createSlice, PayloadAction, createSelector } from '@reduxjs/toolkit'
 import { RootState } from 'store/types'
 import { WalletType } from 'services/wallet/types'
 import {
@@ -88,13 +88,14 @@ export const selectActiveAccount = (state: RootState): Account | undefined => {
   return state.account.accounts[activeAccountId]
 }
 
-export const selectAccountsByWalletId =
-  (walletId: string) =>
-  (state: RootState): Account[] => {
-    return Object.values(state.account.accounts)
+export const selectAccountsByWalletId = createSelector(
+  [selectAccounts, (_: RootState, walletId: string) => walletId],
+  (accounts, walletId) => {
+    return Object.values(accounts)
       .filter(account => account.walletId === walletId)
       .sort((a, b) => a.index - b.index)
   }
+)
 
 export const selectAccountByIndex =
   (walletId: string, index: number) =>

--- a/packages/core-mobile/app/store/account/thunks.ts
+++ b/packages/core-mobile/app/store/account/thunks.ts
@@ -33,7 +33,7 @@ export const addAccount = createAsyncThunk<void, string, ThunkApi>(
     }
 
     const allAccountsCount = Object.keys(allAccounts).length
-    const accountsByWalletId = selectAccountsByWalletId(walletId)(state)
+    const accountsByWalletId = selectAccountsByWalletId(state, walletId)
 
     const acc = await AccountsService.createNextAccount({
       name: `Account ${allAccountsCount + 1}`,
@@ -84,8 +84,9 @@ export const removeAccountWithActiveCheck = createAsyncThunk<
       throw new Error(`Account with ID "${accountId}" not found`)
     }
 
-    const accountsInWallet = selectAccountsByWalletId(accountToRemove.walletId)(
-      state
+    const accountsInWallet = selectAccountsByWalletId(
+      state,
+      accountToRemove.walletId
     )
 
     // Validate removal eligibility

--- a/packages/core-mobile/app/store/wallet/thunks.ts
+++ b/packages/core-mobile/app/store/wallet/thunks.ts
@@ -165,7 +165,7 @@ export const removeWallet = createAsyncThunk<void, string, ThunkApi>(
       selectWallets(stateBefore)
     ).indexOf(activeWalletIdBefore)
 
-    const accountsToRemove = selectAccountsByWalletId(walletId)(stateBefore)
+    const accountsToRemove = selectAccountsByWalletId(stateBefore, walletId)
     accountsToRemove.forEach(account => {
       thunkApi.dispatch(removeAccount(account.id))
     })
@@ -184,8 +184,10 @@ export const removeWallet = createAsyncThunk<void, string, ThunkApi>(
       }
       thunkApi.dispatch(setActiveWallet(newActiveWalletId))
 
-      const accountsForWallet =
-        selectAccountsByWalletId(newActiveWalletId)(stateAfter)
+      const accountsForWallet = selectAccountsByWalletId(
+        stateAfter,
+        newActiveWalletId
+      )
       if (accountsForWallet.length > 0 && accountsForWallet[0]) {
         thunkApi.dispatch(setActiveAccountId(accountsForWallet[0].id))
       }


### PR DESCRIPTION
## Description

**Ticket: [CP-11357]** 

This PR implements a visual grouping feature for private key accounts in the Manage Accounts screen. All imported private key accounts are now displayed under a single collapsible "Imported" section while maintaining the underlying wallet structure.

## Key Changes
1. Virtual Wallet Display (manageAccounts.tsx)
Groups all private key accounts under "Imported" section
Maintains separate display logic for regular wallets
2. Enhanced Account Removal (AccountButtons.tsx & thunks.ts)
Private key accounts can always be removed
Removing a private key account also removes its parent wallet
Proper active account switching when removing currently active private key account
3. Conditional Wallet Actions (WalletCard.tsx)
Added showMoreButton prop to hide dropdown for virtual wallet
4. Memoized Selectors (slice.ts)
Fixed `selectAccountsByWalletId` to use `createSelector` for proper memoization
Prevents unnecessary re-renders and selector warnings

## Video
Posted in ticket for privacy

## Testing
[ ] Private key accounts display under "Imported" section
[ ] Search functionality includes virtual wallet name
[ ] Account selection and details navigation work correctly
[ ] Active account switching works when removing active private key account
[ ] Expansion state properly reflects active private key accounts

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11357]: https://ava-labs.atlassian.net/browse/CP-11357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ