### PR TITLE
CP-11342: Refresh when no public key is stored during Seedless wallet creation. 

### DIFF
--- a/packages/core-mobile/app/services/wallet/WalletFactory.ts
+++ b/packages/core-mobile/app/services/wallet/WalletFactory.ts
@@ -16,7 +16,14 @@ class WalletFactory {
   }): Promise<Wallet> {
     switch (walletType) {
       case WalletType.SEEDLESS: {
-        const pubKeys = await SeedlessPubKeysStorage.retrieve()
+        let pubKeys = await SeedlessPubKeysStorage.retrieve()
+
+        if (pubKeys.length === 0) {
+          // If no public keys are available, refresh them
+          // This can happen if the app was updated from a version that stored with a different key
+          await SeedlessService.refreshPublicKeys()
+          pubKeys = await SeedlessPubKeysStorage.retrieve()
+        }
 
         if (pubKeys.length === 0) throw new Error('Public keys not available')
 

--- a/packages/core-mobile/app/store/account/listeners.ts
+++ b/packages/core-mobile/app/store/account/listeners.ts
@@ -239,12 +239,18 @@ const deriveMissingSeedlessSessionKeys = async (
     walletType: WalletType.SEEDLESS
   })
   if (wallet instanceof SeedlessWallet) {
-    transactionSnackbar.pending({ message: 'Updating accounts...' })
+    try {
+      transactionSnackbar.pending({ message: 'Updating accounts...' })
 
-    // prompt Core Seedless API to derive missing keys
-    await wallet.deriveMissingKeys()
+      // prompt Core Seedless API to derive missing keys
+      await wallet.deriveMissingKeys()
 
-    transactionSnackbar.success({ message: 'Accounts updated' })
+      transactionSnackbar.success({ message: 'Accounts updated' })
+    } catch (error) {
+      transactionSnackbar.error({
+        error: 'Failed to update accounts'
+      })
+    }
   }
 }
 

--- a/packages/core-mobile/app/store/account/listeners.ts
+++ b/packages/core-mobile/app/store/account/listeners.ts
@@ -234,13 +234,13 @@ const migrateSolanaAddressesIfNeeded = async (
 const deriveMissingSeedlessSessionKeys = async (
   walletId: string
 ): Promise<void> => {
-  transactionSnackbar.pending({ message: 'Updating accounts...' })
-
   const wallet = await WalletFactory.createWallet({
     walletId,
     walletType: WalletType.SEEDLESS
   })
   if (wallet instanceof SeedlessWallet) {
+    transactionSnackbar.pending({ message: 'Updating accounts...' })
+
     // prompt Core Seedless API to derive missing keys
     await wallet.deriveMissingKeys()
 


### PR DESCRIPTION
## Description

**Ticket: [CP-11342]** 

* Fix to refresh when no public key is stored during Seedless wallet creation.

[CP-11342]: https://ava-labs.atlassian.net/browse/CP-11342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ