### PR TITLE
CP-11327: Better error messages for Solana transaction failures

### DIFF
--- a/packages/core-mobile/app/utils/getJsonRpcErrorMessage/getJsonRpcErrorMessage.test.ts
+++ b/packages/core-mobile/app/utils/getJsonRpcErrorMessage/getJsonRpcErrorMessage.test.ts
@@ -113,4 +113,151 @@ describe('parseJsonRpcError', () => {
     const error = new JsonRpcError(1234, 'Test RPC error')
     expect(parseJsonRpcError(error)).toBe('Test RPC error')
   })
+
+  describe('Solana errors', () => {
+    it('should handle -32002 with Blockhash not found', () => {
+      const error = new JsonRpcError(1234, 'Test RPC error', {
+        cause: {
+          error: { message: 'Solana error #-32002; Blockhash not found' }
+        }
+      })
+      expect(parseJsonRpcError(error)).toBe(
+        'Transaction failed: The network is experiencing high load. Please try again.'
+      )
+    })
+
+    it('should handle generic -32002 error', () => {
+      const error = new JsonRpcError(1234, 'Test RPC error', {
+        cause: {
+          error: { message: 'Error -32002: Transaction simulation failed' }
+        }
+      })
+      expect(parseJsonRpcError(error)).toBe(
+        'Transaction failed: Please verify your transaction details and try again.'
+      )
+    })
+
+    it('should handle -32003 signature verification error', () => {
+      const error = new JsonRpcError(1234, 'Test RPC error', {
+        cause: {
+          error: {
+            message: 'Error -32003: Transaction signature verification failure'
+          }
+        }
+      })
+      expect(parseJsonRpcError(error)).toBe(
+        'Transaction failed: Invalid signature. Please check your account has sufficient permissions.'
+      )
+    })
+
+    it('should handle -32004 network timeout', () => {
+      const error = new JsonRpcError(1234, 'Test RPC error', {
+        cause: {
+          error: { message: 'Error -32004: Block not available for slot x' }
+        }
+      })
+      expect(parseJsonRpcError(error)).toBe(
+        'Transaction failed: Network timeout. Please try again.'
+      )
+    })
+
+    it('should handle -32005 network delay', () => {
+      const error = new JsonRpcError(1234, 'Test RPC error', {
+        cause: {
+          error: {
+            message:
+              'Error -32005: Node is unhealthy Node is behind by xxxx slots'
+          }
+        }
+      })
+      expect(parseJsonRpcError(error)).toBe(
+        'Transaction failed: Network is temporarily experiencing delays. Please try again in a moment.'
+      )
+    })
+
+    it('should handle -32007/-32009 network sync issues', () => {
+      const error32007 = new JsonRpcError(1234, 'Test RPC error', {
+        cause: {
+          error: {
+            message:
+              'Error -32007: Slot xxxxx was skipped, or missing due to ledger jump to recent snapshot'
+          }
+        }
+      })
+      expect(parseJsonRpcError(error32007)).toBe(
+        'Transaction failed: Network synchronization issue. Please try again.'
+      )
+
+      const error32009 = new JsonRpcError(1234, 'Test RPC error', {
+        cause: {
+          error: {
+            message:
+              'Error -32009: Slot xxxxx was skipped, or missing in long-term storage'
+          }
+        }
+      })
+      expect(parseJsonRpcError(error32009)).toBe(
+        'Transaction failed: Network synchronization issue. Please try again.'
+      )
+    })
+
+    it('should handle -32010 invalid transaction data', () => {
+      const error = new JsonRpcError(1234, 'Test RPC error', {
+        cause: {
+          error: {
+            message:
+              'Error -32010: xxxxxx excluded from account secondary indexes'
+          }
+        }
+      })
+      expect(parseJsonRpcError(error)).toBe(
+        'Transaction failed: Invalid transaction data. Please check your transaction details.'
+      )
+    })
+
+    it('should handle -32013 invalid signature length', () => {
+      const error = new JsonRpcError(1234, 'Test RPC error', {
+        cause: {
+          error: {
+            message:
+              'Error -32013: There is a mismatch in the length of the transaction signature'
+          }
+        }
+      })
+      expect(parseJsonRpcError(error)).toBe(
+        'Transaction failed: Invalid signature format.'
+      )
+    })
+
+    it('should handle -32015 unsupported version', () => {
+      const error = new JsonRpcError(1234, 'Test RPC error', {
+        cause: {
+          error: {
+            message: 'Error -32015: Transaction version (0) is not supported'
+          }
+        }
+      })
+      expect(parseJsonRpcError(error)).toBe(
+        'Transaction failed: Unsupported transaction version. Please update your wallet.'
+      )
+    })
+
+    it('should handle -32602 invalid parameters', () => {
+      const error = new JsonRpcError(1234, 'Test RPC error', {
+        cause: { error: { message: 'Error -32602: Invalid params: xxxxx' } }
+      })
+      expect(parseJsonRpcError(error)).toBe(
+        'Transaction failed: Invalid parameters. Please check your transaction details.'
+      )
+    })
+
+    it('should fallback to default error handling for unknown Solana errors', () => {
+      const error = new JsonRpcError(1234, 'Test RPC error', {
+        cause: { error: { message: 'Error -99999: Some unknown error' } }
+      })
+      expect(parseJsonRpcError(error)).toBe(
+        'Test RPC error\nError: Error -99999: Some unknown error'
+      )
+    })
+  })
 })

--- a/packages/core-mobile/app/utils/getJsonRpcErrorMessage/getJsonRpcErrorMessage.ts
+++ b/packages/core-mobile/app/utils/getJsonRpcErrorMessage/getJsonRpcErrorMessage.ts
@@ -19,6 +19,57 @@ export const getJsonRpcErrorMessage = (error: unknown): string => {
   return 'Unexpected error'
 }
 
+function getSolanaErrorMessage(errorMessage: string): string | null {
+  if (errorMessage.includes('-32002')) {
+    if (errorMessage.includes('Blockhash not found')) {
+      return 'Transaction failed: The network is experiencing high load. Please try again.'
+    }
+    return 'Transaction failed: Please verify your transaction details and try again.'
+  }
+
+  if (errorMessage.includes('-32003')) {
+    return 'Transaction failed: Invalid signature. Please check your account has sufficient permissions.'
+  }
+
+  if (errorMessage.includes('-32004')) {
+    return 'Transaction failed: Network timeout. Please try again.'
+  }
+
+  if (errorMessage.includes('-32005')) {
+    return 'Transaction failed: Network is temporarily experiencing delays. Please try again in a moment.'
+  }
+
+  if (errorMessage.includes('-32007') || errorMessage.includes('-32009')) {
+    return 'Transaction failed: Network synchronization issue. Please try again.'
+  }
+
+  if (errorMessage.includes('-32010')) {
+    return 'Transaction failed: Invalid transaction data. Please check your transaction details.'
+  }
+
+  if (errorMessage.includes('-32013')) {
+    return 'Transaction failed: Invalid signature format.'
+  }
+
+  if (errorMessage.includes('-32014')) {
+    return 'Transaction failed: Network is processing your request. Please try again in a moment.'
+  }
+
+  if (errorMessage.includes('-32015')) {
+    return 'Transaction failed: Unsupported transaction version. Please update your wallet.'
+  }
+
+  if (errorMessage.includes('-32016')) {
+    return 'Transaction failed: Please try again in a moment.'
+  }
+
+  if (errorMessage.includes('-32602')) {
+    return 'Transaction failed: Invalid parameters. Please check your transaction details.'
+  }
+
+  return null
+}
+
 /**
  * Handles JSON-RPC error cases and returns a user-friendly error message.
  * @param error - The error object to process.
@@ -34,6 +85,13 @@ export const parseJsonRpcError = (
 
   // Handle detailed error message based on cause
   if (cause?.error?.message) {
+    // Try to get Solana specific error message
+    const solanaError = getSolanaErrorMessage(cause.error.message)
+    if (solanaError) {
+      return solanaError
+    }
+
+    // Handle existing cases for other chains
     if (cause.error.message.startsWith('transaction underpriced')) {
       return "Transaction failed. The gas price or max priority fee is too low compared to the network's current minimum requirement. Please increase the gas and try again."
     } else if (cause.error.message === 'already known') {


### PR DESCRIPTION
## Description

**Ticket: [CP-11327](https://ava-labs.atlassian.net/browse/CP-11327)** 

Please include a summary of the changes. Please also include relevant motivation and context. List any dependencies that are required for this change. If this is a breaking change, please also include steps to migrate.

- Added handling for solana specific error codes that come through in messages of rpcErrors from VM module 
- List of error codes handled found [here](https://www.quicknode.com/docs/solana/error-references)
- Unit tests for new error handling logic 

## Screenshots/Videos


## Testing


## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
