### PR TITLE
CP-11424: return address for the current account index

### DIFF
--- a/packages/core-mobile/app/services/wallet/WalletService.tsx
+++ b/packages/core-mobile/app/services/wallet/WalletService.tsx
@@ -324,11 +324,17 @@ class WalletService {
     isChange: boolean
     isTestnet: boolean
   }): Promise<string[]> {
+    // core web handles the logic to get the addresses by the account index
     if (
       walletType === WalletType.SEEDLESS ||
       (isChange && chainAlias !== 'X')
     ) {
       return []
+    }
+
+    // We only return the current address for private key wallets
+    if (walletType === WalletType.PRIVATE_KEY) {
+      return [account.addressAVM]
     }
 
     if (walletType === WalletType.MNEMONIC) {


### PR DESCRIPTION
## Description

**Ticket: [CP-11424]** 

- add the condition to return current address by account index for private key.  since each private key can only have one xp address.  (another thing core web should do is to not call getAddressInRange rpc call for private key account)

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
