### PR TITLE
CP-11505 - Global Activity - Should handle date correctly

### DIFF
--- a/packages/core-mobile/app/new/common/components/SubTextNumber.tsx
+++ b/packages/core-mobile/app/new/common/components/SubTextNumber.tsx
@@ -89,7 +89,7 @@ const getSubTextStyle = (textVariant: SubTextNumberVariant): TextStyle => {
     style = { ...style, fontSize: 18, top: 8, fontWeight: '700' }
   }
   if (textVariant === 'buttonMedium') {
-    style = { ...style, fontSize: 15, top: 6, fontWeight: '600' }
+    style = { ...style, fontSize: 15, top: 4, fontWeight: '600' }
   }
 
   return style

--- a/packages/core-mobile/app/new/features/browser/components/HistoryList.tsx
+++ b/packages/core-mobile/app/new/features/browser/components/HistoryList.tsx
@@ -55,7 +55,7 @@ export const HistoryList = (
     const now = new Date()
     const historyDate = new Date(date)
     const diffTime = Math.abs(now.getTime() - historyDate.getTime())
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
+    const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
 
     return diffDays === 0
       ? 'Today'

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/ActivityListItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/ActivityListItem.tsx
@@ -45,10 +45,13 @@ const ActivityListItem: FC<Props> = ({
     const now = new Date()
     const historyDate = new Date(date)
     const diffTime = Math.abs(now.getTime() - historyDate.getTime())
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
+    const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
 
     return diffDays === 0
-      ? 'Today'
+      ? `Today, ${historyDate.toLocaleTimeString('en-US', {
+          hour: '2-digit',
+          minute: '2-digit'
+        })}`
       : diffDays === 1
       ? 'Yesterday'
       : diffDays < 7


### PR DESCRIPTION
## Description

**Ticket: [CP-11505]** 

- Add time to Today's timestamp label
- Added default chain (fixes when user disables current network (from settings) that he is also filtering)
- Small UI fix for SubTextNumber

## Screenshots/Videos

<img width="1206" height="2622" alt="simulator_screenshot_604FEE8D-1DD1-4DDC-AB62-DAB2090C7B1C" src="https://github.com/user-attachments/assets/c236a85b-d365-48a6-b2ba-96408af90b00" />


Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
