### PR TITLE
CP-11169: move confetti to onTransactionPending

### DIFF
--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -44,6 +44,15 @@ class ApprovalController implements VmModuleApprovalController {
 
   onTransactionPending({ request }: { request: RpcRequest }): void {
     transactionSnackbar.pending({ toastId: request.requestId })
+
+    const confettiDisabled = request.context?.[RequestContext.CONFETTI_DISABLED]
+
+    // only show confetti for in-app requests
+    if (isInAppRequest(request) && !confettiDisabled) {
+      setTimeout(() => {
+        confetti.restart()
+      }, 100)
+    }
   }
 
   onTransactionConfirmed({
@@ -54,15 +63,6 @@ class ApprovalController implements VmModuleApprovalController {
     request: RpcRequest
   }): void {
     transactionSnackbar.success({ explorerLink, toastId: request.requestId })
-
-    const confettiDisabled = request.context?.[RequestContext.CONFETTI_DISABLED]
-
-    // only show confetti for in-app requests
-    if (isInAppRequest(request) && !confettiDisabled) {
-      setTimeout(() => {
-        confetti.restart()
-      }, 100)
-    }
   }
 
   onTransactionReverted(): void {


### PR DESCRIPTION
## Description

**Ticket: [CP-11169]** 

- move confetti to onTransactionPending, to indicate the transaction was submitted successfully

## Screenshots/Videos

https://github.com/user-attachments/assets/2e4619e9-89cd-446d-9fc8-6f3fc7eb08de


https://github.com/user-attachments/assets/8bfd7ad0-36a5-4448-add1-a0724098c2a3


https://github.com/user-attachments/assets/b2824526-21c8-41eb-93ed-4559285c2888



## Testing


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11169]: https://ava-labs.atlassian.net/browse/CP-11169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ