### PR TITLE
hide amount selection

### DIFF
--- a/packages/core-mobile/app/new/features/meld/components/SelectAmount.tsx
+++ b/packages/core-mobile/app/new/features/meld/components/SelectAmount.tsx
@@ -371,6 +371,9 @@ export const SelectAmount = ({
             }
             formatInCurrency={amt => formatCurrency({ amount: amt })}
             formatInSubTextNumber={formatInSubTextNumber}
+            enableAmountSelection={
+              category === ServiceProviderCategories.CRYPTO_ONRAMP
+            }
           />
         )}
         {/* token balance or error message */}

--- a/packages/core-mobile/app/new/features/meld/components/SelectMeldCurrency.tsx
+++ b/packages/core-mobile/app/new/features/meld/components/SelectMeldCurrency.tsx
@@ -9,6 +9,7 @@ import {
   setSelectedCurrency
 } from 'store/settings/currency'
 import { useDispatch, useSelector } from 'react-redux'
+import { CurrencyIcon } from 'common/components/CurrencyIcon'
 import { useSearchFiatCurrencies } from '../hooks/useSearchFiatCurrencies'
 import { ServiceProviderCategories } from '../consts'
 
@@ -57,10 +58,15 @@ export const SelectMeldCurrency = ({
 
   const transformedCurrencies = useMemo(() => {
     return sortedCurrencies.map(curr => {
+      const logoUrl = (
+        <CurrencyIcon
+          symbol={(curr.currencyCode?.toUpperCase() ?? '') as CurrencySymbol}
+        />
+      )
       return {
         name: curr.name ?? '',
         symbol: curr.currencyCode?.toUpperCase() ?? '',
-        logoUrl: curr.symbolImageUrl
+        logoUrl
       }
     })
   }, [sortedCurrencies])

--- a/packages/core-mobile/app/new/features/meld/hooks/useSelectAmount.tsx
+++ b/packages/core-mobile/app/new/features/meld/hooks/useSelectAmount.tsx
@@ -238,7 +238,7 @@ export const useSelectAmount = ({
           : 0
 
       const tokenAmount =
-        amt !== null && amt !== undefined
+        amt !== null && amt !== undefined && currentPrice !== 0
           ? (amt / currentPrice) * 10 ** maxDecimals
           : 0
 

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/AssetsScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/AssetsScreen.tsx
@@ -145,7 +145,7 @@ const AssetsScreen: FC<Props> = ({
   }, [isGridView])
 
   const renderEmptyComponent = useCallback(() => {
-    if (isLoadingBalance || !isBalanceLoaded) {
+    if (isLoadingBalance || !isBalanceLoaded || isBalancePolling) {
       return <LoadingState />
     }
 
@@ -161,15 +161,19 @@ const AssetsScreen: FC<Props> = ({
       )
     }
 
-    if (hasNoAssets) {
+    if (
+      filter.selected.section === 0 &&
+      filter.selected.row === 0 &&
+      hasNoAssets
+    ) {
       return <EmptyState goToBuy={goToBuy} />
     }
 
     // if the filter is the default filter, this error state does not apply
     if (
-      filter.selected.section === 0 &&
-      filter.selected.row === 0 &&
-      isBalanceLoaded
+      filter.selected.section !== 0 &&
+      filter.selected.row !== 0 &&
+      hasNoAssets
     ) {
       return (
         <ErrorState
@@ -190,6 +194,7 @@ const AssetsScreen: FC<Props> = ({
     hasNoAssets,
     filter.selected.section,
     filter.selected.row,
+    isBalancePolling,
     refetch,
     goToBuy,
     onResetFilter

--- a/packages/k2-alpine/src/components/FiatAmountInputWidget/FiatAmountInputWidget.tsx
+++ b/packages/k2-alpine/src/components/FiatAmountInputWidget/FiatAmountInputWidget.tsx
@@ -16,6 +16,7 @@ interface FiatAmountInputWidgetProps {
   sx?: SxProp
   disabled?: boolean
   autoFocus?: boolean
+  enableAmountSelection?: boolean
 }
 
 export const FiatAmountInputWidget = ({
@@ -29,69 +30,79 @@ export const FiatAmountInputWidget = ({
   accessory,
   sx,
   disabled,
-  autoFocus
+  autoFocus,
+  enableAmountSelection
 }: FiatAmountInputWidgetProps): JSX.Element => {
   const [predefinedAmountButtons, setPredefinedAmountButtons] = useState<
     { text: string; predefinedAmount: number; isSelected: boolean }[]
-  >([
-    {
-      text: formatIntegerCurrency(100),
-      predefinedAmount: 100,
-      isSelected: false
-    },
-    {
-      text: formatIntegerCurrency(200),
-      predefinedAmount: 200,
-      isSelected: false
-    },
-    {
-      text: formatIntegerCurrency(500),
-      predefinedAmount: 500,
-      isSelected: false
-    }
-  ])
+  >(
+    enableAmountSelection
+      ? [
+          {
+            text: formatIntegerCurrency(100),
+            predefinedAmount: 100,
+            isSelected: false
+          },
+          {
+            text: formatIntegerCurrency(200),
+            predefinedAmount: 200,
+            isSelected: false
+          },
+          {
+            text: formatIntegerCurrency(500),
+            predefinedAmount: 500,
+            isSelected: false
+          }
+        ]
+      : []
+  )
   const textInputRef = useRef<FiatAmountInputHandle>(null)
 
-  const handlePressPredefinedAmountButton = (
-    predefinedAmount: number,
-    index: number
-  ): void => {
-    textInputRef.current?.setValue(predefinedAmount.toString())
+  const handlePressPredefinedAmountButton = useCallback(
+    (predefinedAmount: number, index: number): void => {
+      textInputRef.current?.setValue(predefinedAmount.toString())
 
-    onChange?.(predefinedAmount)
+      onChange?.(predefinedAmount)
 
-    setPredefinedAmountButtons(prevButtons =>
-      prevButtons.map((b, i) =>
-        i === index ? { ...b, isSelected: true } : { ...b, isSelected: false }
-      )
-    )
-  }
+      enableAmountSelection &&
+        setPredefinedAmountButtons(prevButtons =>
+          prevButtons.map((b, i) =>
+            i === index
+              ? { ...b, isSelected: true }
+              : { ...b, isSelected: false }
+          )
+        )
+    },
+    [enableAmountSelection, onChange]
+  )
 
   const handleChange = useCallback(
     (value: string): void => {
-      setPredefinedAmountButtons(prevButtons =>
-        prevButtons.map(b => ({
-          ...b,
-          isSelected: Number(value) === b.predefinedAmount
-        }))
-      )
+      enableAmountSelection &&
+        setPredefinedAmountButtons(prevButtons =>
+          prevButtons.map(b => ({
+            ...b,
+            isSelected: Number(value) === b.predefinedAmount
+          }))
+        )
 
       onChange?.(Number(value))
     },
-    [onChange]
+    [enableAmountSelection, onChange]
   )
 
   useEffect(() => {
     if (amount === undefined || amount === 0) {
       textInputRef.current?.setValue('')
-      setPredefinedAmountButtons(prevButtons =>
-        prevButtons.map(b => ({
-          ...b,
-          isSelected: false
-        }))
-      )
+      enableAmountSelection &&
+        setPredefinedAmountButtons(prevButtons =>
+          prevButtons.map(b => ({
+            ...b,
+            isSelected: false
+          }))
+        )
     }
-  }, [amount, textInputRef])
+  }, [amount, enableAmountSelection, textInputRef])
 
   return (
     <View sx={sx}>
@@ -114,26 +125,28 @@ export const FiatAmountInputWidget = ({
           formatInCurrency={formatInCurrency}
           formatInSubTextNumber={formatInSubTextNumber}
         />
-        <View sx={{ flexDirection: 'row', gap: 7, marginTop: 25 }}>
-          {predefinedAmountButtons.map((button, index) => (
-            <Button
-              key={index}
-              size="small"
-              type={button.isSelected ? 'primary' : 'secondary'}
-              style={{
-                minWidth: 72
-              }}
-              disabled={disabled}
-              onPress={() => {
-                handlePressPredefinedAmountButton(
-                  button.predefinedAmount,
-                  index
-                )
-              }}>
-              {button.text}
-            </Button>
-          ))}
-        </View>
+        {enableAmountSelection && (
+          <View sx={{ flexDirection: 'row', gap: 7, marginTop: 25 }}>
+            {predefinedAmountButtons.map((button, index) => (
+              <Button
+                key={index}
+                size="small"
+                type={button.isSelected ? 'primary' : 'secondary'}
+                style={{
+                  minWidth: 72
+                }}
+                disabled={disabled}
+                onPress={() => {
+                  handlePressPredefinedAmountButton(
+                    button.predefinedAmount,
+                    index
+                  )
+                }}>
+                {button.text}
+              </Button>
+            ))}
+          </View>
+        )}
         {accessory !== undefined && (
           <View
             sx={{

--- a/packages/k2-alpine/src/components/FiatAmountInputWidget/FiatAmountInputWidget.tsx
+++ b/packages/k2-alpine/src/components/FiatAmountInputWidget/FiatAmountInputWidget.tsx
@@ -64,16 +64,13 @@ export const FiatAmountInputWidget = ({
 
       onChange?.(predefinedAmount)
 
-      enableAmountSelection &&
-        setPredefinedAmountButtons(prevButtons =>
-          prevButtons.map((b, i) =>
-            i === index
-              ? { ...b, isSelected: true }
-              : { ...b, isSelected: false }
-          )
+      setPredefinedAmountButtons(prevButtons =>
+        prevButtons.map((b, i) =>
+          i === index ? { ...b, isSelected: true } : { ...b, isSelected: false }
         )
+      )
     },
-    [enableAmountSelection, onChange]
+    [onChange]
   )
 
   const handleChange = useCallback(


### PR DESCRIPTION
## Description

**Ticket: []** 

- we decided not to show predefined amount selection for offramp
- use local currency icon 
- fix crash when currentPrice is 0 in meld select amount screen

## Screenshots/Videos
<img width="350" height="782" alt="Screenshot 2025-07-15 at 3 06 52 PM" src="https://github.com/user-attachments/assets/a0bf7ae4-95f7-4c31-93f3-63915e5fac9c" />


## Testing


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
