### PR TITLE
CP-11547: fix selectLocaleScreen bugs

### DIFF
--- a/packages/core-mobile/app/new/features/meld/components/SelectLocale.tsx
+++ b/packages/core-mobile/app/new/features/meld/components/SelectLocale.tsx
@@ -76,10 +76,11 @@ export const SelectLocale = ({
               borderRadius: 21,
               overflow: 'hidden'
             }}>
-            {selectedCurrency.symbolImageUrl && (
+            {selectedCurrency.currencyCode && (
               <CurrencyIcon
+                size={21}
                 symbol={
-                  selectedCurrency.symbolImageUrl.toUpperCase() as CurrencySymbol
+                  selectedCurrency.currencyCode.toUpperCase() as CurrencySymbol
                 }
               />
             )}

--- a/packages/core-mobile/app/new/features/meld/components/SelectLocale.tsx
+++ b/packages/core-mobile/app/new/features/meld/components/SelectLocale.tsx
@@ -1,15 +1,10 @@
-import {
-  Button,
-  GroupList,
-  Image,
-  Text,
-  useTheme,
-  View
-} from '@avalabs/k2-alpine'
+import { Button, GroupList, Text, useTheme, View } from '@avalabs/k2-alpine'
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import { Space } from 'common/components/Space'
 import React, { useCallback, useMemo } from 'react'
 import { LoadingState } from 'common/components/LoadingState'
+import { CurrencyIcon } from 'common/components/CurrencyIcon'
+import { CurrencySymbol } from 'store/settings/currency'
 import { FiatCurrency, Country } from '../types'
 
 export const SelectLocale = ({
@@ -35,7 +30,13 @@ export const SelectLocale = ({
 
   const renderFooter = (): React.JSX.Element => {
     return (
-      <Button type="primary" size="large" onPress={onNext}>
+      <Button
+        type="primary"
+        size="large"
+        onPress={onNext}
+        disabled={
+          selectedCountry === undefined || selectedCurrency === undefined
+        }>
         Next
       </Button>
     )
@@ -75,10 +76,11 @@ export const SelectLocale = ({
               borderRadius: 21,
               overflow: 'hidden'
             }}>
-            {selectedCurrency?.symbolImageUrl && (
-              <Image
-                source={{ uri: selectedCurrency.symbolImageUrl }}
-                sx={{ width: 21, height: 21 }}
+            {selectedCurrency.symbolImageUrl && (
+              <CurrencyIcon
+                symbol={
+                  selectedCurrency.symbolImageUrl.toUpperCase() as CurrencySymbol
+                }
               />
             )}
           </View>

--- a/packages/core-mobile/app/new/features/meld/hooks/useSearchServiceProviders.ts
+++ b/packages/core-mobile/app/new/features/meld/hooks/useSearchServiceProviders.ts
@@ -2,7 +2,6 @@ import { useQuery, UseQueryResult } from '@tanstack/react-query'
 import MeldService from 'features/meld/services/MeldService'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import { MeldDefaultParams, ServiceProvider } from '../types'
-import { useMeldCountryCode } from '../store'
 
 export type SearchServiceProvidersParams = Omit<
   MeldDefaultParams,
@@ -19,19 +18,15 @@ export const useSearchServiceProviders = ({
   ServiceProvider[],
   Error
 > => {
-  const [countryCode] = useMeldCountryCode()
-
   return useQuery<ServiceProvider[]>({
     queryKey: [
       ReactQueryKeys.MELD_SEARCH_SERVICE_PROVIDERS,
       categories,
       accountFilter,
-      countryCode,
       cryptoCurrencies
     ],
     queryFn: () =>
       MeldService.searchServiceProviders({
-        countries: countryCode ? [countryCode] : undefined,
         categories,
         accountFilter,
         cryptoCurrencies

--- a/packages/core-mobile/app/new/features/meld/offramp/screens/SelectLocaleScreen.tsx
+++ b/packages/core-mobile/app/new/features/meld/offramp/screens/SelectLocaleScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from 'react'
+import React, { useLayoutEffect, useMemo } from 'react'
 import { useRouter } from 'expo-router'
 import { useMeldCountryCode, useMeldToken } from 'features/meld/store'
 import { useLocale } from 'features/meld/hooks/useLocale'
@@ -6,15 +6,12 @@ import { SelectLocale } from 'features/meld/components/SelectLocale'
 import { useSearchCountries } from 'features/meld/hooks/useSearchCountries'
 import { useSearchFiatCurrencies } from 'features/meld/hooks/useSearchFiatCurrencies'
 import { ServiceProviderCategories } from 'features/meld/consts'
-import { useDispatch } from 'react-redux'
-import { setSelectedCurrency } from 'store/settings/currency'
 
 export const SelectLocaleScreen = (): React.JSX.Element => {
   const { navigate } = useRouter()
   const [meldToken] = useMeldToken()
   const { currencyCode, countryCode } = useLocale()
   const [selectedCountryCode, setSelectedCountryCode] = useMeldCountryCode()
-  const dispatch = useDispatch()
   const { data: countries, isLoading: isLoadingCountries } = useSearchCountries(
     {
       categories: [ServiceProviderCategories.CRYPTO_OFFRAMP]
@@ -26,11 +23,10 @@ export const SelectLocaleScreen = (): React.JSX.Element => {
     })
 
   useLayoutEffect(() => {
-    setSelectedCountryCode(countryCode)
-  }, [countryCode, currencyCode, dispatch, setSelectedCountryCode])
+    selectedCountryCode === undefined && setSelectedCountryCode(countryCode)
+  }, [selectedCountryCode, countryCode, setSelectedCountryCode])
 
   const handleOnNext = (): void => {
-    dispatch(setSelectedCurrency(currencyCode))
     if (meldToken) {
       // @ts-ignore TODO: make routes typesafe
       navigate('/meld/offramp/selectWithdrawAmount')
@@ -50,13 +46,13 @@ export const SelectLocaleScreen = (): React.JSX.Element => {
     navigate('/meldOfframpCurrency')
   }
 
-  const selectedCountry = countries?.find(
-    c => c.countryCode === (selectedCountryCode ?? countryCode)
-  )
+  const selectedCountry = useMemo(() => {
+    return countries?.find(c => c.countryCode === selectedCountryCode)
+  }, [countries, selectedCountryCode])
 
-  const selectedCurrency = meldCurrencies?.find(
-    c => c.currencyCode === currencyCode
-  )
+  const selectedCurrency = useMemo(() => {
+    return meldCurrencies?.find(c => c.currencyCode === currencyCode)
+  }, [meldCurrencies, currencyCode])
 
   return (
     <SelectLocale

--- a/packages/core-mobile/app/new/features/meld/onramp/screens/SelectLocaleScreen.tsx
+++ b/packages/core-mobile/app/new/features/meld/onramp/screens/SelectLocaleScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from 'react'
+import React, { useLayoutEffect, useMemo } from 'react'
 import { useRouter } from 'expo-router'
 import { useMeldCountryCode, useMeldToken } from 'features/meld/store'
 import { useLocale } from 'features/meld/hooks/useLocale'
@@ -6,15 +6,12 @@ import { SelectLocale } from 'features/meld/components/SelectLocale'
 import { useSearchCountries } from 'features/meld/hooks/useSearchCountries'
 import { useSearchFiatCurrencies } from 'features/meld/hooks/useSearchFiatCurrencies'
 import { ServiceProviderCategories } from 'features/meld/consts'
-import { useDispatch } from 'react-redux'
-import { setSelectedCurrency } from 'store/settings/currency'
 
 export const SelectLocaleScreen = (): React.JSX.Element => {
   const { navigate } = useRouter()
   const [meldToken] = useMeldToken()
   const { currencyCode, countryCode } = useLocale()
   const [selectedCountryCode, setSelectedCountryCode] = useMeldCountryCode()
-  const dispatch = useDispatch()
   const { data: countries, isLoading: isLoadingCountries } = useSearchCountries(
     {
       categories: [ServiceProviderCategories.CRYPTO_ONRAMP]
@@ -26,11 +23,10 @@ export const SelectLocaleScreen = (): React.JSX.Element => {
     })
 
   useLayoutEffect(() => {
-    setSelectedCountryCode(countryCode)
-  }, [countryCode, currencyCode, dispatch, setSelectedCountryCode])
+    selectedCountryCode === undefined && setSelectedCountryCode(countryCode)
+  }, [selectedCountryCode, countryCode, setSelectedCountryCode])
 
   const handleOnNext = (): void => {
-    dispatch(setSelectedCurrency(currencyCode))
     if (meldToken) {
       // @ts-ignore TODO: make routes typesafe
       navigate('/meld/onramp/selectBuyAmount')
@@ -50,13 +46,13 @@ export const SelectLocaleScreen = (): React.JSX.Element => {
     navigate('/meldOnrampCurrency')
   }
 
-  const selectedCountry = countries?.find(
-    c => c.countryCode === (selectedCountryCode ?? countryCode)
-  )
+  const selectedCountry = useMemo(() => {
+    return countries?.find(c => c.countryCode === selectedCountryCode)
+  }, [countries, selectedCountryCode])
 
-  const selectedCurrency = meldCurrencies?.find(
-    c => c.currencyCode === currencyCode
-  )
+  const selectedCurrency = useMemo(() => {
+    return meldCurrencies?.find(c => c.currencyCode === currencyCode)
+  }, [meldCurrencies, currencyCode])
 
   return (
     <SelectLocale


### PR DESCRIPTION
## Description

**Ticket: [CP-11547]** 
**Ticket: [CP-11546]** 

- do not reset country when exit onramp/offramp flow
- fix incorrect useSearchServiceProvider query param
- disable button if country or currency is not selected
- use local currency icon on SelectLocaleScreen

## Screenshots/Videos

https://github.com/user-attachments/assets/b3779b7c-0422-4d84-b59c-72e014e85501



## Testing


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11547]: https://ava-labs.atlassian.net/browse/CP-11547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-11546]: https://ava-labs.atlassian.net/browse/CP-11546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ