### PR TITLE
CP-11518: Fixes for skipping pin screen when biometrics is disabled

### DIFF
--- a/packages/core-mobile/app/new/routes/loginWithPinOrBiometry.tsx
+++ b/packages/core-mobile/app/new/routes/loginWithPinOrBiometry.tsx
@@ -37,6 +37,8 @@ import { selectSelectedAvatar } from 'store/settings/avatar'
 import { selectActiveWalletId } from 'store/wallet/slice'
 import BiometricsSDK, { BiometricType } from 'utils/BiometricsSDK'
 import Logger from 'utils/Logger'
+import { commonStorage } from 'utils/mmkv'
+import { StorageKey } from 'resources/Constants'
 
 const LoginWithPinOrBiometry = (): JSX.Element => {
   const walletState = useSelector(selectWalletState)
@@ -205,8 +207,27 @@ const LoginWithPinOrBiometry = (): JSX.Element => {
     useCallback(() => {
       InteractionManager.runAfterInteractions(() => {
         const accessType = BiometricsSDK.getAccessType()
-        if (accessType === 'BIO') {
+
+        /*
+         * Fix inconsistent state: if accessType is 'BIO' but biometrics are disabled or not available
+         * This is needed due to previous bug in BiometricsSDK.storeEncryptionKeyWithBiometry()
+         * which was called by KeychainMigrator during app updates/migrations.
+         * The bug set SECURE_ACCESS_SET to 'BIO' before checking if biometric storage succeeded,
+         * leaving users in an inconsistent state when biometrics weren't available.
+         * We automatically correct this by setting SECURE_ACCESS_SET back to 'PIN'
+         */
+        if (accessType === 'BIO' && (!useBiometrics || !isBiometricAvailable)) {
+          commonStorage.set(StorageKey.SECURE_ACCESS_SET, 'PIN')
+          // Re-fetch the corrected access type
+          const correctedAccessType = BiometricsSDK.getAccessType()
+
+          if (correctedAccessType === 'PIN') {
+            focusPinInput()
+          }
+        } else if (accessType === 'BIO') {
           handlePromptBioLogin()
+        } else if (accessType === 'PIN') {
+          focusPinInput()
         } else if (!isBiometricAvailable || !useBiometrics) {
           focusPinInput()
         }

--- a/packages/core-mobile/app/utils/BiometricsSDK.ts
+++ b/packages/core-mobile/app/utils/BiometricsSDK.ts
@@ -196,7 +196,6 @@ class BiometricsSDK {
   async storeEncryptionKeyWithBiometry(
     encryptionKey: string
   ): Promise<boolean> {
-    commonStorage.set(StorageKey.SECURE_ACCESS_SET, 'BIO')
     try {
       await Keychain.setGenericPassword(
         'encryptionKey',
@@ -204,6 +203,7 @@ class BiometricsSDK {
         bioSetOptions
       )
       this.#encryptionKey = encryptionKey
+      commonStorage.set(StorageKey.SECURE_ACCESS_SET, 'BIO')
       return true
     } catch (e) {
       Logger.error('failed to store encryption key with biometry', e)


### PR DESCRIPTION
## Description

**Ticket: [CP-11518](https://ava-labs.atlassian.net/browse/CP-11518)** 

# Fix PIN authentication when biometrics unavailable

## Problem
Users with "Require PIN immediately" enabled weren't being prompted for PIN when biometrics were disabled or unavailable on their device. The app would load briefly then proceed without authentication.

## Root Cause
`SECURE_ACCESS_SET` was incorrectly set to `'BIO'` during onboarding or app updates even when biometrics weren't available, creating an inconsistent state where the app thought biometrics were enabled but they weren't available on the device.

## Solution
Two-part fix to prevent and correct the inconsistent state:

### Prevent for new users
- Modified `BiometricsSDK.storeEncryptionKeyWithBiometry()` to only set `SECURE_ACCESS_SET` to `'BIO'` if biometric storage succeeds
- This prevents the inconsistent state from occurring during onboarding or app updates

### Correct for existing users  
- Added logic in `loginWithPinOrBiometry.tsx` to detect when `accessType` is `'BIO'` but biometrics are disabled or unavailable
- Automatically sets `SECURE_ACCESS_SET` back to `'PIN'` and focuses the PIN input

## Result
- Users with "Require PIN immediately" + no biometrics now get proper PIN prompts
- New users won't experience the issue during onboarding
- Existing users get automatic correction of the inconsistent state 

## Screenshots/Videos

FaceID enabled, onboarding, close app, reopen, and then turning biometrics off and re opening app 
https://github.com/user-attachments/assets/c9c44e6e-71cf-45d1-9836-e1ad5d690598

Existing User with the issue now able to use PIN 
https://github.com/user-attachments/assets/89e82a3f-a88b-4e1e-82af-e65fb2f23163

New User onboarding with NO biometrics on device 
https://github.com/user-attachments/assets/ce285f31-e74b-400d-817c-e1970cc00401





## Testing


## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11518]: https://ava-labs.atlassian.net/browse/CP-11518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ