### PR TITLE
CP-11715 Add notification toggle for Favorite Token Price Alerts

### DIFF
--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/notificationPreferences.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/notificationPreferences.tsx
@@ -39,7 +39,8 @@ const NotificationPreferencesScreen = (): JSX.Element => {
       [ChannelId.PRODUCT_ANNOUNCEMENTS]: isAllNotificationsBlocked,
       [ChannelId.OFFERS_AND_PROMOTIONS]: isAllNotificationsBlocked,
       [ChannelId.MARKET_NEWS]: isAllNotificationsBlocked,
-      [ChannelId.PRICE_ALERTS]: isAllNotificationsBlocked
+      [ChannelId.PRICE_ALERTS]: isAllNotificationsBlocked,
+      [ChannelId.FAV_TOKEN_PRICE_ALERTS]: isAllNotificationsBlocked
     }
   }, [isAllNotificationsBlocked, isEarnBlocked])
 

--- a/packages/core-mobile/app/services/notifications/channels.ts
+++ b/packages/core-mobile/app/services/notifications/channels.ts
@@ -56,7 +56,7 @@ export const notificationChannels = [
     lights: false,
     vibration: false,
     importance: AndroidImportance.DEFAULT,
-    title: 'Product Announcements',
+    title: 'Product announcements',
     subtitle: 'Learn about new features and changes',
     sound: 'default'
   } as AvaxAndroidChannel,
@@ -66,7 +66,7 @@ export const notificationChannels = [
     lights: false,
     vibration: false,
     importance: AndroidImportance.DEFAULT,
-    title: 'Special Offers and Promotions',
+    title: 'Special offers and promotions',
     subtitle: 'Airdrops and promotional offers',
     sound: 'default'
   } as AvaxAndroidChannel,
@@ -76,7 +76,7 @@ export const notificationChannels = [
     lights: false,
     vibration: false,
     importance: AndroidImportance.DEFAULT,
-    title: 'Market News',
+    title: 'Market news',
     subtitle: 'News and market information alerts',
     sound: 'default'
   } as AvaxAndroidChannel,
@@ -86,7 +86,7 @@ export const notificationChannels = [
     lights: false,
     vibration: false,
     importance: AndroidImportance.DEFAULT,
-    title: 'Price Alerts',
+    title: 'Price alerts',
     subtitle: 'Token price movement alerts',
     sound: 'default'
   } as AvaxAndroidChannel,
@@ -96,7 +96,7 @@ export const notificationChannels = [
     lights: false,
     vibration: false,
     importance: AndroidImportance.DEFAULT,
-    title: 'Favorite Token Alerts',
+    title: 'Favorite token alerts',
     subtitle: 'Favorite token price movement alerts',
     sound: 'default'
   } as AvaxAndroidChannel

--- a/packages/core-mobile/app/services/notifications/channels.ts
+++ b/packages/core-mobile/app/services/notifications/channels.ts
@@ -6,7 +6,8 @@ export enum ChannelId {
   PRODUCT_ANNOUNCEMENTS = 'productAnnouncements',
   OFFERS_AND_PROMOTIONS = 'offersAndPromotions',
   MARKET_NEWS = 'marketNews',
-  PRICE_ALERTS = 'priceAlerts'
+  PRICE_ALERTS = 'priceAlerts',
+  FAV_TOKEN_PRICE_ALERTS = 'favTokenPriceAlerts'
 }
 
 export enum NewsChannelId {
@@ -87,6 +88,16 @@ export const notificationChannels = [
     importance: AndroidImportance.DEFAULT,
     title: 'Price Alerts',
     subtitle: 'Token price movement alerts',
+    sound: 'default'
+  } as AvaxAndroidChannel,
+  {
+    id: ChannelId.FAV_TOKEN_PRICE_ALERTS,
+    name: 'Favorite Token Alerts',
+    lights: false,
+    vibration: false,
+    importance: AndroidImportance.DEFAULT,
+    title: 'Favorite Token Alerts',
+    subtitle: 'Favorite token price movement alerts',
     sound: 'default'
   } as AvaxAndroidChannel
 ]

--- a/packages/core-mobile/app/store/index.ts
+++ b/packages/core-mobile/app/store/index.ts
@@ -30,7 +30,7 @@ import { snapshotsReducer as snapshots } from './snapshots/slice'
 import { reduxStorage } from './reduxStorage'
 import { walletsReducer as wallet } from './wallet/slice'
 
-const VERSION = 23
+const VERSION = 24
 
 // list of reducers that don't need to be persisted
 // for nested/partial blacklist, please use transform

--- a/packages/core-mobile/app/store/migrations.ts
+++ b/packages/core-mobile/app/store/migrations.ts
@@ -6,13 +6,13 @@ import BiometricsSDK, {
 import {
   Contact,
   CoreAccountType,
-  WalletType as CoreWalletType,
-  CorePrimaryAccount
+  CorePrimaryAccount,
+  WalletType as CoreWalletType
 } from '@avalabs/types'
 import {
   Account,
-  AccountsState,
   AccountCollection,
+  AccountsState,
   PrimaryAccount
 } from 'store/account'
 import { WalletType } from 'services/wallet/types'
@@ -461,6 +461,19 @@ export const migrations = {
         securityPrivacy: {
           ...state.settings.securityPrivacy,
           lockWalletWithPIN: true
+        }
+      }
+    }
+  },
+  24: (state: any) => {
+    // Make favorite token price alerts enabled by default
+    return {
+      ...state,
+      notifications: {
+        ...state.notifications,
+        notificationSubscriptions: {
+          ...state.notifications.notificationSubscriptions,
+          [ChannelId.FAV_TOKEN_PRICE_ALERTS]: true
         }
       }
     }

--- a/packages/core-mobile/app/store/notifications/listeners/listeners.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/listeners.ts
@@ -199,6 +199,26 @@ export const addNotificationsListeners = (
   })
 
   startListening({
+    matcher: isAnyOf(
+      onRehydrationComplete,
+      onFcmTokenChange,
+      turnOnAllNotifications,
+      onNotificationsEnabled,
+      onNotificationsTurnedOnForFavTokenPriceAlerts
+    ),
+    effect: setPriceAlertNotifications
+  })
+
+  startListening({
+    matcher: isAnyOf(onNotificationsTurnedOffForFavTokenPriceAlerts),
+    effect: async () => {
+      await unsubscribeForPriceAlert().catch(reason => {
+        Logger.error(`[listeners.ts][unsubscribeForPriceAlert]${reason}`)
+      })
+    }
+  })
+
+  startListening({
     matcher: isAnyOf(onNotificationsTurnedOffForNews),
     effect: async () => {
       await unsubscribeForPriceAlert().catch(reason => {
@@ -267,6 +287,30 @@ const onNotificationsTurnedOffForNews = {
       channelId === ChannelId.PRODUCT_ANNOUNCEMENTS ||
       channelId === ChannelId.PRICE_ALERTS
     )
+  }
+}
+
+const onNotificationsTurnedOnForFavTokenPriceAlerts = {
+  match: (
+    action: Action<unknown>
+  ): action is PayloadAction<{ channelId: ChannelId }> => {
+    if (!turnOnNotificationsFor.match(action)) {
+      return false
+    }
+
+    return action.payload.channelId === ChannelId.FAV_TOKEN_PRICE_ALERTS
+  }
+}
+
+const onNotificationsTurnedOffForFavTokenPriceAlerts = {
+  match: (
+    action: Action<unknown>
+  ): action is PayloadAction<{ channelId: ChannelId }> => {
+    if (!turnOffNotificationsFor.match(action)) {
+      return false
+    }
+
+    return action.payload.channelId === ChannelId.FAV_TOKEN_PRICE_ALERTS
   }
 }
 

--- a/packages/core-mobile/app/store/notifications/listeners/setPriceAlertNotifications.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/setPriceAlertNotifications.ts
@@ -17,7 +17,7 @@ export const setPriceAlertNotifications = async (
   const state = listenerApi.getState()
 
   const userHasEnabledPriceAlertNotifications = selectNotificationSubscription(
-    ChannelId.PRICE_ALERTS
+    ChannelId.FAV_TOKEN_PRICE_ALERTS
   )(state)
 
   if (!userHasEnabledPriceAlertNotifications) {
@@ -35,10 +35,10 @@ export const setPriceAlertNotifications = async (
     const fcmToken = await FCMService.getFCMToken()
     const deviceArn = await registerDeviceToNotificationSender(fcmToken)
 
-    //check if only PRICE_ALERTS notifications are denied
+    //check if only FAV_TOKEN_PRICE_ALERTS notifications are denied
     const blockedNotifications =
       await NotificationsService.getBlockedNotifications()
-    if (blockedNotifications.has(ChannelId.PRICE_ALERTS)) {
+    if (blockedNotifications.has(ChannelId.FAV_TOKEN_PRICE_ALERTS)) {
       await unsubscribeForPriceAlert()
       return
     }


### PR DESCRIPTION
## Description

**Ticket: [CP-11715]** 

Adds new notification toggle for price alert movements for favorite tokens.
Includes migration to set it to ON by default

## Screenshots
![Screenshot_20250731_002102_Core Internal](https://github.com/user-attachments/assets/bca94dd5-1d1b-497a-8f73-7e666fc51db9)



## Testing
- please refer to ticket

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11715]: https://ava-labs.atlassian.net/browse/CP-11715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ