### PR TITLE
bump xcode-archive step to 5.8.0

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -257,7 +257,7 @@ workflows:
         - verbose: "true"
         - source_root_path: $BITRISE_SOURCE_DIR/ios
     - save-cocoapods-cache@1: {}
-    - xcode-archive@4:
+    - xcode-archive@5.8.0:
         inputs:
         - project_path: $IOS_PROJECT_PATH
         - scheme: $IOS_SCHEME


### PR DESCRIPTION
CI was failing because new cert has a different format and we need to upgrade this step to support it