### PR TITLE
Notification - should alert the notification permission

### DIFF
--- a/packages/core-mobile/app/store/notifications/listeners/handlePromptNotifications.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/handlePromptNotifications.ts
@@ -4,7 +4,10 @@ import { selectHasBeenViewedOnce, setViewOnce } from 'store/viewOnce/slice'
 import { ViewOnceKey } from 'store/viewOnce/types'
 import NotificationsService from 'services/notifications/NotificationsService'
 import { AuthorizationStatus } from '@notifee/react-native'
-import { selectIsEnableNotificationPromptBlocked } from 'store/posthog'
+import {
+  selectIsEnableNotificationPromptBlocked,
+  selectIsSolanaSupportBlocked
+} from 'store/posthog'
 import { showAlert } from '@avalabs/k2-alpine'
 import { turnOnAllNotifications } from '../slice'
 
@@ -82,6 +85,9 @@ async function waitIfSolanaLaunchScreenIsYetNotDismissed(
 ): Promise<void> {
   const { take } = listenerApi
   const state = listenerApi.getState()
+  const isSolanaSupportBlocked = selectIsSolanaSupportBlocked(state)
+  if (isSolanaSupportBlocked) return
+
   let hasSeenSolanaLaunch = selectHasBeenViewedOnce(ViewOnceKey.SOLANA_LAUNCH)(
     state
   )


### PR DESCRIPTION
## Description

**Ticket: [CP-11722]** 

Fix missing notification prompt at onboarding by skipping `waitIfSolanaLaunchScreenIsYetNotDismissed` if solana feature flag is off


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11722]: https://ava-labs.atlassian.net/browse/CP-11722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ