### PR TITLE
CP-11740 - GA - display send/receive ERC20 properly on C-Chain  

### DIFF
--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
@@ -94,7 +94,7 @@ export const TokenActivityListItem: FC<Props> = ({
       )
     }
 
-    const txType = getTxType(tx)
+    const txType = fixUnknownTxType(tx)
 
     return (
       <View
@@ -130,7 +130,7 @@ export const TokenActivityListItem: FC<Props> = ({
   )
 }
 
-export function getTxType(tx: Transaction): ActivityTransactionType {
+export function fixUnknownTxType(tx: Transaction): ActivityTransactionType {
   if (tx?.txType === TransactionType.UNKNOWN) {
     if (tx.tokens.length === 1) {
       return tx.isSender ? TransactionType.SEND : TransactionType.RECEIVE

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
@@ -47,20 +47,16 @@ export const TokenActivityListItem: FC<Props> = ({
         return PriceChangeStatus.Up
       }
       default: {
+        if (isCollectibleTransaction(tx)) {
+          return PriceChangeStatus.Neutral
+        }
         if (tx.isContractCall) {
           return tx.isSender ? PriceChangeStatus.Down : PriceChangeStatus.Up
         }
         return PriceChangeStatus.Neutral
       }
     }
-  }, [
-    tx.isContractCall,
-    tx.isIncoming,
-    tx.isOutgoing,
-    tx.isSender,
-    tx.tokens,
-    tx.txType
-  ])
+  }, [tx])
 
   const subtitle = useMemo(() => {
     if (isCollectibleTransaction(tx)) {

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
@@ -1,11 +1,11 @@
 import { PriceChangeStatus, useTheme, View } from '@avalabs/k2-alpine'
-import { Transaction, TransactionType } from '@avalabs/vm-module-types'
+import { TransactionType } from '@avalabs/vm-module-types'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import { isCollectibleTransaction } from 'features/activity/utils'
 import { CollectibleFetchAndRender } from 'features/portfolio/collectibles/components/CollectibleFetchAndRender'
 import { useWatchlist } from 'hooks/watchlist/useWatchlist'
 import React, { FC, useMemo } from 'react'
-import { ActivityTransactionType } from 'store/transaction'
+import { ActivityTransactionType, Transaction } from 'store/transaction'
 import ActivityListItem from './ActivityListItem'
 import { TokenActivityListItemTitle } from './TokenActivityListItemTitle'
 import { TransactionTypeIcon } from './TransactionTypeIcon'
@@ -47,10 +47,20 @@ export const TokenActivityListItem: FC<Props> = ({
         return PriceChangeStatus.Up
       }
       default: {
+        if (tx.isContractCall) {
+          return tx.isSender ? PriceChangeStatus.Down : PriceChangeStatus.Up
+        }
         return PriceChangeStatus.Neutral
       }
     }
-  }, [tx.isIncoming, tx.isOutgoing, tx.tokens.length, tx.txType])
+  }, [
+    tx.isContractCall,
+    tx.isIncoming,
+    tx.isOutgoing,
+    tx.isSender,
+    tx.tokens,
+    tx.txType
+  ])
 
   const subtitle = useMemo(() => {
     if (isCollectibleTransaction(tx)) {
@@ -88,6 +98,8 @@ export const TokenActivityListItem: FC<Props> = ({
       )
     }
 
+    const txType = getTxType(tx)
+
     return (
       <View
         sx={{
@@ -101,7 +113,7 @@ export const TokenActivityListItem: FC<Props> = ({
           borderColor: colors.$borderPrimary
         }}>
         <TransactionTypeIcon
-          txType={tx.txType}
+          txType={txType}
           isContractCall={tx.isContractCall}
         />
       </View>
@@ -120,6 +132,21 @@ export const TokenActivityListItem: FC<Props> = ({
       status={status}
     />
   )
+}
+
+export function getTxType(tx: Transaction): ActivityTransactionType {
+  if (tx?.txType === TransactionType.UNKNOWN) {
+    if (tx.tokens.length === 1) {
+      return tx.isSender ? TransactionType.SEND : TransactionType.RECEIVE
+    }
+    if (tx.tokens.length > 1) {
+      if (tx.tokens[0]?.symbol === tx.tokens[1]?.symbol) {
+        return tx.isSender ? TransactionType.SEND : TransactionType.RECEIVE
+      }
+      return TransactionType.SWAP
+    }
+  }
+  return tx.txType as ActivityTransactionType
 }
 
 const ICON_SIZE = 36

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
@@ -93,7 +93,7 @@ export const TokenActivityListItemTitle = ({
       case TransactionType.SEND:
         return [renderAmount(a1), ' ', s1, ' sent']
       case TransactionType.RECEIVE:
-        return [renderAmount(a1), ' ', s1, ' received']
+        return [renderAmount(a1), ' ', s2, ' received']
       case TransactionType.TRANSFER:
         return [renderAmount(a1), ' ', s1, ' transferred']
       case TransactionType.APPROVE:
@@ -112,8 +112,34 @@ export const TokenActivityListItemTitle = ({
           ]
         }
         if (tx.isContractCall) {
-          if (tx.tokens.length >= 1) {
-            return [renderAmount(a1), ' ', s1, ' swapped for ', s2]
+          if (tx.tokens.length === 1) {
+            return [
+              renderAmount(a1),
+              ' ',
+              s1,
+              tx.isSender ? ' sent' : ' received'
+            ]
+          }
+
+          if (tx.tokens.length > 1) {
+            if (tx.tokens[0]?.symbol === tx.tokens[1]?.symbol) {
+              return [
+                renderAmount(a1),
+                ' ',
+                s1,
+                tx.isSender ? ' sent' : ' received'
+              ]
+            }
+
+            return [
+              renderAmount(a1),
+              ' ',
+              s1,
+              ' swapped for ',
+              renderAmount(a2),
+              ' ',
+              s2
+            ]
           }
 
           return ['Contract Call']

--- a/packages/core-mobile/app/new/features/portfolio/assets/hooks/useTokenDetailFilterAndSort.ts
+++ b/packages/core-mobile/app/new/features/portfolio/assets/hooks/useTokenDetailFilterAndSort.ts
@@ -7,6 +7,7 @@ import {
 } from '@avalabs/vm-module-types'
 import { sortUndefined } from 'common/utils/sortUndefined'
 import { isCollectibleTransaction } from 'features/activity/utils'
+import { getTxType } from '../components/TokenActivityListItem'
 
 export type Selection = {
   title: string
@@ -68,9 +69,9 @@ export const useTokenDetailFilterAndSort = ({
         case TokenDetailFilter.NFT:
           return isCollectibleTransaction(tx)
         case TokenDetailFilter.Received:
-          return tx.txType === TransactionType.RECEIVE
+          return getTxType(tx) === TransactionType.RECEIVE
         case TokenDetailFilter.Sent:
-          return tx.txType === TransactionType.SEND
+          return getTxType(tx) === TransactionType.SEND
         case TokenDetailFilter.Bridge:
           return tx.txType === TransactionType.BRIDGE
         case TokenDetailFilter.Swap:

--- a/packages/core-mobile/app/new/features/portfolio/assets/hooks/useTokenDetailFilterAndSort.ts
+++ b/packages/core-mobile/app/new/features/portfolio/assets/hooks/useTokenDetailFilterAndSort.ts
@@ -7,7 +7,7 @@ import {
 } from '@avalabs/vm-module-types'
 import { sortUndefined } from 'common/utils/sortUndefined'
 import { isCollectibleTransaction } from 'features/activity/utils'
-import { getTxType } from '../components/TokenActivityListItem'
+import { fixUnknownTxType } from '../components/TokenActivityListItem'
 
 export type Selection = {
   title: string
@@ -72,18 +72,18 @@ export const useTokenDetailFilterAndSort = ({
           if (isCollectibleTransaction(tx)) {
             return !tx.isSender
           }
-          return getTxType(tx) === TransactionType.RECEIVE
+          return fixUnknownTxType(tx) === TransactionType.RECEIVE
         case TokenDetailFilter.Sent:
           if (isCollectibleTransaction(tx)) {
             return tx.isSender
           }
-          return getTxType(tx) === TransactionType.SEND
+          return fixUnknownTxType(tx) === TransactionType.SEND
         case TokenDetailFilter.Bridge:
           return tx.txType === TransactionType.BRIDGE
         case TokenDetailFilter.Swap:
           return (
             tx.txType === TransactionType.SWAP ||
-            getTxType(tx) === TransactionType.SWAP
+            fixUnknownTxType(tx) === TransactionType.SWAP
           )
 
         default:

--- a/packages/core-mobile/app/new/features/portfolio/assets/hooks/useTokenDetailFilterAndSort.ts
+++ b/packages/core-mobile/app/new/features/portfolio/assets/hooks/useTokenDetailFilterAndSort.ts
@@ -69,16 +69,23 @@ export const useTokenDetailFilterAndSort = ({
         case TokenDetailFilter.NFT:
           return isCollectibleTransaction(tx)
         case TokenDetailFilter.Received:
+          if (isCollectibleTransaction(tx)) {
+            return !tx.isSender
+          }
           return getTxType(tx) === TransactionType.RECEIVE
         case TokenDetailFilter.Sent:
+          if (isCollectibleTransaction(tx)) {
+            return tx.isSender
+          }
           return getTxType(tx) === TransactionType.SEND
         case TokenDetailFilter.Bridge:
           return tx.txType === TransactionType.BRIDGE
         case TokenDetailFilter.Swap:
           return (
             tx.txType === TransactionType.SWAP ||
-            (tx.isContractCall && tx.tokens.length > 1)
+            getTxType(tx) === TransactionType.SWAP
           )
+
         default:
           return true
       }


### PR DESCRIPTION
## Description

**Ticket: [CP-11740]** 

Fixes for UNKNOWN txType
- Send/Receive labels
- Swap/Send/Receive icons
- filter by Send/Receive/Swap when txType is UNKNOWN

## Screenshots/Videos

Receive
<img width="1206" height="2622" alt="simulator_screenshot_007658EF-6229-4196-8630-C332CD6FAD33" src="https://github.com/user-attachments/assets/deb66532-d56b-47fc-95eb-f3807bbd0c1d" />

Sent
<img width="1206" height="2622" alt="simulator_screenshot_80A6656B-DCCD-4DB8-9D2C-1132FCEC8231" src="https://github.com/user-attachments/assets/6b85f3d7-e61a-4c2f-a82f-15927b054596" />


## Checklist


Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11740]: https://ava-labs.atlassian.net/browse/CP-11740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ