### PR TITLE
use numeric on android text input for send flow

### DIFF
--- a/packages/k2-alpine/src/components/TokenUnitInput/TokenUnitInput.tsx
+++ b/packages/k2-alpine/src/components/TokenUnitInput/TokenUnitInput.tsx
@@ -198,7 +198,7 @@ export const TokenUnitInput = forwardRef<
                * See: https://github.com/expo/expo/issues/34156
                */
               keyboardType={Platform.OS === 'ios' ? 'decimal-pad' : undefined}
-              inputMode={Platform.OS === 'android' ? 'decimal' : undefined}
+              inputMode={Platform.OS === 'android' ? 'numeric' : undefined}
               placeholder={PLACEHOLDER}
               placeholderTextColor={alpha(colors.$textSecondary, 0.2)}
               value={value}

--- a/packages/k2-alpine/src/components/TokenUnitInput/TokenUnitInput.tsx
+++ b/packages/k2-alpine/src/components/TokenUnitInput/TokenUnitInput.tsx
@@ -197,7 +197,7 @@ export const TokenUnitInput = forwardRef<
                * Using inputMode="numeric" provides the same behavior without the performance issues.
                * See: https://github.com/expo/expo/issues/34156
                */
-              keyboardType={Platform.OS === 'ios' ? 'decimal-pad' : undefined}
+              keyboardType={Platform.OS === 'ios' ? 'numeric' : undefined}
               inputMode={Platform.OS === 'android' ? 'numeric' : undefined}
               placeholder={PLACEHOLDER}
               placeholderTextColor={alpha(colors.$textSecondary, 0.2)}


### PR DESCRIPTION
## Description

**Ticket: [CP-11746](https://ava-labs.atlassian.net/browse/CP-11746)** 

Please include a summary of the changes. Please also include relevant motivation and context. List any dependencies that are required for this change. If this is a breaking change, please also include steps to migrate.

Fixed regression introduced when solving for replacing "," with "." when entering asset amounts on android 
- changed `TokenUnitInput` to use `numeric` instead of `decimal` 

## Screenshots/Videos
BEFORE

https://github.com/user-attachments/assets/813b5520-4710-42d1-adaa-0608033bd7f2

AFTER 

https://github.com/user-attachments/assets/fed0863c-0c1c-4356-b5b6-60cc948eab38

IOS 


https://github.com/user-attachments/assets/73198d94-84de-4831-b716-a818ba3697e8




## Testing
- manually tested on android device 

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11746]: https://ava-labs.atlassian.net/browse/CP-11746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ