### PR TITLE
CP-11689: Fix endless spinner when upgrading app 

### DIFF
--- a/packages/core-mobile/app/store/network/slice.ts
+++ b/packages/core-mobile/app/store/network/slice.ts
@@ -202,13 +202,8 @@ export const selectNetworks = (state: RootState): Networks => {
 }
 
 export const selectEnabledNetworks = createSelector(
-  [selectEnabledChainIds, selectIsDeveloperMode, selectIsSolanaSupportBlocked],
-  (enabledChainIds, isDeveloperMode, isSolanaSupportBlocked) => {
-    const networks = getNetworksFromCache({
-      includeSolana: !isSolanaSupportBlocked
-    })
-    if (networks === undefined) return []
-
+  [selectEnabledChainIds, selectIsDeveloperMode, selectNetworks],
+  (enabledChainIds, isDeveloperMode, networks) => {
     return enabledChainIds.reduce((acc, chainId) => {
       const network = networks[chainId]
       if (network && network.isTestnet === isDeveloperMode) {


### PR DESCRIPTION
## Description

**Ticket: [CP-11689]** 

* Use `selectNetworks` selector instead of `getNetworksFromCache` to get networks in `selectEnabledNetworks`

[CP-11689]: https://ava-labs.atlassian.net/browse/CP-11689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ