### PR TITLE
CP-11757 - Remove infinite carousel and replace with FlatList

### DIFF
--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -7,7 +7,7 @@ import {
 import { useHeaderHeight } from '@react-navigation/elements'
 import { useFadingHeaderNavigation } from 'common/hooks/useFadingHeaderNavigation'
 import React, { useCallback, useLayoutEffect, useRef, useState } from 'react'
-import { LayoutRectangle, View } from 'react-native'
+import { LayoutRectangle, StyleProp, View, ViewStyle } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
 import {
   KeyboardAwareScrollView,
@@ -69,6 +69,8 @@ interface ScrollScreenProps extends KeyboardAwareScrollViewProps {
   bottomOffset?: number
   /** Whether this screen should show navigation title when scroll. Default is true. */
   showNavigationHeaderTitle?: boolean
+  /** Custom style for the header */
+  headerStyle?: StyleProp<ViewStyle>
 }
 
 const KeyboardScrollView = Animated.createAnimatedComponent(
@@ -86,6 +88,7 @@ export const ScrollScreen = ({
   shouldAvoidKeyboard,
   disableStickyFooter,
   showNavigationHeaderTitle = true,
+  headerStyle,
   renderHeader,
   renderFooter,
   renderHeaderRight,
@@ -153,9 +156,12 @@ export const ScrollScreen = ({
         <View>
           <View
             ref={headerRef}
-            style={{
-              gap: 8
-            }}>
+            style={[
+              headerStyle,
+              {
+                gap: 8
+              }
+            ]}>
             {title ? (
               <Animated.View style={[animatedHeaderStyle]}>
                 <ScreenHeader
@@ -173,7 +179,7 @@ export const ScrollScreen = ({
         </View>
       )
     }
-  }, [animatedHeaderStyle, renderHeader, subtitle, title, titleSx])
+  }, [animatedHeaderStyle, headerStyle, renderHeader, subtitle, title, titleSx])
 
   const animatedContentContainerStyle = useAnimatedStyle(() => {
     return {

--- a/packages/core-mobile/app/new/common/components/SelectAvatar.tsx
+++ b/packages/core-mobile/app/new/common/components/SelectAvatar.tsx
@@ -1,6 +1,5 @@
 import {
   Avatar,
-  AVATAR_BLURAREA_INSET,
   AvatarSelector,
   AvatarType,
   Button,
@@ -10,27 +9,32 @@ import {
 } from '@avalabs/k2-alpine'
 import { loadAvatar } from 'common/utils/loadAvatar'
 import React, { memo, useMemo } from 'react'
-import Animated, { ZoomIn } from 'react-native-reanimated'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { ScrollScreen } from './ScrollScreen'
 
 export const SelectAvatar = memo(
   ({
     selectedAvatar,
     avatars,
+    initialAvatar,
     title,
+    isModal,
     description,
     setSelectedAvatar,
     onSubmit,
     buttonText
   }: {
     avatars: AvatarType[]
+    initialAvatar?: AvatarType
     title: string
     description?: string
     selectedAvatar?: AvatarType
     setSelectedAvatar: (avatar: AvatarType) => void
     onSubmit: () => void
+    isModal?: boolean
     buttonText?: string
   }): React.JSX.Element => {
+    const insets = useSafeAreaInsets()
     const {
       theme: { colors }
     } = useTheme()
@@ -54,44 +58,77 @@ export const SelectAvatar = memo(
       )
     }
 
+    const avatarsWithSelectedAsMiddle = useMemo(() => {
+      if (!initialAvatar || !initialAvatar.source) {
+        return avatars
+      }
+
+      const newAvatars = [...avatars]
+      const selectedIndex = newAvatars.findIndex(
+        _avatar => _avatar.id === initialAvatar.id
+      )
+
+      // Only remove the avatar if it was found in the array
+      if (selectedIndex >= 0) {
+        newAvatars.splice(selectedIndex, 1)
+      }
+
+      // Calculate middle position and ensure it's even (for bottom row)
+      // Even indices (0, 2, 4...) appear in bottom row
+      let middlePosition = Math.floor(newAvatars.length / 2)
+      if (middlePosition % 2 !== 0) {
+        middlePosition -= 1 // Make it even to ensure bottom row
+      }
+
+      newAvatars.splice(middlePosition, 0, initialAvatar)
+
+      return newAvatars
+    }, [avatars, initialAvatar])
+
     return (
       <ScrollScreen
         showNavigationHeaderTitle={false}
         title={title}
+        isModal={isModal}
         subtitle={description}
         renderFooter={renderFooter}
+        scrollEnabled={false}
         contentContainerStyle={{
-          padding: 16,
           flex: 1
+        }}
+        headerStyle={{
+          paddingHorizontal: 16
         }}>
         <View
           style={{
-            justifyContent: 'center',
             flex: 1
           }}>
-          <Animated.View entering={ZoomIn.delay(400)}>
+          {avatar?.source && (
             <View
-              sx={{
-                alignItems: 'center',
+              style={{
+                flex: 1,
                 justifyContent: 'center',
-                paddingVertical: AVATAR_BLURAREA_INSET
+                alignItems: 'center'
               }}>
-              {avatar?.source && (
-                <Avatar
-                  backgroundColor={colors.$surfacePrimary}
-                  source={avatar?.source}
-                  size={isScreenSmall ? 100 : 'large'}
-                  testID="selected_avatar"
-                />
-              )}
+              <Avatar
+                backgroundColor={colors.$surfacePrimary}
+                source={avatar?.source}
+                size={isScreenSmall ? 100 : 'large'}
+                testID="selected_avatar"
+              />
             </View>
-          </Animated.View>
+          )}
 
-          <AvatarSelector
-            selectedId={selectedAvatar?.id}
-            avatars={avatars}
-            onSelect={onSelect}
-          />
+          <View
+            style={{
+              marginBottom: -insets.bottom
+            }}>
+            <AvatarSelector
+              selectedId={selectedAvatar?.id}
+              avatars={avatarsWithSelectedAsMiddle}
+              onSelect={onSelect}
+            />
+          </View>
         </View>
       </ScrollScreen>
     )

--- a/packages/core-mobile/app/new/features/onboarding/hooks/useRandomAvatar.ts
+++ b/packages/core-mobile/app/new/features/onboarding/hooks/useRandomAvatar.ts
@@ -1,9 +1,14 @@
 import { AvatarType } from '@avalabs/k2-alpine'
 import { useMemo } from 'react'
+import { AVATARS } from 'store/settings/avatar'
 
 export function useRandomAvatar(avatars: AvatarType[]): AvatarType {
-  return useMemo(
-    () => avatars[Math.floor(Math.random() * avatars.length)] as AvatarType,
-    [avatars]
-  )
+  return useMemo(() => {
+    // Ensure we have a valid avatars array with at least one avatar
+    if (!avatars || avatars.length === 0) {
+      // Return a fallback avatar from the default AVATARS
+      return AVATARS[0] || { id: 'fallback', source: null }
+    }
+    return avatars[Math.floor(Math.random() * avatars.length)] as AvatarType
+  }, [avatars])
 }

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addressBook/editContactAvatar.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addressBook/editContactAvatar.tsx
@@ -37,9 +37,11 @@ const EditContactAvatarScreen = (): JSX.Element => {
     <SelectAvatar
       title={'Select\ncontact avatar'}
       avatars={randomizedAvatars}
+      initialAvatar={contact?.avatar}
       selectedAvatar={selectedAvatar}
       onSubmit={onSubmit}
       setSelectedAvatar={setSelectedAvatar}
+      isModal
       buttonText="Save"
     />
   )

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addressBook/editContactAvatar.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addressBook/editContactAvatar.tsx
@@ -15,10 +15,9 @@ const EditContactAvatarScreen = (): JSX.Element => {
 
   const randomizedAvatars = useRandomizedAvatars()
   const randomAvatar = useRandomAvatar(randomizedAvatars)
+  const initialAvatar = contact?.avatar ?? randomAvatar
 
-  const [selectedAvatar, setSelectedAvatar] = useState(
-    contact?.avatar ?? randomAvatar
-  )
+  const [selectedAvatar, setSelectedAvatar] = useState(initialAvatar)
 
   const onSubmit = (): void => {
     if (!contact || !selectedAvatar) {
@@ -37,7 +36,7 @@ const EditContactAvatarScreen = (): JSX.Element => {
     <SelectAvatar
       title={'Select\ncontact avatar'}
       avatars={randomizedAvatars}
-      initialAvatar={contact?.avatar}
+      initialAvatar={initialAvatar}
       selectedAvatar={selectedAvatar}
       onSubmit={onSubmit}
       setSelectedAvatar={setSelectedAvatar}

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addressBook/selectContactAvatar.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addressBook/selectContactAvatar.tsx
@@ -1,6 +1,6 @@
+import { SelectAvatar } from 'common/components/SelectAvatar'
 import { useRouter } from 'expo-router'
 import { useNewContactAvatar } from 'features/accountSettings/store'
-import { SelectAvatar } from 'common/components/SelectAvatar'
 import { useRandomAvatar } from 'features/onboarding/hooks/useRandomAvatar'
 import { useRandomizedAvatars } from 'features/onboarding/hooks/useRandomizedAvatars'
 import React, { useState } from 'react'
@@ -11,10 +11,9 @@ const SelectContactAvatarScreen = (): JSX.Element => {
 
   const randomizedAvatars = useRandomizedAvatars()
   const randomAvatar = useRandomAvatar(randomizedAvatars)
+  const initialAvatar = newContactAvatar ?? randomAvatar
 
-  const [selectedAvatar, setSelectedAvatar] = useState(
-    newContactAvatar ?? randomAvatar
-  )
+  const [selectedAvatar, setSelectedAvatar] = useState(initialAvatar)
 
   const onSubmit = (): void => {
     back()
@@ -27,7 +26,7 @@ const SelectContactAvatarScreen = (): JSX.Element => {
     <SelectAvatar
       title={'Select\ncontact avatar'}
       avatars={randomizedAvatars}
-      initialAvatar={newContactAvatar}
+      initialAvatar={initialAvatar}
       selectedAvatar={selectedAvatar}
       onSubmit={onSubmit}
       setSelectedAvatar={setSelectedAvatar}

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addressBook/selectContactAvatar.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/addressBook/selectContactAvatar.tsx
@@ -27,9 +27,11 @@ const SelectContactAvatarScreen = (): JSX.Element => {
     <SelectAvatar
       title={'Select\ncontact avatar'}
       avatars={randomizedAvatars}
+      initialAvatar={newContactAvatar}
       selectedAvatar={selectedAvatar}
       onSubmit={onSubmit}
       setSelectedAvatar={setSelectedAvatar}
+      isModal
       buttonText="Save"
     />
   )

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/selectAvatar.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/selectAvatar.tsx
@@ -1,6 +1,6 @@
+import { SelectAvatar } from 'common/components/SelectAvatar'
 import { useAvatar } from 'common/hooks/useAvatar'
 import { useRouter } from 'expo-router'
-import { SelectAvatar } from 'common/components/SelectAvatar'
 import { useRandomizedAvatars } from 'features/onboarding/hooks/useRandomizedAvatars'
 import React, { useState } from 'react'
 
@@ -23,10 +23,12 @@ const SelectAvatarScreen = (): JSX.Element => {
     <SelectAvatar
       title={`Select your\npersonal avatar`}
       avatars={randomizedAvatars}
+      initialAvatar={avatar}
       selectedAvatar={selectedAvatar}
       onSubmit={onSubmit}
       setSelectedAvatar={setSelectedAvatar}
       buttonText="Save"
+      isModal
     />
   )
 }

--- a/packages/core-mobile/app/new/routes/onboarding/mnemonic/selectAvatar.tsx
+++ b/packages/core-mobile/app/new/routes/onboarding/mnemonic/selectAvatar.tsx
@@ -35,6 +35,7 @@ export default function SelectAvatar(): JSX.Element {
       title={`Select your\npersonal avatar`}
       description="Add a display avatar for your wallet. You can change it at any time in the app's settings"
       selectedAvatar={selectedAvatar}
+      initialAvatar={randomAvatar}
       onSubmit={debouncedOnSubmit}
       buttonText="Next"
       setSelectedAvatar={setSelectedAvatar}

--- a/packages/core-mobile/app/new/routes/onboarding/seedless/selectAvatar.tsx
+++ b/packages/core-mobile/app/new/routes/onboarding/seedless/selectAvatar.tsx
@@ -34,6 +34,7 @@ export default function SelectAvatar(): JSX.Element {
       title={`Select your\npersonal avatar`}
       description="Add a display avatar for your wallet. You can change it at any time in the app's settings"
       selectedAvatar={selectedAvatar}
+      initialAvatar={randomAvatar}
       onSubmit={debouncedHandleNext}
       buttonText="Next"
       setSelectedAvatar={setSelectedAvatar}

--- a/packages/k2-alpine/package.json
+++ b/packages/k2-alpine/package.json
@@ -42,7 +42,6 @@
     "react-native-modal-datetime-picker": "18.0.0",
     "react-native-popover-view": "6.1.0",
     "react-native-reanimated": "3.17.5",
-    "react-native-reanimated-carousel": "v4.0.2",
     "react-native-safe-area-context": "5.5.2",
     "react-native-svg": "15.11.2"
   },

--- a/packages/k2-alpine/src/components/Avatar/HexagonImageView.tsx
+++ b/packages/k2-alpine/src/components/Avatar/HexagonImageView.tsx
@@ -27,6 +27,7 @@ import { AvatarType } from './Avatar'
 export const HexagonImageView = ({
   source,
   height,
+  imageKey,
   backgroundColor,
   isSelected,
   hasLoading = false,
@@ -35,6 +36,7 @@ export const HexagonImageView = ({
   source?: AvatarType['source']
   height: number
   backgroundColor: string
+  imageKey?: string
   isSelected?: boolean
   hasLoading?: boolean
   showAddIcon?: boolean
@@ -62,6 +64,7 @@ export const HexagonImageView = ({
   }, [isSelected, selectedAnimation])
 
   const isSvgComponent = typeof source === 'function'
+  const hasValidSource = source !== null && source !== undefined
 
   return (
     <MaskedView
@@ -70,20 +73,31 @@ export const HexagonImageView = ({
           <Path d={hexagonPath.path} fill={theme.colors.$surfacePrimary} />
         </Svg>
       }>
-      {isSvgComponent ? (
-        // If source is a local SVG component
-        React.createElement(source, { width: height, height: height })
+      {hasValidSource ? (
+        isSvgComponent ? (
+          // If source is a local SVG component
+          React.createElement(source, { width: height, height: height })
+        ) : (
+          // If source is a regular image
+          <Image
+            key={`image-${imageKey ?? source}`}
+            recyclingKey={`image-recycling-${imageKey ?? source}`}
+            contentFit="cover"
+            source={source}
+            style={{ width: height, height: height, backgroundColor }}
+            onLoadStart={hasLoading ? handleLoadStart : undefined}
+            onLoadEnd={hasLoading ? handleLoadEnd : undefined}
+            cachePolicy="memory-disk"
+          />
+        )
       ) : (
-        // If source is a regular image
-        <Image
-          key={`image-${source}`}
-          recyclingKey={`image-recycling-${source}`}
-          contentFit="cover"
-          source={source}
-          style={{ width: height, height: height, backgroundColor }}
-          onLoadStart={hasLoading ? handleLoadStart : undefined}
-          onLoadEnd={hasLoading ? handleLoadEnd : undefined}
-          cachePolicy="memory-disk"
+        // Render a placeholder background when no source is provided
+        <View
+          style={{
+            width: height,
+            height: height,
+            backgroundColor: backgroundColor || theme.colors.$surfaceSecondary
+          }}
         />
       )}
       {isLoading && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -605,7 +605,6 @@ __metadata:
     react-native-modal-datetime-picker: 18.0.0
     react-native-popover-view: 6.1.0
     react-native-reanimated: 3.17.5
-    react-native-reanimated-carousel: v4.0.2
     react-native-safe-area-context: 5.5.2
     react-native-svg: 15.11.2
     react-native-svg-transformer: 1.5.1
@@ -27610,18 +27609,6 @@ __metadata:
     string_decoder: ^1.3.0
     util: ^0.12.5
   checksum: 0fd25e84ab6ba02b794cba5d2cb697686e9c97da453c2c6c00c4918eb1f6f469283e6851333a036249dc5fc820c2f900551a3b2db39515625c97f40cf05225e4
-  languageName: node
-  linkType: hard
-
-"react-native-reanimated-carousel@npm:v4.0.2":
-  version: 4.0.2
-  resolution: "react-native-reanimated-carousel@npm:4.0.2"
-  peerDependencies:
-    react: ">=18.0.0"
-    react-native: ">=0.70.3"
-    react-native-gesture-handler: ">=2.9.0"
-    react-native-reanimated: ">=3.0.0"
-  checksum: 1f3d0434410a9e365420d2aa029d7af087a7dee6edd9be62019cbb3e14b13bb25a5ea4790fcc9a158208b027a3e7203ff02e62184753e6c3cb692392f8dcfdf4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: [CP-11757]** 

- Removed react-native-reanimated-carousel in favor of FlatList.
- removed infinite looping anymore and we don't have to double/triple the avatar list. Design agreed there is no need so you can scroll to beginning and end as long 
- center selected avatar on first load
- rearranged UI for the big avatar to be flexed and centered, avatar selector must be close to button


## Screenshots/Videos

Onboarding
https://github.com/user-attachments/assets/39a76d2d-e0fc-4058-850f-ed2d0a7f0786

Settings + add/edit contact
https://github.com/user-attachments/assets/b25c10d3-72ca-4a22-baa6-38f07bdf51aa

All layouts
<img width="3427" height="1316" alt="Screenshot 2025-08-05 at 18 15 10" src="https://github.com/user-attachments/assets/09c89bc4-c8a4-4980-9b07-d3880d99e669" />


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
