### PR TITLE
CP-11751 - GA - Unable to display `swapped` when swapping ERC20 to AVAX

### DIFF
--- a/packages/core-mobile/app/new/features/activity/utils.ts
+++ b/packages/core-mobile/app/new/features/activity/utils.ts
@@ -129,3 +129,13 @@ export function isNftTransaction(tx: TokenActivityTransaction): boolean {
 export function isSupportedNftChainId(chainId: number): boolean {
   return isAvalancheCChainId(chainId) || isEthereumChainId(chainId)
 }
+
+// To differentiate between swap and sent/received
+// we need to check if the from and to addresses are the same
+// as the from and to addresses of the token
+export function isUnknownSwap(tx: TokenActivityTransaction): boolean {
+  return (
+    tx.from === tx.tokens[0]?.from?.address &&
+    tx.to === tx.tokens[0]?.to?.address
+  )
+}

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
@@ -1,7 +1,10 @@
 import { PriceChangeStatus, useTheme, View } from '@avalabs/k2-alpine'
 import { TransactionType } from '@avalabs/vm-module-types'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
-import { isCollectibleTransaction } from 'features/activity/utils'
+import {
+  isCollectibleTransaction,
+  isUnknownSwap
+} from 'features/activity/utils'
 import { CollectibleFetchAndRender } from 'features/portfolio/collectibles/components/CollectibleFetchAndRender'
 import { useWatchlist } from 'hooks/watchlist/useWatchlist'
 import React, { FC, useMemo } from 'react'
@@ -130,9 +133,13 @@ export const TokenActivityListItem: FC<Props> = ({
   )
 }
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 export function fixUnknownTxType(tx: Transaction): ActivityTransactionType {
   if (tx?.txType === TransactionType.UNKNOWN) {
     if (tx.tokens.length === 1) {
+      if (isUnknownSwap(tx)) {
+        return TransactionType.SWAP
+      }
       return tx.isSender ? TransactionType.SEND : TransactionType.RECEIVE
     }
     if (tx.tokens.length > 1) {

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
@@ -4,7 +4,10 @@ import { HiddenBalanceText } from 'common/components/HiddenBalanceText'
 import { SubTextNumber } from 'common/components/SubTextNumber'
 import { useBlockchainNames } from 'common/utils/useBlockchainNames'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
-import { isCollectibleTransaction } from 'features/activity/utils'
+import {
+  isCollectibleTransaction,
+  isUnknownSwap
+} from 'features/activity/utils'
 import { useNetworks } from 'hooks/networks/useNetworks'
 import React, { ReactNode, useCallback, useMemo } from 'react'
 import { useSelector } from 'react-redux'
@@ -113,6 +116,9 @@ export const TokenActivityListItemTitle = ({
         }
         if (tx.isContractCall) {
           if (tx.tokens.length === 1) {
+            if (isUnknownSwap(tx)) {
+              return [renderAmount(a1), ' ', s1, ' swapped for ', s2]
+            }
             return [
               renderAmount(a1),
               ' ',


### PR DESCRIPTION
## Description

**Ticket: [CP-11751]** 

When a tx method is Unknown we have to check if from and to is equal to the tx.token[0] from and to in case we only have a tx.token.length of 1. 

This would be considered a swap tx. Previously this check was displaying "sent" instead of "swapped for"

## Screenshots/Videos
Before
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-07 at 16 12 52" src="https://github.com/user-attachments/assets/907f7693-30c0-46ff-8511-fc21da602d6f" />

After
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-07 at 16 12 44" src="https://github.com/user-attachments/assets/51aed344-eb3b-4058-858d-7c8bb216b0bc" />

## Testing

Swap from any token to AVAX. 

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
