### PR TITLE
CP-11712: Add unique user id for troubleshooting

### DIFF
--- a/packages/core-mobile/app/new/ContextApp.tsx
+++ b/packages/core-mobile/app/new/ContextApp.tsx
@@ -38,7 +38,7 @@ const ContextProviders: FC<PropsWithChildren> = ({ children }) => (
 
 const ContextApp = (): JSX.Element => {
   return (
-    <Sentry.ErrorBoundary fallback={<TopLevelErrorFallback />}>
+    <Sentry.ErrorBoundary fallback={TopLevelErrorFallback}>
       <ContextProviders>
         <RootSiblingParent>
           <App />

--- a/packages/core-mobile/app/new/common/components/FullScreenWarning.tsx
+++ b/packages/core-mobile/app/new/common/components/FullScreenWarning.tsx
@@ -1,15 +1,29 @@
-import React from 'react'
-import { useTheme, Text, View, Button } from '@avalabs/k2-alpine'
+import React, { useMemo } from 'react'
+import {
+  useTheme,
+  Text,
+  View,
+  Button,
+  SafeAreaView,
+  showAlert,
+  GroupList,
+  GroupListItem,
+  TouchableOpacity
+} from '@avalabs/k2-alpine'
+import Clipboard from '@react-native-clipboard/clipboard'
+import { useUserUniqueID } from 'common/hooks/useUserUniqueID'
 import CoreAppIconLight from '../../assets/icons/core-app-icon-light.svg'
 import CoreAppIconDark from '../../assets/icons/core-app-icon-dark.svg'
 
 export const FullScreenWarning = ({
   title,
   description,
+  error,
   action
 }: {
   title: string
   description: string
+  error?: unknown
   action: {
     label: string
     onPress: () => void
@@ -18,37 +32,57 @@ export const FullScreenWarning = ({
   const {
     theme: { isDark }
   } = useTheme()
+  const userUniqueID = useUserUniqueID()
+
+  const errorData: GroupListItem[] | undefined = useMemo(() => {
+    if (!error) return undefined
+
+    return [
+      {
+        title: 'View details',
+        onPress: () => {
+          showAlert({
+            title: 'Error Details',
+            description: error instanceof Error ? error.message : String(error),
+            buttons: [{ text: 'Close' }]
+          })
+        }
+      }
+    ]
+  }, [error])
+
+  const handlePressUniqueUserId = (): void => {
+    Clipboard.setString(userUniqueID)
+    showAlert({
+      title: '',
+      description: 'Unique user ID copied to clipboard',
+      buttons: [{ text: 'OK' }]
+    })
+  }
 
   return (
-    <View
+    <SafeAreaView
       sx={{
         backgroundColor: '$surfacePrimary',
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        justifyContent: 'center',
-        alignItems: 'center'
+        flex: 1
       }}>
-      <View>
-        <View
-          style={{
-            justifyContent: 'center',
-            alignItems: 'center'
-          }}>
-          <View style={{ marginBottom: 28 }}>
-            {isDark ? <CoreAppIconLight /> : <CoreAppIconDark />}
-            <View
-              style={{
-                position: 'absolute',
-                bottom: -15,
-                right: -14
-              }}>
-              <Text variant="heading6" sx={{ fontSize: 36, lineHeight: 44 }}>
-                ⚠️
-              </Text>
-            </View>
+      <View
+        sx={{
+          flex: 1,
+          justifyContent: 'center',
+          alignItems: 'center'
+        }}>
+        <View style={{ marginBottom: 28 }}>
+          {isDark ? <CoreAppIconLight /> : <CoreAppIconDark />}
+          <View
+            style={{
+              position: 'absolute',
+              bottom: -15,
+              right: -14
+            }}>
+            <Text variant="heading6" sx={{ fontSize: 36, lineHeight: 44 }}>
+              ⚠️
+            </Text>
           </View>
         </View>
         <View style={{ width: '60%' }}>
@@ -67,12 +101,33 @@ export const FullScreenWarning = ({
             {description}
           </Text>
         </View>
-      </View>
-      <View style={{ paddingHorizontal: 0 }}>
         <Button type="secondary" size="medium" onPress={action.onPress}>
           {action.label}
         </Button>
       </View>
-    </View>
+      <View
+        sx={{
+          alignItems: 'center',
+          gap: 3,
+          marginHorizontal: 16
+        }}>
+        <Text
+          variant="body2"
+          sx={{
+            textAlign: 'center',
+            color: '$textSecondary'
+          }}>
+          Please reference this unique user ID when contacting support:
+        </Text>
+        <TouchableOpacity onPress={handlePressUniqueUserId}>
+          <Text variant="mono">{userUniqueID}</Text>
+        </TouchableOpacity>
+      </View>
+      {errorData && (
+        <View sx={{ marginHorizontal: 16, marginVertical: 24 }}>
+          <GroupList data={errorData} />
+        </View>
+      )}
+    </SafeAreaView>
   )
 }

--- a/packages/core-mobile/app/new/common/components/JailbreakCheck.tsx
+++ b/packages/core-mobile/app/new/common/components/JailbreakCheck.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import JailMonkey from 'jail-monkey'
+import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { withK2AlpineThemeProvider } from './withK2AlpineThemeProvider'
 import { FullScreenWarning } from './FullScreenWarning'
 
@@ -14,14 +15,16 @@ const JailbreakCheck = (): JSX.Element | null => {
 
   if (showJailBroken) {
     return (
-      <FullScreenWarning
-        title="This device is jailbroken"
-        description="Using a jailbroken or rooted device could expose your keys and mnemonics to malicious applications"
-        action={{
-          label: 'I understand',
-          onPress: () => setShowJailBroken(false)
-        }}
-      />
+      <SafeAreaProvider>
+        <FullScreenWarning
+          title="This device is jailbroken"
+          description="Using a jailbroken or rooted device could expose your keys and mnemonics to malicious applications"
+          action={{
+            label: 'I understand',
+            onPress: () => setShowJailBroken(false)
+          }}
+        />
+      </SafeAreaProvider>
     )
   }
 

--- a/packages/core-mobile/app/new/common/components/TopLevelErrorFallback.tsx
+++ b/packages/core-mobile/app/new/common/components/TopLevelErrorFallback.tsx
@@ -1,19 +1,33 @@
 import React from 'react'
 import RNRestart from 'react-native-restart'
-import { withK2AlpineThemeProvider } from './withK2AlpineThemeProvider'
+import { SafeAreaProvider } from 'react-native-safe-area-context'
+import { K2AlpineThemeProvider } from '@avalabs/k2-alpine'
+import { useColorScheme } from 'react-native'
 import { FullScreenWarning } from './FullScreenWarning'
 
-const TopLevelErrorFallback = (): JSX.Element => {
+const TopLevelErrorFallback = (errorData: {
+  error: unknown
+  componentStack: string
+  eventId: string
+  resetError(): void
+}): JSX.Element => {
+  const colorScheme = useColorScheme()
+
   return (
-    <FullScreenWarning
-      title={`Oops!\nSomething went wrong`}
-      description="Please reload the application"
-      action={{
-        label: 'Reload',
-        onPress: () => RNRestart.Restart()
-      }}
-    />
+    <K2AlpineThemeProvider colorScheme={colorScheme}>
+      <SafeAreaProvider>
+        <FullScreenWarning
+          title={`Oops!\nSomething went wrong`}
+          description="Please reload the application"
+          action={{
+            label: 'Reload',
+            onPress: () => RNRestart.Restart()
+          }}
+          error={errorData.error}
+        />
+      </SafeAreaProvider>
+    </K2AlpineThemeProvider>
   )
 }
 
-export default withK2AlpineThemeProvider(TopLevelErrorFallback)
+export default TopLevelErrorFallback

--- a/packages/core-mobile/app/new/common/hooks/useUserUniqueID.ts
+++ b/packages/core-mobile/app/new/common/hooks/useUserUniqueID.ts
@@ -1,0 +1,6 @@
+import { useMemo } from 'react'
+import UserService from 'services/user/UserService'
+
+export const useUserUniqueID = (): string => {
+  return useMemo(() => UserService.getUniqueID(), [])
+}

--- a/packages/core-mobile/app/new/features/accountSettings/components/About.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/components/About.tsx
@@ -1,14 +1,7 @@
 import React, { useCallback, useMemo } from 'react'
-import { GroupList } from '@avalabs/k2-alpine'
+import { GroupList, GroupListItem } from '@avalabs/k2-alpine'
 import DeviceInfo from 'react-native-device-info'
-import {
-  BUG_REPORT_URL,
-  FEATURE_REQUEST_URL,
-  HELP_URL,
-  PRIVACY_POLICY_URL,
-  TERMS_OF_USE_URL
-} from 'common/consts/urls'
-import SentryService from 'services/sentry/SentryService'
+import { PRIVACY_POLICY_URL, TERMS_OF_USE_URL } from 'common/consts/urls'
 
 const VERSION = DeviceInfo.getReadableVersion()
 
@@ -17,29 +10,6 @@ export const About = ({
 }: {
   onPressItem: ({ url, title }: { url: string; title: string }) => void
 }): React.JSX.Element => {
-  const user = useMemo(() => SentryService.getUser(), [])
-
-  const openHelpCenter = useCallback(() => {
-    onPressItem({
-      url: HELP_URL,
-      title: 'Help center'
-    })
-  }, [onPressItem])
-
-  const openBugReport = useCallback(() => {
-    onPressItem({
-      url: BUG_REPORT_URL,
-      title: 'Bug report'
-    })
-  }, [onPressItem])
-
-  const openFeatureRequest = useCallback(() => {
-    onPressItem({
-      url: FEATURE_REQUEST_URL,
-      title: 'Feature request'
-    })
-  }, [onPressItem])
-
   const openTermsOfUse = useCallback(() => {
     onPressItem({
       url: TERMS_OF_USE_URL,
@@ -55,15 +25,7 @@ export const About = ({
   }, [onPressItem])
 
   const data = useMemo(() => {
-    const items = [
-      {
-        title: 'Send feedback',
-        onPress: openFeatureRequest
-      },
-      {
-        title: 'Report a bug',
-        onPress: openBugReport
-      },
+    const items: GroupListItem[] = [
       {
         title: 'Terms of use',
         onPress: openTermsOfUse
@@ -73,36 +35,19 @@ export const About = ({
         onPress: openPrivacyPolicy
       },
       {
-        title: 'Help center',
-        onPress: openHelpCenter
-      },
-      {
         title: 'App version',
         value: VERSION
       }
     ]
 
-    if (user?.id) {
-      items.push({
-        title: 'User ID',
-        value: user.id.toString()
-      })
-    }
-
     return items
-  }, [
-    openBugReport,
-    openFeatureRequest,
-    openTermsOfUse,
-    openPrivacyPolicy,
-    openHelpCenter,
-    user
-  ])
+  }, [openTermsOfUse, openPrivacyPolicy])
 
   return (
     <GroupList
       data={data}
       titleSx={{ fontSize: 16, lineHeight: 22, fontFamily: 'Inter-Regular' }}
+      textContainerSx={{ marginRight: 32 }}
       separatorMarginRight={16}
     />
   )

--- a/packages/core-mobile/app/new/features/accountSettings/components/About.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/components/About.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { GroupList } from '@avalabs/k2-alpine'
 import DeviceInfo from 'react-native-device-info'
 import {
@@ -8,6 +8,7 @@ import {
   PRIVACY_POLICY_URL,
   TERMS_OF_USE_URL
 } from 'common/consts/urls'
+import SentryService from 'services/sentry/SentryService'
 
 const VERSION = DeviceInfo.getReadableVersion()
 
@@ -16,67 +17,87 @@ export const About = ({
 }: {
   onPressItem: ({ url, title }: { url: string; title: string }) => void
 }): React.JSX.Element => {
-  const openHelpCenter = (): void => {
+  const user = useMemo(() => SentryService.getUser(), [])
+
+  const openHelpCenter = useCallback(() => {
     onPressItem({
       url: HELP_URL,
       title: 'Help center'
     })
-  }
+  }, [onPressItem])
 
-  const openBugReport = (): void => {
+  const openBugReport = useCallback(() => {
     onPressItem({
       url: BUG_REPORT_URL,
       title: 'Bug report'
     })
-  }
+  }, [onPressItem])
 
-  const openFeatureRequest = (): void => {
+  const openFeatureRequest = useCallback(() => {
     onPressItem({
       url: FEATURE_REQUEST_URL,
       title: 'Feature request'
     })
-  }
+  }, [onPressItem])
 
-  const openTermsOfUse = (): void => {
+  const openTermsOfUse = useCallback(() => {
     onPressItem({
       url: TERMS_OF_USE_URL,
       title: 'Terms of use'
     })
-  }
+  }, [onPressItem])
 
-  const openPrivacyPolicy = (): void => {
+  const openPrivacyPolicy = useCallback(() => {
     onPressItem({
       url: PRIVACY_POLICY_URL,
       title: 'Privacy policy'
     })
-  }
+  }, [onPressItem])
 
-  const data = [
-    {
-      title: 'Send feedback',
-      onPress: openFeatureRequest
-    },
-    {
-      title: 'Report a bug',
-      onPress: openBugReport
-    },
-    {
-      title: 'Terms of use',
-      onPress: openTermsOfUse
-    },
-    {
-      title: 'Privacy policy',
-      onPress: openPrivacyPolicy
-    },
-    {
-      title: 'Help center',
-      onPress: openHelpCenter
-    },
-    {
-      title: 'App version',
-      value: VERSION
+  const data = useMemo(() => {
+    const items = [
+      {
+        title: 'Send feedback',
+        onPress: openFeatureRequest
+      },
+      {
+        title: 'Report a bug',
+        onPress: openBugReport
+      },
+      {
+        title: 'Terms of use',
+        onPress: openTermsOfUse
+      },
+      {
+        title: 'Privacy policy',
+        onPress: openPrivacyPolicy
+      },
+      {
+        title: 'Help center',
+        onPress: openHelpCenter
+      },
+      {
+        title: 'App version',
+        value: VERSION
+      }
+    ]
+
+    if (user?.id) {
+      items.push({
+        title: 'User ID',
+        value: user.id.toString()
+      })
     }
-  ]
+
+    return items
+  }, [
+    openBugReport,
+    openFeatureRequest,
+    openTermsOfUse,
+    openPrivacyPolicy,
+    openHelpCenter,
+    user
+  ])
 
   return (
     <GroupList

--- a/packages/core-mobile/app/new/features/accountSettings/components/Support.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/components/Support.tsx
@@ -1,0 +1,82 @@
+import React, { useCallback, useMemo } from 'react'
+import { GroupList, GroupListItem } from '@avalabs/k2-alpine'
+import {
+  BUG_REPORT_URL,
+  FEATURE_REQUEST_URL,
+  HELP_URL
+} from 'common/consts/urls'
+import { useUserUniqueID } from 'common/hooks/useUserUniqueID'
+import { copyToClipboard } from 'common/utils/clipboard'
+
+export const Support = ({
+  onPressItem
+}: {
+  onPressItem: ({ url, title }: { url: string; title: string }) => void
+}): React.JSX.Element => {
+  const userUniqueID = useUserUniqueID()
+
+  const openHelpCenter = useCallback(() => {
+    onPressItem({
+      url: HELP_URL,
+      title: 'Help center'
+    })
+  }, [onPressItem])
+
+  const openBugReport = useCallback(() => {
+    onPressItem({
+      url: BUG_REPORT_URL,
+      title: 'Bug report'
+    })
+  }, [onPressItem])
+
+  const openFeatureRequest = useCallback(() => {
+    onPressItem({
+      url: FEATURE_REQUEST_URL,
+      title: 'Feature request'
+    })
+  }, [onPressItem])
+
+  const handlePressUniqueUserId = useCallback(() => {
+    copyToClipboard(userUniqueID, 'Unique user ID copied to clipboard')
+  }, [userUniqueID])
+
+  const data = useMemo(() => {
+    const items: GroupListItem[] = [
+      {
+        title: 'Send feedback',
+        onPress: openFeatureRequest
+      },
+      {
+        title: 'Report a bug',
+        onPress: openBugReport
+      },
+      {
+        title: 'Help center',
+        onPress: openHelpCenter
+      },
+      {
+        title: 'Unique user ID',
+        value: userUniqueID,
+        onPress: handlePressUniqueUserId,
+        accessory: <></>
+      }
+    ]
+
+    return items
+  }, [
+    openBugReport,
+    openFeatureRequest,
+    openHelpCenter,
+    handlePressUniqueUserId,
+    userUniqueID
+  ])
+
+  return (
+    <GroupList
+      data={data}
+      titleSx={{ fontSize: 16, lineHeight: 22, fontFamily: 'Inter-Regular' }}
+      textContainerSx={{ marginRight: 32 }}
+      separatorMarginRight={16}
+    />
+  )
+}

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/index.tsx
@@ -34,6 +34,7 @@ import {
   togglePrivacyMode
 } from 'store/settings/securityPrivacy'
 import { useCoreBrowser } from 'common/hooks/useCoreBrowser'
+import { Support } from 'features/accountSettings/components/Support'
 
 const AccountSettingsScreen = (): JSX.Element => {
   const { deleteWallet } = useDeleteWallet()
@@ -215,6 +216,7 @@ const AccountSettingsScreen = (): JSX.Element => {
               selectNotificationPreferences={goToNotificationPreferences}
               selectSecurityPrivacy={goToSecurityPrivacy}
             />
+            <Support onPressItem={handlePressAboutItem} />
             <About onPressItem={handlePressAboutItem} />
           </View>
           <TouchableOpacity

--- a/packages/core-mobile/app/resources/Constants.ts
+++ b/packages/core-mobile/app/resources/Constants.ts
@@ -4,7 +4,8 @@ export enum StorageKey {
   HAS_MIGRATED_FROM_ASYNC_STORAGE = 'hasMigratedFromAsyncStorage',
   NOTIFICATIONS_OPTIMIZATION = 'NOTIFICATIONS_OPTIMIZATION',
   LAST_TRANSACTED_ERC20_NETWORKS = 'lastTransactedErc20Networks',
-  ADDRESSES_IN_RANGE = 'addressesInRange'
+  ADDRESSES_IN_RANGE = 'addressesInRange',
+  USER_UNIQUE_ID = 'USER_UNIQUE_ID'
 }
 
 export enum ZustandStorageKeys {

--- a/packages/core-mobile/app/services/sentry/SentryService.ts
+++ b/packages/core-mobile/app/services/sentry/SentryService.ts
@@ -4,6 +4,7 @@ import { DefaultSampleRate } from 'services/sentry/SentryWrapper'
 import { scrub } from 'utils/data/scrubber'
 import DevDebuggingConfig from 'utils/debugging/DevDebuggingConfig'
 import { ErrorEvent, TransactionEvent } from '@sentry/core'
+import UserService from 'services/user/UserService'
 
 if (!Config.SENTRY_DSN)
   // (require cycle)
@@ -61,7 +62,10 @@ const init = (): void => {
       tracesSampler: samplingContext => {
         return __DEV__ ? 1 : samplingContext.sampleRate ?? DefaultSampleRate
       },
-      integrations: [navigationIntegration]
+      integrations: [navigationIntegration],
+      onReady: async () => {
+        Sentry.getGlobalScope().setUser({ id: UserService.getUniqueID() })
+      }
     })
   }
 }
@@ -81,15 +85,9 @@ const captureException = (message: string, value?: unknown): void => {
   }
 }
 
-const getUser = (): Sentry.User | undefined => {
-  const scope = Sentry.getCurrentScope()
-  return scope?.getUser()
-}
-
 export default {
   init,
   isAvailable,
   captureException,
-  navigationIntegration,
-  getUser
+  navigationIntegration
 }

--- a/packages/core-mobile/app/services/sentry/SentryService.ts
+++ b/packages/core-mobile/app/services/sentry/SentryService.ts
@@ -81,4 +81,15 @@ const captureException = (message: string, value?: unknown): void => {
   }
 }
 
-export default { init, isAvailable, captureException, navigationIntegration }
+const getUser = (): Sentry.User | undefined => {
+  const scope = Sentry.getCurrentScope()
+  return scope?.getUser()
+}
+
+export default {
+  init,
+  isAvailable,
+  captureException,
+  navigationIntegration,
+  getUser
+}

--- a/packages/core-mobile/app/services/user/UserService.ts
+++ b/packages/core-mobile/app/services/user/UserService.ts
@@ -1,0 +1,23 @@
+import { MMKV } from 'react-native-mmkv'
+import { uuid } from 'utils/uuid'
+
+const storage = new MMKV({
+  id: `user`
+})
+
+class UserService {
+  static getUniqueID(): string {
+    const UNIQUE_ID_KEY = 'USER_SERVICE_UNIQUE_ID'
+
+    let id = storage.getString(UNIQUE_ID_KEY)
+
+    if (!id) {
+      id = uuid()
+      storage.set(UNIQUE_ID_KEY, id)
+    }
+
+    return id
+  }
+}
+
+export default UserService

--- a/packages/core-mobile/app/services/user/UserService.ts
+++ b/packages/core-mobile/app/services/user/UserService.ts
@@ -1,19 +1,14 @@
-import { MMKV } from 'react-native-mmkv'
+import { StorageKey } from 'resources/Constants'
+import { commonStorage } from 'utils/mmkv'
 import { uuid } from 'utils/uuid'
-
-const storage = new MMKV({
-  id: `user`
-})
 
 class UserService {
   static getUniqueID(): string {
-    const UNIQUE_ID_KEY = 'USER_SERVICE_UNIQUE_ID'
-
-    let id = storage.getString(UNIQUE_ID_KEY)
+    let id = commonStorage.getString(StorageKey.USER_UNIQUE_ID)
 
     if (!id) {
       id = uuid()
-      storage.set(UNIQUE_ID_KEY, id)
+      commonStorage.set(StorageKey.USER_UNIQUE_ID, id)
     }
 
     return id


### PR DESCRIPTION
## Description

**Ticket: [CP-11712]** 

* Add unique user ID to help us troubleshoot more efficiently

## Screenshots/Videos
* iOS
https://github.com/user-attachments/assets/a0191d15-781a-4406-ac20-ed0b8b4e1b73

* Android
https://github.com/user-attachments/assets/6a0d680a-c8e6-42da-bfaf-de5944504a6e

## Testing
* If you’d like to check the unique user ID in the `FullScreenWarning` component, you should trigger an error that falls back to the Sentry error boundary. The easiest way is to throw an error from within a React component during render. For example:
```
const Component = (): JSX.Element => {
  throw new Error("Test");
};
```
* To fall back to `TopLevelErrorFallback` in the local build, follow the steps below.

index.js
```
if (__DEV__) {
  // ...
  
  DevDebuggingConfig.LOGBOX_DISABLED && LogBox.ignoreAllLogs(true)

  // Add these three lines
  ErrorUtils.setGlobalHandler((error, isFatal) => {
    DefaultErrorReporter(error, isFatal)
  })

   // ...
}
```

DevDebuggingConfig.ts
```
const DevDebuggingConfig = {
  WDYR: false,
  STORYBOOK_ENABLED: false,
  LOGBOX_DISABLED: true, // <= set to true
  SHOW_DEMO_NFTS: false,
  API_MOCKING: false,
  SENTRY_SPOTLIGHT: true,  // <= set to true
  METRO_DEV_MENU: false
}
```

[CP-11712]: https://ava-labs.atlassian.net/browse/CP-11712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ