### PR TITLE
CP-9810: Show the destination address to 'to' instead of contract address

### DIFF
--- a/packages/core-mobile/app/new/common/hooks/send/useEVMSend.ts
+++ b/packages/core-mobile/app/new/common/hooks/send/useEVMSend.ts
@@ -63,7 +63,7 @@ const useEVMSend: SendAdapterEVM = ({
         toAddress: addressToSend,
         amount: amount?.toSubUnit(),
         context: {
-          [RequestContext.NON_CONTRACT_RECIPIENT]: true
+          [RequestContext.NON_CONTRACT_RECIPIENT_ADDRESS]: addressToSend
         }
       })
     } finally {

--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/utils.test.ts
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/utils.test.ts
@@ -153,7 +153,7 @@ describe('overrideContractItem', () => {
     const request: RpcRequest = {
       method: RpcMethod.ETH_SEND_TRANSACTION,
       context: {
-        [RequestContext.NON_CONTRACT_RECIPIENT]: true
+        [RequestContext.NON_CONTRACT_RECIPIENT_ADDRESS]: '0xToAddress'
       },
       requestId: '1',
       sessionId: '1',
@@ -164,7 +164,8 @@ describe('overrideContractItem', () => {
     const result = overrideContractItem(item, request)
     expect(result).toEqual({
       ...item,
-      label: 'To'
+      label: 'To',
+      value: '0xToAddress'
     })
     expect(result).not.toBe(item) // Ensure a new object is returned
   })
@@ -178,7 +179,7 @@ describe('overrideContractItem', () => {
     const request: RpcRequest = {
       method: RpcMethod.ETH_SEND_TRANSACTION,
       context: {
-        [RequestContext.NON_CONTRACT_RECIPIENT]: true
+        [RequestContext.NON_CONTRACT_RECIPIENT_ADDRESS]: '0xToAddress'
       },
       requestId: '1',
       sessionId: '1',
@@ -189,7 +190,8 @@ describe('overrideContractItem', () => {
     const result = overrideContractItem(item, request)
     expect(result).toEqual({
       ...item,
-      label: 'To'
+      label: 'To',
+      value: '0xToAddress'
     })
   })
 

--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/utils.ts
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/utils.ts
@@ -1,4 +1,9 @@
-import { RpcRequest, DetailItem, RpcMethod } from '@avalabs/vm-module-types'
+import {
+  RpcRequest,
+  DetailItem,
+  RpcMethod,
+  DetailItemType
+} from '@avalabs/vm-module-types'
 import { RequestContext } from 'store/rpc/types'
 import { isInAppRequest } from 'store/rpc/utils/isInAppRequest'
 
@@ -30,11 +35,16 @@ export const overrideContractItem = (
 
   // evm module hardcodes "Contract" for the to field for all transactions
   // we are overriding this with "To" for non-contract recipients
-  const isNonContractRecipient = Boolean(
-    request.context?.[RequestContext.NON_CONTRACT_RECIPIENT]
-  )
-  if (item.label.toLowerCase() === 'contract' && isNonContractRecipient) {
-    return { ...item, label: 'To' }
+  const nonContractRecipientAddress =
+    request.context?.[RequestContext.NON_CONTRACT_RECIPIENT_ADDRESS]
+
+  if (
+    item.label.toLowerCase() === 'contract' &&
+    nonContractRecipientAddress &&
+    typeof nonContractRecipientAddress === 'string' &&
+    item.type === DetailItemType.ADDRESS
+  ) {
+    return { ...item, label: 'To', value: nonContractRecipientAddress }
   }
 
   return item

--- a/packages/core-mobile/app/store/rpc/types.ts
+++ b/packages/core-mobile/app/store/rpc/types.ts
@@ -164,6 +164,6 @@ export enum RequestContext {
   CONFETTI_DISABLED = 'confettiDisabled',
 
   // used to determine if the recipient/to address is a contract
-  // if true, we will show "To" instead of "Contract" in the approval screen
-  NON_CONTRACT_RECIPIENT = 'nonContractRecipient'
+  // If we set an address for this key, the approval screen will show “To” instead of “Contract” along with the address.
+  NON_CONTRACT_RECIPIENT_ADDRESS = 'nonContractRecipient'
 }


### PR DESCRIPTION
## Description

**Ticket: [CP-9810]** 

* Set the RequestContext.NON_CONTRACT_RECIPIENT_ADDRESS key with addressToSend and display it in the “To” section of the approval screen for EVM send
* Fixed to reset the amount when changing the selected token in send

## Screenshots/Videos
* iOS
https://github.com/user-attachments/assets/8db655ca-b33a-4baf-9a3f-603d95bc3dec

* Android
https://github.com/user-attachments/assets/863f2191-2baf-4506-9cbc-854076142947