### PR TITLE
CP-11169: don't show balance-transferred notifications while foregrounded

### DIFF
--- a/packages/core-mobile/app/services/fcm/FCMService.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.ts
@@ -65,8 +65,11 @@ class FCMService {
         return
       }
 
-      if (result.data.data.event === BalanceChangeEvents.BALANCES_SPENT) {
-        // skip showing notification if user just spent balance in app
+      if (
+        result.data.data.event === BalanceChangeEvents.BALANCES_SPENT ||
+        result.data.data.event === BalanceChangeEvents.BALANCES_TRANSFERRED
+      ) {
+        // skip showing notification if user just spent balance in app, or transferred balance between user's own accounts
         return
       }
 


### PR DESCRIPTION
## Description

**Ticket: [CP-11169]** 

* Fix to stop showing `balance-transferred` type notifications when the app is in the foreground

[CP-11169]: https://ava-labs.atlassian.net/browse/CP-11169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ