### PR TITLE
CP-11879: fix double navigate issue

### DIFF
--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/recoveryPhraseVerifyPin.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/recoveryPhraseVerifyPin.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { VerifyWithPinOrBiometry } from 'common/components/VerifyWithPinOrBiometry'
 import { useRouter } from 'expo-router'
 import { useActiveWalletId } from 'common/hooks/useActiveWallet'
@@ -9,7 +9,7 @@ const RecoveryPhraseVerifyPinScreen = (): JSX.Element => {
   const { replace } = useRouter()
   const walletId = useActiveWalletId()
 
-  const handleVerifySuccess = async (): Promise<void> => {
+  const handleVerifySuccess = useCallback(async (): Promise<void> => {
     try {
       const result = await BiometricsSDK.loadWalletSecret(walletId)
       if (!result.success) {
@@ -26,7 +26,7 @@ const RecoveryPhraseVerifyPinScreen = (): JSX.Element => {
     } catch (err) {
       Logger.error('Error loading wallet secret', err)
     }
-  }
+  }, [replace, walletId])
 
   return <VerifyWithPinOrBiometry onVerifySuccess={handleVerifySuccess} />
 }

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/verifyPinForPrivateKey.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/verifyPinForPrivateKey.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { VerifyWithPinOrBiometry } from 'common/components/VerifyWithPinOrBiometry'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import Logger from 'utils/Logger'
@@ -19,18 +19,18 @@ const VerifyPinForPrivateKeyScreen = (): JSX.Element => {
   const cChainNetwork = useCChainNetwork()
   const wallet = useSelector(selectWalletById(walletId))
 
-  const getPrivateKeyFromMnemonic = async (
-    mnemonic: string,
-    network: Network
-  ): Promise<string> => {
-    return WalletService.getPrivateKeyFromMnemonic(
-      mnemonic,
-      network,
-      parseInt(accountIndex)
-    )
-  }
+  const getPrivateKeyFromMnemonic = useCallback(
+    async (mnemonic: string, network: Network): Promise<string> => {
+      return WalletService.getPrivateKeyFromMnemonic(
+        mnemonic,
+        network,
+        parseInt(accountIndex)
+      )
+    },
+    [accountIndex]
+  )
 
-  const handleLoginSuccess = async (): Promise<void> => {
+  const handleLoginSuccess = useCallback(async (): Promise<void> => {
     if (!wallet) {
       Logger.error('Wallet not found for ID:', walletId)
       return
@@ -67,7 +67,7 @@ const VerifyPinForPrivateKeyScreen = (): JSX.Element => {
           Logger.error('Error getting private key from mnemonic', error)
         })
     }
-  }
+  }, [wallet, walletId, replace, cChainNetwork, getPrivateKeyFromMnemonic])
 
   return <VerifyWithPinOrBiometry onVerifySuccess={handleLoginSuccess} />
 }


### PR DESCRIPTION
## Description

**Ticket: [CP-11879]** 

- on pin verified, replace was getting called twice, wrap it with useCallback to fix it.

## Screenshots/Videos


## Testing


## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11879]: https://ava-labs.atlassian.net/browse/CP-11879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ