### PR TITLE
CP-11810 - spend limit + swap/send/nft/bridge with onboarding back interaction

### DIFF
--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
@@ -138,6 +138,7 @@ const ApprovalScreen = ({
         maxPriorityFeePerGas,
         overrideData: hashedCustomSpend
       })
+      router.canGoBack() && router.back()
     } catch (error: unknown) {
       Logger.error('Error approving transaction', error)
     } finally {

--- a/packages/core-mobile/app/new/features/bridge/screens/BridgeScreen.tsx
+++ b/packages/core-mobile/app/new/features/bridge/screens/BridgeScreen.tsx
@@ -201,7 +201,7 @@ export const BridgeScreen = (): JSX.Element => {
       audioFeedback(Audios.Send)
       back()
       const state = getState()
-      if (state?.routes[state?.index ?? 0]?.name === 'onboarding') {
+      if (state?.routes.some(route => route.name === 'onboarding')) {
         canGoBack() && back()
       }
       navigate({

--- a/packages/core-mobile/app/new/features/collectibleSend/screens/RecentContactsScreen.tsx
+++ b/packages/core-mobile/app/new/features/collectibleSend/screens/RecentContactsScreen.tsx
@@ -63,7 +63,7 @@ export const RecentContactsScreen = (): JSX.Element | null => {
             canGoBack() && back()
             // dismiss onboarding modal
             const state = getState()
-            if (state?.routes[state?.index ?? 0]?.name === 'onboarding') {
+            if (state?.routes.some(route => route.name === 'onboarding')) {
               canGoBack() && back()
             }
             contact?.type &&

--- a/packages/core-mobile/app/new/features/collectibleSend/screens/ScanQrCodeScreen.tsx
+++ b/packages/core-mobile/app/new/features/collectibleSend/screens/ScanQrCodeScreen.tsx
@@ -16,6 +16,7 @@ import { useSendSelectedToken } from 'features/send/store'
 import { useNetworks } from 'hooks/networks/useNetworks'
 import { useNetworkFee } from 'hooks/useNetworkFee'
 import React, { useCallback, useMemo, useState } from 'react'
+import { InteractionManager } from 'react-native'
 import { useSelector } from 'react-redux'
 import { selectActiveAccount } from 'store/account'
 import { useSendTransactionCallbacks } from '../hooks/useSendTransactionCallbacks'
@@ -64,13 +65,15 @@ export const ScanQrCodeScreen = (): JSX.Element => {
           txHash,
           onDismiss: () => {
             canDismiss() && dismiss()
-            const navigationState = getState()
-            if (
-              navigationState?.routes[navigationState?.index ?? 0]?.name ===
-              'recentContacts'
-            ) {
-              canDismiss() && dismiss()
-            }
+            InteractionManager.runAfterInteractions(() => {
+              const navigationState = getState()
+              if (
+                navigationState?.routes[navigationState?.index ?? 0]?.name ===
+                'recentContacts'
+              ) {
+                canDismiss() && dismiss()
+              }
+            })
           }
         })
       } catch (reason) {

--- a/packages/core-mobile/app/new/features/collectibleSend/screens/ScanQrCodeScreen.tsx
+++ b/packages/core-mobile/app/new/features/collectibleSend/screens/ScanQrCodeScreen.tsx
@@ -5,20 +5,19 @@ import {
   useTheme,
   View
 } from '@avalabs/k2-alpine'
+import React, { useCallback, useMemo, useState } from 'react'
 import { useHeaderHeight } from '@react-navigation/elements'
 import { useNavigation } from '@react-navigation/native'
 import { QrCodeScanner } from 'common/components/QrCodeScanner'
 import { useCollectibleSend } from 'common/hooks/send/useCollectibleSend'
-import { isAddress } from 'ethers'
 import { useRouter } from 'expo-router'
 import { useNativeTokenWithBalanceByNetwork } from 'features/send/hooks/useNativeTokenWithBalanceByNetwork'
 import { useSendSelectedToken } from 'features/send/store'
 import { useNetworks } from 'hooks/networks/useNetworks'
 import { useNetworkFee } from 'hooks/useNetworkFee'
-import React, { useCallback, useMemo, useState } from 'react'
-import { InteractionManager } from 'react-native'
 import { useSelector } from 'react-redux'
 import { selectActiveAccount } from 'store/account'
+import { isAddress } from 'ethers'
 import { useSendTransactionCallbacks } from '../hooks/useSendTransactionCallbacks'
 
 export const ScanQrCodeScreen = (): JSX.Element => {
@@ -27,7 +26,7 @@ export const ScanQrCodeScreen = (): JSX.Element => {
   } = useTheme()
   const headerHeight = useHeaderHeight()
   const { getNetwork } = useNetworks()
-  const { canDismiss, dismiss } = useRouter()
+  const { canGoBack, back } = useRouter()
   const { getState } = useNavigation()
   const fromAddress = useSelector(selectActiveAccount)?.addressC ?? ''
   const [selectedToken] = useSendSelectedToken()
@@ -64,16 +63,22 @@ export const ScanQrCodeScreen = (): JSX.Element => {
         onSuccess({
           txHash,
           onDismiss: () => {
-            canDismiss() && dismiss()
-            InteractionManager.runAfterInteractions(() => {
-              const navigationState = getState()
-              if (
-                navigationState?.routes[navigationState?.index ?? 0]?.name ===
-                'recentContacts'
-              ) {
-                canDismiss() && dismiss()
-              }
-            })
+            // dismiss QR code modal
+            canGoBack() && back()
+            // dismiss recent contacts modal
+            const navigationState = getState()
+            if (
+              navigationState?.routes.some(
+                route => route.name === 'recentContacts'
+              )
+            ) {
+              canGoBack() && back()
+            }
+            // dismiss onboarding modal
+            const state = getState()
+            if (state?.routes.some(route => route.name === 'onboarding')) {
+              canGoBack() && back()
+            }
           }
         })
       } catch (reason) {
@@ -82,7 +87,7 @@ export const ScanQrCodeScreen = (): JSX.Element => {
         setIsSending(false)
       }
     },
-    [canDismiss, dismiss, getState, onFailure, onSuccess, selectedToken, send]
+    [back, canGoBack, getState, onFailure, onSuccess, selectedToken, send]
   )
 
   return (

--- a/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
+++ b/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
@@ -57,20 +57,11 @@ export const SendScreen = (): JSX.Element => {
         )
 
       canDismiss() && dismiss()
-      const navigationState = getState()
-      if (
-        navigationState?.routes[navigationState?.index ?? 0]?.name === 'send' ||
-        navigationState?.routes[navigationState?.index ?? 0]?.name ===
-          'recentContacts'
-      ) {
-        canDismiss() && dismiss()
-      }
-
       InteractionManager.runAfterInteractions(() => {
-        const state = getState()
+        const navigationState = getState()
         if (
-          state?.routes[state?.index ?? 0]?.name === 'recentContacts' ||
-          state?.routes[state?.index ?? 0]?.name === 'send'
+          navigationState?.routes[navigationState?.index ?? 0]?.name ===
+          'recentContacts'
         ) {
           canDismiss() && dismiss()
         }

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -557,7 +557,6 @@ export const SwapScreen = (): JSX.Element => {
 
   useEffect(() => {
     if (swapStatus === 'Success') {
-      dismiss()
       InteractionManager.runAfterInteractions(() => {
         const state = getState()
         if (state?.routes[state?.index ?? 0]?.name === 'swap') {

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -15,28 +15,16 @@ import {
 import { TokenWithBalance } from '@avalabs/vm-module-types'
 import { SwapSide } from '@paraswap/sdk'
 import { useNavigation } from '@react-navigation/native'
-import Big from 'big.js'
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import { TokenInputWidget } from 'common/components/TokenInputWidget'
-import {
-  AVAX_TOKEN_ID,
-  SOLANA_TOKEN_LOCAL_ID,
-  USDC_AVALANCHE_C_TOKEN_ID,
-  USDC_SOLANA_TOKEN_ID
-} from 'common/consts/swap'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import { usePreventScreenRemoval } from 'common/hooks/usePreventScreenRemoval'
-import { usePrevious } from 'common/hooks/usePrevious'
-import { useSwapList } from 'common/hooks/useSwapList'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { ParaswapError, ParaswapErrorCode } from 'errors/swapError'
 import { useGlobalSearchParams, useRouter } from 'expo-router'
 import useCChainNetwork from 'hooks/earn/useCChainNetwork'
-import useSolanaNetwork from 'hooks/earn/useSolanaNetwork'
-import { useNetworks } from 'hooks/networks/useNetworks'
 import { useWatchlist } from 'hooks/watchlist/useWatchlist'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { InteractionManager } from 'react-native'
 import Animated, {
   FadeIn,
   FadeOut,
@@ -48,11 +36,22 @@ import {
   LocalTokenWithBalance,
   selectTokensWithZeroBalanceByNetworks
 } from 'store/balance'
+import { basisPointsToPercentage } from 'utils/basisPointsToPercentage'
+import Big from 'big.js'
+import { useSwapList } from 'common/hooks/useSwapList'
+import useSolanaNetwork from 'hooks/earn/useSolanaNetwork'
+import { useNetworks } from 'hooks/networks/useNetworks'
+import {
+  AVAX_TOKEN_ID,
+  SOLANA_TOKEN_LOCAL_ID,
+  USDC_AVALANCHE_C_TOKEN_ID,
+  USDC_SOLANA_TOKEN_ID
+} from 'common/consts/swap'
 import {
   selectIsSwapFeesBlocked,
   selectIsSwapFeesJupiterBlocked
 } from 'store/posthog'
-import { basisPointsToPercentage } from 'utils/basisPointsToPercentage'
+import { usePrevious } from 'common/hooks/usePrevious'
 import { SlippageInput } from '../components.tsx/SlippageInput'
 import {
   JUPITER_PARTNER_FEE_BPS,
@@ -60,17 +59,17 @@ import {
   PARASWAP_PARTNER_FEE_BPS
 } from '../consts'
 import { useSwapContext } from '../contexts/SwapContext'
-import { useSwapRate } from '../hooks/useSwapRate'
 import {
   isJupiterQuote,
   isMarkrQuote,
   isParaswapQuote,
   SwapProviders
 } from '../types'
+import { useSwapRate } from '../hooks/useSwapRate'
 
 export const SwapScreen = (): JSX.Element => {
   const { theme } = useTheme()
-  const { navigate, canDismiss, dismiss } = useRouter()
+  const { navigate, back, canGoBack } = useRouter()
   const { getState } = useNavigation()
   const params = useGlobalSearchParams<{
     initialTokenIdFrom?: string
@@ -557,14 +556,13 @@ export const SwapScreen = (): JSX.Element => {
 
   useEffect(() => {
     if (swapStatus === 'Success') {
-      InteractionManager.runAfterInteractions(() => {
-        const state = getState()
-        if (state?.routes[state?.index ?? 0]?.name === 'swap') {
-          canDismiss() && dismiss()
-        }
-      })
+      back()
+      const state = getState()
+      if (state?.routes.some(route => route.name === 'onboarding')) {
+        canGoBack() && back()
+      }
     }
-  }, [dismiss, canDismiss, getState, swapStatus])
+  }, [back, canGoBack, getState, swapStatus])
 
   useEffect(validateInputs, [validateInputs])
   useEffect(applyQuote, [applyQuote])


### PR DESCRIPTION
## Description

**Ticket: [CP-11810]** 

- fixes spend limit bug
- fixed navigation getState which wasn't valid by index anymore so I had to do the check by using .some
- fixed all flows send/nft send/swap/bridge with onboarding to properly navigate from tokenDetails and 

## Screenshots/Videos

https://github.com/user-attachments/assets/9ed92e60-b534-4cad-a9b5-960ac2d7087f

## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11810]: https://ava-labs.atlassian.net/browse/CP-11810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ