### PR TITLE
CP-11887: deep compare network filter data

### DIFF
--- a/packages/core-mobile/app/new/features/activity/hooks/useActivityFilterAndSearch.ts
+++ b/packages/core-mobile/app/new/features/activity/hooks/useActivityFilterAndSearch.ts
@@ -24,7 +24,7 @@ import { isSupportedNftChainId } from '../utils'
 
 export type ActivityNetworkFilter = {
   filterName: string
-  chainId: number
+  chainId?: number
 }
 
 export const useActivityFilterAndSearch = ({

--- a/packages/core-mobile/app/new/features/portfolio/assets/hooks/useAssetsFilterAndSort.ts
+++ b/packages/core-mobile/app/new/features/portfolio/assets/hooks/useAssetsFilterAndSort.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   ASSET_BALANCE_SORTS,
   ASSET_MANAGE_VIEWS,
@@ -13,6 +13,9 @@ import { DropdownSelection } from 'common/types'
 import { useErc20ContractTokens } from 'common/hooks/useErc20ContractTokens'
 import { useSelector } from 'react-redux'
 import { selectEnabledNetworks } from 'store/network'
+import { usePrevious } from 'common/hooks/usePrevious'
+import { ActivityNetworkFilter } from 'features/activity/hooks/useActivityFilterAndSearch'
+import { isEqual } from 'lodash'
 
 export const useAssetsFilterAndSort = (): {
   onResetFilter: () => void
@@ -43,6 +46,18 @@ export const useAssetsFilterAndSort = (): {
       ...enabledNetworksFilter
     ]
   }, [enabledNetworks])
+
+  const [selectedNetworkFilters, setSelectedNetworkFilters] =
+    useState<ActivityNetworkFilter[]>(networkFilters)
+
+  const prevNetworkFilters = usePrevious(networkFilters)
+
+  useEffect(() => {
+    if (isEqual(prevNetworkFilters, networkFilters)) {
+      return
+    }
+    setSelectedNetworkFilters(networkFilters)
+  }, [networkFilters, prevNetworkFilters])
 
   const [selectedFilter, setSelectedFilter] = useState<AssetNetworkFilter>(
     AssetNetworkFilter.AllNetworks
@@ -100,14 +115,14 @@ export const useAssetsFilterAndSort = (): {
     () => [
       {
         key: 'network-filters',
-        items: networkFilters.map(f => ({
+        items: selectedNetworkFilters.map(f => ({
           id: f.filterName,
           title: f.filterName,
           selected: f.filterName === selectedFilter
         }))
       }
     ],
-    [networkFilters, selectedFilter]
+    [selectedNetworkFilters, selectedFilter]
   )
 
   const sortData = useMemo(() => {


### PR DESCRIPTION
## Description

**Ticket: [CP-11887]** 

- use combination of usePrevious and lodash.isEqual to deep compare previous and new network filter object array

## Screenshots/Videos

https://github.com/user-attachments/assets/eec2d894-734f-47f6-b78f-8ab082ceab36



## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11887]: https://ava-labs.atlassian.net/browse/CP-11887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ