### PR TITLE
CP-11894: show loading state when switching segment

### DIFF
--- a/packages/core-mobile/app/new/common/hooks/useTokenDetails.ts
+++ b/packages/core-mobile/app/new/common/hooks/useTokenDetails.ts
@@ -114,44 +114,45 @@ export const useTokenDetails = ({
     return getWatchlistPrice(tokenId)
   }, [trendingTokenData, getWatchlistPrice, token, tokenId])
 
+  const extractChartData = useCallback((): void => {
+    const chart = getWatchlistChart(tokenId)
+
+    if (chart) {
+      setChartData(chart.dataPoints)
+      setRanges(chart.ranges)
+    } else {
+      // simply set to empty to hide the loading state.
+      setChartData([])
+    }
+  }, [getWatchlistChart, tokenId])
+
+  const getChartDataFromCoingecko = useCallback(async (): Promise<void> => {
+    const data = await TokenService.getChartDataForCoinId({
+      coingeckoId,
+      days: chartDays,
+      currency
+    })
+
+    if (data) {
+      setChartData(data.dataPoints)
+      setRanges(data.ranges)
+    } else {
+      // simply set to empty to hide the loading state.
+      setChartData([])
+    }
+  }, [coingeckoId, chartDays, currency])
+
   // get chart data
   useEffect(() => {
-    const extractChartData = (): void => {
-      const chart = getWatchlistChart(tokenId)
-
-      if (chart) {
-        setChartData(chart.dataPoints)
-        setRanges(chart.ranges)
-      } else {
-        // simply set to empty to hide the loading state.
-        setChartData([])
-      }
-    }
-
-    const getChartDataFromCoingecko = async (): Promise<void> => {
-      const data = await TokenService.getChartDataForCoinId({
-        coingeckoId,
-        days: chartDays,
-        currency
-      })
-
-      if (data) {
-        setChartData(data.dataPoints)
-        setRanges(data.ranges)
-      } else {
-        // simply set to empty to hide the loading state.
-        setChartData([])
-      }
-    }
-
     InteractionManager.runAfterInteractions(() => {
+      setChartData(undefined)
       if (coingeckoId) {
         getChartDataFromCoingecko()
       } else {
         extractChartData()
       }
     })
-  }, [getWatchlistChart, token, tokenId, chartDays, coingeckoId, currency])
+  }, [coingeckoId, getChartDataFromCoingecko, extractChartData])
 
   // get market cap, volume, etc
   useEffect(() => {

--- a/packages/core-mobile/app/new/common/hooks/useTokenDetails.ts
+++ b/packages/core-mobile/app/new/common/hooks/useTokenDetails.ts
@@ -16,6 +16,7 @@ import { Ranges, TrendingToken } from 'services/token/types'
 import { selectSelectedCurrency } from 'store/settings/currency'
 import { useCoreBrowser } from 'new/common/hooks/useCoreBrowser'
 import { getTokenAddress, getTokenChainId } from 'features/track/utils/utils'
+import { usePrevious } from './usePrevious'
 
 const isTrendingToken = (token: MarketToken | undefined): boolean =>
   token !== undefined && token.marketType === MarketType.TRENDING
@@ -45,6 +46,7 @@ export const useTokenDetails = ({
   tokenId: string
 }): {
   isFavorite: boolean
+  isUpdatingChartData: boolean
   openUrl: ({ url, title }: { url: string; title: string }) => void
   handleFavorite: () => void
   chainId: number | undefined
@@ -89,6 +91,7 @@ export const useTokenDetails = ({
 
   const [tokenInfo, setTokenInfo] = useState<TokenInfo>()
   const [chartData, setChartData] = useState<{ date: Date; value: number }[]>()
+  const [isUpdatingChartData, setIsUpdatingChartData] = useState(false)
   const [chartDays, setChartDays] = useState(1)
   const [ranges, setRanges] = useState<Ranges>({
     minDate: 0,
@@ -114,17 +117,24 @@ export const useTokenDetails = ({
     return getWatchlistPrice(tokenId)
   }, [trendingTokenData, getWatchlistPrice, token, tokenId])
 
+  const updateDataPoints = useCallback(
+    (dataPoints?: { date: Date; value: number }[], r?: Ranges) => {
+      if (dataPoints && r) {
+        setChartData(dataPoints)
+        setRanges(r)
+        setIsUpdatingChartData(false)
+      } else {
+        // simply set to empty to hide the loading state.
+        setChartData([])
+      }
+    },
+    []
+  )
+
   const extractChartData = useCallback((): void => {
     const chart = getWatchlistChart(tokenId)
-
-    if (chart) {
-      setChartData(chart.dataPoints)
-      setRanges(chart.ranges)
-    } else {
-      // simply set to empty to hide the loading state.
-      setChartData([])
-    }
-  }, [getWatchlistChart, tokenId])
+    updateDataPoints(chart.dataPoints, chart.ranges)
+  }, [getWatchlistChart, tokenId, updateDataPoints])
 
   const getChartDataFromCoingecko = useCallback(async (): Promise<void> => {
     const data = await TokenService.getChartDataForCoinId({
@@ -132,20 +142,12 @@ export const useTokenDetails = ({
       days: chartDays,
       currency
     })
-
-    if (data) {
-      setChartData(data.dataPoints)
-      setRanges(data.ranges)
-    } else {
-      // simply set to empty to hide the loading state.
-      setChartData([])
-    }
-  }, [coingeckoId, chartDays, currency])
+    updateDataPoints(data?.dataPoints, data?.ranges)
+  }, [coingeckoId, chartDays, currency, updateDataPoints])
 
   // get chart data
   useEffect(() => {
     InteractionManager.runAfterInteractions(() => {
-      setChartData(undefined)
       if (coingeckoId) {
         getChartDataFromCoingecko()
       } else {
@@ -222,12 +224,21 @@ export const useTokenDetails = ({
     dispatch(toggleWatchListFavorite(tokenId))
   }, [tokenId, dispatch])
 
-  const changeChartDays = useCallback((days: number) => {
-    setChartDays(days)
-  }, [])
+  const prevChartDays = usePrevious(chartDays)
+
+  const changeChartDays = useCallback(
+    (days: number) => {
+      if (prevChartDays !== days) {
+        setChartDays(days)
+        setIsUpdatingChartData(true)
+      }
+    },
+    [prevChartDays]
+  )
 
   return {
     isFavorite,
+    isUpdatingChartData,
     coingeckoId,
     chainId,
     openUrl,

--- a/packages/core-mobile/app/new/features/track/components/SparklineChart.tsx
+++ b/packages/core-mobile/app/new/features/track/components/SparklineChart.tsx
@@ -1,11 +1,4 @@
-import {
-  alpha,
-  ANIMATED,
-  SPRING_LINEAR_TRANSITION,
-  Text,
-  useTheme,
-  View
-} from '@avalabs/k2-alpine'
+import { alpha, ANIMATED, Text, useTheme, View } from '@avalabs/k2-alpine'
 import { K2AlpineTheme } from '@avalabs/k2-alpine/src/theme/theme'
 import { HORIZONTAL_MARGIN } from 'common/consts'
 import React, { FC, useCallback } from 'react'
@@ -85,9 +78,7 @@ const SparklineChart: FC<Props> = ({
         isLoading={data.length === 0}
       />
       {data?.length ? (
-        <Animated.View
-          entering={FadeIn.delay(100).duration(600)}
-          layout={SPRING_LINEAR_TRANSITION}>
+        <Animated.View entering={FadeIn.delay(100).duration(600)}>
           <LineGraph
             style={{ width: '100%', height: '100%' }}
             verticalPadding={verticalPadding}

--- a/packages/core-mobile/app/new/features/track/components/TokenDetailChart.tsx
+++ b/packages/core-mobile/app/new/features/track/components/TokenDetailChart.tsx
@@ -12,6 +12,7 @@ import { formatCurrency } from 'utils/FormatCurrency'
 import { hapticFeedback } from 'utils/HapticFeedback'
 import { ChartOverlay } from './ChartOverlay'
 import SparklineChart from './SparklineChart'
+import { LoadingState } from 'common/components/LoadingState'
 
 export const TokenDetailChart = ({
   chartData,
@@ -19,7 +20,8 @@ export const TokenDetailChart = ({
   negative,
   onDataSelected,
   onGestureStart,
-  onGestureEnd
+  onGestureEnd,
+  isUpdatingChartData
 }: {
   negative: boolean
   ranges: {
@@ -34,6 +36,7 @@ export const TokenDetailChart = ({
   onDataSelected?: (p: GraphPoint) => void
   onGestureStart?: () => void
   onGestureEnd?: () => void
+  isUpdatingChartData: boolean
 }): JSX.Element => {
   const selectedCurrency = useSelector(selectSelectedCurrency)
   const hasBeenViewedChart = useSelector(
@@ -83,7 +86,8 @@ export const TokenDetailChart = ({
       <SparklineChart
         style={{
           width: '100%',
-          height: '100%'
+          height: '100%',
+          opacity: isUpdatingChartData ? 0.3 : 1
         }}
         labels={chartLabels}
         data={chartData ?? []}
@@ -99,6 +103,11 @@ export const TokenDetailChart = ({
         shouldShowInstruction={!hasBeenViewedChart}
         onInstructionRead={handleInstructionRead}
       />
+      {isUpdatingChartData && (
+        <LoadingState
+          sx={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+        />
+      )}
     </View>
   )
 }

--- a/packages/core-mobile/app/new/features/track/components/TokenDetailChart.tsx
+++ b/packages/core-mobile/app/new/features/track/components/TokenDetailChart.tsx
@@ -10,9 +10,9 @@ import {
 } from 'store/viewOnce'
 import { formatCurrency } from 'utils/FormatCurrency'
 import { hapticFeedback } from 'utils/HapticFeedback'
+import { LoadingState } from 'common/components/LoadingState'
 import { ChartOverlay } from './ChartOverlay'
 import SparklineChart from './SparklineChart'
-import { LoadingState } from 'common/components/LoadingState'
 
 export const TokenDetailChart = ({
   chartData,

--- a/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
+++ b/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
@@ -458,7 +458,7 @@ const TrackTokenDetailScreen = (): JSX.Element => {
         onGestureEnd={handleChartGestureEnd}
       />
 
-      {lastUpdatedDate && (
+      {lastUpdatedDate ? (
         <View sx={styles.lastUpdatedContainer}>
           <Animated.View
             entering={FadeIn.delay(DELAY * 3)}
@@ -482,6 +482,8 @@ const TrackTokenDetailScreen = (): JSX.Element => {
             </Animated.View>
           </Animated.View>
         </View>
+      ) : (
+        <View sx={styles.lastUpdatedContainer} />
       )}
       {tokenInfo?.has24hChartDataOnly === false && (
         <Animated.View

--- a/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
+++ b/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
@@ -49,10 +49,12 @@ import { MarketType } from 'store/watchlist'
 import { getDomainFromUrl } from 'utils/getDomainFromUrl/getDomainFromUrl'
 import { isPositiveNumber } from 'utils/isPositiveNumber/isPositiveNumber'
 import { formatLargeCurrency } from 'utils/Utils'
+import { useDebouncedCallback } from 'use-debounce'
 import { useTrackTokenActions } from '../hooks/useTrackTokenActions'
 
 const MAX_VALUE_WIDTH = '80%'
 const DELAY = 200
+const DEFAULT_DEBOUNCE_MILLISECONDS = 500
 
 const TrackTokenDetailScreen = (): JSX.Element => {
   const { theme } = useTheme()
@@ -81,6 +83,7 @@ const TrackTokenDetailScreen = (): JSX.Element => {
     chartData,
     ranges,
     changeChartDays,
+    isUpdatingChartData,
     tokenInfo,
     isFavorite,
     handleFavorite,
@@ -150,15 +153,20 @@ const TrackTokenDetailScreen = (): JSX.Element => {
     []
   )
 
+  const debouncedHandleDataSelected = useDebouncedCallback(
+    (index: number) =>
+      changeChartDays(
+        SEGMENT_INDEX_MAP[index] ?? 1 // default to 1 day if index is not found
+      ),
+    DEFAULT_DEBOUNCE_MILLISECONDS
+  )
+
   const handleSelectSegment = useCallback(
     (index: number) => {
       selectedSegmentIndex.value = index
-
-      changeChartDays(
-        SEGMENT_INDEX_MAP[index] ?? 1 // default to 1 day if index is not found
-      )
+      debouncedHandleDataSelected(index)
     },
-    [selectedSegmentIndex, changeChartDays]
+    [selectedSegmentIndex, debouncedHandleDataSelected]
   )
 
   const handleChartGestureStart = useCallback((): void => {
@@ -456,6 +464,7 @@ const TrackTokenDetailScreen = (): JSX.Element => {
         onDataSelected={handleDataSelected}
         onGestureStart={handleChartGestureStart}
         onGestureEnd={handleChartGestureEnd}
+        isUpdatingChartData={isUpdatingChartData}
       />
 
       {lastUpdatedDate ? (


### PR DESCRIPTION
## Description

**Ticket: [CP-11894]** 

- set chartData to undefined before we load new chart data to show the loading state.

## Screenshots/Videos

https://github.com/user-attachments/assets/f65526e9-4d88-4f77-98a0-dc2046af88fd



## Checklist

Please check all that apply (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11894]: https://ava-labs.atlassian.net/browse/CP-11894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ