### PR TITLE
Fix multiple biometric prompt after denying first biometric prompt (Android only)

### DIFF
--- a/packages/core-mobile/app/new/routes/onboarding/mnemonic/createPin.tsx
+++ b/packages/core-mobile/app/new/routes/onboarding/mnemonic/createPin.tsx
@@ -40,7 +40,8 @@ export default function CreatePin(): JSX.Element {
           walletType: WalletType.MNEMONIC
         })
         if (useBiometrics) {
-          await BiometricsSDK.enableBiometry()
+          const enabled = await BiometricsSDK.enableBiometry()
+          setUseBiometrics(enabled)
         }
         navigateToSetWalletName()
       } catch (error) {
@@ -49,10 +50,11 @@ export default function CreatePin(): JSX.Element {
     },
     [
       mnemonic,
-      activeWalletId,
       onPinCreated,
+      activeWalletId,
       useBiometrics,
-      navigateToSetWalletName
+      navigateToSetWalletName,
+      setUseBiometrics
     ]
   )
 

--- a/packages/core-mobile/app/new/routes/onboarding/seedless/createPin.tsx
+++ b/packages/core-mobile/app/new/routes/onboarding/seedless/createPin.tsx
@@ -34,14 +34,21 @@ export default function CreatePin(): JSX.Element {
           walletType: WalletType.SEEDLESS
         })
         if (useBiometrics) {
-          await BiometricsSDK.enableBiometry()
+          const enabled = await BiometricsSDK.enableBiometry()
+          setUseBiometrics(enabled)
         }
         navigateToNextStep()
       } catch (error) {
         Logger.error('Failed to create pin', error)
       }
     },
-    [activeWalletId, onPinCreated, useBiometrics, navigateToNextStep]
+    [
+      activeWalletId,
+      onPinCreated,
+      useBiometrics,
+      navigateToNextStep,
+      setUseBiometrics
+    ]
   )
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -27730,7 +27730,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: d6ceb75e1d0f5755370d6d91f67902bd2b8a23a3ca43cb853d2964b43798f30477e8ab0223ea8b620534fbdf5f56d39550f40d24bec2d2398c323ccfe8a5a556
+  checksum: e08d1254d04f3074970b63cdf0a363d6b189009270d457e868a26ef534addd69b320b85bef2a22e4eddb79006751bded431b56aaf2baf41976a6d0a5a2a2b91e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -27730,7 +27730,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: e08d1254d04f3074970b63cdf0a363d6b189009270d457e868a26ef534addd69b320b85bef2a22e4eddb79006751bded431b56aaf2baf41976a6d0a5a2a2b91e
+  checksum: d6ceb75e1d0f5755370d6d91f67902bd2b8a23a3ca43cb853d2964b43798f30477e8ab0223ea8b620534fbdf5f56d39550f40d24bec2d2398c323ccfe8a5a556
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

## Summary of changes 
- BiometricsSDK.enableBiometry() was triggered again when biometric prompt is cancel/deny and screen is unmounted.  setUseBiometrics to false to prevent it getting triggered again. (Android only issue)

## Screenshots/Videos
Please include Screenshots / Videos of iOS and android

- Android:
https://github.com/user-attachments/assets/fa6fe4c4-cf46-4df4-ba98-cb6b3741a93d

- iOS:
https://github.com/user-attachments/assets/f838754a-dd6a-41c0-8d23-174855876ed7

## Testing

## Dev Testing Steps 
Please include steps for testing happy path of your feature, and be sure to move this ticket into the "Dev Testing" column 
- go through onboarding
- deny biometric 
- biometric prompt should not prompt again on setWalletName screen

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [X] I have included screenshots / videos of android and ios 
- [X] I have added Dev testing steps 
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation
