### PR TITLE
CP-11925: Keep user on previous screen after unlock

### DIFF
--- a/packages/core-mobile/app/new/common/components/NavigationRedirect.tsx
+++ b/packages/core-mobile/app/new/common/components/NavigationRedirect.tsx
@@ -1,3 +1,4 @@
+import { useDeepCompareMemo } from 'common/hooks/useDeepCompareMemo'
 import { hasRouteByName } from 'common/utils/hasRouteByName'
 import { usePathname, useRootNavigationState, useRouter } from 'expo-router'
 import { useEffect } from 'react'
@@ -12,7 +13,9 @@ export const NavigationRedirect = (): null => {
   const walletState = useSelector(selectWalletState)
   const navigationState = useRootNavigationState()
 
-  const isSignedIn = hasRouteByName(navigationState, '(signedIn)')
+  const isSignedIn = useDeepCompareMemo(() => {
+    return hasRouteByName(navigationState, '(signedIn)')
+  }, [navigationState])
 
   const isNavigationReady = Boolean(navigationState?.key)
   // Additional check for Expo Router - ensure segments are loaded

--- a/packages/core-mobile/app/new/common/components/NavigationRedirect.tsx
+++ b/packages/core-mobile/app/new/common/components/NavigationRedirect.tsx
@@ -1,3 +1,4 @@
+import { hasRouteByName } from 'common/utils/hasRouteByName'
 import { usePathname, useRootNavigationState, useRouter } from 'expo-router'
 import { useEffect } from 'react'
 import { InteractionManager } from 'react-native'
@@ -11,9 +12,7 @@ export const NavigationRedirect = (): null => {
   const walletState = useSelector(selectWalletState)
   const navigationState = useRootNavigationState()
 
-  const isSignedIn = navigationState?.routes.some(
-    (route: { name: string }) => route.name === '(signedIn)'
-  )
+  const isSignedIn = hasRouteByName(navigationState, '(signedIn)')
 
   const isNavigationReady = Boolean(navigationState?.key)
   // Additional check for Expo Router - ensure segments are loaded

--- a/packages/core-mobile/app/new/common/hooks/useDeepCompareMemo.ts
+++ b/packages/core-mobile/app/new/common/hooks/useDeepCompareMemo.ts
@@ -1,0 +1,17 @@
+import { useRef } from 'react'
+import { deepEqual } from 'fast-equals'
+
+export function useDeepCompareMemo<T>(
+  factory: () => T,
+  deps: unknown[]
+): T | null {
+  const prevDepsRef = useRef<unknown[]>([])
+  const prevValueRef = useRef<T | null>(null)
+
+  if (!prevDepsRef.current || !deepEqual(prevDepsRef.current, deps)) {
+    prevDepsRef.current = deps
+    prevValueRef.current = factory()
+  }
+
+  return prevValueRef.current
+}

--- a/packages/core-mobile/app/new/common/utils/hasRouteByName.test.ts
+++ b/packages/core-mobile/app/new/common/utils/hasRouteByName.test.ts
@@ -1,0 +1,72 @@
+import { hasRouteByName } from './hasRouteByName'
+
+type NavState = {
+  routes?: Array<{ name?: string; state?: NavState }>
+}
+
+describe('hasRouteByName', () => {
+  it('should return false if state is undefined', () => {
+    expect(hasRouteByName(undefined, '(signedIn)')).toBe(false)
+  })
+
+  it('should return false if state has no routes', () => {
+    const state: NavState = {}
+    expect(hasRouteByName(state, '(signedIn)')).toBe(false)
+  })
+
+  it('should return true if target route is at the root level', () => {
+    const state: NavState = {
+      routes: [{ name: '(signedIn)' }, { name: 'home' }]
+    }
+    expect(hasRouteByName(state, '(signedIn)')).toBe(true)
+  })
+
+  it('should return true if target route is nested', () => {
+    const state: NavState = {
+      routes: [
+        {
+          name: 'root',
+          state: {
+            routes: [{ name: 'dashboard' }, { name: '(signedIn)' }]
+          }
+        }
+      ]
+    }
+    expect(hasRouteByName(state, '(signedIn)')).toBe(true)
+  })
+
+  it('should return false if target route does not exist', () => {
+    const state: NavState = {
+      routes: [{ name: 'root', state: { routes: [{ name: 'dashboard' }] } }]
+    }
+    expect(hasRouteByName(state, '(signedIn)')).toBe(false)
+  })
+
+  it('should return true if deeply nested route matches', () => {
+    const state: NavState = {
+      routes: [
+        {
+          name: 'root',
+          state: {
+            routes: [
+              {
+                name: 'level1',
+                state: {
+                  routes: [
+                    {
+                      name: 'level2',
+                      state: {
+                        routes: [{ name: '(signedIn)' }]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+    expect(hasRouteByName(state, '(signedIn)')).toBe(true)
+  })
+})

--- a/packages/core-mobile/app/new/common/utils/hasRouteByName.ts
+++ b/packages/core-mobile/app/new/common/utils/hasRouteByName.ts
@@ -1,0 +1,15 @@
+type NavState = {
+  routes?: Array<{ name?: string; state?: NavState }>
+}
+
+export function hasRouteByName(
+  state: NavState | undefined,
+  target: string
+): boolean {
+  if (!state?.routes) return false
+  for (const r of state.routes) {
+    if (r?.name === target) return true
+    if (r?.state && hasRouteByName(r.state, target)) return true
+  }
+  return false
+}

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -133,6 +133,7 @@
     "expo-router": "5.1.4",
     "expo-sms": "13.1.4",
     "expo-video": "2.2.2",
+    "fast-equals": "5.2.2",
     "https-browserify": "1.0.0",
     "hypersdk-client": "0.4.16",
     "jail-monkey": "2.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -347,6 +347,7 @@ __metadata:
     expo-router: 5.1.4
     expo-sms: 13.1.4
     expo-video: 2.2.2
+    fast-equals: 5.2.2
     https-browserify: 1.0.0
     hypersdk-client: 0.4.16
     jail-monkey: 2.8.0
@@ -19353,6 +19354,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-equals@npm:5.2.2":
+  version: 5.2.2
+  resolution: "fast-equals@npm:5.2.2"
+  checksum: 7156bcade0be5ee4dc335969d255a5815348d57080e1876fa1584451eafd0c92588de5f5840e55f81841b6d907ade2a49a46e4ec33e6f7a283a209c0fd8f8a59
+  languageName: node
+  linkType: hard
+
 "fast-fifo@npm:^1.1.0, fast-fifo@npm:^1.2.0":
   version: 1.3.2
   resolution: "fast-fifo@npm:1.3.2"
@@ -27757,7 +27765,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: d6ceb75e1d0f5755370d6d91f67902bd2b8a23a3ca43cb853d2964b43798f30477e8ab0223ea8b620534fbdf5f56d39550f40d24bec2d2398c323ccfe8a5a556
+  checksum: 44ee8c8ebc4dc4d3423e9045e1aebac31829eb518824e24f41b2bd10ab1e8343e824e9d912f259bfec7bfa798e96513cc05dbdcdf36087b2a43806f74a3b0fa2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: [CP-11925](https://ava-labs.atlassian.net/browse/CP-11925)** 

## Screenshots/Videos
* iOS
https://github.com/user-attachments/assets/d8dbfbf5-c240-434b-b5fa-1d54407e54b0

* Android
https://github.com/user-attachments/assets/d1016f5c-f5dd-46ff-a5a2-343042d46171

## Testing

## Dev Testing Steps 
* iOS(5937)
* Android([5938](https://app.bitrise.io/app/7d7ca5af7066e290/installable-artifacts/703126ff0ff488dc/public-install-page/9ebb6691c92d13c0dbfc2ba7b54ae1ba))

1. open the app and navigate to any screen other than Portfolio.
2. send the app to the background and wait for longer than 5 seconds to lock the app.
3. bring the app back to the foreground and unlock the app
4. verify that the app remains on the last screen visited

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [X] I have included screenshots / videos of android and ios 
- [X] I have added Dev testing steps 
- [X] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11925]: https://ava-labs.atlassian.net/browse/CP-11925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ