### PR TITLE
CP-11970 - Global Activity is incorrect when swapping USDC to AWAVAX

### DIFF
--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
@@ -137,17 +137,28 @@ export const TokenActivityListItem: FC<Props> = ({
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export function fixUnknownTxType(tx: Transaction): ActivityTransactionType {
   if (tx?.txType === TransactionType.UNKNOWN) {
-    if (tx.tokens.length === 1) {
-      if (isPotentiallySwap(tx)) {
-        return TransactionType.SWAP
+    // if the tx has 3 tokens, it means we funded the gas
+    if (tx.tokens.length > 2) {
+      // if all the tokens have the same symbol, it's a send/receive
+      if (
+        tx.tokens[0]?.symbol === tx.tokens[1]?.symbol &&
+        tx.tokens[1]?.symbol === tx.tokens[2]?.symbol
+      ) {
+        return tx.isSender ? TransactionType.SEND : TransactionType.RECEIVE
       }
-      return tx.isSender ? TransactionType.SEND : TransactionType.RECEIVE
+      return TransactionType.SWAP
     }
     if (tx.tokens.length > 1) {
       if (tx.tokens[0]?.symbol === tx.tokens[1]?.symbol) {
         return tx.isSender ? TransactionType.SEND : TransactionType.RECEIVE
       }
       return TransactionType.SWAP
+    }
+    if (tx.tokens.length === 1) {
+      if (isPotentiallySwap(tx)) {
+        return TransactionType.SWAP
+      }
+      return tx.isSender ? TransactionType.SEND : TransactionType.RECEIVE
     }
   }
   return tx.txType as ActivityTransactionType

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
@@ -115,18 +115,6 @@ export const TokenActivityListItemTitle = ({
           ]
         }
         if (tx.isContractCall) {
-          if (tx.tokens.length === 1) {
-            if (isPotentiallySwap(tx)) {
-              return [renderAmount(a1), ' ', s1, ' swapped for ', s2]
-            }
-            return [
-              renderAmount(a1),
-              ' ',
-              s1,
-              tx.isSender ? ' sent' : ' received'
-            ]
-          }
-
           // if the tx has 3 tokens, it means we funded the gas
           if (tx.tokens.length > 2) {
             const a3 = tx.tokens[2]?.amount
@@ -173,6 +161,18 @@ export const TokenActivityListItemTitle = ({
               renderAmount(a2),
               ' ',
               s2
+            ]
+          }
+
+          if (tx.tokens.length === 1) {
+            if (isPotentiallySwap(tx)) {
+              return [renderAmount(a1), ' ', s1, ' swapped for ', s2]
+            }
+            return [
+              renderAmount(a1),
+              ' ',
+              s1,
+              tx.isSender ? ' sent' : ' received'
             ]
           }
 

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
@@ -127,6 +127,34 @@ export const TokenActivityListItemTitle = ({
             ]
           }
 
+          // if the tx has 3 tokens, it means we funded the gas
+          if (tx.tokens.length > 2) {
+            const a3 = tx.tokens[2]?.amount
+            const s3 = tx.tokens[2]?.symbol
+            // if all the tokens have the same symbol, it's a send/receive
+            if (
+              tx.tokens[0]?.symbol === tx.tokens[1]?.symbol &&
+              tx.tokens[1]?.symbol === tx.tokens[2]?.symbol
+            ) {
+              return [
+                renderAmount(a1),
+                ' ',
+                s1,
+                tx.isSender ? ' sent' : ' received'
+              ]
+            }
+
+            return [
+              renderAmount(a1),
+              ' ',
+              s1,
+              ' swapped for ',
+              renderAmount(a3),
+              ' ',
+              s3
+            ]
+          }
+
           if (tx.tokens.length > 1) {
             if (tx.tokens[0]?.symbol === tx.tokens[1]?.symbol) {
               return [

--- a/packages/core-mobile/ios/Podfile.lock
+++ b/packages/core-mobile/ios/Podfile.lock
@@ -3830,7 +3830,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
+  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   CatCrypto: a477899b6be4954e75be4897e732da098cc0a5a8
   ComputableLayout: c50faffac4ed9f8f05b0ce5e6f3a60df1f6042c8
   ContextMenuAuxiliaryPreview: 20be0be795b783b68f8792732eed4bed9f202c1c
@@ -3843,7 +3843,7 @@ SPEC CHECKSUMS:
   DatadogTrace: 23df8545911d219d4c15446a4c6c04862ff76175
   DatadogWebViewTracking: e88b8057eb5ff06a68baf232ae37637b8bb7518b
   DGSwiftUtilities: 567f8d5ee618f0b7afb185b17aa45ff356315a0f
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EXApplication: 50cc8ea58c138da6e3f25cd789634219c86b90d5
   EXConstants: 9d62a46a36eae6d28cb978efcbc68aef354d1704
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
@@ -3881,8 +3881,8 @@ SPEC CHECKSUMS:
   FirebaseCoreInternal: f47dd28ae7782e6a4738aad3106071a8fe0af604
   FirebaseInstallations: d8063d302a426d114ac531cd82b1e335a0565745
   FirebaseMessaging: 9f4e42053241bd45ce8565c881bfdd9c1df2f7da
-  fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
+  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1

--- a/yarn.lock
+++ b/yarn.lock
@@ -27765,7 +27765,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 44ee8c8ebc4dc4d3423e9045e1aebac31829eb518824e24f41b2bd10ab1e8343e824e9d912f259bfec7bfa798e96513cc05dbdcdf36087b2a43806f74a3b0fa2
+  checksum: 3e4689674406deb2ad9efa9f529597341b4ab33e379b7c7cd72aff8d5e37862fda1a37aba984951a67cc3938969be138bc3c4469e4963dd170b172148339e056
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: [CP-11970](https://ava-labs.atlassian.net/browse/CP-11970)** 

## Summary of changes 
When we pay the gas the tokens array returns 3 items.
We need to verify if all 3 symbols are the same (this means it's a send/receive with gas payed)
If they're not the same then it's a swap

## Screenshots/Videos

Before
![222a84e9-2a77-41d2-ae60-e53be129c63e](https://github.com/user-attachments/assets/1a258795-068e-4e1c-bc70-c74ac79265ee)

After
<img width="1206" height="2622" alt="simulator_screenshot_41F33D24-3164-44BF-988B-F7224847E0F0" src="https://github.com/user-attachments/assets/e98a6f1f-d418-4c8b-94e7-f40207ed4d84" />
<img width="1206" height="2622" alt="simulator_screenshot_007523F4-EB5F-4FC9-B3A9-181D41558197" src="https://github.com/user-attachments/assets/4b477e27-880e-42f3-b91a-0be63168964b" />

## Testing

## Dev Testing Steps 

1. Swap USDC to Aave v3 AVAX (AWAVAX) 
2. Select gas payed by us
3. Check last global activity tx (it should display x AWAVAX swapped for X USDC) 
4. Also try to send WAVAX with gas

## Checklist

Please check all that apply (if applicable)
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios 
- [x] I have added Dev testing steps 
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11970]: https://ava-labs.atlassian.net/browse/CP-11970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ