### PR TITLE
CP-11911: update approval screen token width

### DIFF
--- a/packages/core-mobile/app/new/features/approval/components/BalanceChange/TokenDiffGroup.tsx
+++ b/packages/core-mobile/app/new/features/approval/components/BalanceChange/TokenDiffGroup.tsx
@@ -160,7 +160,7 @@ const TokenDiffItemComponent = ({
           flexDirection: 'row',
           alignItems: 'center',
           gap: 12,
-          width: '35%'
+          width: '20%'
         }}>
         {renderTokenLogo()}
         <Text
@@ -177,7 +177,7 @@ const TokenDiffItemComponent = ({
       <View
         sx={{
           alignItems: 'flex-end',
-          flex: 1
+          width: '65%'
         }}>
         {diffItem.displayValue !== undefined && (
           <Text


### PR DESCRIPTION
## Description

**Ticket: [CP-11911](https://ava-labs.atlassian.net/browse/CP-11911)** 

## Summary of changes 
- adjust width of the token symbol and displayValue so they don't overlap

## Screenshots/Videos
Please include Screenshots / Videos of iOS and android
<img width="847" height="933" alt="Screenshot 2025-09-03 at 10 23 12 AM" src="https://github.com/user-attachments/assets/62af685a-c362-404c-a23c-9c7b961c480d" />



## Testing

## Dev Testing Steps 
Please include steps for testing happy path of your feature, and be sure to move this ticket into the "Dev Testing" column 
- initiate a swap with a token that has long symbol (e.g. qiAvalanche) and long amount length
- the symbol name and amount should be truncated and not overlapped each other

## Checklist

Please check all that apply (if applicable)
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [X] I have included screenshots / videos of android and ios 
- [X] I have added Dev testing steps 
- [ ] I have added/updated necessary unit tests 
- [ ] I have updated the documentation


[CP-11911]: https://ava-labs.atlassian.net/browse/CP-11911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ