### PR TITLE
CP-12002: Fix unknown XP tx in activity tab

### DIFF
--- a/packages/core-mobile/app/new/features/activity/components/ActivityList.tsx
+++ b/packages/core-mobile/app/new/features/activity/components/ActivityList.tsx
@@ -9,10 +9,16 @@ import { PendingBridgeTransactionItem } from 'features/portfolio/assets/componen
 import { TokenActivityListItem } from 'features/portfolio/assets/components/TokenActivityListItem'
 import { XpActivityListItem } from 'features/portfolio/assets/components/XpActivityListItem'
 import React, { useCallback } from 'react'
+import { TokenWithBalance } from '@avalabs/vm-module-types'
+import {
+  isTokenWithBalanceAVM,
+  isTokenWithBalancePVM
+} from '@avalabs/avalanche-module'
 import { ActivityListItem } from '../utils'
 
 export const ActivityList = ({
   data,
+  xpToken,
   overrideProps,
   isRefreshing,
   refresh,
@@ -23,6 +29,7 @@ export const ActivityList = ({
 }: {
   data: ActivityListItem[]
   overrideProps?: FlashListProps<ActivityListItem>['overrideProps']
+  xpToken: TokenWithBalance | undefined
   isRefreshing: boolean
   handlePendingBridge: (transaction: BridgeTransaction | BridgeTransfer) => void
   handleExplorerLink: (explorerLink: string) => void
@@ -47,7 +54,10 @@ export const ActivityList = ({
       }
 
       const transaction = item.transaction
-      const isXpTx = isXpTransaction(transaction.txType)
+      const isXpTx =
+        isXpTransaction(transaction.txType) &&
+        xpToken &&
+        (isTokenWithBalanceAVM(xpToken) || isTokenWithBalancePVM(xpToken))
 
       const props = {
         tx: transaction,
@@ -77,13 +87,14 @@ export const ActivityList = ({
         />
       )
     },
-    [data, handleExplorerLink, handlePendingBridge]
+    [data, handleExplorerLink, handlePendingBridge, xpToken]
   )
 
   const keyExtractor = useCallback((item: ActivityListItem) => item.id, [])
 
   return (
     <CollapsibleTabs.FlashList
+      key={xpToken?.symbol}
       overrideProps={overrideProps}
       data={data}
       renderItem={renderItem}

--- a/packages/core-mobile/app/new/features/activity/components/ActivityList.tsx
+++ b/packages/core-mobile/app/new/features/activity/components/ActivityList.tsx
@@ -1,11 +1,6 @@
-import {
-  isTokenWithBalanceAVM,
-  isTokenWithBalancePVM
-} from '@avalabs/avalanche-module'
 import { BridgeTransfer } from '@avalabs/bridge-unified'
 import { BridgeTransaction } from '@avalabs/core-bridge-sdk'
 import { Text, useTheme, View } from '@avalabs/k2-alpine'
-import { TokenWithBalance } from '@avalabs/vm-module-types'
 import { FlashListProps, ListRenderItem } from '@shopify/flash-list'
 import { CollapsibleTabs } from 'common/components/CollapsibleTabs'
 import { isXpTransaction } from 'common/utils/isXpTransactions'
@@ -18,7 +13,6 @@ import { ActivityListItem } from '../utils'
 
 export const ActivityList = ({
   data,
-  xpToken,
   overrideProps,
   isRefreshing,
   refresh,
@@ -29,7 +23,6 @@ export const ActivityList = ({
 }: {
   data: ActivityListItem[]
   overrideProps?: FlashListProps<ActivityListItem>['overrideProps']
-  xpToken: TokenWithBalance | undefined
   isRefreshing: boolean
   handlePendingBridge: (transaction: BridgeTransaction | BridgeTransfer) => void
   handleExplorerLink: (explorerLink: string) => void
@@ -54,10 +47,7 @@ export const ActivityList = ({
       }
 
       const transaction = item.transaction
-      const isXpTx =
-        isXpTransaction(transaction.txType) &&
-        xpToken &&
-        (isTokenWithBalanceAVM(xpToken) || isTokenWithBalancePVM(xpToken))
+      const isXpTx = isXpTransaction(transaction.txType)
 
       const props = {
         tx: transaction,
@@ -87,7 +77,7 @@ export const ActivityList = ({
         />
       )
     },
-    [data, handleExplorerLink, handlePendingBridge, xpToken]
+    [data, handleExplorerLink, handlePendingBridge]
   )
 
   const keyExtractor = useCallback((item: ActivityListItem) => item.id, [])

--- a/packages/core-mobile/app/new/features/activity/hooks/useActivityFilterAndSearch.ts
+++ b/packages/core-mobile/app/new/features/activity/hooks/useActivityFilterAndSearch.ts
@@ -1,9 +1,7 @@
 import { BridgeTransfer } from '@avalabs/bridge-unified'
 import { BridgeTransaction } from '@avalabs/core-bridge-sdk'
 import { ChainId, Network } from '@avalabs/core-chains-sdk'
-import { TokenWithBalance, TransactionType } from '@avalabs/vm-module-types'
-import { useErc20ContractTokens } from 'common/hooks/useErc20ContractTokens'
-import { useSearchableTokenList } from 'common/hooks/useSearchableTokenList'
+import { TransactionType } from '@avalabs/vm-module-types'
 import { DropdownSelection } from 'common/types'
 import usePendingBridgeTransactions from 'features/bridge/hooks/usePendingBridgeTransactions'
 import {
@@ -16,7 +14,7 @@ import { useCallback, useEffect, useMemo } from 'react'
 import { isAvalancheNetwork } from 'services/network/utils/isAvalancheNetwork'
 import { Transaction } from 'store/transaction'
 import { useGetRecentTransactions } from 'store/transaction/hooks/useGetRecentTransactions'
-import { isPChain, isXChain } from 'utils/network/isAvalancheNetwork'
+import { isPChain } from 'utils/network/isAvalancheNetwork'
 import { DropdownGroup } from 'common/components/DropdownMenu'
 import { useActivity } from '../store'
 import { ActivityListItem, buildGroupedData, getDateGroups } from '../utils'
@@ -42,17 +40,11 @@ export const useActivityFilterAndSearch = ({
   isLoading: boolean
   isRefreshing: boolean
   isError: boolean
-  xpToken: TokenWithBalance | undefined
   refresh: () => void
   setSelectedNetwork: (network: ActivityNetworkFilter) => void
 } => {
   const { enabledNetworks, getNetwork } = useNetworks()
   const { selectedNetwork, setSelectedNetwork } = useActivity()
-
-  const erc20ContractTokens = useErc20ContractTokens()
-  const { filteredTokenList } = useSearchableTokenList({
-    tokens: erc20ContractTokens
-  })
 
   const networkFilters: ActivityNetworkFilter[] = useMemo(() => {
     return enabledNetworks.map(network => ({
@@ -74,17 +66,6 @@ export const useActivityFilterAndSearch = ({
   const network = useMemo(() => {
     return getNetwork(selectedNetwork?.chainId)
   }, [getNetwork, selectedNetwork?.chainId])
-
-  const xpToken = useMemo(() => {
-    return filteredTokenList.find(tk => {
-      return (
-        selectedNetwork?.chainId &&
-        (isPChain(selectedNetwork?.chainId) ||
-          isXChain(selectedNetwork?.chainId)) &&
-        Number(tk.networkChainId) === Number(selectedNetwork?.chainId)
-      )
-    })
-  }, [filteredTokenList, selectedNetwork?.chainId])
 
   const { transactions, refresh, isLoading, isRefreshing, isError } =
     useGetRecentTransactions(network)
@@ -210,7 +191,6 @@ export const useActivityFilterAndSearch = ({
 
   return {
     data: combinedData as ActivityListItem[],
-    xpToken,
     sort,
     filter,
     isLoading,

--- a/packages/core-mobile/app/new/features/activity/hooks/useActivityFilterAndSearch.ts
+++ b/packages/core-mobile/app/new/features/activity/hooks/useActivityFilterAndSearch.ts
@@ -1,7 +1,7 @@
 import { BridgeTransfer } from '@avalabs/bridge-unified'
 import { BridgeTransaction } from '@avalabs/core-bridge-sdk'
 import { ChainId, Network } from '@avalabs/core-chains-sdk'
-import { TransactionType } from '@avalabs/vm-module-types'
+import { TokenWithBalance, TransactionType } from '@avalabs/vm-module-types'
 import { DropdownSelection } from 'common/types'
 import usePendingBridgeTransactions from 'features/bridge/hooks/usePendingBridgeTransactions'
 import {
@@ -14,7 +14,9 @@ import { useCallback, useEffect, useMemo } from 'react'
 import { isAvalancheNetwork } from 'services/network/utils/isAvalancheNetwork'
 import { Transaction } from 'store/transaction'
 import { useGetRecentTransactions } from 'store/transaction/hooks/useGetRecentTransactions'
-import { isPChain } from 'utils/network/isAvalancheNetwork'
+import { isPChain, isXChain } from 'utils/network/isAvalancheNetwork'
+import { useSearchableTokenList } from 'common/hooks/useSearchableTokenList'
+import { useErc20ContractTokens } from 'common/hooks/useErc20ContractTokens'
 import { DropdownGroup } from 'common/components/DropdownMenu'
 import { useActivity } from '../store'
 import { ActivityListItem, buildGroupedData, getDateGroups } from '../utils'
@@ -40,11 +42,18 @@ export const useActivityFilterAndSearch = ({
   isLoading: boolean
   isRefreshing: boolean
   isError: boolean
+  xpToken: TokenWithBalance | undefined
+  isXpChain: boolean
   refresh: () => void
   setSelectedNetwork: (network: ActivityNetworkFilter) => void
 } => {
   const { enabledNetworks, getNetwork } = useNetworks()
   const { selectedNetwork, setSelectedNetwork } = useActivity()
+
+  const erc20ContractTokens = useErc20ContractTokens()
+  const { filteredTokenList } = useSearchableTokenList({
+    tokens: erc20ContractTokens
+  })
 
   const networkFilters: ActivityNetworkFilter[] = useMemo(() => {
     return enabledNetworks.map(network => ({
@@ -66,6 +75,23 @@ export const useActivityFilterAndSearch = ({
   const network = useMemo(() => {
     return getNetwork(selectedNetwork?.chainId)
   }, [getNetwork, selectedNetwork?.chainId])
+
+  const isXpChain = useMemo(() => {
+    return (
+      selectedNetwork?.chainId !== undefined &&
+      (isPChain(selectedNetwork?.chainId) || isXChain(selectedNetwork?.chainId))
+    )
+  }, [selectedNetwork?.chainId])
+
+  const xpToken = useMemo(() => {
+    return filteredTokenList.find(tk => {
+      return (
+        selectedNetwork?.chainId &&
+        isXpChain &&
+        Number(tk.networkChainId) === Number(selectedNetwork.chainId)
+      )
+    })
+  }, [filteredTokenList, selectedNetwork?.chainId, isXpChain])
 
   const { transactions, refresh, isLoading, isRefreshing, isError } =
     useGetRecentTransactions(network)
@@ -191,11 +217,13 @@ export const useActivityFilterAndSearch = ({
 
   return {
     data: combinedData as ActivityListItem[],
+    xpToken,
     sort,
     filter,
-    isLoading,
+    isLoading: isLoading,
     isRefreshing,
     isError,
+    isXpChain,
     refresh,
     network: network as Network,
     networkFilters,

--- a/packages/core-mobile/app/new/features/activity/screens/ActivityScreen.tsx
+++ b/packages/core-mobile/app/new/features/activity/screens/ActivityScreen.tsx
@@ -47,7 +47,6 @@ export const ActivityScreen = ({
     isLoading,
     isRefreshing,
     isError,
-    xpToken,
     network,
     networkFilterDropdown,
     refresh
@@ -139,7 +138,6 @@ export const ActivityScreen = ({
       }}>
       <ActivityList
         data={data}
-        xpToken={xpToken}
         handlePendingBridge={handlePendingBridge}
         handleExplorerLink={handleExplorerLink}
         overrideProps={{

--- a/packages/core-mobile/app/new/features/activity/screens/ActivityScreen.tsx
+++ b/packages/core-mobile/app/new/features/activity/screens/ActivityScreen.tsx
@@ -47,10 +47,16 @@ export const ActivityScreen = ({
     isLoading,
     isRefreshing,
     isError,
+    xpToken,
     network,
     networkFilterDropdown,
+    isXpChain,
     refresh
   } = useActivityFilterAndSearch({ searchText })
+
+  const isLoadingXpToken = useMemo(() => {
+    return isXpChain && !xpToken
+  }, [isXpChain, xpToken])
 
   const keyboardAvoidingStyle = useAnimatedStyle(() => {
     return {
@@ -87,7 +93,7 @@ export const ActivityScreen = ({
   }, [filter, network, networkFilterDropdown])
 
   const emptyComponent = useMemo(() => {
-    if (isRefreshing || isLoading) {
+    if (isRefreshing || isLoading || isLoadingXpToken) {
       return <LoadingState />
     }
 
@@ -113,7 +119,14 @@ export const ActivityScreen = ({
         description="Interact with this token onchain and see your activity here"
       />
     )
-  }, [isError, isLoading, isRefreshing, refresh, searchText.length])
+  }, [
+    isError,
+    isLoading,
+    isLoadingXpToken,
+    isRefreshing,
+    refresh,
+    searchText.length
+  ])
 
   const renderEmpty = useCallback(() => {
     return (
@@ -129,6 +142,10 @@ export const ActivityScreen = ({
     )
   }, [containerStyle.minHeight, emptyComponent, keyboardAvoidingStyle])
 
+  const activityListData = useMemo(() => {
+    return isLoadingXpToken ? [] : data
+  }, [data, isLoadingXpToken])
+
   return (
     <Animated.View
       entering={getListItemEnteringAnimation(5)}
@@ -137,7 +154,8 @@ export const ActivityScreen = ({
         flex: 1
       }}>
       <ActivityList
-        data={data}
+        data={activityListData}
+        xpToken={xpToken}
         handlePendingBridge={handlePendingBridge}
         handleExplorerLink={handleExplorerLink}
         overrideProps={{

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TransactionHistory.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TransactionHistory.tsx
@@ -179,7 +179,6 @@ const TransactionHistory: FC<Props> = ({
       }}>
       <ActivityList
         data={combinedData}
-        xpToken={token}
         handlePendingBridge={handlePendingBridge}
         handleExplorerLink={handleExplorerLink}
         overrideProps={{

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TransactionHistory.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TransactionHistory.tsx
@@ -179,6 +179,7 @@ const TransactionHistory: FC<Props> = ({
       }}>
       <ActivityList
         data={combinedData}
+        xpToken={token}
         handlePendingBridge={handlePendingBridge}
         handleExplorerLink={handleExplorerLink}
         overrideProps={{


### PR DESCRIPTION
## Description

**Ticket: [CP-12002]**

Please provide:

- A summary of the changes
   - xp transactions are rendered as unknown when quickly tap on activity tab after app is launched.  we should keep showing loading state until xp token is fetchd when selectedNetwork is X/P.
  
- Motivation and context for this change
- Any dependencies introduced
- (If breaking) migration steps and instructions

## Screenshots/Videos

Include relevant screenshots or screen recordings of iOS and Android.

(please see updated video in the comment)
https://github.com/user-attachments/assets/09b0a0e7-7a48-4178-97c9-95bc809027cd




## Testing

**Dev Testing (if applicable)**

- Provide steps to test the happy path of your feature
    - launch the app and go to activity tab and select X or P Chain
    - now the default network is saved 
    - close the app and relaunch the app
    - quickly tap activity tab
    - X or P chain transactions should show up correctly
- Provide steps to test edge cases and error states
- Trigger a build on bitrise and reference it here
    - iOS: 0.0.0.5977
    - Android: 0.0.0.5978
- Move the ticket into the "Testing" column on Jira

**QA Testing (if applicable)**

- Provide instructions for QA to test this feature thoroughly
- State expected behavior / acceptance criteria

## Checklist

Please check all that apply (if applicable)

- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [X] I have included screenshots / videos of android and ios
- [X] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-12002]: https://ava-labs.atlassian.net/browse/CP-12002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ