### PR TITLE
Chore: use bundler moduleResolution in tsconfig

### DIFF
--- a/packages/core-mobile/app/hooks/earn/usePeers.ts
+++ b/packages/core-mobile/app/hooks/earn/usePeers.ts
@@ -1,11 +1,14 @@
-import { Peer } from '@avalabs/avalanchejs/dist/info/model'
+import { info } from '@avalabs/avalanchejs'
 import { UseQueryResult, useQuery } from '@tanstack/react-query'
 import { useSelector } from 'react-redux'
 import EarnService from 'services/earn/EarnService'
 import NetworkService from 'services/network/NetworkService'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 
-export const usePeers = (): UseQueryResult<Record<string, Peer>, Error> => {
+export const usePeers = (): UseQueryResult<
+  Record<string, info.Peer>,
+  Error
+> => {
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
 
   return useQuery({
@@ -20,7 +23,7 @@ export const usePeers = (): UseQueryResult<Record<string, Peer>, Error> => {
       return data.peers.reduce(
         // eslint-disable-next-line no-sequences
         (acc, peer) => ((acc[peer.nodeID] = peer), acc),
-        {} as Record<string, Peer>
+        {} as Record<string, info.Peer>
       )
     }
   })

--- a/packages/core-mobile/app/new/common/consts/screenOptions.tsx
+++ b/packages/core-mobile/app/new/common/consts/screenOptions.tsx
@@ -6,9 +6,8 @@ import {
 } from '@react-navigation/stack'
 import BackBarButton from 'common/components/BackBarButton'
 import React from 'react'
-import { Platform } from 'react-native'
+import { Animated, Platform } from 'react-native'
 import BlurredBackgroundView from 'common/components/BlurredBackgroundView'
-import { TransitionSpec } from '@react-navigation/stack/lib/typescript/commonjs/src/types'
 
 export const MODAL_TOP_MARGIN = 28
 export const MODAL_BORDER_RADIUS = 40
@@ -56,3 +55,19 @@ export const androidModalTransitionSpec = {
     config: { duration: 0 }
   } as TransitionSpec
 }
+
+export type TransitionSpec =
+  | {
+      animation: 'spring'
+      config: Omit<
+        Animated.SpringAnimationConfig,
+        'toValue' | keyof Animated.AnimationConfig
+      >
+    }
+  | {
+      animation: 'timing'
+      config: Omit<
+        Animated.TimingAnimationConfig,
+        'toValue' | keyof Animated.AnimationConfig
+      >
+    }

--- a/packages/core-mobile/app/services/earn/EarnService.ts
+++ b/packages/core-mobile/app/services/earn/EarnService.ts
@@ -7,7 +7,7 @@ import { exportP } from 'services/earn/exportP'
 import WalletService from 'services/wallet/WalletService'
 import { AvalancheTransactionRequest, WalletType } from 'services/wallet/types'
 import NetworkService from 'services/network/NetworkService'
-import { pvm, UnsignedTx } from '@avalabs/avalanchejs'
+import { pvm, UnsignedTx, info } from '@avalabs/avalanchejs'
 import Logger from 'utils/Logger'
 import { retry, RetryBackoffPolicy } from 'utils/js/retry'
 import {
@@ -15,10 +15,6 @@ import {
   RecoveryEvents
 } from 'services/earn/types'
 import { getUnixTime } from 'date-fns'
-import {
-  GetCurrentSupplyResponse,
-  GetCurrentValidatorsResponse
-} from '@avalabs/avalanchejs/dist/vms/pvm'
 import { Seconds } from 'types/siUnits'
 import {
   BlockchainId,
@@ -27,7 +23,6 @@ import {
   PChainTransactionType,
   SortOrder
 } from '@avalabs/glacier-sdk'
-import { GetPeersResponse } from '@avalabs/avalanchejs/dist/info/model'
 import { isOnGoing } from 'utils/earn/status'
 import { glacierApi } from 'utils/network/glacier'
 import AnalyticsService from 'services/analytics/AnalyticsService'
@@ -47,7 +42,7 @@ class EarnService {
    */
   getCurrentValidators = (
     provider: Avalanche.JsonRpcProvider
-  ): Promise<GetCurrentValidatorsResponse> => {
+  ): Promise<pvm.GetCurrentValidatorsResponse> => {
     return provider.getApiP().getCurrentValidators()
   }
 
@@ -297,7 +292,7 @@ class EarnService {
    */
   getCurrentSupply(
     provider: Avalanche.JsonRpcProvider
-  ): Promise<GetCurrentSupplyResponse> {
+  ): Promise<pvm.GetCurrentSupplyResponse> {
     return provider.getApiP().getCurrentSupply()
   }
 
@@ -430,7 +425,7 @@ class EarnService {
   getPeers = (
     provider: Avalanche.JsonRpcProvider,
     nodeIds?: string[]
-  ): Promise<GetPeersResponse> => {
+  ): Promise<info.GetPeersResponse> => {
     return provider.getInfo().peers(nodeIds)
   }
 }

--- a/packages/core-mobile/app/services/earn/exportC.ts
+++ b/packages/core-mobile/app/services/earn/exportC.ts
@@ -1,5 +1,4 @@
-import { UnsignedTx } from '@avalabs/avalanchejs'
-import { GetAtomicTxStatusResponse } from '@avalabs/avalanchejs/dist/vms/evm/model'
+import { evm, UnsignedTx } from '@avalabs/avalanchejs'
 import { ErrorBase } from 'errors/ErrorBase'
 import { FundsStuckError } from 'hooks/earn/errors'
 import NetworkService from 'services/network/NetworkService'
@@ -82,7 +81,7 @@ export async function exportC({
   Logger.trace('txID', txID)
 
   try {
-    const { status } = await retry<GetAtomicTxStatusResponse>({
+    const { status } = await retry<evm.GetAtomicTxStatusResponse>({
       operation: () => avaxProvider.getApiC().getAtomicTxStatus(txID),
       shouldStop: result =>
         result.status === 'Accepted' || result.status === 'Dropped',

--- a/packages/core-mobile/app/services/earn/importC.ts
+++ b/packages/core-mobile/app/services/earn/importC.ts
@@ -1,5 +1,4 @@
-import { UnsignedTx } from '@avalabs/avalanchejs'
-import { GetAtomicTxStatusResponse } from '@avalabs/avalanchejs/dist/vms/evm'
+import { evm, UnsignedTx } from '@avalabs/avalanchejs'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { ErrorBase } from 'errors/ErrorBase'
 import { FundsStuckError } from 'hooks/earn/errors'
@@ -92,7 +91,7 @@ export async function importC({
   Logger.trace('txID', txID)
 
   try {
-    const { status } = await retry<GetAtomicTxStatusResponse>({
+    const { status } = await retry<evm.GetAtomicTxStatusResponse>({
       operation: () => avaxProvider.getApiC().getAtomicTxStatus(txID),
       shouldStop: result =>
         result.status === 'Accepted' || result.status === 'Dropped',

--- a/packages/core-mobile/app/services/earn/utils.ts
+++ b/packages/core-mobile/app/services/earn/utils.ts
@@ -12,7 +12,7 @@ import { FujiParams, MainnetParams, StakingConfig } from 'utils/NetworkParams'
 import { MAX_VALIDATOR_WEIGHT_FACTOR } from 'consts/earn'
 import Logger from 'utils/Logger'
 import { valid, compare } from 'semver'
-import { Peer } from '@avalabs/avalanchejs/dist/info/model'
+import { info } from '@avalabs/avalanchejs'
 import { PChainTransaction } from '@avalabs/glacier-sdk'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { UTCDate } from '@date-fns/utc'
@@ -217,7 +217,7 @@ export const getFilteredValidators = ({
  */
 export const getSimpleSortedValidators = (
   validators: NodeValidators,
-  peers?: Record<string, Peer>,
+  peers?: Record<string, info.Peer>,
   isEndTimeOverOneYear = false
 ): NodeValidators => {
   if (isEndTimeOverOneYear) {
@@ -280,7 +280,7 @@ export const getRandomValidator = (
 export const getAdvancedSortedValidators = (
   validators: NodeValidators,
   sortFilter: AdvancedSortFilter,
-  peers?: Record<string, Peer>
+  peers?: Record<string, info.Peer>
 ): NodeValidators => {
   const clonedValidators = [...validators]
   switch (sortFilter) {

--- a/packages/core-mobile/app/types/earn.ts
+++ b/packages/core-mobile/app/types/earn.ts
@@ -1,9 +1,10 @@
-import type { GetCurrentValidatorsResponse } from '@avalabs/avalanchejs/dist/vms/pvm'
+import type { pvm } from '@avalabs/avalanchejs'
 
-export type NodeValidator = GetCurrentValidatorsResponse['validators'][0] & {
-  delegatorCount?: string
-  delegatorWeight?: string
-}
+export type NodeValidator =
+  pvm.GetCurrentValidatorsResponse['validators'][0] & {
+    delegatorCount?: string
+    delegatorWeight?: string
+  }
 
 export type NodeValidators = NodeValidator[]
 

--- a/packages/tsconfig-mobile/base.json
+++ b/packages/tsconfig-mobile/base.json
@@ -10,7 +10,7 @@
     "jsx": "react",
     "lib": ["DOM", "ESNext"],
     "skipLibCheck": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noEmit": true,
     "strict": true,
     "target": "ES2020",


### PR DESCRIPTION
## Description

* Update tsconfig to use `bundler` moduleResolution since `node` is deprecated and modern React Native projects use `bundler`. ([link](https://github.com/facebook/react-native/blob/2ae5a74f067d491de73ac30a063c5742ea6584f7/packages/typescript-config/tsconfig.json#L28))

## Testing
* Please verify that the app is running properly.

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [X] I have included screenshots / videos of android and ios
- [X] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation