### PR TITLE
CP-12088: Fix crash when user tries to navigate within a browser tab

### DIFF
--- a/packages/core-mobile/.eslintrc.js
+++ b/packages/core-mobile/.eslintrc.js
@@ -25,7 +25,8 @@ module.exports = {
       files: ['e2e/**/*'],
       rules: {
         'no-console': 0,
-        '@typescript-eslint/explicit-function-return-type': 0
+        '@typescript-eslint/explicit-function-return-type': 0,
+        'no-param-reassign': 0
       }
     }
   ]

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/hooks/useCollectiblesFilterAndSort.ts
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/hooks/useCollectiblesFilterAndSort.ts
@@ -173,18 +173,20 @@ export const useCollectiblesFilterAndSort = (
         CollectibleTypeFilter.Videos
       ]
 
+      let tempNfts = [...nfts]
+
       if (isUnprocessableHidden)
-        nfts = nfts.filter((nft: NftItem) => {
+        tempNfts = tempNfts.filter((nft: NftItem) => {
           return nft.status === NftLocalStatus.Processed
         })
 
       if (contentType !== CollectibleStatus.Hidden)
-        nfts = nfts.filter((nft: NftItem) => {
+        tempNfts = tempNfts.filter((nft: NftItem) => {
           return isCollectibleVisible(collectiblesVisibility, nft)
         })
 
       if (availableNetworks.includes(network as AssetNetworkFilter))
-        nfts = nfts.filter((nft: NftItem) => {
+        tempNfts = tempNfts.filter((nft: NftItem) => {
           switch (network) {
             case AssetNetworkFilter.AvalancheCChain:
               return isAvalancheChainId(nft.networkChainId)
@@ -196,7 +198,7 @@ export const useCollectiblesFilterAndSort = (
         })
 
       if (availableContentTypes.includes(contentType as CollectibleTypeFilter))
-        nfts = nfts.filter((nft: NftItem) => {
+        tempNfts = tempNfts.filter((nft: NftItem) => {
           switch (contentType) {
             case CollectibleTypeFilter.Pictures:
               return (
@@ -214,7 +216,7 @@ export const useCollectiblesFilterAndSort = (
           }
         })
 
-      return nfts
+      return tempNfts
     },
     [filter.selected, isUnprocessableHidden, collectiblesVisibility]
   )

--- a/packages/core-mobile/app/new/features/swap/hooks/useNavigateToSwap.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useNavigateToSwap.ts
@@ -8,8 +8,14 @@ export const useNavigateToSwap = (): {
 
   const navigateToSwap = (fromTokenId?: string, toTokenId?: string): void => {
     if (fromTokenId === undefined && toTokenId === undefined) {
-      fromTokenId = AVAX_TOKEN_ID
-      toTokenId = USDC_AVALANCHE_C_TOKEN_ID
+      navigate({
+        // @ts-ignore TODO: make routes typesafe
+        pathname: '/swap',
+        params: {
+          initialTokenIdFrom: AVAX_TOKEN_ID,
+          initialTokenIdTo: USDC_AVALANCHE_C_TOKEN_ID
+        }
+      })
     }
 
     navigate({

--- a/packages/core-mobile/app/store/balance/slice.ts
+++ b/packages/core-mobile/app/store/balance/slice.ts
@@ -190,10 +190,7 @@ export const selectBalanceTotalForAccount =
           isTokenVisible(tokenVisibility, token) &&
           enabledChainIds.includes(token.networkChainId)
       )
-      .reduce((total, token) => {
-        total += token.balance ?? 0n
-        return total
-      }, 0n)
+      .reduce((acc, token) => acc + (token.balance ?? 0n), 0n)
   }
 
 export const selectBalanceTotalInCurrencyForAccount =
@@ -208,10 +205,7 @@ export const selectBalanceTotalInCurrencyForAccount =
           isTokenVisible(tokenVisibility, token) &&
           enabledChainIds.includes(token.networkChainId)
       )
-      .reduce((total, token) => {
-        total += token.balanceInCurrency ?? 0
-        return total
-      }, 0)
+      .reduce((acc, token) => acc + (token.balanceInCurrency ?? 0), 0)
   }
 
 export const selectBalanceForAccountIsAccurate =

--- a/packages/core-mobile/app/store/browser/slices/tabs.ts
+++ b/packages/core-mobile/app/store/browser/slices/tabs.ts
@@ -105,7 +105,13 @@ const tabSlice = createSlice({
 
       // limit max tab histories
       if (tab.historyIds.length > MAXIMUM_TAB_HISTORIES) {
-        tab.historyIds = tab.historyIds.slice(-MAXIMUM_TAB_HISTORIES)
+        const trimmedHistoryIds = tab.historyIds.slice(-MAXIMUM_TAB_HISTORIES)
+        tabAdapter.updateOne(state, {
+          id: activeTabId,
+          changes: {
+            historyIds: trimmedHistoryIds
+          }
+        })
       }
     },
     removeTab: (state: TabState, action: PayloadAction<TabPayload>) => {

--- a/packages/core-mobile/app/store/browser/utils.ts
+++ b/packages/core-mobile/app/store/browser/utils.ts
@@ -17,13 +17,15 @@ export const getLatestTab = (tabs: Tab[]): Tab => {
   return latestTab
 }
 
-export const tabAdapter = createEntityAdapter<Tab>({ selectId: tab => tab.id })
+export const tabAdapter = createEntityAdapter<Readonly<Tab>>({
+  selectId: tab => tab.id
+})
 export const tabAdapterSelectors = tabAdapter.getSelectors()
 
-export const historyAdapter = createEntityAdapter<History>({
+export const historyAdapter = createEntityAdapter<Readonly<History>>({
   selectId: history => history.id
 })
-export const favoriteAdapter = createEntityAdapter<Favorite>({
+export const favoriteAdapter = createEntityAdapter<Readonly<Favorite>>({
   selectId: favorite => favorite.id
 })
 

--- a/packages/core-mobile/app/store/index.ts
+++ b/packages/core-mobile/app/store/index.ts
@@ -69,6 +69,7 @@ export const rootReducer = (state: any, action: AnyAction) => {
   if (action.type === onLogOut.type) {
     // reset state
     // except the following keys
+    // eslint-disable-next-line no-param-reassign
     state = {
       app: state.app,
       posthog: state.posthog

--- a/packages/core-mobile/app/utils/data/scrubber.ts
+++ b/packages/core-mobile/app/utils/data/scrubber.ts
@@ -4,10 +4,12 @@ const SECRET_REGEXPS = [
   new RegExp('(auth=)([a-zA-Z0-9._-]+)', 'gi') // captures auth=eyJhbGci.Oi_JF-ZERTQSIs
 ]
 
-export const scrub = (raw: string) => {
+export const scrub = (raw: string): string => {
+  let scrubbed = raw
+
   for (const regex of SECRET_REGEXPS) {
-    raw = raw.replace(regex, `$1${SECRET_MASK}`)
+    scrubbed = scrubbed.replace(regex, `$1${SECRET_MASK}`)
   }
 
-  return raw
+  return scrubbed
 }

--- a/packages/eslint-mobile/src/configs.js
+++ b/packages/eslint-mobile/src/configs.js
@@ -25,6 +25,7 @@ const recommended = {
   ],
   rules: {
     'no-console': 2,
+    'no-param-reassign': 2,
     radix: 'off',
     'react-hooks/exhaustive-deps': 1,
     'react-native/no-inline-styles': 'off',


### PR DESCRIPTION
## Description

**Ticket: [CP-12088]**

This PR fixes state mutation issues in the tab history reducer. Previously, we were mutating selector outputs (e.g., tab.historyIds = …), which caused runtime crashes due to Redux Toolkit’s immutability feature.

**Change:**
- Replaced direct mutations with updateOne calls to ensure immutable state updates.
- Added ESLint rule `no-param-reassign` to catch unsafe mutations.
- Added TypeScript typings with Readonly to enforce immutability at compile time for all the redux data adapters.

## Screenshots/Videos

**Before:**
https://github.com/user-attachments/assets/887c7116-a201-4723-a692-ae7cfa1b20f3

**After:**
https://github.com/user-attachments/assets/8a38b48e-87c2-4a65-8975-5e22464dc1ad



## Testing

**Dev Testing (if applicable)**

- Provide steps to test the happy path of your feature
- Provide steps to test edge cases and error states
- Trigger a build on bitrise and reference it here
- Move the ticket into the "Testing" column on Jira

**QA Testing (if applicable)**

- Provide instructions for QA to test this feature thoroughly
- State expected behavior / acceptance criteria

## Checklist

Please check all that apply (if applicable)

- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation
