### PR TITLE
CP-12127 - Keyboard blocking the select a token screen

### DIFF
--- a/packages/core-mobile/app/new/common/screens/SelectTokenScreen.tsx
+++ b/packages/core-mobile/app/new/common/screens/SelectTokenScreen.tsx
@@ -98,7 +98,9 @@ export const SelectTokenScreen = <T extends object>({
   }, [networkChainId, networks])
 
   useEffect(() => {
-    dismissKeyboardIfNeeded()
+    setTimeout(() => {
+      dismissKeyboardIfNeeded()
+    }, 0)
   }, [])
 
   return (

--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
@@ -222,7 +222,9 @@ const ApprovalScreen = ({
   }, [validateEthSendTransaction, gaslessEnabled])
 
   useEffect(() => {
-    dismissKeyboardIfNeeded()
+    setTimeout(() => {
+      dismissKeyboardIfNeeded()
+    }, 0)
   }, [])
 
   const renderGaslessAlert = useCallback((): JSX.Element | null => {

--- a/packages/core-mobile/app/new/features/meld/components/SelectAmount.tsx
+++ b/packages/core-mobile/app/new/features/meld/components/SelectAmount.tsx
@@ -13,6 +13,7 @@ import {
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import useInAppBrowser from 'common/hooks/useInAppBrowser'
+import { dismissKeyboardIfNeeded } from 'common/utils/dismissKeyboardIfNeeded'
 import { LogoWithNetwork } from 'features/portfolio/assets/components/LogoWithNetwork'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -22,7 +23,6 @@ import { useResetMeldTokenList } from '../hooks/useResetMeldTokenList'
 import { useSelectAmount } from '../hooks/useSelectAmount'
 import { useOfframpActivityIndicator, useOfframpSessionId } from '../store'
 import { getErrorMessage } from '../utils'
-import { dismissKeyboardIfNeeded } from 'common/utils/dismissKeyboardIfNeeded'
 
 interface SelectAmountProps {
   title: string

--- a/packages/core-mobile/app/new/features/meld/components/SelectAmount.tsx
+++ b/packages/core-mobile/app/new/features/meld/components/SelectAmount.tsx
@@ -13,7 +13,6 @@ import {
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import useInAppBrowser from 'common/hooks/useInAppBrowser'
-import { dismissKeyboardIfNeeded } from 'common/utils/dismissKeyboardIfNeeded'
 import { LogoWithNetwork } from 'features/portfolio/assets/components/LogoWithNetwork'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -23,6 +22,7 @@ import { useResetMeldTokenList } from '../hooks/useResetMeldTokenList'
 import { useSelectAmount } from '../hooks/useSelectAmount'
 import { useOfframpActivityIndicator, useOfframpSessionId } from '../store'
 import { getErrorMessage } from '../utils'
+import { dismissKeyboardIfNeeded } from 'common/utils/dismissKeyboardIfNeeded'
 
 interface SelectAmountProps {
   title: string

--- a/packages/core-mobile/app/new/features/meld/components/SelectToken.tsx
+++ b/packages/core-mobile/app/new/features/meld/components/SelectToken.tsx
@@ -124,6 +124,7 @@ export const SelectToken = ({
   return (
     <ScrollScreen
       title={title}
+      isModal
       contentContainerStyle={{ padding: 16, flexGrow: 1 }}>
       <Space y={16} />
       {isLoadingCryptoCurrencies ? (

--- a/packages/core-mobile/app/new/features/swap/screens/SwapPricingDetailsScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapPricingDetailsScreen.tsx
@@ -1,30 +1,31 @@
-import React, { useCallback, useMemo } from 'react'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import {
-  useTheme,
-  View,
-  Text,
   GroupList,
   GroupListItem,
-  TouchableOpacity,
-  Separator,
   Icons,
-  Logos
+  Logos,
+  Separator,
+  Text,
+  TouchableOpacity,
+  useTheme,
+  View
 } from '@avalabs/k2-alpine'
 import { ScrollScreen } from 'common/components/ScrollScreen'
-import { FlatList } from 'react-native-gesture-handler'
-import { LocalTokenWithBalance } from 'store/balance/types'
-import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
+import { dismissKeyboardIfNeeded } from 'common/utils/dismissKeyboardIfNeeded'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
+import React, { useCallback, useEffect, useMemo } from 'react'
+import { FlatList } from 'react-native-gesture-handler'
 import { SvgProps } from 'react-native-svg'
+import { LocalTokenWithBalance } from 'store/balance/types'
+import { useSwapRate } from '../hooks/useSwapRate'
+import { MarkrQuote } from '../services/MarkrService'
 import {
   isJupiterQuote,
   isMarkrQuote,
   NormalizedSwapQuote,
   NormalizedSwapQuoteResult
 } from '../types'
-import { MarkrQuote } from '../services/MarkrService'
-import { useSwapRate } from '../hooks/useSwapRate'
 
 // Provider logo mapping
 const PRICE_PROVIDER_ICONS: Record<string, React.FC<SvgProps> | undefined> = {
@@ -254,6 +255,12 @@ export const SwapPricingDetailsScreen = ({
 
     return items
   }, [quotes, fromToken, toToken, manuallySelected, renderItem, rate])
+
+  useEffect(() => {
+    setTimeout(() => {
+      dismissKeyboardIfNeeded()
+    }, 0)
+  }, [])
 
   return (
     <ScrollScreen


### PR DESCRIPTION
## Description

**Ticket: [CP-12127](https://ava-labs.atlassian.net/browse/CP-12127)**

Please provide:

- A summary of the changes
- Motivation and context for this change
- Any dependencies introduced
- (If breaking) migration steps and instructions

(Android) Added a setTimeout for first screen renders to hide the keyboard it's open

## Screenshots/Videos

Include relevant screenshots or screen recordings of iOS and Android.

https://github.com/user-attachments/assets/9984e2d9-c636-4c2b-b213-8958a3768a7a

## Testing

**Dev Testing (if applicable)**

- Provide steps to test the happy path of your feature
- Provide steps to test edge cases and error states
- Trigger a build on bitrise and reference it here
- Move the ticket into the "Testing" column on Jira

iOS - 6152
Android - 6153

1. Open up swap, focus the textinput and tap on token to navigate to Select a Token
2. Notice if keyboard gets dismissed
3. While keyboard open, press 25%, scroll down a bit and press on pricing details to open Pricing Details route
4. Notice if keyboard gets dismissed

**QA Testing (if applicable)**

- Provide instructions for QA to test this feature thoroughly
- State expected behavior / acceptance criteria

## Checklist

Please check all that apply (if applicable)

- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-12127]: https://ava-labs.atlassian.net/browse/CP-12127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ