### PR TITLE
CP-12134: Prevent multiple browser tabs from opening per deeplink

### DIFF
--- a/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/browser/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/browser/index.tsx
@@ -2,7 +2,7 @@ import { alpha, ANIMATED, useTheme, View } from '@avalabs/k2-alpine'
 import { colors } from '@avalabs/k2-alpine/src/theme/tokens/colors'
 import { BlurViewWithFallback } from 'common/components/BlurViewWithFallback'
 import { useBottomTabBarHeight } from 'common/hooks/useBottomTabBarHeight'
-import { useFocusEffect, useLocalSearchParams } from 'expo-router'
+import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router'
 import { useBrowserContext } from 'features/browser/BrowserContext'
 import { BrowserControls } from 'features/browser/components/BrowserControls'
 import { BrowserSnapshot } from 'features/browser/components/BrowserSnapshot'
@@ -33,7 +33,8 @@ const Browser = (): React.ReactNode => {
   const tabBarHeight = useBottomTabBarHeight()
   const { browserRefs } = useBrowserContext()
   const dispatch = useDispatch()
-  const { deeplinkUrl } = useLocalSearchParams<{ deeplinkUrl: string }>()
+  const router = useRouter()
+  const { deeplinkUrl } = useLocalSearchParams<{ deeplinkUrl?: string }>()
   const activeTab = useSelector(selectActiveTab)
   const allTabs = useSelector(selectAllTabs)
   const showEmptyTab = useSelector(selectIsTabEmpty)
@@ -48,8 +49,12 @@ const Browser = (): React.ReactNode => {
     if (deeplinkUrl) {
       dispatch(addTab())
       dispatch(addHistoryForActiveTab({ url: deeplinkUrl, title: '' }))
+
+      // Clear the deeplinkUrl param to mark it as handled
+      // @ts-expect-error
+      router.setParams({ deeplinkUrl: undefined })
     }
-  }, [dispatch, deeplinkUrl])
+  }, [dispatch, deeplinkUrl, router])
 
   useEffect(() => {
     tabs.forEach(tab => {

--- a/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/browser/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/browser/index.tsx
@@ -2,7 +2,7 @@ import { alpha, ANIMATED, useTheme, View } from '@avalabs/k2-alpine'
 import { colors } from '@avalabs/k2-alpine/src/theme/tokens/colors'
 import { BlurViewWithFallback } from 'common/components/BlurViewWithFallback'
 import { useBottomTabBarHeight } from 'common/hooks/useBottomTabBarHeight'
-import { useFocusEffect, useGlobalSearchParams, useRouter } from 'expo-router'
+import { useFocusEffect, useLocalSearchParams } from 'expo-router'
 import { useBrowserContext } from 'features/browser/BrowserContext'
 import { BrowserControls } from 'features/browser/components/BrowserControls'
 import { BrowserSnapshot } from 'features/browser/components/BrowserSnapshot'
@@ -33,8 +33,7 @@ const Browser = (): React.ReactNode => {
   const tabBarHeight = useBottomTabBarHeight()
   const { browserRefs } = useBrowserContext()
   const dispatch = useDispatch()
-  const router = useRouter()
-  const { deeplinkUrl } = useGlobalSearchParams<{ deeplinkUrl: string }>()
+  const { deeplinkUrl } = useLocalSearchParams<{ deeplinkUrl: string }>()
   const activeTab = useSelector(selectActiveTab)
   const allTabs = useSelector(selectAllTabs)
   const showEmptyTab = useSelector(selectIsTabEmpty)
@@ -50,7 +49,7 @@ const Browser = (): React.ReactNode => {
       dispatch(addTab())
       dispatch(addHistoryForActiveTab({ url: deeplinkUrl, title: '' }))
     }
-  }, [dispatch, deeplinkUrl, router])
+  }, [dispatch, deeplinkUrl])
 
   useEffect(() => {
     tabs.forEach(tab => {

--- a/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/browser/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/browser/index.tsx
@@ -51,7 +51,7 @@ const Browser = (): React.ReactNode => {
       dispatch(addHistoryForActiveTab({ url: deeplinkUrl, title: '' }))
 
       // Clear the deeplinkUrl param to mark it as handled
-      // @ts-expect-error
+      // @ts-ignore
       router.setParams({ deeplinkUrl: undefined })
     }
   }, [dispatch, deeplinkUrl, router])


### PR DESCRIPTION
## Description

**Ticket: [CP-12134]**

## Screenshots/Videos
* iOS

https://github.com/user-attachments/assets/e914ba6c-ce1f-4014-b948-aeb27d847829

* Android

https://github.com/user-attachments/assets/dafded08-d948-4aac-82b0-2a8b5aac3d49

## Testing
* iOS: 6158, Android: [6159](https://app.bitrise.io/app/7d7ca5af7066e290/installable-artifacts/21192d03e1375799/public-install-page/2dac90079fc7047a186452ec3773d08e)

* Open a deeplink with core://browser?deeplinkUrl=https%3A%2F%2Fcore.app
* Verify that only one browser tab is opened for the deeplink.
* Repeat with multiple deeplink taps — the number of tabs should not increase unexpectedly.

## Note
To test deeplinks on android, use this command
```
adb -s [YOUR_DEVICE_ID] shell am start \
  -a android.intent.action.VIEW \
  -d "core://browser?deeplinkUrl=https%3A%2F%2Fcore.app"
```

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [X] I have included screenshots / videos of android and ios
- [X] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-12134]: https://ava-labs.atlassian.net/browse/CP-12134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ