### PR TITLE
CP-12115: Add error handling for invalid amount

### DIFF
--- a/packages/core-mobile/app/new/features/meld/hooks/useSelectAmount.tsx
+++ b/packages/core-mobile/app/new/features/meld/hooks/useSelectAmount.tsx
@@ -305,9 +305,11 @@ export const useSelectAmount = ({
         cryptoQuotesError.message.toLowerCase().includes('not found')) ||
       (cryptoQuotesError?.statusCode ===
         CreateCryptoQuoteErrorCode.INCOMPATIBLE_REQUEST &&
-        cryptoQuotesError.message
+        cryptoQuotesError?.message
           .toLowerCase()
-          .includes('not within the payment method limits'))
+          .includes('not within the payment method limits')) ||
+      cryptoQuotesError?.message.toLowerCase().includes('crypto_min_limit') ||
+      cryptoQuotesError?.message.toLowerCase().includes('crypto_max_limit')
     ) {
       return 'The selected amount is not within the minimum and maximum limits'
     }


### PR DESCRIPTION
## Description

**Ticket: [CP-12115]**

Please provide:

- A summary of the changes
- Motivation and context for this change
- Any dependencies introduced
- (If breaking) migration steps and instructions

- add another condition to show invalid amount error message if the cryptoQuotesError has status code `INCOMPATIBLE_REQUEST` and the message contains `not within the payment method limits`


## Screenshots/Videos

Include relevant screenshots or screen recordings of iOS and Android.

## Testing

**Dev Testing (if applicable)**

- Provide steps to test the happy path of your feature
- Provide steps to test edge cases and error states
- Trigger a build on bitrise and reference it here
- Move the ticket into the "Testing" column on Jira

**for dev tester**
- go to offramp and try to withdraw token with less than 1 usd
- try avax token and different erc20 tokens

**QA Testing (if applicable)**

- Provide instructions for QA to test this feature thoroughly
- State expected behavior / acceptance criteria

## Checklist

Please check all that apply (if applicable)

- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-12115]: https://ava-labs.atlassian.net/browse/CP-12115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ