### PR TITLE
CP-12050: Handle wrapped tokens and trailing spaces in market token lookup

### DIFF
--- a/packages/core-mobile/app/hooks/watchlist/useWatchlist.ts
+++ b/packages/core-mobile/app/hooks/watchlist/useWatchlist.ts
@@ -167,7 +167,8 @@ export const useWatchlist = (): UseWatchListReturnType => {
   const getMarketTokenBySymbol = useCallback(
     (symbol: string): MarketToken | undefined =>
       allTokens.find(
-        token => token.symbol.toLowerCase() === symbol.toLowerCase()
+        token =>
+          token.symbol.toLowerCase().trim() === symbol.toLowerCase().trim() // handle symbols with different casing or extra spaces
       ),
     [allTokens]
   )

--- a/packages/core-mobile/app/hooks/watchlist/useWatchlist.ts
+++ b/packages/core-mobile/app/hooks/watchlist/useWatchlist.ts
@@ -12,6 +12,7 @@ import { useSelector } from 'react-redux'
 import { ChartData } from 'services/token/types'
 import { transformTrendingTokens } from 'services/watchlist/utils/transform'
 import { useIsFocused } from '@react-navigation/native'
+import { unwrapAssetSymbol } from 'common/utils/bridgeUtils'
 import { useGetPrices } from './useGetPrices'
 import { useGetTokensAndCharts } from './useGetTokensAndCharts'
 import { useGetTrendingTokens } from './useGetTrendingTokens'
@@ -166,10 +167,14 @@ export const useWatchlist = (): UseWatchListReturnType => {
 
   const getMarketTokenBySymbol = useCallback(
     (symbol: string): MarketToken | undefined =>
-      allTokens.find(
-        token =>
-          token.symbol.toLowerCase().trim() === symbol.toLowerCase().trim() // handle symbols with different casing or extra spaces
-      ),
+      allTokens.find(token => {
+        const sourceSymbol = token.symbol.toLowerCase().trim()
+        const targetSymbol = symbol.toLowerCase().trim()
+        return (
+          sourceSymbol === targetSymbol ||
+          sourceSymbol === unwrapAssetSymbol(targetSymbol)
+        )
+      }),
     [allTokens]
   )
 

--- a/packages/core-mobile/app/hooks/watchlist/useWatchlist.ts
+++ b/packages/core-mobile/app/hooks/watchlist/useWatchlist.ts
@@ -13,7 +13,7 @@ import { ChartData } from 'services/token/types'
 import { transformTrendingTokens } from 'services/watchlist/utils/transform'
 import { useIsFocused } from '@react-navigation/native'
 import { LocalTokenWithBalance } from 'store/balance'
-import { getCaip2ChainIdForTokenType } from 'utils/caip2ChainIds'
+import { getCaip2ChainIdForToken } from 'utils/caip2ChainIds'
 import { isNetworkContractToken } from 'utils/isNetworkContractToken'
 import { useGetPrices } from './useGetPrices'
 import { useGetTokensAndCharts } from './useGetTokensAndCharts'
@@ -187,7 +187,7 @@ export const useWatchlist = (): UseWatchListReturnType => {
 
   const resolveMarketToken = useCallback(
     (token: LocalTokenWithBalance): MarketToken | undefined => {
-      const caip2ChainId = getCaip2ChainIdForTokenType({
+      const caip2ChainId = getCaip2ChainIdForToken({
         type: token.type,
         chainId: token.networkChainId
       })

--- a/packages/core-mobile/app/hooks/watchlist/useWatchlist.ts
+++ b/packages/core-mobile/app/hooks/watchlist/useWatchlist.ts
@@ -191,17 +191,27 @@ export const useWatchlist = (): UseWatchListReturnType => {
         type: token.type,
         chainId: token.networkChainId
       })
+      const contractTokenAddress = isNetworkContractToken(token)
+        ? token.address.toLowerCase()
+        : undefined
       const targetSymbol = token.symbol.toLowerCase().trim()
 
       return allTokens.find(marketToken => {
+        // First try to match by internal id
+        if (token.internalId === marketToken.id) {
+          return true
+        }
+
+        // Next try to match by contract address if possible
         if (
-          isNetworkContractToken(token) &&
+          contractTokenAddress &&
           marketToken.platforms?.[caip2ChainId]?.toLowerCase() ===
-            token.address.toLowerCase()
+            contractTokenAddress
         ) {
           return true
         }
 
+        // Finally, fallback to matching by symbol (not ideal, but better than nothing)
         return marketToken.symbol.toLowerCase().trim() === targetSymbol
       })
     },

--- a/packages/core-mobile/app/new/common/hooks/useMarketToken.ts
+++ b/packages/core-mobile/app/new/common/hooks/useMarketToken.ts
@@ -1,0 +1,38 @@
+import { useWatchlist } from 'hooks/watchlist/useWatchlist'
+import { useMemo } from 'react'
+import { LocalTokenWithBalance } from 'store/balance'
+import { MarketToken } from 'store/watchlist'
+import Logger from 'utils/Logger'
+
+export const useMarketToken = ({
+  token,
+  errorContext
+}: {
+  token: LocalTokenWithBalance | undefined
+  errorContext?: string
+}): MarketToken | undefined => {
+  const { resolveMarketToken } = useWatchlist()
+
+  return useMemo(() => {
+    if (!token) return undefined
+
+    const resolvedMarketToken = resolveMarketToken(token)
+    if (errorContext && !resolvedMarketToken) {
+      Logger.error(`[${errorContext}] Market token not found`, {
+        symbol: token.symbol
+      })
+    }
+    if (
+      errorContext &&
+      resolvedMarketToken?.priceChangePercentage24h === undefined
+    ) {
+      Logger.error(
+        `[${errorContext}] Market token priceChangePercentage24h is undefined`,
+        {
+          symbol: token.symbol
+        }
+      )
+    }
+    return resolvedMarketToken
+  }, [token, resolveMarketToken, errorContext])
+}

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenListItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenListItem.tsx
@@ -2,8 +2,8 @@ import { PriceChangeStatus } from '@avalabs/k2-alpine'
 import { useFormatCurrency } from 'new/common/hooks/useFormatCurrency'
 import React, { useRef, useCallback } from 'react'
 import { LocalTokenWithBalance } from 'store/balance'
-import { useMarketTokenBySymbol } from 'common/hooks/useMarketTokenBySymbol'
 import { useTokenNameForDisplay } from 'common/hooks/useTokenNameForDisplay'
+import { useMarketToken } from 'common/hooks/useMarketToken'
 import { TokenListView } from './TokenListView'
 import { TokenGridView } from './TokenGridView'
 
@@ -21,15 +21,15 @@ export const TokenListItem = ({
   onPress
 }: TokenListItemProps): React.JSX.Element => {
   const { formatCurrency } = useFormatCurrency()
-  const { balanceInCurrency, symbol } = token
+  const { balanceInCurrency } = token
   const formattedBalance = balanceInCurrency
     ? formatCurrency({ amount: balanceInCurrency })
     : undefined
 
   const tokenNameForDisplay = useTokenNameForDisplay({ token }) ?? token.name
 
-  const marketToken = useMarketTokenBySymbol({
-    symbol,
+  const marketToken = useMarketToken({
+    token,
     errorContext: 'TokenListItem'
   })
   const percentChange = marketToken?.priceChangePercentage24h ?? undefined

--- a/packages/core-mobile/app/utils/caip2ChainIds.ts
+++ b/packages/core-mobile/app/utils/caip2ChainIds.ts
@@ -6,6 +6,7 @@ import {
   ChainId,
   SolanaCaip2ChainId
 } from '@avalabs/core-chains-sdk'
+import { TokenType } from '@avalabs/vm-module-types'
 
 /**
  * Legacy Solana chain ID format used by some WalletConnect dApps. While the standard
@@ -231,4 +232,26 @@ export const getCaip2ChainId = (chainId: number): string => {
 
   // Default to EVM for any other chain ID
   return getEvmCaip2ChainId(chainId)
+}
+
+export const getCaip2ChainIdForTokenType = ({
+  chainId,
+  type
+}: {
+  chainId: number
+  type: TokenType
+}): string => {
+  if (
+    type === TokenType.ERC1155 ||
+    type === TokenType.ERC721 ||
+    type === TokenType.ERC20
+  ) {
+    return getEvmCaip2ChainId(chainId)
+  }
+
+  if (type === TokenType.SPL) {
+    return getSolanaCaip2ChainId(chainId)
+  }
+
+  return getCaip2ChainId(chainId)
 }

--- a/packages/core-mobile/app/utils/caip2ChainIds.ts
+++ b/packages/core-mobile/app/utils/caip2ChainIds.ts
@@ -234,7 +234,7 @@ export const getCaip2ChainId = (chainId: number): string => {
   return getEvmCaip2ChainId(chainId)
 }
 
-export const getCaip2ChainIdForTokenType = ({
+export const getCaip2ChainIdForToken = ({
   chainId,
   type
 }: {

--- a/packages/core-mobile/app/utils/isNetworkContractToken.ts
+++ b/packages/core-mobile/app/utils/isNetworkContractToken.ts
@@ -1,0 +1,13 @@
+import { NetworkContractToken, TokenType } from '@avalabs/vm-module-types'
+
+export function isNetworkContractToken(token: {
+  type: TokenType
+}): token is NetworkContractToken {
+  return (
+    token.type === TokenType.ERC20 ||
+    token.type === TokenType.ERC1155 ||
+    token.type === TokenType.ERC721 ||
+    token.type === TokenType.NONERC ||
+    token.type === TokenType.SPL
+  )
+}


### PR DESCRIPTION
## Description

**Ticket: [CP-12050]**

Some coin symbols and names (e.g., [fartcoin](https://solscan.io/token/9BB6NFEcjBCtnNLFko2FqVQBq8HHM13kCyYcdQbgpump#metadata)) may intentionally include trailing spaces, which can cause mismatches with the data we manage in Contentful. To ensure consistent matching, this PR updates getMarketTokenBySymbol to trim the symbol before comparison.



## Screenshots
| Before | After |
| --- | --- |
|  <img width="320" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-09-23 at 15 17 53" src="https://github.com/user-attachments/assets/4d813717-d5ce-4ae4-808a-977cafa46130" /> | <img width="320" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-09-23 at 15 17 09" src="https://github.com/user-attachments/assets/d5e2b202-d982-4ef3-bff0-9dd4367b0c98" /> |

## Testing
iOS: 6198, Android: [6199](https://app.bitrise.io/app/7d7ca5af7066e290/installable-artifacts/8fcb838cffaa34ec/public-install-page/68d076af02d59e5ad4eee0aadeb9e311)
* Verify that tokens with spaces in their symbol (e.g., `Fartcoin`) correctly display price change in the portfolio.
* Verify that wrapped contract tokens (e.g., `WETH.e`) correctly display price change in the portfolio.

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [X] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-12050]: https://ava-labs.atlassian.net/browse/CP-12050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ