### PR TITLE
CP-12202: Place Solana launch modal behind a feature flag

### DIFF
--- a/packages/core-mobile/app/services/posthog/types.ts
+++ b/packages/core-mobile/app/services/posthog/types.ts
@@ -37,6 +37,7 @@ export enum FeatureGates {
   GASLESS = 'gasless-feature',
   SWAP_FEES = 'swap-fees',
   SOLANA_SUPPORT = 'solana-support',
+  SOLANA_LAUNCH_MODAL = 'solana-launch-modal',
   MELD_ONRAMP = 'meld-onramp',
   MELD_OFFRAMP = 'meld-offramp',
   SWAP_USE_MARKR = 'swap-use-markr',

--- a/packages/core-mobile/app/store/notifications/listeners/handleAfterLoginFlows.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/handleAfterLoginFlows.ts
@@ -5,6 +5,7 @@ import { AppUpdateService } from 'services/AppUpdateService/AppUpdateService'
 import NotificationsService from 'services/notifications/NotificationsService'
 import {
   selectIsEnableNotificationPromptBlocked,
+  selectIsSolanaLaunchModalBlocked,
   selectIsSolanaSupportBlocked
 } from 'store/posthog'
 import { AppListenerEffectAPI } from 'store/types'
@@ -128,9 +129,12 @@ const promptSolanaLaunchModalIfNeeded = async (
   )(state)
 
   const isSolanaSupportBlocked = selectIsSolanaSupportBlocked(state)
+  const isSolanaLaunchModalBlocked = selectIsSolanaLaunchModalBlocked(state)
 
   const shouldShowSolanaLaunchModal =
-    !hasBeenViewedSolanaLaunch && !isSolanaSupportBlocked
+    !hasBeenViewedSolanaLaunch &&
+    !isSolanaSupportBlocked &&
+    !isSolanaLaunchModalBlocked
   if (shouldShowSolanaLaunchModal) {
     await waitForInteractions()
 

--- a/packages/core-mobile/app/store/posthog/slice.ts
+++ b/packages/core-mobile/app/store/posthog/slice.ts
@@ -427,6 +427,14 @@ export const selectIsEnableMeldSandboxBlocked = (state: RootState): boolean => {
   )
 }
 
+export const selectIsSolanaLaunchModalBlocked = (state: RootState): boolean => {
+  const { featureFlags } = state.posthog
+  return (
+    !featureFlags[FeatureGates.SOLANA_LAUNCH_MODAL] ||
+    !featureFlags[FeatureGates.EVERYTHING]
+  )
+}
+
 // actions
 export const { regenerateUserId, toggleAnalytics, setFeatureFlags } =
   posthogSlice.actions

--- a/packages/core-mobile/app/store/posthog/types.ts
+++ b/packages/core-mobile/app/store/posthog/types.ts
@@ -49,7 +49,8 @@ export const DefaultFeatureFlagConfig = {
   [FeatureGates.SWAP_SOLANA]: true,
   [FeatureGates.SWAP_FEES_JUPITER]: true,
   [FeatureGates.IN_APP_UPDATE_ANDROID]: false,
-  [FeatureGates.ENABLE_MELD_SANDBOX]: false
+  [FeatureGates.ENABLE_MELD_SANDBOX]: false,
+  [FeatureGates.SOLANA_LAUNCH_MODAL]: false
 }
 
 export const initialState = {


### PR DESCRIPTION
## Description

**Ticket: [CP-12202]**

* Place Solana launch modal behind a feature flag: `solana-launch-modal`

## Testing
* Please verify that toggling the `solana-launch-modal` flag controls whether the Solana Launch Modal is shown after onboarding.

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [] I have updated the documentation
