### PR TITLE
CP-12211: Show negative daily price change in portfolio header

### DIFF
--- a/packages/core-mobile/app/new/features/portfolio/screens/PortfolioScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/screens/PortfolioScreen.tsx
@@ -156,9 +156,9 @@ const PortfolioHomeScreen = (): JSX.Element => {
   )
 
   const formattedPriceChange =
-    totalPriceChanged > 0
+    totalPriceChanged !== 0
       ? formatCurrency({ amount: Math.abs(totalPriceChanged) })
-      : ''
+      : undefined
 
   const indicatorStatus =
     totalPriceChanged > 0
@@ -319,7 +319,7 @@ const PortfolioHomeScreen = (): JSX.Element => {
               formattedBalance={formattedBalance}
               currency={selectedCurrency}
               priceChange={
-                totalPriceChanged > 0
+                totalPriceChanged !== 0
                   ? {
                       formattedPrice: formattedPriceChange,
                       status: indicatorStatus,


### PR DESCRIPTION
## Description

**Ticket: [CP-12211]**

* Show negative daily price change in portfolio header

## Screenshots/Videos
| | positive | negative |
| --- | --- | --- |
| iOS | <img width="320" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-09-26 at 14 53 04" src="https://github.com/user-attachments/assets/03cc26cd-e629-45ac-96ee-f39989da11ac" /> | <img width="320" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-09-26 at 14 53 20" src="https://github.com/user-attachments/assets/c27602bb-5221-4861-a870-8b2da90ba7d2" /> |
| Android | <img width="320" alt="Screenshot 2025-09-26 at 3 03 43 PM" src="https://github.com/user-attachments/assets/414d253b-2122-4818-831f-3f09e6eb6e8b" /> | <img width="320" alt="Screenshot 2025-09-26 at 2 59 41 PM" src="https://github.com/user-attachments/assets/29c8250b-8b2a-4bb8-a8d2-c1a09377a51b" /> |

## Testing
iOS: 6219 Android: [6220](https://app.bitrise.io/app/7d7ca5af7066e290/installable-artifacts/69ef3ff5bf9d311b/public-install-page/d60d9a27410b264c693c4db1fa23c0d7)
Please verify that the portfolio header shows the price change both when it’s positive and when it’s negative.

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [X] I have included screenshots / videos of android and ios
- [X] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation
