### PR TITLE
CP-12242: Fix toast width covering full screen and blocking interactions outside toast

### DIFF
--- a/packages/core-mobile/app/new/ContextApp.tsx
+++ b/packages/core-mobile/app/new/ContextApp.tsx
@@ -7,19 +7,12 @@ import { EncryptedStoreProvider } from 'contexts/EncryptedStoreProvider'
 import { PosthogContextProvider } from 'contexts/PosthogContext'
 import { ReactQueryProvider } from 'contexts/ReactQueryProvider'
 import React, { FC, PropsWithChildren } from 'react'
-import { Platform } from 'react-native'
 import { ConfettiMethods } from 'react-native-fast-confetti'
 import { RootSiblingParent } from 'react-native-root-siblings'
-import { FullWindowOverlay } from 'react-native-screens'
-import Toast from 'react-native-toast-notifications'
 import SentryService from 'services/sentry/SentryService'
 import { App } from './App'
 import JailbreakCheck from './common/components/JailbreakCheck'
 import TopLevelErrorFallback from './common/components/TopLevelErrorFallback'
-
-const setGlobalToast = (toast: Toast): void => {
-  global.toast = toast
-}
 
 const setGlobalConfetti = (confetti: ConfettiMethods): void => {
   global.confetti = confetti
@@ -44,22 +37,6 @@ const ContextApp = (): JSX.Element => {
           <App />
         </RootSiblingParent>
         <JailbreakCheck />
-        <Toast
-          ToastContainerWrapper={
-            Platform.OS === 'ios'
-              ? {
-                  component: FullWindowOverlay,
-                  props: {
-                    children: undefined
-                  }
-                }
-              : undefined
-          }
-          ref={setGlobalToast}
-          offsetTop={30}
-          normalColor={'00FFFFFF'}
-        />
-
         <Confetti ref={setGlobalConfetti} />
       </ContextProviders>
     </Sentry.ErrorBoundary>

--- a/packages/core-mobile/app/new/common/utils/toast.tsx
+++ b/packages/core-mobile/app/new/common/utils/toast.tsx
@@ -43,6 +43,7 @@ export const GlobalToast = (): JSX.Element => {
             }
           : undefined
       }
+      containerStyle={{ width: undefined }}
       placement="top"
       animationType="slide-in"
       offsetTop={offsetTop}

--- a/packages/k2-alpine/src/components/Toast/TransactionSnackbar.tsx
+++ b/packages/k2-alpine/src/components/Toast/TransactionSnackbar.tsx
@@ -110,7 +110,7 @@ export const TransactionSnackbar = ({
       onPress={onPress}>
       <View
         style={{
-          width: SCREEN_WIDTH,
+          maxWidth: SCREEN_WIDTH - 32,
           justifyContent: 'center',
           alignItems: 'center'
         }}>
@@ -129,7 +129,6 @@ export const TransactionSnackbar = ({
             variant="body1"
             numberOfLines={1}
             sx={{
-              maxWidth: '80%',
               marginLeft: 5,
               fontSize: 14,
               color: textColor


### PR DESCRIPTION
## Description

**Ticket: [CP-12242]**

The toast component was styled with full-width coverage, so tapping outside its visible area would both dismiss the toast and block interaction with other UI elements.(i.e. setting, connect buttons in the header)
Now the touchable area is limited to the toast itself, preventing unintended dismissals and allowing normal interaction with the rest of the screen.

## Screenshots/Videos
* iOS

https://github.com/user-attachments/assets/d5012497-dab8-4ad1-a565-eac3c1fced38

 * Android

https://github.com/user-attachments/assets/4366e95f-3ce4-4618-8a93-ba9750dd6a43


## Testing
iOS: 6280, Android: [6281](https://app.bitrise.io/app/7d7ca5af7066e290/installable-artifacts/8d0adcae966fb806/public-install-page/c28d7118bd771c5c0630851d5628e0e4)
1. Trigger a toast.
2. Taps on the left or right side of the toast should not dismiss it
3. Other UI elements should remain interactive while the toast is visible.

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [X] I have included screenshots / videos of android and ios
- [X] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation
