### PR TITLE
Add get active addresses

### DIFF
--- a/packages/core-mobile/app/services/wallet/types.ts
+++ b/packages/core-mobile/app/services/wallet/types.ts
@@ -7,7 +7,7 @@ import {
   JsonRpcBatchInternal
 } from '@avalabs/core-wallets-sdk'
 import { pvm, UnsignedTx } from '@avalabs/avalanchejs'
-import { Network } from '@avalabs/core-chains-sdk'
+import { Network, NetworkVMType } from '@avalabs/core-chains-sdk'
 import {
   MessageTypes,
   RpcMethod,
@@ -255,4 +255,15 @@ export interface Wallet {
     network: Network
     provider: SolanaProvider
   }): Promise<string>
+}
+
+export interface AddressEntry {
+  address: string
+  index: number
+}
+
+export interface NetworkAddresses {
+  networkType: NetworkVMType.AVM | NetworkVMType.PVM
+  externalAddresses: AddressEntry[]
+  internalAddresses: AddressEntry[]
 }

--- a/packages/core-mobile/ios/Podfile.lock
+++ b/packages/core-mobile/ios/Podfile.lock
@@ -3957,7 +3957,7 @@ SPEC CHECKSUMS:
   OpenTelemetrySwiftApi: aaee576ed961e0c348af78df58b61300e95bd104
   PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
+  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: 5f638f65935e273753b1f31a365db6a8d6dc53b5
   RCTRequired: 8b46a520ea9071e2bc47d474aa9ca31b4a935bd8
   RCTTypeSafety: cc4740278c2a52cbf740592b0a0a40df1587c9ab

--- a/yarn.lock
+++ b/yarn.lock
@@ -28746,7 +28746,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 3e4689674406deb2ad9efa9f529597341b4ab33e379b7c7cd72aff8d5e37862fda1a37aba984951a67cc3938969be138bc3c4469e4963dd170b172148339e056
+  checksum: d6ceb75e1d0f5755370d6d91f67902bd2b8a23a3ca43cb853d2964b43798f30477e8ab0223ea8b620534fbdf5f56d39550f40d24bec2d2398c323ccfe8a5a556
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
Just a quick pr to add a method to WalletService to retrieve active addresses for mnemonic wallets 

## Testing

**Dev Testing (if applicable)**
Simply try to run this code
```
const addresses = await WalletService.getActiveAddresses({
    walletId,
    walletType: WalletType.MNEMONIC,
    networkType: NetworkVMType.PVM,
    isTestnet
  })
```

## Checklist

Please check all that apply (if applicable)

- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation
