### PR TITLE
CP-13898: auto-enable L1 networks with non-zero balance on app unlock

### DIFF
--- a/packages/core-mobile/app/services/glacier/GlacierService.ts
+++ b/packages/core-mobile/app/services/glacier/GlacierService.ts
@@ -2,6 +2,7 @@ import {
   Erc1155Token,
   Erc721Token,
   Glacier,
+  GetNativeBalanceResponse,
   ListAddressChainsResponse
 } from '@avalabs/glacier-sdk'
 import Config from 'react-native-config'
@@ -93,6 +94,19 @@ class GlacierService {
     address: string
   }): Promise<ListAddressChainsResponse> {
     return this.glacierSdk.evmChains.listAddressChains({
+      address
+    })
+  }
+
+  async getNativeBalance({
+    chainId,
+    address
+  }: {
+    chainId: string
+    address: string
+  }): Promise<GetNativeBalanceResponse> {
+    return this.glacierSdk.evmBalances.getNativeBalance({
+      chainId,
       address
     })
   }

--- a/packages/core-mobile/app/store/network/listeners.ts
+++ b/packages/core-mobile/app/store/network/listeners.ts
@@ -1,4 +1,4 @@
-import { ChainId, Network } from '@avalabs/core-chains-sdk'
+import { ChainId, Network, NetworkVMType } from '@avalabs/core-chains-sdk'
 import { AppListenerEffectAPI, AppStartListening } from 'store/types'
 import { onAppUnlocked } from 'store/app'
 import {
@@ -7,7 +7,10 @@ import {
   setActive,
   selectEnabledChainIds,
   toggleEnabledChainId,
-  enableL2ChainIds
+  enableL2ChainIds,
+  enableChainIds,
+  alwaysEnabledChainIds,
+  defaultEnabledL2ChainIds
 } from 'store/network/slice'
 import {
   selectIsDeveloperMode,
@@ -20,6 +23,11 @@ import {
   setViewOnce,
   ViewOnceKey
 } from 'store/viewOnce'
+import { selectActiveAccount } from 'store/account'
+import GlacierService from 'services/glacier/GlacierService'
+import { getNetworksFromCache } from 'hooks/networks/utils/getNetworksFromCache'
+import { isXChain } from 'utils/network/isAvalancheNetwork'
+import Logger from 'utils/Logger'
 
 const adjustActiveNetwork = (
   _: AnyAction,
@@ -86,6 +94,95 @@ const enableL2ChainIdsIfNeeded = (
   }
 }
 
+/**
+ * On every app unlock, check all known Avalanche L1 networks (those that are
+ * not default/always-enabled chains and not X-chain) for a non-zero native
+ * balance on the active account's EVM address via Glacier.  Any L1 with a
+ * balance is automatically added to the user's enabled chain list.
+ *
+ * Running on each unlock (rather than once) means newly-funded L1s are picked
+ * up without the user having to manually enable them.
+ */
+const autoEnableL1Networks = async (
+  _: AnyAction,
+  listenerApi: AppListenerEffectAPI
+): Promise<void> => {
+  const { dispatch, getState } = listenerApi
+  const state = getState()
+
+  const activeAccount = selectActiveAccount(state)
+  const address = activeAccount?.addressC
+  if (!address) {
+    return
+  }
+
+  const isDeveloperMode = selectIsDeveloperMode(state)
+  const enabledChainIds = selectEnabledChainIds(state)
+  const customNetworks = selectCustomNetworks(state)
+  const customChainIds = Object.values(customNetworks).map(n => n.chainId)
+
+  // Fetch the full network list from the React Query cache (populated at
+  // startup by useGetNetworks).  If the cache is empty we bail out – the
+  // listener will run again on the next unlock.
+  const allNetworks = getNetworksFromCache({ includeSolana: false })
+  if (!allNetworks) {
+    return
+  }
+
+  // Identify L1 candidates: EVM mainnet/testnet networks that are not already
+  // in the always-enabled, default-L2 or X-chain sets, and are not custom
+  // networks, and are not already enabled by the user.
+  const l1Candidates = Object.values(allNetworks).filter(
+    (network): network is Network =>
+      network !== undefined &&
+      network.vmName === NetworkVMType.EVM &&
+      network.isTestnet === isDeveloperMode &&
+      !alwaysEnabledChainIds.includes(network.chainId) &&
+      !defaultEnabledL2ChainIds.includes(network.chainId) &&
+      !isXChain(network.chainId) &&
+      !customChainIds.includes(network.chainId) &&
+      !enabledChainIds.includes(network.chainId)
+  )
+
+  if (l1Candidates.length === 0) {
+    return
+  }
+
+  // Query Glacier for each candidate in parallel; collect those with a
+  // non-zero balance.
+  const results = await Promise.allSettled(
+    l1Candidates.map(async network => {
+      const response = await GlacierService.getNativeBalance({
+        chainId: network.chainId.toString(),
+        address
+      })
+      return { chainId: network.chainId, balance: response.nativeTokenBalance.balance }
+    })
+  )
+
+  const chainIdsWithBalance: number[] = results.reduce<number[]>(
+    (acc, result) => {
+      if (
+        result.status === 'fulfilled' &&
+        result.value.balance !== '0'
+      ) {
+        acc.push(result.value.chainId)
+      }
+      return acc
+    },
+    []
+  )
+
+  if (chainIdsWithBalance.length === 0) {
+    return
+  }
+
+  Logger.info(
+    `[autoEnableL1Networks] enabling ${chainIdsWithBalance.length} L1 network(s) with balance: ${chainIdsWithBalance.join(', ')}`
+  )
+  dispatch(enableChainIds(chainIdsWithBalance))
+}
+
 export const addNetworkListeners = (
   startListening: AppStartListening
 ): void => {
@@ -107,5 +204,10 @@ export const addNetworkListeners = (
   startListening({
     matcher: isAnyOf(onAppUnlocked),
     effect: enableL2ChainIdsIfNeeded
+  })
+
+  startListening({
+    actionCreator: onAppUnlocked,
+    effect: autoEnableL1Networks
   })
 }

--- a/packages/core-mobile/app/store/network/slice.ts
+++ b/packages/core-mobile/app/store/network/slice.ts
@@ -88,6 +88,13 @@ export const networkSlice = createSlice({
         }
       })
     },
+    enableChainIds: (state, action: PayloadAction<number[]>) => {
+      action.payload.forEach(chainId => {
+        if (!state.enabledChainIds.includes(chainId)) {
+          state.enabledChainIds.push(chainId)
+        }
+      })
+    },
     toggleDisabledLastTransactedChainId: (
       state,
       action: PayloadAction<number>
@@ -308,7 +315,8 @@ export const {
   addCustomNetwork,
   removeCustomNetwork,
   updateCustomNetwork,
-  enableL2ChainIds
+  enableL2ChainIds,
+  enableChainIds
 } = networkSlice.actions
 
 export const networkReducer = networkSlice.reducer


### PR DESCRIPTION
## Description

**Ticket: [CP-13898](https://avalabs.atlassian.net/browse/CP-13898)**

Users with funds on Avalanche L1 networks not in their enabled list couldn't see those funds in portfolio or use them in Fusion. This change automatically detects and enables L1 networks with a non-zero native balance on every app unlock.

**Changes:**
- `GlacierService.ts` — added `getNativeBalance({ chainId, address })` via `evmBalances.getNativeBalance`
- `store/network/slice.ts` — added `enableChainIds` reducer (idempotent)
- `store/network/listeners.ts` — added `autoEnableL1Networks` listener on `onAppUnlocked`: queries Glacier in parallel for each non-default L1, dispatches `enableChainIds` for those with balance

**Design decisions:**
- Runs on every unlock so newly-funded L1s are always detected; idempotent so no duplicates
- `Promise.allSettled` means a single Glacier failure doesn't block other networks
- Non-blocking — runs async after unlock, no impact on portfolio/Fusion load time

## Screenshots/Videos

_Not applicable — background detection, no UI changes._

## Testing

**Dev Testing**

1. Fund a wallet on an L1 not in your enabled networks list
2. Lock and unlock the app
3. Verify the L1 appears in portfolio and Fusion's FROM selector
4. Verify L1s with zero balance are not added
5. Verify re-unlock doesn't duplicate the network

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [x] I have updated the documentation

[CP-13898]: https://ava-labs.atlassian.net/browse/CP-13898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ