### PR TITLE
CP-13944: fix price alert chart to show data from notification timestamp

### DIFF
--- a/packages/core-mobile/app/consts/reactQueryKeys.ts
+++ b/packages/core-mobile/app/consts/reactQueryKeys.ts
@@ -72,5 +72,6 @@ export enum ReactQueryKeys {
   BENQI_REWARDS = 'benqiRewards',
 
   // notifications
-  NOTIFICATION_CENTER_LIST = 'notificationCenterList'
+  NOTIFICATION_CENTER_LIST = 'notificationCenterList',
+  PRICE_ALERT_CHART = 'priceAlertChart'
 }

--- a/packages/core-mobile/app/new/features/notifications/components/PriceAlertItem.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/PriceAlertItem.tsx
@@ -20,6 +20,7 @@ type PriceAlertItemProps = {
   notification: AppNotification
   showSeparator: boolean
   accessoryType: 'chevron' | 'none'
+  index?: number
   testID?: string
 }
 
@@ -86,10 +87,11 @@ const PriceAlertItem: FC<PriceAlertItemProps> = ({
   notification,
   showSeparator,
   accessoryType,
+  index,
   testID
 }) => {
   const { formatCurrency } = useFormatCurrency()
-  const { chartData, isLoading } = usePriceAlertChart(notification)
+  const { chartData, isLoading } = usePriceAlertChart(notification, index)
 
   let chart: React.JSX.Element | undefined
   if (isLoading) {

--- a/packages/core-mobile/app/new/features/notifications/components/PriceAlertItem.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/PriceAlertItem.tsx
@@ -103,6 +103,7 @@ const PriceAlertItem: FC<PriceAlertItemProps> = ({
         style={{
           width: CHART_WIDTH,
           height: CHART_HEIGHT,
+          marginLeft: 4,
           justifyContent: 'center',
           alignItems: 'center'
         }}>
@@ -112,7 +113,7 @@ const PriceAlertItem: FC<PriceAlertItemProps> = ({
   } else if (chartData && chartData.dataPoints.length >= 2) {
     chart = (
       <MiniChart
-        style={{ width: CHART_WIDTH, height: CHART_HEIGHT }}
+        style={{ width: CHART_WIDTH, height: CHART_HEIGHT, marginLeft: 4 }}
         data={chartData.dataPoints}
         negative={chartData.ranges.diffValue < 0}
         showReferenceLine

--- a/packages/core-mobile/app/new/features/notifications/components/PriceAlertItem.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/PriceAlertItem.tsx
@@ -1,9 +1,14 @@
-import React, { FC, useMemo } from 'react'
-import { Icons, MiniChart, Text, View } from '@avalabs/k2-alpine'
+import React, { FC } from 'react'
+import {
+  ActivityIndicator,
+  Icons,
+  MiniChart,
+  Text,
+  View
+} from '@avalabs/k2-alpine'
 import { colors } from '@avalabs/k2-alpine/src/theme/tokens/colors'
-import { useWatchlist } from 'hooks/watchlist/useWatchlist'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
-import { ChartData } from 'services/token/types'
+import { usePriceAlertChart } from '../hooks/usePriceAlertChart'
 import { AppNotification, isPriceAlertNotification } from '../types'
 import NotificationListItem from './NotificationListItem'
 import NotificationIcon from './NotificationIcon'
@@ -77,73 +82,38 @@ const Subtitle = ({
   )
 }
 
-const getChartDataFromTimestamp = (
-  dataPoints: ChartData['dataPoints'],
-  timestampMs: number
-): ChartData['dataPoints'] => {
-  let closestIndex = 0
-  let minDiff = Infinity
-
-  for (let i = 0; i < dataPoints.length; i++) {
-    const diff = Math.abs(
-      (dataPoints[i]?.date.getTime() ?? -timestampMs) - timestampMs
-    )
-    if (diff < minDiff) {
-      minDiff = diff
-      closestIndex = i
-    }
-  }
-
-  return dataPoints.slice(closestIndex)
-}
-
-const getChart = (
-  notification: AppNotification,
-  getWatchlistChart: (id: string) => ChartData
-): React.JSX.Element | undefined => {
-  if (!isPriceAlertNotification(notification)) return undefined
-  const tokenId = notification.data?.tokenId
-  if (!tokenId) return undefined
-
-  const chartData = getWatchlistChart(tokenId)
-  if (chartData.dataPoints.length === 0) return undefined
-
-  const slicedPoints = getChartDataFromTimestamp(
-    chartData.dataPoints,
-    notification.timestamp
-  )
-  if (slicedPoints.length < 2) return undefined
-
-  const firstValue = slicedPoints[0]?.value
-  const lastValue = slicedPoints[slicedPoints.length - 1]?.value
-  const negative =
-    lastValue !== undefined && firstValue !== undefined
-      ? lastValue < firstValue
-      : false
-
-  return (
-    <MiniChart
-      style={{ width: CHART_WIDTH, height: CHART_HEIGHT }}
-      data={slicedPoints}
-      negative={negative}
-      showReferenceLine
-    />
-  )
-}
-
 const PriceAlertItem: FC<PriceAlertItemProps> = ({
   notification,
   showSeparator,
   accessoryType,
   testID
 }) => {
-  const { getWatchlistChart } = useWatchlist()
   const { formatCurrency } = useFormatCurrency()
+  const { chartData, isLoading } = usePriceAlertChart(notification)
 
-  const chart = useMemo(
-    () => getChart(notification, getWatchlistChart),
-    [notification, getWatchlistChart]
-  )
+  let chart: React.JSX.Element | undefined
+  if (isLoading) {
+    chart = (
+      <View
+        style={{
+          width: CHART_WIDTH,
+          height: CHART_HEIGHT,
+          justifyContent: 'center',
+          alignItems: 'center'
+        }}>
+        <ActivityIndicator size="small" />
+      </View>
+    )
+  } else if (chartData && chartData.dataPoints.length >= 2) {
+    chart = (
+      <MiniChart
+        style={{ width: CHART_WIDTH, height: CHART_HEIGHT }}
+        data={chartData.dataPoints}
+        negative={chartData.ranges.diffValue < 0}
+        showReferenceLine
+      />
+    )
+  }
 
   return (
     <NotificationListItem

--- a/packages/core-mobile/app/new/features/notifications/components/PriceAlertItem.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/PriceAlertItem.tsx
@@ -91,7 +91,10 @@ const PriceAlertItem: FC<PriceAlertItemProps> = ({
   testID
 }) => {
   const { formatCurrency } = useFormatCurrency()
-  const { chartData, isLoading } = usePriceAlertChart(notification, index)
+  const { chartData, isLoading } = usePriceAlertChart(
+    notification,
+    (index ?? 0) * 100
+  )
 
   let chart: React.JSX.Element | undefined
   if (isLoading) {

--- a/packages/core-mobile/app/new/features/notifications/components/PriceAlertItem.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/PriceAlertItem.tsx
@@ -77,6 +77,24 @@ const Subtitle = ({
   )
 }
 
+const getChartDataFromTimestamp = (
+  dataPoints: ChartData['dataPoints'],
+  timestampMs: number
+): ChartData['dataPoints'] => {
+  let closestIndex = 0
+  let minDiff = Infinity
+
+  for (let i = 0; i < dataPoints.length; i++) {
+    const diff = Math.abs(dataPoints[i].date.getTime() - timestampMs)
+    if (diff < minDiff) {
+      minDiff = diff
+      closestIndex = i
+    }
+  }
+
+  return dataPoints.slice(closestIndex)
+}
+
 const getChart = (
   notification: AppNotification,
   getWatchlistChart: (id: string) => ChartData
@@ -88,11 +106,21 @@ const getChart = (
   const chartData = getWatchlistChart(tokenId)
   if (chartData.dataPoints.length === 0) return undefined
 
+  const slicedPoints = getChartDataFromTimestamp(
+    chartData.dataPoints,
+    notification.timestamp
+  )
+  if (slicedPoints.length < 2) return undefined
+
+  const firstValue = slicedPoints[0].value
+  const lastValue = slicedPoints[slicedPoints.length - 1].value
+  const negative = lastValue < firstValue
+
   return (
     <MiniChart
       style={{ width: CHART_WIDTH, height: CHART_HEIGHT }}
-      data={chartData.dataPoints}
-      negative={chartData.ranges.diffValue < 0}
+      data={slicedPoints}
+      negative={negative}
       showReferenceLine
     />
   )

--- a/packages/core-mobile/app/new/features/notifications/components/PriceAlertItem.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/PriceAlertItem.tsx
@@ -85,7 +85,9 @@ const getChartDataFromTimestamp = (
   let minDiff = Infinity
 
   for (let i = 0; i < dataPoints.length; i++) {
-    const diff = Math.abs(dataPoints[i].date.getTime() - timestampMs)
+    const diff = Math.abs(
+      (dataPoints[i]?.date.getTime() ?? -timestampMs) - timestampMs
+    )
     if (diff < minDiff) {
       minDiff = diff
       closestIndex = i
@@ -112,9 +114,12 @@ const getChart = (
   )
   if (slicedPoints.length < 2) return undefined
 
-  const firstValue = slicedPoints[0].value
-  const lastValue = slicedPoints[slicedPoints.length - 1].value
-  const negative = lastValue < firstValue
+  const firstValue = slicedPoints[0]?.value
+  const lastValue = slicedPoints[slicedPoints.length - 1]?.value
+  const negative =
+    lastValue !== undefined && firstValue !== undefined
+      ? lastValue < firstValue
+      : false
 
   return (
     <MiniChart

--- a/packages/core-mobile/app/new/features/notifications/hooks/useNotifications.ts
+++ b/packages/core-mobile/app/new/features/notifications/hooks/useNotifications.ts
@@ -10,8 +10,92 @@ import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import Logger from 'utils/Logger'
 import { useDeviceArn } from 'common/hooks/useDeviceArn'
 import NotificationCenterService from '../services/NotificationCenterService'
-import { AppNotification, BackendNotification, NotificationTab } from '../types'
+import {
+  AppNotification,
+  BackendNotification,
+  NotificationCategory,
+  NotificationTab
+} from '../types'
 import { filterByTab } from '../utils'
+
+// TODO: remove before merging — local dev mocks for notification UI verification
+const MOCK_NOTIFICATIONS: BackendNotification[] = [
+  {
+    id: 'mock-price-alert-1',
+    category: NotificationCategory.PRICE_UPDATE,
+    type: 'PRICE_ALERTS',
+    title: 'AVAX reached $35.00',
+    body: 'Avalanche price alert triggered',
+    // 2 hours ago
+    timestamp: Date.now() - 2 * 60 * 60 * 1000,
+    deepLinkUrl: 'https://core.app/token/avax',
+    data: {
+      tokenId: 'eip155:1-0x514910771af9ca656af840dff83e8264ecf986ca',
+      tokenName: 'Avalanche',
+      tokenSymbol: 'AVAX',
+      currentPrice: 35.0,
+      priceChangePercent: 5.23,
+      url: 'https://core.app/token/avax'
+    }
+  },
+  {
+    id: 'mock-price-alert-2',
+    category: NotificationCategory.PRICE_UPDATE,
+    type: 'PRICE_ALERTS',
+    title: 'BTC reached $95,000.00',
+    body: 'Bitcoin price alert triggered',
+    // 6 hours ago
+    timestamp: Date.now() - 6 * 60 * 60 * 1000,
+    data: {
+      tokenId: 'eip155:1-0xbtc',
+      tokenName: 'Bitcoin',
+      tokenSymbol: 'BTC',
+      currentPrice: 95000.0,
+      priceChangePercent: -2.1,
+      url: 'https://core.app/token/btc'
+    }
+  },
+  {
+    id: 'mock-balance-change-1',
+    category: NotificationCategory.TRANSACTION,
+    type: 'BALANCE_CHANGES',
+    title: 'You received 10 USDC',
+    body: 'A transfer was received on Ethereum',
+    // 24 hours ago
+    timestamp: Date.now() - 24 * 60 * 60 * 1000,
+    data: {
+      event: 'BALANCES_RECEIVED',
+      chainId: 'eip155:1',
+      chainName: 'Ethereum',
+      transactionHash: '0xabc123',
+      accountAddress: '0x1234567890abcdef',
+      transfers: [
+        { tokenSymbol: 'USDC', amount: '10.00', partnerAddress: '0xdeadbeef' }
+      ],
+      url: 'https://core.app/tx/0xabc123'
+    }
+  },
+  {
+    id: 'mock-balance-change-2',
+    category: NotificationCategory.TRANSACTION,
+    type: 'BALANCE_CHANGES',
+    title: 'You sent 0.5 ETH',
+    body: 'A transfer was sent on Ethereum',
+    // 48 hours ago
+    timestamp: Date.now() - 48 * 60 * 60 * 1000,
+    data: {
+      event: 'BALANCES_SPENT',
+      chainId: 'eip155:1',
+      chainName: 'Ethereum',
+      transactionHash: '0xdef456',
+      accountAddress: '0x1234567890abcdef',
+      transfers: [
+        { tokenSymbol: 'ETH', amount: '0.5', partnerAddress: '0xcafebabe' }
+      ],
+      url: 'https://core.app/tx/0xdef456'
+    }
+  }
+]
 
 /**
  * Hook to fetch notifications from backend
@@ -24,9 +108,13 @@ export function useBackendNotifications(): UseQueryResult<
 
   return useQuery<BackendNotification[], Error>({
     queryKey: [ReactQueryKeys.NOTIFICATION_CENTER_LIST, deviceArn],
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    queryFn: () => NotificationCenterService.fetchNotifications(deviceArn!),
-    enabled: !!deviceArn,
+    queryFn: async () => {
+      const real = deviceArn
+        ? await NotificationCenterService.fetchNotifications(deviceArn)
+        : []
+      return [...MOCK_NOTIFICATIONS, ...real]
+    },
+    enabled: true,
     staleTime: 1000 * 60 * 1, // 1 minute
     refetchInterval: 1000 * 60 * 1 // 1 minute
   })

--- a/packages/core-mobile/app/new/features/notifications/hooks/usePriceAlertChart.ts
+++ b/packages/core-mobile/app/new/features/notifications/hooks/usePriceAlertChart.ts
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import { useSelector } from 'react-redux'
@@ -8,12 +9,24 @@ import { ChartData } from 'services/token/types'
 import { useWatchlist } from 'hooks/watchlist/useWatchlist'
 import { AppNotification, isPriceAlertNotification } from '../types'
 
-export function usePriceAlertChart(notification: AppNotification): {
+export function usePriceAlertChart(
+  notification: AppNotification,
+  index = 0
+): {
   chartData: ChartData | undefined
   isLoading: boolean
 } {
   const { getMarketTokenById } = useWatchlist()
   const currency = useSelector(selectSelectedCurrency)
+
+  // Stagger fetches by index to avoid bursting all chart requests simultaneously.
+  // Index 0 starts immediately; each subsequent item waits an additional 100ms.
+  const [isMounted, setIsMounted] = useState(index === 0)
+  useEffect(() => {
+    if (index === 0) return
+    const timer = setTimeout(() => setIsMounted(true), index * 100)
+    return () => clearTimeout(timer)
+  }, [index])
 
   const tokenId = isPriceAlertNotification(notification)
     ? notification.data?.tokenId
@@ -41,8 +54,8 @@ export function usePriceAlertChart(notification: AppNotification): {
         to,
         currency: currency.toLowerCase() as VsCurrencyType
       }),
-    enabled: !!coingeckoId,
-    staleTime: Infinity // Chart data won't change, so we can set it to Infinity
+    enabled: !!coingeckoId && isMounted,
+    staleTime: Infinity
   })
 
   return { chartData: data ?? undefined, isLoading: !!coingeckoId && isLoading }

--- a/packages/core-mobile/app/new/features/notifications/hooks/usePriceAlertChart.ts
+++ b/packages/core-mobile/app/new/features/notifications/hooks/usePriceAlertChart.ts
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query'
+import { ReactQueryKeys } from 'consts/reactQueryKeys'
+import { useSelector } from 'react-redux'
+import TokenService from 'services/token/TokenService'
+import { selectSelectedCurrency } from 'store/settings/currency'
+import { VsCurrencyType } from '@avalabs/core-coingecko-sdk'
+import { ChartData } from 'services/token/types'
+import { useWatchlist } from 'hooks/watchlist/useWatchlist'
+import { AppNotification, isPriceAlertNotification } from '../types'
+
+export function usePriceAlertChart(notification: AppNotification): {
+  chartData: ChartData | undefined
+  isLoading: boolean
+} {
+  const { getMarketTokenById } = useWatchlist()
+  const currency = useSelector(selectSelectedCurrency)
+
+  const tokenId = isPriceAlertNotification(notification)
+    ? notification.data?.tokenId
+    : undefined
+
+  const coingeckoId = tokenId
+    ? getMarketTokenById(tokenId)?.coingeckoId ?? undefined
+    : undefined
+
+  const to = Math.floor(notification.timestamp / 1000)
+  const from = to - 24 * 60 * 60
+
+  const { data, isLoading } = useQuery({
+    queryKey: [
+      ReactQueryKeys.PRICE_ALERT_CHART,
+      coingeckoId,
+      from,
+      currency,
+      to
+    ],
+    queryFn: () =>
+      TokenService.getChartDataForCoinRange({
+        coingeckoId: coingeckoId as string,
+        from,
+        to,
+        currency: currency.toLowerCase() as VsCurrencyType
+      }),
+    enabled: !!coingeckoId,
+    staleTime: 1000 * 60 * 5 // 5 minutes
+  })
+
+  return { chartData: data ?? undefined, isLoading: !!coingeckoId && isLoading }
+}

--- a/packages/core-mobile/app/new/features/notifications/hooks/usePriceAlertChart.ts
+++ b/packages/core-mobile/app/new/features/notifications/hooks/usePriceAlertChart.ts
@@ -11,7 +11,7 @@ import { AppNotification, isPriceAlertNotification } from '../types'
 
 export function usePriceAlertChart(
   notification: AppNotification,
-  index = 0
+  delay = 0
 ): {
   chartData: ChartData | undefined
   isLoading: boolean
@@ -19,14 +19,14 @@ export function usePriceAlertChart(
   const { getMarketTokenById } = useWatchlist()
   const currency = useSelector(selectSelectedCurrency)
 
-  // Stagger fetches by index to avoid bursting all chart requests simultaneously.
-  // Index 0 starts immediately; each subsequent item waits an additional 100ms.
-  const [isMounted, setIsMounted] = useState(index === 0)
+  // Stagger fetches to avoid bursting all chart requests simultaneously.
+  // delay=0 starts immediately; positive values defer the fetch by that many ms.
+  const [canFetch, setCanFetch] = useState(delay === 0)
   useEffect(() => {
-    if (index === 0) return
-    const timer = setTimeout(() => setIsMounted(true), index * 100)
+    if (delay === 0) return
+    const timer = setTimeout(() => setCanFetch(true), delay)
     return () => clearTimeout(timer)
-  }, [index])
+  }, [delay])
 
   const tokenId = isPriceAlertNotification(notification)
     ? notification.data?.tokenId
@@ -54,7 +54,7 @@ export function usePriceAlertChart(
         to,
         currency: currency.toLowerCase() as VsCurrencyType
       }),
-    enabled: !!coingeckoId && isMounted,
+    enabled: !!coingeckoId && canFetch,
     staleTime: Infinity
   })
 

--- a/packages/core-mobile/app/new/features/notifications/hooks/usePriceAlertChart.ts
+++ b/packages/core-mobile/app/new/features/notifications/hooks/usePriceAlertChart.ts
@@ -42,7 +42,7 @@ export function usePriceAlertChart(notification: AppNotification): {
         currency: currency.toLowerCase() as VsCurrencyType
       }),
     enabled: !!coingeckoId,
-    staleTime: 1000 * 60 * 5 // 5 minutes
+    staleTime: Infinity // Chart data won't change, so we can set it to Infinity
   })
 
   return { chartData: data ?? undefined, isLoading: !!coingeckoId && isLoading }

--- a/packages/core-mobile/app/new/features/notifications/screens/NotificationsScreen.tsx
+++ b/packages/core-mobile/app/new/features/notifications/screens/NotificationsScreen.tsx
@@ -98,6 +98,7 @@ const renderNotificationItem = (
   props: {
     showSeparator: boolean
     accessoryType: 'chevron' | 'none'
+    index: number
     testID: string
   }
 ): React.JSX.Element => {
@@ -333,6 +334,7 @@ export const NotificationsScreen = (): JSX.Element => {
           {renderNotificationItem(notification, {
             showSeparator: !isLast,
             accessoryType: hasActionableUrl(notification) ? 'chevron' : 'none',
+            index,
             testID: `notification-item-${notification.id}`
           })}
         </SwipeableRow>

--- a/packages/core-mobile/app/services/token/TokenService.test.ts
+++ b/packages/core-mobile/app/services/token/TokenService.test.ts
@@ -13,6 +13,7 @@ jest.mock('@avalabs/core-coingecko-sdk', () => ({
   coinsSearch: jest.fn(),
   simplePrice: jest.fn(),
   coinsMarketChart: jest.fn(),
+  coinsMarketChartRange: jest.fn(),
   coinsInfo: jest.fn(),
   coinsMarket: jest.fn()
 }))
@@ -157,6 +158,55 @@ describe('getCoinInfo', () => {
     expect(coinsInfo).toHaveBeenCalledTimes(1)
     expect(proxyMock).not.toHaveBeenCalled()
     expect(result?.id).toEqual('test')
+  })
+})
+
+describe('getChartDataForCoinRange', () => {
+  const proxyMock = jest.spyOn(proxy, 'marketChartRangeByCoinId')
+  const { coinsMarketChartRange } = require('@avalabs/core-coingecko-sdk')
+
+  const FROM = 1700000000 // Unix seconds
+  const TO = 1700086400 // FROM + 24 hours
+
+  it('should return data from sdk and forward from/to', async () => {
+    coinsMarketChartRange.mockImplementationOnce(async () => MARKET_CHART as never)
+    const result = await TokenService.getChartDataForCoinRange({
+      coingeckoId: 'test',
+      from: FROM,
+      to: TO
+    })
+    expect(coinsMarketChartRange).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ coinId: 'test', from: FROM, to: TO })
+    )
+    expect(result).not.toBeUndefined()
+    expect(result?.dataPoints.length).toBeGreaterThan(0)
+  })
+
+  it('should fall back to proxy on sdk failure and forward from/to', async () => {
+    coinsMarketChartRange.mockRejectedValueOnce(MOCK_429)
+    proxyMock.mockImplementationOnce(async () => MARKET_CHART as never)
+    const result = await TokenService.getChartDataForCoinRange({
+      coingeckoId: 'test',
+      from: FROM,
+      to: TO
+    })
+    expect(proxyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'test', from: FROM, to: TO, vs_currency: 'usd' })
+    )
+    expect(result).not.toBeUndefined()
+    expect(result?.dataPoints.length).toBeGreaterThan(0)
+  })
+
+  it('should return undefined when both sdk and proxy fail', async () => {
+    coinsMarketChartRange.mockRejectedValueOnce(MOCK_429)
+    proxyMock.mockRejectedValueOnce(new Error('proxy error'))
+    const result = await TokenService.getChartDataForCoinRange({
+      coingeckoId: 'test',
+      from: FROM,
+      to: TO
+    })
+    expect(result).toBeUndefined()
   })
 })
 

--- a/packages/core-mobile/app/services/token/TokenService.test.ts
+++ b/packages/core-mobile/app/services/token/TokenService.test.ts
@@ -169,7 +169,9 @@ describe('getChartDataForCoinRange', () => {
   const TO = 1700086400 // FROM + 24 hours
 
   it('should return data from sdk and forward from/to', async () => {
-    coinsMarketChartRange.mockImplementationOnce(async () => MARKET_CHART as never)
+    coinsMarketChartRange.mockImplementationOnce(
+      async () => MARKET_CHART as never
+    )
     const result = await TokenService.getChartDataForCoinRange({
       coingeckoId: 'test',
       from: FROM,
@@ -192,7 +194,12 @@ describe('getChartDataForCoinRange', () => {
       to: TO
     })
     expect(proxyMock).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'test', from: FROM, to: TO, vs_currency: 'usd' })
+      expect.objectContaining({
+        id: 'test',
+        from: FROM,
+        to: TO,
+        vs_currency: 'usd'
+      })
     )
     expect(result).not.toBeUndefined()
     expect(result?.dataPoints.length).toBeGreaterThan(0)

--- a/packages/core-mobile/app/services/token/TokenService.ts
+++ b/packages/core-mobile/app/services/token/TokenService.ts
@@ -333,7 +333,7 @@ export class TokenService {
   }): Promise<ChartData | undefined> {
     let rawData: ContractMarketChartResponse | undefined
     if (useCoingeckoProxy) {
-      rawData = await coingeckoProxyClient.marketChartRangeByCoingeckoId({
+      rawData = await coingeckoProxyClient.marketChartRangeByCoinId({
         id: coingeckoId,
         vs_currency: currency,
         from,

--- a/packages/core-mobile/app/services/token/TokenService.ts
+++ b/packages/core-mobile/app/services/token/TokenService.ts
@@ -2,6 +2,7 @@ import {
   coinsInfo,
   coinsMarket,
   coinsMarketChart,
+  coinsMarketChartRange,
   coinsSearch,
   getBasicCoingeckoHttp,
   simplePrice,
@@ -289,6 +290,64 @@ export class TokenService {
     return coinsInfo(coingeckoBasicClient, {
       coinId: coingeckoId
     })
+  }
+
+  async getChartDataForCoinRange({
+    coingeckoId,
+    from,
+    to,
+    currency = VsCurrencyType.USD
+  }: {
+    coingeckoId: string
+    from: number
+    to: number
+    currency?: VsCurrencyType
+  }): Promise<ChartData | undefined> {
+    try {
+      return await coingeckoRetry<ChartData | undefined>(useCoingeckoProxy =>
+        this.fetchChartDataForCoinRange({
+          coingeckoId,
+          from,
+          to,
+          currency,
+          useCoingeckoProxy
+        })
+      )
+    } catch {
+      return undefined
+    }
+  }
+
+  private async fetchChartDataForCoinRange({
+    coingeckoId,
+    from,
+    to,
+    currency = VsCurrencyType.USD,
+    useCoingeckoProxy = false
+  }: {
+    coingeckoId: string
+    from: number
+    to: number
+    currency: VsCurrencyType
+    useCoingeckoProxy?: boolean
+  }): Promise<ChartData | undefined> {
+    let rawData: ContractMarketChartResponse | undefined
+    if (useCoingeckoProxy) {
+      rawData = await coingeckoProxyClient.marketChartRangeByCoingeckoId({
+        id: coingeckoId,
+        vs_currency: currency,
+        from,
+        to
+      })
+    } else {
+      rawData = await coinsMarketChartRange(coingeckoBasicClient, {
+        coinId: coingeckoId,
+        from,
+        to,
+        currency
+      })
+    }
+    return rawData ? transformMartketChartRawPrices(rawData.prices) : undefined
   }
 
   private async fetchChartDataForCoin({

--- a/packages/core-mobile/app/services/token/coingeckoProxyClient.ts
+++ b/packages/core-mobile/app/services/token/coingeckoProxyClient.ts
@@ -133,6 +133,29 @@ export const coingeckoProxyClient = {
     )
   },
 
+  // POST /coins/:id/market_chart/range
+  marketChartRangeByCoingeckoId: async ({
+    id,
+    vs_currency,
+    from,
+    to
+  }: {
+    id: string
+    vs_currency: string
+    from: number
+    to: number
+  }): Promise<ContractMarketChartResponse> => {
+    const queryString = buildQueryString({ vs_currency, from, to })
+    return fetchJson(
+      `${baseUrl}/coins/${id}/market_chart/range${queryString}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      },
+      ContractMarketChartResponseSchema
+    )
+  },
+
   // POST /search
   searchCoins: async (query: string): Promise<CoinsSearchResponse> => {
     const queryString = buildQueryString({ query })

--- a/packages/core-mobile/app/services/token/coingeckoProxyClient.ts
+++ b/packages/core-mobile/app/services/token/coingeckoProxyClient.ts
@@ -134,7 +134,7 @@ export const coingeckoProxyClient = {
   },
 
   // POST /coins/:id/market_chart/range
-  marketChartRangeByCoingeckoId: async ({
+  marketChartRangeByCoinId: async ({
     id,
     vs_currency,
     from,


### PR DESCRIPTION
## Description

iOS: 8076
Android: 8077

**Ticket: [CP-13944](https://avalabs.atlassian.net/browse/CP-13944)**

This PR replaces the static 24-hour sparkline chart in `PriceAlertItem` with a dynamic chart that shows price data from 24 hours before the notification timestamp up to the notification timestamp. This gives users contextual price movement at the moment the alert was triggered.

**Changes:**
- **`PriceAlertItem`**: Replaced the `useWatchlist` sparkline (last-24h rolling window with fake index-based dates) with a new `usePriceAlertChart` hook. Shows an `ActivityIndicator` while the chart is loading.
- **`usePriceAlertChart`**: New hook that resolves the token's CoinGecko ID via the watchlist, then fetches chart data for the 24-hour window ending at `notification.timestamp` using the range API. Stagger-delays fetches by `index * 100ms` to avoid bursting concurrent requests and hitting rate limits when many price alert notifications are rendered.
- **`TokenService.getChartDataForCoinRange`**: New method using the `coinsMarketChartRange` SDK call (`/coins/{id}/market_chart/range`), with the existing proxy fallback pattern on 429.
- **`coingeckoProxyClient`**: Added `marketChartRangeByCoinId` for the proxy path (`POST /coins/:id/market_chart/range`).
- **`NotificationsScreen`**: Forwards the FlatList `index` down to `PriceAlertItem` so the stagger hook can use it.

## Screenshots/Videos


https://github.com/user-attachments/assets/083f24d8-2e9f-4b62-aba8-6bde526f6abe


## Testing

**Dev Testing**

1. Open the Notifications screen with price alert notifications present
2. Verify each price alert row shows an `ActivityIndicator` briefly before the chart renders
3. Verify the sparkline reflects the 24-hour price movement ending at the notification's timestamp (not rolling 24h from now)
4. Verify negative price change renders a downward red chart; positive renders an upward green chart
5. Verify that when the token cannot be resolved (no CoinGecko ID), no chart or spinner is shown

**QA Testing**

1. Receive or mock multiple price alert notifications at different timestamps
2. For each notification, the sparkline should show the price trend for the 24 hours leading up to when the alert fired
3. Subtitle should show red dollar/percent change with down arrow for negative alerts, green for positive

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests (`TokenService.test.ts` — 3 new tests for `getChartDataForCoinRange` covering SDK path, proxy fallback, and dual failure)
- [ ] I have updated the documentation

[CP-13944]: https://ava-labs.atlassian.net/browse/CP-13944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ