### PR TITLE
CP-13634: Switch to Tokens v2 API

### DIFF
--- a/packages/core-mobile/app/new/common/components/ListScreenV2.tsx
+++ b/packages/core-mobile/app/new/common/components/ListScreenV2.tsx
@@ -101,6 +101,8 @@ export interface ListScreenProps<T>
   renderEmpty?: () => React.ReactNode
   /** Optional function to render a fixed footer at the bottom of the screen */
   renderFooter?: () => React.ReactNode
+  /** Optional function to render a true list footer rendered after the last item (maps to FlashList's ListFooterComponent). Use this for infinite-scroll spinners instead of renderFooter. */
+  renderListFooter?: () => React.ReactNode
   /** Whether to show the sticky header */
   shouldShowStickyHeader?: boolean
   /** Optional ref to the flat list */
@@ -124,6 +126,7 @@ export const ListScreenV2 = <T,>({
   renderHeader,
   renderHeaderRight,
   renderFooter,
+  renderListFooter,
   shouldShowStickyHeader = true,
   flatListRef,
   ...props
@@ -607,6 +610,7 @@ export const ListScreenV2 = <T,>({
           internalKeyExtractor as (item: T, index: number) => string
         }
         getItemType={internalGetItemType as FlashListProps<T>['getItemType']}
+        ListFooterComponent={renderListFooter ? renderListFooter : undefined}
         style={StyleSheet.flatten([
           {
             backgroundColor: backgroundColor ?? 'transparent',

--- a/packages/core-mobile/app/new/common/hooks/useAddCustomToken.ts
+++ b/packages/core-mobile/app/new/common/hooks/useAddCustomToken.ts
@@ -81,7 +81,7 @@ const useAddCustomToken = (callback: () => void): CustomToken => {
 
   const tokens = useNetworkContractTokens(selectedNetwork)
   const activeAccount = useSelector(selectActiveAccount)
-  const tokensWithBalance = useTokensWithBalanceByNetworkForAccount(
+  const { tokens: tokensWithBalance } = useTokensWithBalanceByNetworkForAccount(
     activeAccount,
     chainId
   )

--- a/packages/core-mobile/app/new/features/bridge/hooks/useAssetBalances.ts
+++ b/packages/core-mobile/app/new/features/bridge/hooks/useAssetBalances.ts
@@ -22,7 +22,7 @@ export function useAssetBalances(sourceNetworkChainId?: number): {
 } {
   const tokenVisibility = useSelector(selectTokenVisibility)
   const activeAccount = useSelector(selectActiveAccount)
-  const tokens = useTokensWithBalanceByNetworkForAccount(
+  const { tokens } = useTokensWithBalanceByNetworkForAccount(
     activeAccount,
     sourceNetworkChainId
   )

--- a/packages/core-mobile/app/new/features/portfolio/hooks/useTokensWithBalanceByNetworkForAccount.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/useTokensWithBalanceByNetworkForAccount.ts
@@ -9,8 +9,8 @@ type Result = {
 }
 
 /**
- * Returns token balances for a specific account + network (chainId).
- * Returns [] if data not yet available or if no account or chainId is provided.
+ * Returns token balances and loading state for a specific account + network (chainId).
+ * Returns `{ tokens: [], isLoading }` if data not yet available or if no account or chainId is provided.
  */
 export function useTokensWithBalanceByNetworkForAccount(
   account?: Account,

--- a/packages/core-mobile/app/new/features/portfolio/hooks/useTokensWithBalanceByNetworkForAccount.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/useTokensWithBalanceByNetworkForAccount.ts
@@ -3,6 +3,11 @@ import { Account } from 'store/account/types'
 import { LocalTokenWithBalance } from 'store/balance/types'
 import { useAccountBalances } from './useAccountBalances'
 
+type Result = {
+  tokens: LocalTokenWithBalance[]
+  isLoading: boolean
+}
+
 /**
  * Returns token balances for a specific account + network (chainId).
  * Returns [] if data not yet available or if no account or chainId is provided.
@@ -10,12 +15,12 @@ import { useAccountBalances } from './useAccountBalances'
 export function useTokensWithBalanceByNetworkForAccount(
   account?: Account,
   chainId?: number
-): LocalTokenWithBalance[] {
-  const { data } = useAccountBalances(account)
+): Result {
+  const { data, isLoading } = useAccountBalances(account)
 
   // TODO: fix type mismatch after fully migrating to the new backend balance types
   // @ts-ignore
-  return useMemo(() => {
+  const tokens = useMemo(() => {
     if (!account || !chainId) return []
 
     // Find cached balance entry for this chain
@@ -26,4 +31,6 @@ export function useTokensWithBalanceByNetworkForAccount(
     // Return tokens for that network, or [] if not found
     return balanceForNetwork?.tokens ?? []
   }, [account, chainId, data])
+
+  return { tokens, isLoading }
 }

--- a/packages/core-mobile/app/new/features/portfolio/hooks/useTokensWithBalanceByNetworkForAccount.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/useTokensWithBalanceByNetworkForAccount.ts
@@ -18,8 +18,6 @@ export function useTokensWithBalanceByNetworkForAccount(
 ): Result {
   const { data, isLoading } = useAccountBalances(account)
 
-  // TODO: fix type mismatch after fully migrating to the new backend balance types
-  // @ts-ignore
   const tokens = useMemo(() => {
     if (!account || !chainId) return []
 
@@ -32,5 +30,7 @@ export function useTokensWithBalanceByNetworkForAccount(
     return balanceForNetwork?.tokens ?? []
   }, [account, chainId, data])
 
+  // TODO: fix type mismatch after fully migrating to the new backend balance types
+  // @ts-ignore
   return { tokens, isLoading }
 }

--- a/packages/core-mobile/app/new/features/send/hooks/useNativeTokenWithBalanceByNetwork.ts
+++ b/packages/core-mobile/app/new/features/send/hooks/useNativeTokenWithBalanceByNetwork.ts
@@ -9,7 +9,7 @@ export const useNativeTokenWithBalanceByNetwork = (
   network?: Network
 ): NetworkTokenWithBalance | undefined => {
   const activeAccount = useSelector(selectActiveAccount)
-  const tokens = useTokensWithBalanceByNetworkForAccount(
+  const { tokens } = useTokensWithBalanceByNetworkForAccount(
     activeAccount,
     network?.chainId
   )

--- a/packages/core-mobile/app/new/features/swap/hooks/useFilteredSwapTokens.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFilteredSwapTokens.ts
@@ -34,7 +34,7 @@ export const useFilteredSwapTokens = ({
     }
 
     // Sort by balance in currency (highest first)
-    return filteredTokens.sort(
+    return [...filteredTokens].sort(
       (a, b) => (b.balanceInCurrency ?? 0) - (a.balanceInCurrency ?? 0)
     )
   }, [tokens, hideZeroBalance, tokenVisibility, enabledChainIds])

--- a/packages/core-mobile/app/new/features/swap/hooks/useFilteredSwapTokens.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFilteredSwapTokens.ts
@@ -4,21 +4,16 @@ import { LocalTokenWithBalance } from 'store/balance'
 import { isTokenVisible } from 'store/balance/utils'
 import { selectEnabledChainIds } from 'store/network'
 import { selectTokenVisibility } from 'store/portfolio'
-import { selectIsDeveloperMode } from 'store/settings/advanced'
-import { isAddressLikeSearch } from 'common/utils/isAddressLikeSearch'
 
 export const useFilteredSwapTokens = ({
   tokens,
-  searchText,
   hideZeroBalance
 }: {
   tokens: LocalTokenWithBalance[]
-  searchText: string
   hideZeroBalance: boolean
 }): LocalTokenWithBalance[] => {
   const tokenVisibility = useSelector(selectTokenVisibility)
   const enabledChainIds = useSelector(selectEnabledChainIds)
-  const isDeveloperMode = useSelector(selectIsDeveloperMode)
 
   return useMemo(() => {
     let filteredTokens = tokens
@@ -38,29 +33,9 @@ export const useFilteredSwapTokens = ({
       filteredTokens = filteredTokens.filter(token => token.balance > 0n)
     }
 
-    // Filter by search text - only search localId when input looks like an address
-    // (avoids Solana base58 false positives e.g. "pump" matching random addresses)
-    if (searchText.trim().length > 0) {
-      const query = searchText.toLowerCase().trim()
-      const searchByAddress = isAddressLikeSearch(searchText, isDeveloperMode)
-      filteredTokens = filteredTokens.filter(
-        token =>
-          token.name.toLowerCase().includes(query) ||
-          token.symbol.toLowerCase().includes(query) ||
-          (searchByAddress && token.localId.toLowerCase().includes(query))
-      )
-    }
-
     // Sort by balance in currency (highest first)
     return filteredTokens.sort(
       (a, b) => (b.balanceInCurrency ?? 0) - (a.balanceInCurrency ?? 0)
     )
-  }, [
-    tokens,
-    searchText,
-    hideZeroBalance,
-    tokenVisibility,
-    enabledChainIds,
-    isDeveloperMode
-  ])
+  }, [tokens, hideZeroBalance, tokenVisibility, enabledChainIds])
 }

--- a/packages/core-mobile/app/new/features/swap/hooks/useSwapTokens.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useSwapTokens.ts
@@ -16,6 +16,7 @@ import { getLocalTokenIdFromApi } from '../utils/getLocalTokenIdFromApi'
 
 const STALE_TIME = 2 * 60 * 1000 // 2 minutes
 const PAGE_LIMIT = 50 // max tokens per page
+const EMPTY_SEARCH_PARAMS = {} // stable reference to avoid spurious query key changes
 
 type UseSwapTokensResult = {
   tokens: LocalTokenWithBalance[]
@@ -59,9 +60,11 @@ export const useSwapTokens = (
   )
 
   // Determine server-side search params
+  // Use a stable constant for the empty case so the query key doesn't change
+  // on every keystroke while the search term is still too short to send.
   const searchParams = useMemo(() => {
     const trimmed = searchText?.trim() ?? ''
-    if (trimmed.length < 2) return {}
+    if (trimmed.length < 2) return EMPTY_SEARCH_PARAMS
     if (isAddressLikeSearch(trimmed, isDeveloperMode)) {
       return { address: trimmed }
     }

--- a/packages/core-mobile/app/new/features/swap/hooks/useSwapTokens.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useSwapTokens.ts
@@ -1,88 +1,114 @@
 import { useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import { useSelector } from 'react-redux'
-import { getV1Tokens } from 'utils/api/generated/tokenAggregator/aggregatorApi.client'
+import { getV2Tokens } from 'utils/api/generated/tokenAggregator/aggregatorApi.client'
 import { tokenAggregatorApi } from 'utils/api/clients/aggregatedTokensApiClient'
 import { LocalTokenWithBalance } from 'store/balance'
 import { getChainIdFromCaip2, isSvmChainId } from 'utils/caip2ChainIds'
 import { selectActiveAccount } from 'store/account'
 import { useTokensWithBalanceByNetworkForAccount } from 'features/portfolio/hooks/useTokensWithBalanceByNetworkForAccount'
-import { useNetworks } from 'hooks/networks/useNetworks'
-import { TokenType } from '@avalabs/vm-module-types'
-import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import { selectIsSolanaSwapBlocked } from 'store/posthog'
+import { selectIsDeveloperMode } from 'store/settings/advanced'
+import { isAddressLikeSearch } from 'common/utils/isAddressLikeSearch'
 import { mapApiTokenToLocal } from '../utils/mapApiTokenToLocal'
 import { getLocalTokenIdFromApi } from '../utils/getLocalTokenIdFromApi'
 
-const STALE_TIME = 5 * 60 * 1000 // 5 minutes
+const STALE_TIME = 2 * 60 * 1000 // 2 minutes
+const PAGE_LIMIT = 50 // max tokens per page
 
-/**
- * Fetches and prepares tokens for Swap token selection.
- *
- * This hook:
- * 1. Fetches tokens from the token aggregator API for the specified network
- * 2. Merges API token data with user's balance data from their active account
- * 3. Manually adds native tokens (AVAX for C-Chain, SOL for Solana) since the API doesn't return them
- *
- * @param caip2Id - CAIP-2 chain identifier (e.g., "eip155:43114" for Avalanche C-Chain)
- * @returns Object containing:
- *   - tokens: Array of tokens with balance data merged
- *   - isLoading: Boolean indicating if the initial fetch is in progress
- *   - error: Error object if the fetch failed, null otherwise
- */
-export const useSwapTokens = (
-  caip2Id: string
-): {
+type UseSwapTokensResult = {
   tokens: LocalTokenWithBalance[]
   isLoading: boolean
   error: Error | null
-} => {
+  fetchNextPage: () => void
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+}
+
+/**
+ * Fetches and prepares tokens for Swap token selection using the v2 API.
+ *
+ * This hook:
+ * 1. Fetches paginated tokens from the /v2/tokens endpoint for the specified network
+ * 2. Supports server-side keyword/address search via searchText param
+ * 3. Merges API token data with user's balance data from their active account
+ * 4. Native tokens are returned directly by the API (no manual injection)
+ *
+ * @param caip2Id - CAIP-2 chain identifier (e.g., "eip155:43114" for Avalanche C-Chain)
+ * @param searchText - Optional search text; passed to API as keyword or address filter
+ */
+export const useSwapTokens = (
+  caip2Id: string,
+  searchText?: string
+): UseSwapTokensResult => {
   const isSolanaSwapBlocked = useSelector(selectIsSolanaSwapBlocked)
+  const isDeveloperMode = useSelector(selectIsDeveloperMode)
 
-  const isSolanaBlocked = useMemo(() => {
-    return isSvmChainId(caip2Id) && isSolanaSwapBlocked
-  }, [caip2Id, isSolanaSwapBlocked])
-
-  // Derive chainId from caip2Id
-  const chainId = useMemo(() => getChainIdFromCaip2(caip2Id), [caip2Id])
-  const activeAccount = useSelector(selectActiveAccount)
-  const { getNetwork } = useNetworks()
-
-  // Get current network
-  const currentNetwork = useMemo(
-    () => (chainId ? getNetwork(chainId) : undefined),
-    [chainId, getNetwork]
+  const isSolanaBlocked = useMemo(
+    () => isSvmChainId(caip2Id) && isSolanaSwapBlocked,
+    [caip2Id, isSolanaSwapBlocked]
   )
 
-  // Get balances
+  const chainId = useMemo(() => getChainIdFromCaip2(caip2Id), [caip2Id])
+  const activeAccount = useSelector(selectActiveAccount)
+
   const balances = useTokensWithBalanceByNetworkForAccount(
     activeAccount,
     chainId
   )
 
-  // Fetch tokens from API
-  const query = useQuery({
-    queryKey: [ReactQueryKeys.FUSION_TOKENS, caip2Id, isSolanaBlocked],
-    queryFn: async () => {
-      if (!caip2Id || isSolanaBlocked) return []
+  // Determine server-side search params
+  const searchParams = useMemo(() => {
+    const trimmed = searchText?.trim() ?? ''
+    if (trimmed.length < 2) return {}
+    if (isAddressLikeSearch(trimmed, isDeveloperMode)) {
+      return { address: trimmed }
+    }
+    return { keyword: trimmed }
+  }, [searchText, isDeveloperMode])
 
-      const response = await getV1Tokens({
+  const query = useInfiniteQuery({
+    queryKey: [
+      ReactQueryKeys.FUSION_TOKENS,
+      caip2Id,
+      isSolanaBlocked,
+      searchParams
+    ],
+    queryFn: async ({ pageParam }) => {
+      if (!caip2Id || isSolanaBlocked) return null
+
+      const response = await getV2Tokens({
         client: tokenAggregatorApi,
-        query: { caip2Id }
+        query: {
+          caip2Id,
+          page: pageParam as number,
+          limit: PAGE_LIMIT,
+          ...searchParams
+        }
       })
 
-      return response.data?.data || []
+      return response.data ?? null
+    },
+    initialPageParam: 1,
+    getNextPageParam: lastPage => {
+      if (!lastPage?.metadata) return undefined
+      const { currentPage, totalPages } = lastPage.metadata
+      return currentPage < totalPages ? currentPage + 1 : undefined
     },
     enabled: !!caip2Id && !isSolanaBlocked,
     staleTime: STALE_TIME
   })
 
-  // Transform and merge with balance data
   const tokens = useMemo((): LocalTokenWithBalance[] => {
-    if (!chainId || query.data === undefined) return []
+    if (!chainId || !query.data) return []
 
-    // Create balance lookup map by localId
+    // Flatten all pages into a single token array
+    const allApiTokens = query.data.pages.flatMap(
+      page => page?.data?.tokens ?? []
+    )
+
+    // Build balance lookup by localId
     const balanceMap = new Map<string, LocalTokenWithBalance>()
     balances?.forEach(balance => {
       if (balance.localId) {
@@ -90,59 +116,19 @@ export const useSwapTokens = (
       }
     })
 
-    // Create native token if network is available
-    let nativeToken: LocalTokenWithBalance | null = null
-
-    if (currentNetwork) {
-      const symbol = currentNetwork.networkToken.symbol
-      const decimals = currentNetwork.networkToken.decimals
-      const localId = `NATIVE-${symbol.toLowerCase()}`
-      const nativeBalanceData = balanceMap.get(localId.toLowerCase())
-
-      const balance = nativeBalanceData?.balance ?? 0n
-      const balanceDisplayValue = new TokenUnit(
-        balance,
-        decimals,
-        symbol
-      ).toDisplay()
-
-      nativeToken = {
-        type: TokenType.NATIVE,
-        symbol,
-        name: currentNetwork.networkToken.name,
-        description: currentNetwork.networkToken.description,
-        decimals,
-        logoUri: currentNetwork.logoUri,
-        localId,
-        internalId: localId,
-        networkChainId: chainId,
-        isDataAccurate: true,
-        balance,
-        balanceDisplayValue,
-        balanceInCurrency: nativeBalanceData?.balanceInCurrency ?? 0,
-        priceInCurrency: nativeBalanceData?.priceInCurrency ?? 0,
-        coingeckoId:
-          currentNetwork.pricingProviders?.coingecko.nativeTokenId ?? ''
-      }
-    }
-
-    // Map API tokens (if any)
-    const apiTokens =
-      query.data.length > 0
-        ? query.data.map(apiToken => {
-            const localId = getLocalTokenIdFromApi(apiToken)
-            const balanceData = balanceMap.get(localId.toLowerCase())
-            return mapApiTokenToLocal(apiToken, chainId, balanceData)
-          })
-        : []
-
-    // Add native token
-    return nativeToken ? [nativeToken, ...apiTokens] : apiTokens
-  }, [query.data, balances, chainId, currentNetwork])
+    return allApiTokens.map(apiToken => {
+      const localId = getLocalTokenIdFromApi(apiToken)
+      const balanceData = balanceMap.get(localId.toLowerCase())
+      return mapApiTokenToLocal(apiToken, chainId, balanceData)
+    })
+  }, [query.data, balances, chainId])
 
   return {
     tokens,
     isLoading: query.isLoading,
-    error: query.error
+    error: query.error,
+    fetchNextPage: query.fetchNextPage,
+    hasNextPage: query.hasNextPage ?? false,
+    isFetchingNextPage: query.isFetchingNextPage
   }
 }

--- a/packages/core-mobile/app/new/features/swap/hooks/useSwapTokens.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useSwapTokens.ts
@@ -20,8 +20,8 @@ const PAGE_LIMIT = 50 // max tokens per page
 type UseSwapTokensResult = {
   tokens: LocalTokenWithBalance[]
   isLoading: boolean
-  error: Error | null
-  fetchNextPage: () => void
+  error: unknown | null
+  fetchNextPage: () => Promise<unknown>
   hasNextPage: boolean
   isFetchingNextPage: boolean
 }
@@ -53,7 +53,7 @@ export const useSwapTokens = (
   const chainId = useMemo(() => getChainIdFromCaip2(caip2Id), [caip2Id])
   const activeAccount = useSelector(selectActiveAccount)
 
-  const balances = useTokensWithBalanceByNetworkForAccount(
+  const { tokens: balances } = useTokensWithBalanceByNetworkForAccount(
     activeAccount,
     chainId
   )

--- a/packages/core-mobile/app/new/features/swap/screens/SelectFromSwapTokenScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SelectFromSwapTokenScreen.tsx
@@ -22,6 +22,8 @@ import { ListRenderItem } from '@shopify/flash-list'
 import { LocalTokenWithBalance } from 'store/balance'
 import { useSelector } from 'react-redux'
 import { selectActiveAccount } from 'store/account'
+import { selectIsDeveloperMode } from 'store/settings/advanced'
+import { isAddressLikeSearch } from 'common/utils/isAddressLikeSearch'
 import { useFilteredSwapTokens } from '../hooks/useFilteredSwapTokens'
 
 /**
@@ -56,6 +58,7 @@ export const SelectFromSwapTokenScreen = ({
   )
 
   const activeAccount = useSelector(selectActiveAccount)
+  const isDeveloperMode = useSelector(selectIsDeveloperMode)
 
   useEffect(() => {
     if (!networks || networks.length === 0) return
@@ -67,10 +70,11 @@ export const SelectFromSwapTokenScreen = ({
     }
   }, [defaultNetworkChainId, networks])
 
-  const portfolioTokens = useTokensWithBalanceByNetworkForAccount(
-    activeAccount,
-    selectedNetwork?.chainId
-  )
+  const { tokens: portfolioTokens, isLoading: isBalanceLoading } =
+    useTokensWithBalanceByNetworkForAccount(
+      activeAccount,
+      selectedNetwork?.chainId
+    )
 
   // Apply visibility/chain/zero-balance filtering
   const filteredTokens = useFilteredSwapTokens({
@@ -82,13 +86,14 @@ export const SelectFromSwapTokenScreen = ({
   const searchedResults = useMemo(() => {
     const q = searchText.trim().toLowerCase()
     if (q.length === 0) return filteredTokens
-    return filteredTokens.filter(
-      token =>
-        token.name.toLowerCase().includes(q) ||
-        token.symbol.toLowerCase().includes(q) ||
-        token.localId.toLowerCase().includes(q)
+    const addressLike = isAddressLikeSearch(searchText.trim(), isDeveloperMode)
+    return filteredTokens.filter(token =>
+      addressLike
+        ? token.localId.toLowerCase().includes(q)
+        : token.name.toLowerCase().includes(q) ||
+          token.symbol.toLowerCase().includes(q)
     )
-  }, [filteredTokens, searchText])
+  }, [filteredTokens, searchText, isDeveloperMode])
 
   const results = useMemo(
     () =>
@@ -202,11 +207,11 @@ export const SelectFromSwapTokenScreen = ({
   )
 
   const renderEmpty = useCallback(() => {
-    if (!networks || !selectedNetwork) {
+    if (!networks || !selectedNetwork || isBalanceLoading) {
       return <ActivityIndicator />
     }
     return <ErrorState icon={undefined} title="No tokens found" />
-  }, [networks, selectedNetwork])
+  }, [networks, selectedNetwork, isBalanceLoading])
 
   return (
     <ListScreenV2

--- a/packages/core-mobile/app/new/features/swap/screens/SelectFromSwapTokenScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SelectFromSwapTokenScreen.tsx
@@ -1,0 +1,224 @@
+import React, { useMemo, useState, useCallback, useEffect } from 'react'
+import { ScrollView } from 'react-native'
+import { ChainId, Network } from '@avalabs/core-chains-sdk'
+import {
+  ActivityIndicator,
+  Button,
+  Icons,
+  SCREEN_WIDTH,
+  SearchBar,
+  Separator,
+  Text,
+  TouchableOpacity,
+  useTheme,
+  View
+} from '@avalabs/k2-alpine'
+import { ErrorState } from 'common/components/ErrorState'
+import { ListScreenV2 } from 'common/components/ListScreenV2'
+import { useRouter } from 'expo-router'
+import { LogoWithNetwork } from 'features/portfolio/assets/components/LogoWithNetwork'
+import { useTokensWithBalanceByNetworkForAccount } from 'features/portfolio/hooks/useTokensWithBalanceByNetworkForAccount'
+import { ListRenderItem } from '@shopify/flash-list'
+import { LocalTokenWithBalance } from 'store/balance'
+import { useSelector } from 'react-redux'
+import { selectActiveAccount } from 'store/account'
+import { useFilteredSwapTokens } from '../hooks/useFilteredSwapTokens'
+
+/**
+ * Token selection screen for the "from" side of a swap.
+ *
+ * Uses the user's portfolio directly — no API call, client-side search.
+ * Only shows tokens the user actually owns (non-zero balance).
+ */
+export const SelectFromSwapTokenScreen = ({
+  selectedToken,
+  setSelectedToken,
+  defaultNetworkChainId,
+  networks,
+  tokenFilter
+}: {
+  selectedToken: LocalTokenWithBalance | undefined
+  setSelectedToken: (token: LocalTokenWithBalance) => void
+  defaultNetworkChainId?: number
+  networks: Network[] | undefined
+  tokenFilter?: (
+    token: LocalTokenWithBalance,
+    selectedNetwork: Network | undefined
+  ) => boolean
+}): JSX.Element => {
+  const {
+    theme: { colors }
+  } = useTheme()
+  const { back, canGoBack } = useRouter()
+  const [searchText, setSearchText] = useState<string>('')
+  const [selectedNetwork, setSelectedNetwork] = useState<Network | undefined>(
+    undefined
+  )
+
+  const activeAccount = useSelector(selectActiveAccount)
+
+  useEffect(() => {
+    if (!networks || networks.length === 0) return
+    if (defaultNetworkChainId) {
+      const found = networks.find(n => n.chainId === defaultNetworkChainId)
+      setSelectedNetwork(found ?? networks[0])
+    } else {
+      setSelectedNetwork(networks[0])
+    }
+  }, [defaultNetworkChainId, networks])
+
+  const portfolioTokens = useTokensWithBalanceByNetworkForAccount(
+    activeAccount,
+    selectedNetwork?.chainId
+  )
+
+  // Apply visibility/chain/zero-balance filtering
+  const filteredTokens = useFilteredSwapTokens({
+    tokens: portfolioTokens,
+    hideZeroBalance: true
+  })
+
+  // Client-side text search against portfolio (small set, no API needed)
+  const searchedResults = useMemo(() => {
+    const q = searchText.trim().toLowerCase()
+    if (q.length === 0) return filteredTokens
+    return filteredTokens.filter(
+      token =>
+        token.name.toLowerCase().includes(q) ||
+        token.symbol.toLowerCase().includes(q) ||
+        token.localId.toLowerCase().includes(q)
+    )
+  }, [filteredTokens, searchText])
+
+  const results = useMemo(
+    () =>
+      tokenFilter
+        ? searchedResults.filter(t => tokenFilter(t, selectedNetwork))
+        : searchedResults,
+    [searchedResults, tokenFilter, selectedNetwork]
+  )
+
+  const handleSelectToken = useCallback(
+    (token: LocalTokenWithBalance) => {
+      setSelectedToken(token)
+      canGoBack() && back()
+    },
+    [setSelectedToken, canGoBack, back]
+  )
+
+  const renderNetworkSelector = useCallback(() => {
+    if (!networks || networks.length <= 1) return null
+
+    return (
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ gap: 8 }}>
+        {networks.map(network => (
+          <Button
+            key={network.chainId}
+            testID={`network_selector__${network.chainName}`}
+            size="small"
+            type={
+              network.chainId === selectedNetwork?.chainId
+                ? 'primary'
+                : 'secondary'
+            }
+            onPress={() => setSelectedNetwork(network)}
+            style={{ flexShrink: 0 }}>
+            {network.chainId === ChainId.AVALANCHE_MAINNET_ID
+              ? 'Avalanche (C-Chain)'
+              : network.chainName}
+          </Button>
+        ))}
+      </ScrollView>
+    )
+  }, [networks, selectedNetwork])
+
+  const renderItem: ListRenderItem<LocalTokenWithBalance> = useCallback(
+    ({ item, index }) => {
+      const isSelected =
+        selectedToken?.localId === item.localId &&
+        selectedToken.networkChainId === item.networkChainId
+      const isLastItem = index === results.length - 1
+
+      return (
+        <TouchableOpacity
+          onPress={() => handleSelectToken(item)}
+          sx={{ marginTop: 10, paddingLeft: 16 }}>
+          <View
+            sx={{
+              width: '100%',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              paddingRight: 16
+            }}>
+            <View sx={{ flexDirection: 'row', gap: 10 }}>
+              <LogoWithNetwork
+                token={item}
+                outerBorderColor={colors.$surfaceSecondary}
+              />
+              <View>
+                <Text
+                  testID={`token_selector__${item.symbol}`}
+                  variant="buttonMedium"
+                  numberOfLines={1}
+                  sx={{ width: SCREEN_WIDTH * 0.65 }}>
+                  {item.name}
+                </Text>
+                <Text variant="subtitle2">
+                  {item.balanceDisplayValue} {item.symbol}
+                </Text>
+              </View>
+            </View>
+            {isSelected && (
+              <Icons.Custom.CheckSmall color={colors.$textPrimary} />
+            )}
+          </View>
+          {!isLastItem && (
+            <Separator
+              sx={{
+                marginTop: 10,
+                marginLeft: 46,
+                width: '100%'
+              }}
+            />
+          )}
+        </TouchableOpacity>
+      )
+    },
+    [selectedToken, results.length, handleSelectToken, colors]
+  )
+
+  const renderHeader = useCallback(
+    () => (
+      <View sx={{ gap: 12 }}>
+        <SearchBar onTextChanged={setSearchText} searchText={searchText} />
+        {renderNetworkSelector()}
+      </View>
+    ),
+    [searchText, renderNetworkSelector]
+  )
+
+  const renderEmpty = useCallback(() => {
+    if (!networks || !selectedNetwork) {
+      return <ActivityIndicator />
+    }
+    return <ErrorState icon={undefined} title="No tokens found" />
+  }, [networks, selectedNetwork])
+
+  return (
+    <ListScreenV2
+      title="Select a token"
+      data={results}
+      isModal
+      renderItem={renderItem}
+      keyExtractor={(item: LocalTokenWithBalance) =>
+        `token-${item.localId}-${item.networkChainId}`
+      }
+      renderHeader={renderHeader}
+      renderEmpty={renderEmpty}
+    />
+  )
+}

--- a/packages/core-mobile/app/new/features/swap/screens/SelectSwapTokenScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SelectSwapTokenScreen.tsx
@@ -20,6 +20,7 @@ import { LogoWithNetwork } from 'features/portfolio/assets/components/LogoWithNe
 import { ListRenderItem } from '@shopify/flash-list'
 import { LocalTokenWithBalance } from 'store/balance'
 import { getCaip2ChainId } from 'utils/caip2ChainIds'
+import { useDebounce } from 'hooks/useDebounce'
 import { useFilteredSwapTokens } from '../hooks/useFilteredSwapTokens'
 import { useSwapTokens } from '../hooks/useSwapTokens'
 
@@ -46,6 +47,7 @@ export const SelectSwapTokenScreen = ({
   } = useTheme()
   const { back, canGoBack } = useRouter()
   const [searchText, setSearchText] = useState<string>('')
+  const { debounced: debouncedSearchText } = useDebounce(searchText, 300)
 
   // Selected network state (default to first network or provided default)
   const [selectedNetwork, setSelectedNetwork] = useState<Network | undefined>(
@@ -73,12 +75,12 @@ export const SelectSwapTokenScreen = ({
   }, [selectedNetwork])
 
   // Lazy load tokens for selected network (with balance data merged)
-  const { tokens, isLoading } = useSwapTokens(caip2Id)
+  const { tokens, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useSwapTokens(caip2Id, debouncedSearchText)
 
   // Filter and sort tokens
   const baseResults = useFilteredSwapTokens({
     tokens,
-    searchText,
     hideZeroBalance
   })
   const results = useMemo(
@@ -97,6 +99,19 @@ export const SelectSwapTokenScreen = ({
     },
     [setSelectedToken, canGoBack, back]
   )
+
+  // Handle end reached for infinite scroll pagination
+  const handleEndReached = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage()
+    }
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage])
+
+  // Render footer spinner while fetching next page
+  const renderListFooter = useCallback(() => {
+    if (!isFetchingNextPage) return null
+    return <ActivityIndicator sx={{ paddingVertical: 16 }} />
+  }, [isFetchingNextPage])
 
   // Render network tabs
   const renderNetworkSelector = useCallback(() => {
@@ -218,6 +233,9 @@ export const SelectSwapTokenScreen = ({
       }
       renderHeader={renderHeader}
       renderEmpty={renderEmpty}
+      onEndReached={handleEndReached}
+      onEndReachedThreshold={0.5}
+      renderFooter={renderListFooter}
     />
   )
 }

--- a/packages/core-mobile/app/new/features/swap/screens/SelectToSwapTokenScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SelectToSwapTokenScreen.tsx
@@ -24,7 +24,7 @@ import { useDebounce } from 'hooks/useDebounce'
 import { useFilteredSwapTokens } from '../hooks/useFilteredSwapTokens'
 import { useSwapTokens } from '../hooks/useSwapTokens'
 
-export const SelectSwapTokenScreen = ({
+export const SelectToSwapTokenScreen = ({
   selectedToken,
   setSelectedToken,
   defaultNetworkChainId,

--- a/packages/core-mobile/app/new/features/swap/screens/SelectToSwapTokenScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SelectToSwapTokenScreen.tsx
@@ -235,7 +235,7 @@ export const SelectToSwapTokenScreen = ({
       renderEmpty={renderEmpty}
       onEndReached={handleEndReached}
       onEndReachedThreshold={0.5}
-      renderFooter={renderListFooter}
+      renderListFooter={renderListFooter}
     />
   )
 }

--- a/packages/core-mobile/app/new/features/swap/types.ts
+++ b/packages/core-mobile/app/new/features/swap/types.ts
@@ -1,8 +1,9 @@
-import { TokensResponse } from 'utils/api/generated/tokenAggregator/aggregatorApi.client'
+import { NetworkTokensByCaip2Response } from 'utils/api/generated/tokenAggregator/aggregatorApi.client'
 import type { Transfer } from '@avalabs/fusion-sdk'
 
-// Token Aggregator API types
-export type ApiToken = TokensResponse['data'][number]
+// Token Aggregator API types — now using v2 token shape
+// v2 tokens include: internalId, address, name, symbol, isNative, logoUri, decimals, top250Rank, networkCaip2Id
+export type ApiToken = NetworkTokensByCaip2Response['tokens'][number]
 
 // Fusion transfer storage types
 export type FusionTransfer = {

--- a/packages/core-mobile/app/new/features/swap/utils/buildLocalToken.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/buildLocalToken.ts
@@ -71,7 +71,9 @@ export const buildLocalToken = ({
       }),
       isNative,
       internalId: balanceData?.internalId ?? tokenInfo.internalId,
-      logoUri: balanceData?.logoUri ?? tokenInfo.meta?.logoUri ?? null
+      logoUri: balanceData?.logoUri ?? tokenInfo.meta?.logoUri ?? null,
+      networkCaip2Id: caip2Id,
+      top250Rank: null
     },
     chainId,
     balanceData

--- a/packages/core-mobile/app/new/features/swap/utils/getLocalTokenIdFromApi.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/getLocalTokenIdFromApi.test.ts
@@ -11,7 +11,9 @@ describe('getLocalTokenIdFromApi', () => {
         decimals: 18,
         isNative: true,
         internalId: 'avax-native',
-        logoUri: 'https://example.com/avax.png'
+        logoUri: 'https://example.com/avax.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe('NATIVE-AVAX')
@@ -25,7 +27,9 @@ describe('getLocalTokenIdFromApi', () => {
         decimals: 9,
         isNative: true,
         internalId: 'sol-native',
-        logoUri: 'https://example.com/sol.png'
+        logoUri: 'https://example.com/sol.png',
+        networkCaip2Id: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        top250Rank: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe('NATIVE-SOL')
@@ -39,7 +43,9 @@ describe('getLocalTokenIdFromApi', () => {
         decimals: 8,
         isNative: true,
         internalId: 'btc-native',
-        logoUri: 'https://example.com/btc.png'
+        logoUri: 'https://example.com/btc.png',
+        networkCaip2Id: 'bip122:000000000019d6689c085ae165831e93',
+        top250Rank: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe('NATIVE-BTC')
@@ -53,7 +59,9 @@ describe('getLocalTokenIdFromApi', () => {
         decimals: 18,
         isNative: true,
         internalId: 'eth-native',
-        logoUri: 'https://example.com/eth.png'
+        logoUri: 'https://example.com/eth.png',
+        networkCaip2Id: 'eip155:1',
+        top250Rank: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe('NATIVE-ETH')
@@ -69,7 +77,9 @@ describe('getLocalTokenIdFromApi', () => {
         decimals: 6,
         isNative: false,
         internalId: 'usdc-avax-c',
-        logoUri: 'https://example.com/usdc.png'
+        logoUri: 'https://example.com/usdc.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe(
@@ -85,7 +95,9 @@ describe('getLocalTokenIdFromApi', () => {
         decimals: 6,
         isNative: false,
         internalId: 'usdc-solana',
-        logoUri: 'https://example.com/usdc.png'
+        logoUri: 'https://example.com/usdc.png',
+        networkCaip2Id: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        top250Rank: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe(
@@ -101,7 +113,9 @@ describe('getLocalTokenIdFromApi', () => {
         decimals: 18,
         isNative: false,
         internalId: 'dai-ethereum',
-        logoUri: 'https://example.com/dai.png'
+        logoUri: 'https://example.com/dai.png',
+        networkCaip2Id: 'eip155:1',
+        top250Rank: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe(
@@ -117,7 +131,9 @@ describe('getLocalTokenIdFromApi', () => {
         decimals: 18,
         isNative: false,
         internalId: 'weth-ethereum',
-        logoUri: 'https://example.com/weth.png'
+        logoUri: 'https://example.com/weth.png',
+        networkCaip2Id: 'eip155:1',
+        top250Rank: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe(
@@ -133,7 +149,9 @@ describe('getLocalTokenIdFromApi', () => {
         decimals: 6,
         isNative: false,
         internalId: 'usdt-ethereum',
-        logoUri: 'https://example.com/usdt.png'
+        logoUri: 'https://example.com/usdt.png',
+        networkCaip2Id: 'eip155:1',
+        top250Rank: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe(
@@ -151,7 +169,9 @@ describe('getLocalTokenIdFromApi', () => {
         decimals: 18,
         isNative: false,
         internalId: 'token-1',
-        logoUri: 'https://example.com/token.png'
+        logoUri: 'https://example.com/token.png',
+        networkCaip2Id: 'eip155:1',
+        top250Rank: null
       }
 
       const token2: ApiToken = {
@@ -161,7 +181,9 @@ describe('getLocalTokenIdFromApi', () => {
         decimals: 18,
         isNative: false,
         internalId: 'token-2',
-        logoUri: 'https://example.com/token.png'
+        logoUri: 'https://example.com/token.png',
+        networkCaip2Id: 'eip155:1',
+        top250Rank: null
       }
 
       // Both should return the same localId (lowercase)
@@ -182,7 +204,9 @@ describe('getLocalTokenIdFromApi', () => {
         decimals: 18,
         isNative: true,
         internalId: 'avax',
-        logoUri: 'https://example.com/avax.png'
+        logoUri: 'https://example.com/avax.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe('NATIVE-AVAX')
@@ -196,7 +220,9 @@ describe('getLocalTokenIdFromApi', () => {
         decimals: 18,
         isNative: true,
         internalId: 'avax-bridged',
-        logoUri: 'https://example.com/avax.png'
+        logoUri: 'https://example.com/avax.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe('NATIVE-AVAX.e')
@@ -210,7 +236,9 @@ describe('getLocalTokenIdFromApi', () => {
         decimals: 8,
         isNative: true,
         internalId: 'btc2',
-        logoUri: 'https://example.com/btc.png'
+        logoUri: 'https://example.com/btc.png',
+        networkCaip2Id: 'bip122:000000000019d6689c085ae165831e93',
+        top250Rank: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe('NATIVE-BTC2.0')
@@ -225,7 +253,9 @@ describe('getLocalTokenIdFromApi', () => {
         decimals: 18,
         isNative: false,
         internalId: 'long-token',
-        logoUri: 'https://example.com/long.png'
+        logoUri: 'https://example.com/long.png',
+        networkCaip2Id: 'eip155:1',
+        top250Rank: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe(longAddress.toLowerCase())

--- a/packages/core-mobile/app/new/features/swap/utils/mapApiTokenToLocal.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/mapApiTokenToLocal.test.ts
@@ -15,7 +15,9 @@ describe('mapApiTokenToLocal', () => {
         decimals: 18,
         isNative: true,
         internalId: 'avax-native',
-        logoUri: 'https://example.com/avax.png'
+        logoUri: 'https://example.com/avax.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -40,7 +42,9 @@ describe('mapApiTokenToLocal', () => {
         decimals: 9,
         isNative: true,
         internalId: 'sol-native',
-        logoUri: 'https://example.com/sol.png'
+        logoUri: 'https://example.com/sol.png',
+        networkCaip2Id: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        top250Rank: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.SOLANA_MAINNET_ID)
@@ -63,7 +67,9 @@ describe('mapApiTokenToLocal', () => {
         decimals: 6,
         isNative: false,
         internalId: 'usdc-avax-c',
-        logoUri: 'https://example.com/usdc.png'
+        logoUri: 'https://example.com/usdc.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -89,7 +95,9 @@ describe('mapApiTokenToLocal', () => {
         decimals: 18,
         isNative: false,
         internalId: 'dai-ethereum',
-        logoUri: 'https://example.com/dai.png'
+        logoUri: 'https://example.com/dai.png',
+        networkCaip2Id: 'eip155:1',
+        top250Rank: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.ETHEREUM_HOMESTEAD)
@@ -110,7 +118,9 @@ describe('mapApiTokenToLocal', () => {
         decimals: 6,
         isNative: false,
         internalId: 'usdc-solana',
-        logoUri: 'https://example.com/usdc.png'
+        logoUri: 'https://example.com/usdc.png',
+        networkCaip2Id: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        top250Rank: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.SOLANA_MAINNET_ID)
@@ -135,7 +145,9 @@ describe('mapApiTokenToLocal', () => {
         decimals: 18,
         isNative: true,
         internalId: 'avax-native',
-        logoUri: 'https://example.com/avax.png'
+        logoUri: 'https://example.com/avax.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       const balanceData: Partial<LocalTokenWithBalance> = {
@@ -167,7 +179,9 @@ describe('mapApiTokenToLocal', () => {
         decimals: 6,
         isNative: false,
         internalId: 'usdc-avax-c',
-        logoUri: 'https://example.com/usdc.png'
+        logoUri: 'https://example.com/usdc.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       const balanceData: Partial<LocalTokenWithBalance> = {
@@ -198,7 +212,9 @@ describe('mapApiTokenToLocal', () => {
         decimals: 18,
         isNative: true,
         internalId: 'avax-native',
-        logoUri: 'https://example.com/avax.png'
+        logoUri: 'https://example.com/avax.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -258,7 +274,9 @@ describe('mapApiTokenToLocal', () => {
         decimals: 18,
         isNative: true,
         internalId: 'avax-native',
-        logoUri: 'https://example.com/avax.png'
+        logoUri: 'https://example.com/avax.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -279,7 +297,9 @@ describe('mapApiTokenToLocal', () => {
         decimals: 18,
         isNative: true,
         internalId: 'avax-native',
-        logoUri: 'https://example.com/avax.png'
+        logoUri: 'https://example.com/avax.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -298,7 +318,9 @@ describe('mapApiTokenToLocal', () => {
         decimals: 18,
         isNative: true,
         internalId: 'avax-native',
-        logoUri: 'https://example.com/avax.png'
+        logoUri: 'https://example.com/avax.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -317,7 +339,9 @@ describe('mapApiTokenToLocal', () => {
         decimals: 6,
         isNative: false,
         internalId: 'usdc-avax-c-chain',
-        logoUri: 'https://example.com/usdc.png'
+        logoUri: 'https://example.com/usdc.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -336,7 +360,9 @@ describe('mapApiTokenToLocal', () => {
         decimals: 18,
         isNative: true,
         internalId: 'avax-native',
-        logoUri: 'https://example.com/avax.png'
+        logoUri: 'https://example.com/avax.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -357,7 +383,9 @@ describe('mapApiTokenToLocal', () => {
         decimals: 18,
         isNative: true,
         internalId: 'test-token',
-        logoUri: 'https://example.com/test.png'
+        logoUri: 'https://example.com/test.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       const balanceData: Partial<LocalTokenWithBalance> = {
@@ -385,7 +413,9 @@ describe('mapApiTokenToLocal', () => {
         decimals: 18,
         isNative: true,
         internalId: 'avax-native',
-        logoUri: 'https://example.com/avax.png'
+        logoUri: 'https://example.com/avax.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null
       }
 
       const balanceData: Partial<LocalTokenWithBalance> = {

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/selectSwapFromToken/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/selectSwapFromToken/index.tsx
@@ -4,7 +4,7 @@ import type { Network } from '@avalabs/core-chains-sdk'
 import type { LocalTokenWithBalance } from 'store/balance'
 import { isBitcoinChainId } from 'utils/network/isBitcoinNetwork'
 import { isAvalancheCChainId } from 'services/network/utils/isAvalancheNetwork'
-import { SelectSwapTokenScreen } from 'features/swap/screens/SelectSwapTokenScreen'
+import { SelectFromSwapTokenScreen } from 'features/swap/screens/SelectFromSwapTokenScreen'
 import {
   useSwapSelectedFromToken,
   useSwapSelectedToToken
@@ -37,10 +37,9 @@ const SelectSwapFromTokenScreen = (): JSX.Element => {
   )
 
   return (
-    <SelectSwapTokenScreen
+    <SelectFromSwapTokenScreen
       selectedToken={selectedFromToken}
       setSelectedToken={setSelectedFromToken}
-      hideZeroBalance={true}
       // Pre-select network to match "to" token's network
       defaultNetworkChainId={
         networkChainId ? parseInt(networkChainId, 10) : undefined

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/selectSwapToToken/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/selectSwapToToken/index.tsx
@@ -3,7 +3,7 @@ import { useLocalSearchParams } from 'expo-router'
 import type { Network } from '@avalabs/core-chains-sdk'
 import type { LocalTokenWithBalance } from 'store/balance'
 import { isBitcoinChainId } from 'utils/network/isBitcoinNetwork'
-import { SelectSwapTokenScreen } from 'features/swap/screens/SelectSwapTokenScreen'
+import { SelectToSwapTokenScreen } from 'features/swap/screens/SelectToSwapTokenScreen'
 import {
   useSwapSelectedFromToken,
   useSwapSelectedToToken
@@ -52,7 +52,7 @@ const SelectSwapToTokenScreen = (): JSX.Element => {
   )
 
   return (
-    <SelectSwapTokenScreen
+    <SelectToSwapTokenScreen
       selectedToken={selectedToToken}
       setSelectedToken={setSelectedToToken}
       // Pre-select network to match "from" token's network


### PR DESCRIPTION
## Description

**Ticket: [CP-13634]**
 - Migrated swap token list from `/v1/tokens` to `/v2/tokens` (Token Aggregator)                                           
  - Added infinite scroll pagination via `useInfiniteQuery`                                                                 
  - Moved token search server-side (name/symbol via `keyword`, contract address via `address` param)
  - Added 300ms debounce on search input to avoid firing on every keystroke                                                 
  - Removed manual native token injection (v2 API includes native tokens)
  - Extracted `SelectFromSwapTokenScreen` — "From" token selection now uses portfolio data directly (no API call,           
  client-side search), since users can only swap tokens they own                                                            
  - Renamed `SelectSwapTokenScreen` → `SelectToSwapTokenScreen` for clarity                                                 
                 
## Screenshots/Videos
https://github.com/user-attachments/assets/3eaab36b-4deb-4f75-a4db-78c4ad253ba2

## Testing
**iOS: 0.0.0.8083
Android: 0.0.0.8084**

#### From token selection                                                                                                 
  1. Open Swap, tap **"From"** token selector                          
  2. Verify only tokens with non-zero balance appear
  3. Search by name (e.g. `USDC`) — list filters client-side with no loading spinner                                        
  4. Search by symbol (e.g. `eth`) — matches correctly
  5. Search by contract address (e.g. paste a known ERC-20 address) — token appears                                                  
                                                                                                                            
  #### To token selection                                                                                                   
  1. Open Swap, tap **"To"** token selector                                                                                 
  2. Verify full paginated token list loads                                                 
  3. Scroll to bottom — next page loads automatically (infinite scroll)                                                     
  4. Search by name/symbol — results update after ~300ms debounce (no instant firing)                                       
  5. Search by contract address — routes to address-based API query, returns correct token
  6. Switching networks resets and reloads the token list                                                                   
                                                                                                                                 
  #### Regression                                                      
  1. Select a "From" and "To" token and confirm a quote loads                                                               
  2. Swap flow completes end-to-end (quote → approve → submit) 

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-13634]: https://ava-labs.atlassian.net/browse/CP-13634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ