### PR TITLE
CP-13949: Use Ledger device BLE name as default wallet name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ packages/*/coverage/
 /AvaxWallet.iml
 /.idea/
 /packages/core-mobile/boosts/
+
+# Migration
+/docs/local/

--- a/packages/core-mobile/app/new/features/ledger/components/LedgerAppConnection.tsx
+++ b/packages/core-mobile/app/new/features/ledger/components/LedgerAppConnection.tsx
@@ -60,7 +60,7 @@ export const LedgerAppConnection: React.FC<LedgerAppConnectionProps> = ({
   } = useTheme()
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const isSolanaSupportBlocked = useSelector(selectIsSolanaSupportBlocked)
-  const deviceName = connectedDeviceName || 'Ledger Device'
+  const deviceName = connectedDeviceName || 'Ledger'
   const keysByNetwork = isDeveloperMode ? keys?.testnet : keys?.mainnet
 
   const hasAllKeys = useMemo(() => {

--- a/packages/core-mobile/app/new/features/ledger/components/LedgerDeviceList.tsx
+++ b/packages/core-mobile/app/new/features/ledger/components/LedgerDeviceList.tsx
@@ -45,7 +45,7 @@ export const LedgerDeviceList: React.FC<LedgerDeviceListProps> = ({
   const deviceListData: GroupListItem[] = useMemo(
     () =>
       devices.map((device: LedgerDevice) => ({
-        title: device.name || 'Ledger Device',
+        title: device.name || 'Ledger',
         subtitle: (
           <Text
             variant="caption"

--- a/packages/core-mobile/app/new/features/ledger/contexts/LedgerSetupContext.tsx
+++ b/packages/core-mobile/app/new/features/ledger/contexts/LedgerSetupContext.tsx
@@ -43,7 +43,7 @@ export const LedgerSetupProvider: React.FC<LedgerSetupProviderProps> = ({
     null
   )
   const [connectedDeviceName, setConnectedDeviceName] =
-    useState<string>('Ledger Device')
+    useState<string>('Ledger')
   const [isUpdatingWallet, setIsUpdatingWallet] = useState<boolean>(false)
   const [isConnecting, setIsConnecting] = useState<boolean>(false)
 
@@ -58,7 +58,7 @@ export const LedgerSetupProvider: React.FC<LedgerSetupProviderProps> = ({
   const resetSetup = useCallback(() => {
     setSelectedDerivationPath(null)
     setConnectedDeviceId(null)
-    setConnectedDeviceName('Ledger Device')
+    setConnectedDeviceName('Ledger')
     setIsUpdatingWallet(false)
     setIsConnecting(false)
   }, [])
@@ -68,7 +68,7 @@ export const LedgerSetupProvider: React.FC<LedgerSetupProviderProps> = ({
       setIsConnecting(true)
       try {
         await LedgerService.ensureConnection(deviceId)
-        handleSetConnectedDevice(deviceId, deviceName || 'Ledger Device')
+        handleSetConnectedDevice(deviceId, deviceName || 'Ledger')
       } finally {
         setIsConnecting(false)
       }

--- a/packages/core-mobile/app/new/features/ledger/hooks/useLedgerWallet.ts
+++ b/packages/core-mobile/app/new/features/ledger/hooks/useLedgerWallet.ts
@@ -70,7 +70,7 @@ export function useLedgerWallet(): UseLedgerWalletReturn {
   const createLedgerWallet = useCallback(
     async ({
       deviceId,
-      deviceName = 'Ledger Device',
+      deviceName = 'Ledger',
       derivationPathType = LedgerDerivationPathType.BIP44,
       avalancheKeys,
       solanaKeys = [],
@@ -104,7 +104,7 @@ export function useLedgerWallet(): UseLedgerWalletReturn {
         await dispatch(
           storeWallet({
             walletId: newWalletId,
-            name: `Ledger ${deviceName}`,
+            name: deviceName,
             walletSecret: buildLedgerWalletSecret({
               type: WalletSecretOperation.NEW,
               deviceId,
@@ -132,7 +132,7 @@ export function useLedgerWallet(): UseLedgerWalletReturn {
 
         setLedgerWalletMap(
           newWalletId,
-          { id: deviceId, name: deviceName || 'Ledger Device' },
+          { id: deviceId, name: deviceName || 'Ledger' },
           derivationPathType
         )
 
@@ -236,7 +236,7 @@ export function useLedgerWallet(): UseLedgerWalletReturn {
             walletSecret: buildLedgerWalletSecret({
               type: WalletSecretOperation.UPDATE,
               deviceId,
-              deviceName: deviceName || 'Ledger Device',
+              deviceName: deviceName || 'Ledger',
               derivationPathType,
               existingWalletSecret: parsedWalletSecret as unknown as Record<
                 string,
@@ -252,7 +252,7 @@ export function useLedgerWallet(): UseLedgerWalletReturn {
 
         setLedgerWalletMap(
           walletId,
-          { id: deviceId, name: deviceName || 'Ledger Device' },
+          { id: deviceId, name: deviceName || 'Ledger' },
           derivationPathType
         )
 
@@ -292,7 +292,7 @@ export function useLedgerWallet(): UseLedgerWalletReturn {
   const createLedgerWalletWithDiscovery = useCallback(
     async ({
       deviceId,
-      deviceName = 'Ledger Device',
+      deviceName = 'Ledger',
       derivationPathType = LedgerDerivationPathType.BIP44,
       multiIndexKeys,
       activeIndices
@@ -330,7 +330,7 @@ export function useLedgerWallet(): UseLedgerWalletReturn {
         await dispatch(
           storeWallet({
             walletId: newWalletId,
-            name: `Ledger ${deviceName}`,
+            name: deviceName,
             walletSecret: buildLedgerWalletSecret({
               type: WalletSecretOperation.NEW,
               deviceId,
@@ -348,7 +348,7 @@ export function useLedgerWallet(): UseLedgerWalletReturn {
 
         setLedgerWalletMap(
           newWalletId,
-          { id: deviceId, name: deviceName || 'Ledger Device' },
+          { id: deviceId, name: deviceName || 'Ledger' },
           derivationPathType
         )
 

--- a/packages/core-mobile/app/new/features/ledger/screens/AppConnectionAddAccountScreen.tsx
+++ b/packages/core-mobile/app/new/features/ledger/screens/AppConnectionAddAccountScreen.tsx
@@ -142,7 +142,7 @@ export const AppConnectionAddAccountScreen = (): JSX.Element => {
       completeStepTitle={`Your Account\nis being set up`}
       handleComplete={handleComplete}
       deviceId={device?.id}
-      deviceName={device?.name ?? 'Ledger Device'}
+      deviceName={device?.name ?? 'Ledger'}
       handleCancel={handleCancel}
       isUpdatingWallet={isUpdatingWallet}
       accountIndex={accounts?.length ?? 0}

--- a/packages/core-mobile/app/new/features/ledger/screens/AppConnectionScreen.tsx
+++ b/packages/core-mobile/app/new/features/ledger/screens/AppConnectionScreen.tsx
@@ -42,7 +42,7 @@ export default function AppConnectionScreen({
   isUpdatingWallet,
   handleComplete,
   deviceId,
-  deviceName = 'Ledger Device',
+  deviceName = 'Ledger',
   handleCancel,
   accountIndex,
   showProgressDots = true,

--- a/packages/core-mobile/app/new/routes/onboarding/ledger/setWalletName.tsx
+++ b/packages/core-mobile/app/new/routes/onboarding/ledger/setWalletName.tsx
@@ -5,9 +5,11 @@ import { useRouter } from 'expo-router'
 import { SetWalletName as Component } from 'features/onboarding/components/SetWalletName'
 import { setWalletName } from 'store/wallet/slice'
 import { useActiveWallet } from 'common/hooks/useActiveWallet'
+import { useLedgerSetupContext } from 'new/features/ledger/contexts/LedgerSetupContext'
 
 export default function SetWalletName(): JSX.Element {
-  const [name, setName] = useState<string>('Wallet 1')
+  const { connectedDeviceName } = useLedgerSetupContext()
+  const [name, setName] = useState<string>(connectedDeviceName)
   const dispatch = useDispatch()
   const { navigate } = useRouter()
   const activeWallet = useActiveWallet()


### PR DESCRIPTION
## Description

iOS: 8089
Android: 8090

**Ticket: [CP-13949]**

Please provide:

- In the ledger onboarding flow, `setWalletName` now defaults to the connected device's BLE name (`connectedDeviceName` from `LedgerSetupContext`) instead of the hardcoded `"Ledger 1"`
- In the import ledger wallet flow (`createLedgerWallet`, `createLedgerWalletWithDiscovery`), the wallet name is now set directly from the BLE device name instead of being prefixed with `"Ledger "`

## Screenshots/Videos


https://github.com/user-attachments/assets/edce5551-11d5-4151-9d9b-0cdbd7b80bba


https://github.com/user-attachments/assets/d32acc73-4f3b-42fd-b0e7-24c3346808b5




## Testing

**Dev Testing (if applicable)**

1. Go through ledger onboarding (`Connect Ledger` → pair device → open Avalanche app)
2. On the "Set Wallet Name" screen, verify the default name matches the Ledger device's BLE name (e.g. `"Flex"` or whatever name appears in your Bluetooth settings)
3. Go through the import ledger wallet flow (`Add Wallet` → `Ledger`)
4. After completion, verify the wallet name in wallet list matches the device's BLE name
5. Devices with a user-set custom name should show that custom name; uncustomized devices

**QA Testing (if applicable)**

- Provide instructions for QA to test this feature thoroughly
- State expected behavior / acceptance criteria

## Checklist

Please check all that apply (if applicable)

- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-13949]: https://ava-labs.atlassian.net/browse/CP-13949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ