### PR TITLE
Show Ledger derivation path type in wallet card and fix Solana label in swap network selector

### DIFF
--- a/packages/core-mobile/app/new/common/components/WalletCard.tsx
+++ b/packages/core-mobile/app/new/common/components/WalletCard.tsx
@@ -24,6 +24,7 @@ import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated'
 import { WalletType } from 'services/wallet/types'
 import { selectIsWalletLedger } from 'store/wallet/slice'
 import { useSelector } from 'react-redux'
+import { LedgerDerivationPathType } from 'services/ledger/types'
 import { DropdownMenu } from './DropdownMenu'
 import { WalletIcon } from './WalletIcon'
 
@@ -233,13 +234,26 @@ const WalletCard = ({
               <Text
                 numberOfLines={1}
                 style={{
+                  marginTop: 4,
                   fontSize: 12,
                   lineHeight: 12,
                   color: colors.$textSecondary
                 }}>
-                {wallet.accounts.length > 1
-                  ? `${wallet.accounts.length} accounts`
-                  : '1 account'}
+                {(() => {
+                  const accountCountText =
+                    wallet.accounts.length > 1
+                      ? `${wallet.accounts.length} accounts`
+                      : '1 account'
+                  const derivationPathLabel =
+                    wallet.type === WalletType.LEDGER
+                      ? LedgerDerivationPathType.BIP44
+                      : wallet.type === WalletType.LEDGER_LIVE
+                      ? LedgerDerivationPathType.LedgerLive
+                      : null
+                  return derivationPathLabel
+                    ? `${derivationPathLabel} – ${accountCountText}`
+                    : accountCountText
+                })()}
               </Text>
             </View>
           </View>

--- a/packages/core-mobile/app/new/features/swap/screens/SelectFromSwapTokenScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SelectFromSwapTokenScreen.tsx
@@ -130,6 +130,8 @@ export const SelectFromSwapTokenScreen = ({
               ? 'Avalanche (C-Chain)'
               : network.chainId === ChainId.AVALANCHE_TESTNET_ID
               ? 'Avalanche (C-Chain Testnet)'
+              : network.chainId === ChainId.SOLANA_MAINNET_ID
+              ? 'Solana '
               : network.chainName}
           </Button>
         ))}

--- a/packages/core-mobile/app/new/features/swap/screens/SelectToSwapTokenScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SelectToSwapTokenScreen.tsx
@@ -212,6 +212,8 @@ export const SelectToSwapTokenScreen = ({
               ? 'Avalanche (C-Chain)'
               : network.chainId === ChainId.AVALANCHE_TESTNET_ID
               ? 'Avalanche (C-Chain Testnet)'
+              : network.chainId === ChainId.SOLANA_MAINNET_ID
+              ? 'Solana '
               : network.chainName}
           </Button>
         ))}


### PR DESCRIPTION
## Description

iOS: 8145
Android: 8146

**Ticket: [CP-]**

- In `WalletCard`, the subtitle below the wallet name now shows the derivation path type for Ledger wallets: `bip44 – N accounts` for `WalletType.LEDGER` and `ledger live – N accounts` for `WalletType.LEDGER_LIVE`. Non-Ledger wallets are unchanged.
- In `SelectFromSwapTokenScreen` and `SelectToSwapTokenScreen`, the network selector now shows an explicit `Solana` label for `ChainId.SOLANA_MAINNET_ID`, consistent with how Avalanche C-Chain is handled.

No new dependencies introduced.

## Screenshots/Videos
<img width="320" height="568" alt="IMG_1803" src="https://github.com/user-attachments/assets/646baa8a-e45f-4f35-a178-bc3a37b05a5c" />

<img width="491" height="773" alt="Screenshot 2026-04-15 at 1 52 51 PM" src="https://github.com/user-attachments/assets/02ae8295-9f66-4c1a-abf2-e15b2c063038" />


## Testing

**Dev Testing (if applicable)**

- On the My Wallets screen, connect a Ledger wallet (bip44 or ledger live) and verify the subtitle reads `bip44 – N accounts` or `ledger live – N accounts`
- On the Swap → Select Token screen with multiple supported networks (including Solana), verify the Solana tab in the network selector displays `Solana`

## Checklist

Please check all that apply (if applicable)

- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation
