### PR TITLE
CP-13938: Fusion - Hide price impact for non-MARKR routes

### DIFF
--- a/packages/core-mobile/app/new/features/swap/hooks/usePriceImpact.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/usePriceImpact.test.ts
@@ -1,0 +1,152 @@
+import { renderHook, act } from '@testing-library/react-hooks'
+import type { LocalTokenWithBalance } from 'store/balance'
+import { PriceImpactAvailability } from '../consts'
+import type { Quote } from '../types'
+import fusionService from '../services/FusionService'
+import { usePriceImpact } from './usePriceImpact'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('@avalabs/fusion-sdk', () => ({
+  ServiceType: {
+    MARKR: 'MARKR',
+    AVALANCHE_EVM: 'AVALANCHE_EVM',
+    WRAP_UNWRAP: 'WRAP_UNWRAP',
+    LOMBARD_BTC_TO_BTCB: 'LOMBARD_BTC_TO_BTCB',
+    LOMBARD_BTCB_TO_BTC: 'LOMBARD_BTCB_TO_BTC'
+  }
+}))
+
+jest.mock('../services/FusionService', () => ({
+  __esModule: true,
+  default: {
+    calculatePriceImpactFromQuote: jest.fn()
+  }
+}))
+
+const mockCalculatePriceImpactFromQuote = jest.mocked(
+  fusionService.calculatePriceImpactFromQuote
+)
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const fromToken = { priceInCurrency: 10 } as LocalTokenWithBalance
+const toToken = { priceInCurrency: 20 } as LocalTokenWithBalance
+
+const markrQuote = {
+  id: 'q-markr',
+  serviceType: 'MARKR'
+} as unknown as Quote
+
+const avalancheEvmQuote = {
+  id: 'q-evm',
+  serviceType: 'AVALANCHE_EVM'
+} as unknown as Quote
+
+const wrapUnwrapQuote = {
+  id: 'q-wrap',
+  serviceType: 'WRAP_UNWRAP'
+} as unknown as Quote
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('usePriceImpact — non-MARKR quotes', () => {
+  it.each([
+    ['AVALANCHE_EVM', avalancheEvmQuote],
+    ['WRAP_UNWRAP', wrapUnwrapQuote]
+  ])(
+    'does not call the SDK calculator for %s service type',
+    async (_, quote) => {
+      renderHook(() => usePriceImpact(quote as Quote, fromToken, toToken))
+      await act(() => Promise.resolve())
+      expect(mockCalculatePriceImpactFromQuote).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each([
+    ['AVALANCHE_EVM', avalancheEvmQuote],
+    ['WRAP_UNWRAP', wrapUnwrapQuote]
+  ])(
+    'returns hidden availability and neutral flags for %s service type',
+    async (_, quote) => {
+      const { result } = renderHook(() =>
+        usePriceImpact(quote as Quote, fromToken, toToken)
+      )
+      await act(() => Promise.resolve())
+      expect(result.current.priceImpactAvailability).toBe(
+        PriceImpactAvailability.Hidden
+      )
+      expect(result.current.isPriceImpactCalculating).toBe(false)
+      expect(result.current.isPriceImpactTooHigh).toBe(false)
+    }
+  )
+})
+
+describe('usePriceImpact — missing inputs', () => {
+  it('returns hidden availability when quote is undefined', async () => {
+    const { result } = renderHook(() =>
+      usePriceImpact(undefined, fromToken, toToken)
+    )
+    await act(() => Promise.resolve())
+    expect(result.current.priceImpactAvailability).toBe(
+      PriceImpactAvailability.Hidden
+    )
+    expect(result.current.isPriceImpactCalculating).toBe(false)
+    expect(result.current.isPriceImpactTooHigh).toBe(false)
+    expect(mockCalculatePriceImpactFromQuote).not.toHaveBeenCalled()
+  })
+})
+
+describe('usePriceImpact — MARKR quotes', () => {
+  it('calls the SDK calculator', async () => {
+    mockCalculatePriceImpactFromQuote.mockResolvedValue(200) // 2%
+    renderHook(() => usePriceImpact(markrQuote, fromToken, toToken))
+    await act(() => Promise.resolve())
+    expect(mockCalculatePriceImpactFromQuote).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns Ready availability when calculation succeeds', async () => {
+    mockCalculatePriceImpactFromQuote.mockResolvedValue(200) // 2%
+    const { result } = renderHook(() =>
+      usePriceImpact(markrQuote, fromToken, toToken)
+    )
+    await act(() => Promise.resolve())
+    expect(result.current.priceImpactAvailability).toBe(
+      PriceImpactAvailability.Ready
+    )
+    expect(result.current.isPriceImpactCalculating).toBe(false)
+    expect(result.current.isPriceImpactTooHigh).toBe(false)
+  })
+})
+
+describe('usePriceImpact — switching from MARKR to non-MARKR', () => {
+  it('immediately returns neutral flags without waiting for the effect to flush', async () => {
+    // Calculation starts but never resolves (simulates in-flight request)
+    mockCalculatePriceImpactFromQuote.mockReturnValue(
+      new Promise(() => {
+        // do nothing
+      })
+    )
+
+    let currentQuote: Quote = markrQuote
+    const { result, rerender } = renderHook(() =>
+      usePriceImpact(currentQuote, fromToken, toToken)
+    )
+
+    // Effect fires — quote is MARKR so we should be in Calculating state
+    await act(() => Promise.resolve())
+    expect(result.current.isPriceImpactCalculating).toBe(true)
+
+    // Switch to non-MARKR synchronously — isMarkrQuote is derived in the render
+    // body, so flags should be false immediately without waiting for the effect
+    currentQuote = avalancheEvmQuote
+    rerender()
+
+    expect(result.current.isPriceImpactCalculating).toBe(false)
+    expect(result.current.isPriceImpactTooHigh).toBe(false)
+  })
+})

--- a/packages/core-mobile/app/new/features/swap/hooks/usePriceImpact.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/usePriceImpact.ts
@@ -101,15 +101,18 @@ export function usePriceImpact(
   }, [fromToken, quote, sourcePrice, targetPrice, toToken])
 
   const priceImpactSeverity = getPriceImpactSeverity(priceImpact)
+  const isMarkrQuote = quote?.serviceType === ServiceType.MARKR
 
   return {
     priceImpact,
     priceImpactSeverity,
     priceImpactAvailability,
     isPriceImpactTooHigh:
+      isMarkrQuote &&
       priceImpactAvailability === PriceImpactAvailability.Ready &&
       priceImpactSeverity === PriceImpactSeverity.Critical,
     isPriceImpactCalculating:
+      isMarkrQuote &&
       priceImpactAvailability === PriceImpactAvailability.Calculating
   }
 }

--- a/packages/core-mobile/app/new/features/swap/hooks/usePriceImpact.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/usePriceImpact.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import type { LocalTokenWithBalance } from 'store/balance'
 import fusionService from '../services/FusionService'
-import type { Quote } from '../types'
+import { type Quote, ServiceType } from '../types'
 import { PriceImpactAvailability, PriceImpactSeverity } from '../consts'
 
 const HIGH_IMPACT_THRESHOLD = 5
@@ -43,6 +43,12 @@ export function usePriceImpact(
 
   useEffect(() => {
     if (!quote || !fromToken || !toToken) {
+      setPriceImpact(undefined)
+      setPriceImpactAvailability(PriceImpactAvailability.Hidden)
+      return
+    }
+
+    if (quote.serviceType !== ServiceType.MARKR) {
       setPriceImpact(undefined)
       setPriceImpactAvailability(PriceImpactAvailability.Hidden)
       return

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -632,7 +632,9 @@ export const SwapScreen = (): JSX.Element => {
       })
     }
 
-    items.push(priceImpactItem)
+    if (activeQuote.serviceType === ServiceType.MARKR) {
+      items.push(priceImpactItem)
+    }
 
     return items
   }, [

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -347,7 +347,7 @@ export const SwapScreen = (): JSX.Element => {
     }
   }, [activeQuote, debouncedFromTokenValue])
 
-  const showFeesAndSlippage = activeQuote?.serviceType === ServiceType.MARKR
+  const isMarkrRoute = activeQuote?.serviceType === ServiceType.MARKR
 
   const isLombard =
     activeQuote?.serviceType === ServiceType.LOMBARD_BTC_TO_BTCB ||
@@ -619,7 +619,7 @@ export const SwapScreen = (): JSX.Element => {
       })
     }
 
-    if (showFeesAndSlippage) {
+    if (isMarkrRoute) {
       const displayValue = getDisplaySlippageValue({
         autoSlippage,
         quoteSlippageBps: activeQuote?.slippageBps,
@@ -632,7 +632,7 @@ export const SwapScreen = (): JSX.Element => {
       })
     }
 
-    if (activeQuote.serviceType === ServiceType.MARKR) {
+    if (isMarkrRoute) {
       items.push(priceImpactItem)
     }
 
@@ -643,7 +643,7 @@ export const SwapScreen = (): JSX.Element => {
     rate,
     activeQuote,
     allQuotes,
-    showFeesAndSlippage,
+    isMarkrRoute,
     slippage,
     autoSlippage,
     isSwapping,

--- a/packages/core-mobile/app/new/features/swap/types.ts
+++ b/packages/core-mobile/app/new/features/swap/types.ts
@@ -1,4 +1,4 @@
-import { NetworkTokensByCaip2Response } from 'utils/api/generated/tokenAggregator/aggregatorApi.client'
+import type { NetworkTokensByCaip2Response } from 'utils/api/generated/tokenAggregator/aggregatorApi.client'
 import type { Transfer } from '@avalabs/fusion-sdk'
 
 // Token Aggregator API types — now using v2 token shape

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -38,7 +38,7 @@
     "@avalabs/core-utils-sdk": "3.1.0-alpha.82",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.82",
     "@avalabs/evm-module": "3.6.1",
-    "@avalabs/fusion-sdk": "0.0.0-fix-fusion-price-impact-20260415104810",
+    "@avalabs/fusion-sdk": "0.15.1",
     "@avalabs/glacier-sdk": "3.1.0-alpha.82",
     "@avalabs/k2-alpine": "workspace:*",
     "@avalabs/svm-module": "3.6.1",

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -38,7 +38,7 @@
     "@avalabs/core-utils-sdk": "3.1.0-alpha.82",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.82",
     "@avalabs/evm-module": "3.6.1",
-    "@avalabs/fusion-sdk": "0.15.0",
+    "@avalabs/fusion-sdk": "0.0.0-fix-fusion-price-impact-20260415104810",
     "@avalabs/glacier-sdk": "3.1.0-alpha.82",
     "@avalabs/k2-alpine": "workspace:*",
     "@avalabs/svm-module": "3.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -491,7 +491,7 @@ __metadata:
     "@avalabs/core-utils-sdk": 3.1.0-alpha.82
     "@avalabs/core-wallets-sdk": 3.1.0-alpha.82
     "@avalabs/evm-module": 3.6.1
-    "@avalabs/fusion-sdk": 0.15.0
+    "@avalabs/fusion-sdk": 0.0.0-fix-fusion-price-impact-20260415104810
     "@avalabs/glacier-sdk": 3.1.0-alpha.82
     "@avalabs/k2-alpine": "workspace:*"
     "@avalabs/svm-module": 3.6.1
@@ -892,9 +892,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/fusion-sdk@npm:0.15.0":
-  version: 0.15.0
-  resolution: "@avalabs/fusion-sdk@npm:0.15.0"
+"@avalabs/fusion-sdk@npm:0.0.0-fix-fusion-price-impact-20260415104810":
+  version: 0.0.0-fix-fusion-price-impact-20260415104810
+  resolution: "@avalabs/fusion-sdk@npm:0.0.0-fix-fusion-price-impact-20260415104810"
   dependencies:
     "@bitcoinerlab/secp256k1": ^1.2.0
     "@layerzerolabs/lz-v2-utilities": ^3.0.17
@@ -909,7 +909,7 @@ __metadata:
     "@solana/kit": ^5.0.0 || ^6.0.0
     viem: ^2.38.0
     zod: ^4.1.0
-  checksum: 1624076117fcbd277a6c35b7353270345fae09df8d86185f53f2552c954288e168a98da2a65220a994c561239cee9a4e8d886a6ad60ac6e432a14da60035a790
+  checksum: 8b0bc25dbf8756cd66db5ae51158ac2354a78fb691039db93b8c881264afa05a5247cf6751c94fbd54fd6a28c30b9847e8662d81da4fae02a6b335494e921833
   languageName: node
   linkType: hard
 
@@ -36979,7 +36979,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 5626fe58ec789ff8b2a62625e758ae9891078b64563e1099120c6af4ebb541cbb4de5d3bb33c1eafd31686221ccf8cb8f0d4b179e7e4eff961deaa8ac4e6da00
+  checksum: d6ceb75e1d0f5755370d6d91f67902bd2b8a23a3ca43cb853d2964b43798f30477e8ab0223ea8b620534fbdf5f56d39550f40d24bec2d2398c323ccfe8a5a556
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -491,7 +491,7 @@ __metadata:
     "@avalabs/core-utils-sdk": 3.1.0-alpha.82
     "@avalabs/core-wallets-sdk": 3.1.0-alpha.82
     "@avalabs/evm-module": 3.6.1
-    "@avalabs/fusion-sdk": 0.0.0-fix-fusion-price-impact-20260415104810
+    "@avalabs/fusion-sdk": 0.15.1
     "@avalabs/glacier-sdk": 3.1.0-alpha.82
     "@avalabs/k2-alpine": "workspace:*"
     "@avalabs/svm-module": 3.6.1
@@ -892,9 +892,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/fusion-sdk@npm:0.0.0-fix-fusion-price-impact-20260415104810":
-  version: 0.0.0-fix-fusion-price-impact-20260415104810
-  resolution: "@avalabs/fusion-sdk@npm:0.0.0-fix-fusion-price-impact-20260415104810"
+"@avalabs/fusion-sdk@npm:0.15.1":
+  version: 0.15.1
+  resolution: "@avalabs/fusion-sdk@npm:0.15.1"
   dependencies:
     "@bitcoinerlab/secp256k1": ^1.2.0
     "@layerzerolabs/lz-v2-utilities": ^3.0.17
@@ -909,7 +909,7 @@ __metadata:
     "@solana/kit": ^5.0.0 || ^6.0.0
     viem: ^2.38.0
     zod: ^4.1.0
-  checksum: 8b0bc25dbf8756cd66db5ae51158ac2354a78fb691039db93b8c881264afa05a5247cf6751c94fbd54fd6a28c30b9847e8662d81da4fae02a6b335494e921833
+  checksum: 1f7d703e04d8a923fdb2e87216bd486a8c2e3be94d848e7a4bce68f5d3ad685dbaa991f93bb065167ded09ace56818d0584445ba995e75b6dceed3cd1a54934f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: [CP-13938](https://ava-labs.atlassian.net/browse/CP-13938)**

- Hide price impact row and skip price impact calculation for non-MARKR quotes (e.g. Avalanche EVM bridge, BTC bridge, native wrap/unwrap)
- Price impact is only relevant for MARKR service type routes; showing it for other route types was misleading and incorrectly blocked swaps via the critical impact guard

## Screenshots/Videos
https://github.com/user-attachments/assets/6f625891-3297-4a3a-a47e-5abd26c74455

## Testing
**iOS: 0.0.0.8152
Android: 0.0.0.8153**
- Swap BTC <> BTC.b — price impact row should not appear, swap button should be enabled
- Swap using an Avalanche EVM bridge provider route (for example ETH (Ethereum) -> WETH (C-Chain)) — price impact row should not appear
- Perform a native wrap/unwrap (for example AVAX -> WAVAX (C-Chain) — price impact row should not appear
- Swap using a MARKR route — price impact row should still appear as before

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-13938]: https://ava-labs.atlassian.net/browse/CP-13938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ