### PR TITLE
CP-13828: Android Light mode - should not have pink header/background

### DIFF
--- a/packages/core-mobile/android/app/src/main/res/values-night/styles.xml
+++ b/packages/core-mobile/android/app/src/main/res/values-night/styles.xml
@@ -5,7 +5,6 @@
              tints from the default M3 baseline purple seed color. -->
         <item name="colorSurface">@color/neutral850</item>
         <item name="android:colorBackground">@color/neutral850</item>
-        <item name="colorBackground">@color/neutral850</item>
         <item name="colorSurfaceVariant">@color/neutral800</item>
         <item name="colorSurfaceContainerLowest">@color/neutral900</item>
         <item name="colorSurfaceContainerLow">@color/neutral850</item>

--- a/packages/core-mobile/android/app/src/main/res/values-night/styles.xml
+++ b/packages/core-mobile/android/app/src/main/res/values-night/styles.xml
@@ -1,8 +1,10 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="AppTheme" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Override Material3 surface colors in dark mode to prevent unwanted
-             tints from the default M3 baseline purple seed color. -->
+    <!-- Dark mode application theme.
+         Inherits all shared items from BaseAppTheme (defined in values/styles.xml)
+         and overrides Material3 surface colors to prevent unwanted tints from
+         the default M3 baseline purple seed color. -->
+    <style name="AppTheme" parent="BaseAppTheme">
         <item name="colorSurface">@color/neutral850</item>
         <item name="android:colorBackground">@color/neutral850</item>
         <item name="colorSurfaceVariant">@color/neutral800</item>

--- a/packages/core-mobile/android/app/src/main/res/values-night/styles.xml
+++ b/packages/core-mobile/android/app/src/main/res/values-night/styles.xml
@@ -1,0 +1,17 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <style name="AppTheme" parent="Theme.Material3.DayNight.NoActionBar">
+        <!-- Override Material3 surface colors in dark mode to prevent unwanted
+             tints from the default M3 baseline purple seed color. -->
+        <item name="colorSurface">@color/neutral850</item>
+        <item name="android:colorBackground">@color/neutral850</item>
+        <item name="colorBackground">@color/neutral850</item>
+        <item name="colorSurfaceVariant">@color/neutral800</item>
+        <item name="colorSurfaceContainerLowest">@color/neutral900</item>
+        <item name="colorSurfaceContainerLow">@color/neutral850</item>
+        <item name="colorSurfaceContainer">@color/neutral800</item>
+        <item name="colorSurfaceContainerHigh">@color/neutral800</item>
+        <item name="colorSurfaceContainerHighest">@color/neutral800</item>
+    </style>
+
+</resources>

--- a/packages/core-mobile/android/app/src/main/res/values/colors.xml
+++ b/packages/core-mobile/android/app/src/main/res/values/colors.xml
@@ -7,6 +7,7 @@
     <color name="dialogTextColor">#28282E</color>
     <color name="neutral900">#1A1A1C</color>
     <color name="neutral850">#2A2A2D</color>
+    <color name="neutral800">#3E3E43</color>
     <color name="bootsplash_background">#28282E</color>
     <color name="iconBackgroundBling">#000000</color>
     <color name="iconBackgroundGrid">#091B25</color>

--- a/packages/core-mobile/android/app/src/main/res/values/styles.xml
+++ b/packages/core-mobile/android/app/src/main/res/values/styles.xml
@@ -21,7 +21,6 @@
              in light mode on Android, especially in transparent-header screens. -->
         <item name="colorSurface">@color/white</item>
         <item name="android:colorBackground">@color/white</item>
-        <item name="colorBackground">@color/white</item>
         <item name="colorSurfaceVariant">@color/neutral50</item>
         <item name="colorSurfaceContainerLowest">@color/white</item>
         <item name="colorSurfaceContainerLow">@color/white</item>

--- a/packages/core-mobile/android/app/src/main/res/values/styles.xml
+++ b/packages/core-mobile/android/app/src/main/res/values/styles.xml
@@ -15,6 +15,19 @@
         <!-- default tint color for dialog button text -->
         <item name="android:colorPrimary">@color/dialogTextColor</item>
         <item name="colorPrimary">@color/dialogTextColor</item>
+
+        <!-- Override Material3 surface colors to prevent the default purple/lavender
+             tint (from the M3 baseline seed color) from appearing as a pink header
+             in light mode on Android, especially in transparent-header screens. -->
+        <item name="colorSurface">@color/white</item>
+        <item name="android:colorBackground">@color/white</item>
+        <item name="colorBackground">@color/white</item>
+        <item name="colorSurfaceVariant">@color/neutral50</item>
+        <item name="colorSurfaceContainerLowest">@color/white</item>
+        <item name="colorSurfaceContainerLow">@color/white</item>
+        <item name="colorSurfaceContainer">@color/neutral50</item>
+        <item name="colorSurfaceContainerHigh">@color/neutral50</item>
+        <item name="colorSurfaceContainerHighest">@color/neutral50</item>
     </style>
 
     <style name="CustomBottomNavigationStyle" parent="Widget.Material3.BottomNavigationView">

--- a/packages/core-mobile/android/app/src/main/res/values/styles.xml
+++ b/packages/core-mobile/android/app/src/main/res/values/styles.xml
@@ -1,24 +1,29 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Customize your theme here. -->
+    <!-- Base theme containing all shared, mode-independent items.
+         Both light and night AppTheme inherit from this so that
+         resource-qualified style overrides (values-night/) don't
+         accidentally drop window, system bar, or dialog settings. -->
+    <style name="BaseAppTheme" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
 
-         <!--style for react-native-community/datetimepicker -->
+        <!--style for react-native-community/datetimepicker -->
         <item name="android:datePickerDialogTheme">@style/MyDatePickerDialogTheme</item>
         <item name="bottomNavigationStyle">@style/CustomBottomNavigationStyle</item>
 
         <!-- default tint color for dialog button text -->
         <item name="android:colorPrimary">@color/dialogTextColor</item>
         <item name="colorPrimary">@color/dialogTextColor</item>
+    </style>
 
-        <!-- Override Material3 surface colors to prevent the default purple/lavender
-             tint (from the M3 baseline seed color) from appearing as a pink header
-             in light mode on Android, especially in transparent-header screens. -->
+    <!-- Light mode application theme.
+         Overrides Material3 surface colors to prevent the default purple/lavender
+         tint (from the M3 baseline seed color) from appearing as a pink header
+         in light mode on Android, especially in transparent-header screens. -->
+    <style name="AppTheme" parent="BaseAppTheme">
         <item name="colorSurface">@color/white</item>
         <item name="android:colorBackground">@color/white</item>
         <item name="colorSurfaceVariant">@color/neutral50</item>


### PR DESCRIPTION
## Description

**Ticket: [CP-13828](https://ava-labs.atlassian.net/browse/CP-13828)**

On Android in light mode, the app's `AppTheme` inherits from `Theme.Material3.DayNight.NoActionBar`. Material3's default baseline theme derives surface/container colors from a purple seed color, giving them a lavender/pink tint (e.g. `colorSurfaceVariant` = `#E7E0EC`, `colorSurfaceContainerLow` = `#F7F2FA`). These bleed through transparent navigation headers (`headerTransparent: true`) used in the Fusion (swap) flow and potentially other screens, appearing as a pink header/background in light mode.

**Changes:**
- Override all Material3 surface/container color attributes in `AppTheme` (light mode) to neutral white/gray values that match the app's design system
- Add a new `values-night/styles.xml` with dark mode equivalents using the existing neutral palette
- Add `neutral800` (`#3E3E43`) to `colors.xml` for use in dark mode surface overrides

## Screenshots/Videos
**Before**
<img width="300" alt="10195" src="https://github.com/user-attachments/assets/f5238564-ac69-4416-a8d3-82bb2bd19cfd" />
<img width="300" alt="10199" src="https://github.com/user-attachments/assets/4b09406f-ea4f-404c-b0e9-00fb4edc3bd1" />
<img width="300" alt="10197" src="https://github.com/user-attachments/assets/d6e68e3d-ca8b-47f4-9fad-ab2014fc729d" />

**After**
<img width="300" alt="10212" src="https://github.com/user-attachments/assets/d425009c-9ba6-4079-bd77-738f452c81a8" />
<img width="300" alt="10210" src="https://github.com/user-attachments/assets/15625c4b-bf4b-4dc6-8d78-a61d4673f900" />
<img width="300" alt="10214" src="https://github.com/user-attachments/assets/da63f311-1166-4c8d-ab9f-8b4eb75e4f5f" />
<img width="300" alt="10206" src="https://github.com/user-attachments/assets/8bcb1085-f23e-4eb3-aa50-e989531dcbce" />
<img width="300" alt="10208" src="https://github.com/user-attachments/assets/355a6eb1-031e-4805-bc07-805265ce1e4e" />
<img width="300" alt="10204" src="https://github.com/user-attachments/assets/ddf81c34-c7f9-436f-89c8-d6a7fe458930" />

## Testing

1. Run the app on an Android device or emulator in light mode
2. Open Swap - Select a Token screen
3. Verify that the header/background is white (not pink/lavender)
4. Switch to dark mode and verify that headers/backgrounds remain dark (no purple tint)
5. Also verify the date picker dialog still renders correctly (it has its own explicit color overrides and is unaffected)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-13828]: https://ava-labs.atlassian.net/browse/CP-13828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ