### PR TITLE
CP-13951: Ledger - suppress retry alert after approval sheet is dismissed

### DIFF
--- a/packages/core-mobile/app/new/features/approval/hooks/useLedgerApproval.tsx
+++ b/packages/core-mobile/app/new/features/approval/hooks/useLedgerApproval.tsx
@@ -11,6 +11,7 @@ import { TRANSACTION_CANCELLED_BY_USER } from 'vmModule/ApprovalController/utils
 
 type UseLedgerApprovalReturn = {
   renderLedgerFooter: () => JSX.Element | null
+  cancelLedger: () => void
 }
 
 export const useLedgerApproval = (
@@ -156,5 +157,5 @@ export const useLedgerApproval = (
     cancelLedger
   ])
 
-  return { renderLedgerFooter }
+  return { renderLedgerFooter, cancelLedger }
 }

--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
@@ -129,9 +129,9 @@ const ApprovalScreen = ({
   // in-flight resolveWithRetry skips the retry alert and any already-visible
   // retry alert's Retry button becomes a no-op.
   const handleClose = useCallback((): void => {
-    cancelLedger()
+    if (isLedger) cancelLedger()
     onReject()
-  }, [cancelLedger, onReject])
+  }, [cancelLedger, isLedger, onReject])
 
   const handleGaslessPreApprove = useCallback(async (): Promise<boolean> => {
     if (!shouldShowGaslessSwitch || !gaslessEnabled) return true

--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
@@ -57,7 +57,7 @@ const ApprovalScreen = ({
   const activeWallet = useActiveWallet()
   const isLedger = useSelector(selectIsWalletLedger(activeWallet.id))
   const isGaslessInstantBlocked = useSelector(selectIsGaslessInstantBlocked)
-  const { renderLedgerFooter } = useLedgerApproval(isLedger)
+  const { renderLedgerFooter, cancelLedger } = useLedgerApproval(isLedger)
 
   const symbol = chainId
     ? (L2_NETWORK_SYMBOL_MAPPING[chainId] as NetworkTokenSymbols)
@@ -123,6 +123,15 @@ const ApprovalScreen = ({
     },
     [onReject]
   )
+
+  // When the sheet is closed via the X button or swipe (not the in-footer Cancel
+  // button), cancelLedger ensures the userCancelledMap flag is set so any
+  // in-flight resolveWithRetry skips the retry alert and any already-visible
+  // retry alert's Retry button becomes a no-op.
+  const handleClose = useCallback((): void => {
+    cancelLedger()
+    onReject()
+  }, [cancelLedger, onReject])
 
   const handleGaslessPreApprove = useCallback(async (): Promise<boolean> => {
     if (!shouldShowGaslessSwitch || !gaslessEnabled) return true
@@ -450,7 +459,7 @@ const ApprovalScreen = ({
       navigationTitle={
         displayData.dAppInfo ? displayData?.dAppInfo?.name : displayData.title
       }
-      onClose={onReject}
+      onClose={handleClose}
       alert={alert}
       confirm={{
         label: 'Approve',

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -211,12 +211,18 @@ class ApprovalController implements VmModuleApprovalController {
           error: value.error,
           network: params.network,
           rpcMethod: request.method,
-          onRetry: () =>
+          onRetry: () => {
+            // Guard: if the approval sheet was dismissed while the alert was
+            // visible, userCancelledMap will be set — don't retry in that case.
+            if (this.userCancelledMap.get(requestId)) {
+              return
+            }
             onApprove({
               ...params,
               signingData,
               resolve: resolveWithRetry
-            }),
+            })
+          },
           onCancel: () => {
             this.userCancelledMap.set(requestId, true)
             this.handleGoBackIfNeeded()

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -215,6 +215,7 @@ class ApprovalController implements VmModuleApprovalController {
             // Guard: if the approval sheet was dismissed while the alert was
             // visible, userCancelledMap will be set — don't retry in that case.
             if (this.userCancelledMap.get(requestId)) {
+              this.userCancelledMap.delete(requestId)
               return
             }
             onApprove({


### PR DESCRIPTION
## Description

iOS: 8190
Android: 8191

**Ticket: [CP-13951](https://ava-labs.atlassian.net/browse/CP-13951)**

After rejecting a sign request on the Ledger device and quickly dismissing the
approval bottom sheet (X button or swipe), a "Retry" alert would still appear.
Tapping Retry would re-send the sign request to the Ledger indefinitely.

**Root cause:** `ActionSheet.onClose` was wired to `ApprovalParams.onReject`,
which resolves the outer promise but does not set the `userCancelledMap` flag
in `ApprovalController`. Without that flag, `resolveWithRetry` had no signal
that the sheet was gone and would show the retry alert anyway. Additionally,
once the alert was on screen there was no guard on `onRetry` to prevent it from
firing after the sheet was dismissed.

**Fix:**
- `useLedgerApproval` now exposes `cancelLedger` so `ApprovalScreen` can call
  it from `onClose`
- `ApprovalScreen` introduces a `handleClose` callback that runs `cancelLedger`
  (sets the cancelled flag, cleans up Ledger state) before the normal `onReject`
- `ApprovalController.resolveWithRetry` guards `onRetry` with a
  `userCancelledMap` check — covers the race where the alert was already visible
  when the sheet was dismissed; tapping Retry becomes a no-op

## Screenshots/Videos

Include relevant screenshots or screen recordings of iOS and Android.

## Testing

**Dev Testing**

1. Connect a Ledger device via BLE
2. Initiate a swap or any transaction that requires a Ledger sign request
3. Reject the sign request on the Ledger device
4. Immediately press X (or swipe down) on the approval sheet
5. Verify no retry alert appears — or if the alert appeared before dismissal,
   tapping Retry does nothing
6. Repeat several times to confirm the loop is fully broken

**QA Testing**

- Reproduce steps above on both iOS and Android
- Confirm the in-footer **Cancel** button still works correctly (Ledger
  disconnects, sheet closes, no retry loop)
- Confirm a successful Ledger signing flow is unaffected

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-13951]: https://ava-labs.atlassian.net/browse/CP-13951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ