### PR TITLE
CP-14007: Fix max button not showing for wrap/unwrap token pairs

### DIFF
--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -38,7 +38,7 @@
     "@avalabs/core-utils-sdk": "3.1.0-alpha.82",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.82",
     "@avalabs/evm-module": "3.6.1",
-    "@avalabs/fusion-sdk": "0.0.0-fix-unsubscribe-20260420150218",
+    "@avalabs/fusion-sdk": "0.16.0",
     "@avalabs/glacier-sdk": "3.1.0-alpha.82",
     "@avalabs/k2-alpine": "workspace:*",
     "@avalabs/prediction-market-sdk": "0.3.0",

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -38,7 +38,7 @@
     "@avalabs/core-utils-sdk": "3.1.0-alpha.82",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.82",
     "@avalabs/evm-module": "3.6.1",
-    "@avalabs/fusion-sdk": "0.15.1",
+    "@avalabs/fusion-sdk": "0.0.0-fix-unsubscribe-20260420150218",
     "@avalabs/glacier-sdk": "3.1.0-alpha.82",
     "@avalabs/k2-alpine": "workspace:*",
     "@avalabs/prediction-market-sdk": "0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -491,7 +491,7 @@ __metadata:
     "@avalabs/core-utils-sdk": 3.1.0-alpha.82
     "@avalabs/core-wallets-sdk": 3.1.0-alpha.82
     "@avalabs/evm-module": 3.6.1
-    "@avalabs/fusion-sdk": 0.15.1
+    "@avalabs/fusion-sdk": 0.0.0-fix-unsubscribe-20260420150218
     "@avalabs/glacier-sdk": 3.1.0-alpha.82
     "@avalabs/k2-alpine": "workspace:*"
     "@avalabs/prediction-market-sdk": 0.3.0
@@ -893,9 +893,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/fusion-sdk@npm:0.15.1":
-  version: 0.15.1
-  resolution: "@avalabs/fusion-sdk@npm:0.15.1"
+"@avalabs/fusion-sdk@npm:0.0.0-fix-unsubscribe-20260420150218":
+  version: 0.0.0-fix-unsubscribe-20260420150218
+  resolution: "@avalabs/fusion-sdk@npm:0.0.0-fix-unsubscribe-20260420150218"
   dependencies:
     "@bitcoinerlab/secp256k1": ^1.2.0
     "@layerzerolabs/lz-v2-utilities": ^3.0.17
@@ -910,7 +910,7 @@ __metadata:
     "@solana/kit": ^5.0.0 || ^6.0.0
     viem: ^2.38.0
     zod: ^4.1.0
-  checksum: 1f7d703e04d8a923fdb2e87216bd486a8c2e3be94d848e7a4bce68f5d3ad685dbaa991f93bb065167ded09ace56818d0584445ba995e75b6dceed3cd1a54934f
+  checksum: c11025b0a06f722e6d5d4b7a87bfb3e54faf477f99d36ee762e5e82f0e5d3573e889f5968b6e4a9a012d3e891dfe116a185677ff16ee962335b051b21ba99fb4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -491,7 +491,7 @@ __metadata:
     "@avalabs/core-utils-sdk": 3.1.0-alpha.82
     "@avalabs/core-wallets-sdk": 3.1.0-alpha.82
     "@avalabs/evm-module": 3.6.1
-    "@avalabs/fusion-sdk": 0.0.0-fix-unsubscribe-20260420150218
+    "@avalabs/fusion-sdk": 0.16.0
     "@avalabs/glacier-sdk": 3.1.0-alpha.82
     "@avalabs/k2-alpine": "workspace:*"
     "@avalabs/prediction-market-sdk": 0.3.0
@@ -893,9 +893,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/fusion-sdk@npm:0.0.0-fix-unsubscribe-20260420150218":
-  version: 0.0.0-fix-unsubscribe-20260420150218
-  resolution: "@avalabs/fusion-sdk@npm:0.0.0-fix-unsubscribe-20260420150218"
+"@avalabs/fusion-sdk@npm:0.16.0":
+  version: 0.16.0
+  resolution: "@avalabs/fusion-sdk@npm:0.16.0"
   dependencies:
     "@bitcoinerlab/secp256k1": ^1.2.0
     "@layerzerolabs/lz-v2-utilities": ^3.0.17
@@ -910,7 +910,7 @@ __metadata:
     "@solana/kit": ^5.0.0 || ^6.0.0
     viem: ^2.38.0
     zod: ^4.1.0
-  checksum: c11025b0a06f722e6d5d4b7a87bfb3e54faf477f99d36ee762e5e82f0e5d3573e889f5968b6e4a9a012d3e891dfe116a185677ff16ee962335b051b21ba99fb4
+  checksum: 145c06a133414067544985c8f7c2e182b7b082ea5e8ad1199dd2bd7a9ffafa3dfce6add1ec119baa721c3ef2f21de113b575f0c8fe803121dd7681014c8c5d92
   languageName: node
   linkType: hard
 
@@ -37013,7 +37013,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 3e4689674406deb2ad9efa9f529597341b4ab33e379b7c7cd72aff8d5e37862fda1a37aba984951a67cc3938969be138bc3c4469e4963dd170b172148339e056
+  checksum: d6ceb75e1d0f5755370d6d91f67902bd2b8a23a3ca43cb853d2964b43798f30477e8ab0223ea8b620534fbdf5f56d39550f40d24bec2d2398c323ccfe8a5a556
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: [CP-14007](https://ava-labs.atlassian.net/browse/CP-14007)**

Bumps `@avalabs/fusion-sdk` to `0.16.0` to fix the Max button not displaying for wrap/unwrap token pairs (e.g. AVAX ↔ WAVAX).

### Root cause

`Quoter.subscribe()` calls `start()` synchronously before returning the unsubscribe function. In two cases, `start()` fires subscriber callbacks before `subscribe()` returns:

1. **wrap/unwrap** — its `streamQuotes()` emits `'quote'` and `'done'` synchronously, whereas all other providers (MARKR, Avalanche EVM bridge, Lombard) emit asynchronously.
2. **No eligible services / same-chain no-op** — `start()` calls `complete()` immediately, which fires `'done'` synchronously.

In both cases, any consumer that references `unsubscribe` inside the callback hits a JavaScript Temporal Dead Zone (TDZ) `ReferenceError` because `const unsubscribe = quoter.subscribe(...)` hasn't completed yet.

In mobile, `subscribeToFirstQuote` in `usePreQuote.ts` references `unsubscribe` inside the callback. The `catch` block returned `undefined`, and the `if (!cleanup)` guard in the `useEffect` set `preQuoteFailed = true`, which propagated through `useMaxSwapAmount` to disable the Max button.

### SDK fix
https://github.com/ava-labs/consumer-sdks/pull/204

The fix is entirely inside `Quoter` — no changes to individual providers:

- **`startStreamForService()`** — wraps the service handler with a `guardedHandler` that buffers any events fired synchronously during `streamQuotes()`, then flushes them via `queueMicrotask` after `streamQuotes()` returns.
- **`complete()`** — if called during `subscribe()→start()`, defers the `'done'` emission via `queueMicrotask` using a new `isStartingFromSubscribe` flag set around the `start()` call.

Both paths ensure `subscribe()` always returns before any subscriber callback fires.

## Screenshots/Videos
| Before    | After |
| -------- | ------- |
| <img width="812" height="490" alt="Screenshot 2026-04-20 at 10 07 28 AM" src="https://github.com/user-attachments/assets/6e1fa2f2-3e2a-4d31-a130-17c749b8f9f4" />  | <img width="400" alt="Simulator Screenshot - iPhone 16 Pro - 2026-04-20 at 10 13 46" src="https://github.com/user-attachments/assets/c6fc96f8-9122-44f1-bf3d-d5ae5a8aad04" />   |

## Testing
**iOS: 0.0.0.8249
Android: 0.0.0.8250**
1. Open the swap screen
2. Select a wrap/unwrap pair (e.g. AVAX → WAVAX or WAVAX → AVAX)
3. Verify the Max button becomes enabled and tapping it populates the correct amount
4. Verify the Max button still works for non-wrap/unwrap pairs (MARKR routes)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14007]: https://ava-labs.atlassian.net/browse/CP-14007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ