### PR TITLE
CP-14070: Prevent duplicate handler execution via ref guard on Ledger connection screens

### DIFF
--- a/packages/core-mobile/app/new/features/ledger/screens/AppConnectionAddAccountScreen.tsx
+++ b/packages/core-mobile/app/new/features/ledger/screens/AppConnectionAddAccountScreen.tsx
@@ -35,6 +35,8 @@ export const AppConnectionAddAccountScreen = (): JSX.Element => {
     return getLedgerInfoByWalletId(walletId)
   }, [getLedgerInfoByWalletId, walletId])
 
+  const isHandlingCompleteRef = useRef(false)
+
   const {
     resetSetup,
     disconnectDevice,
@@ -51,6 +53,9 @@ export const AppConnectionAddAccountScreen = (): JSX.Element => {
 
   const handleComplete = useCallback(
     async (multiIndexKeys: LedgerMultiIndexKeys) => {
+      if (isHandlingCompleteRef.current) return
+      isHandlingCompleteRef.current = true
+
       const keys = {
         mainnet: multiIndexKeys.mainnet[accountIndex],
         testnet: multiIndexKeys.testnet[accountIndex]
@@ -104,6 +109,7 @@ export const AppConnectionAddAccountScreen = (): JSX.Element => {
           // Stop polling since we no longer need app detection
           LedgerService.stopAppPolling()
           setIsUpdatingWallet(false)
+          isHandlingCompleteRef.current = false
           resetSetup()
           dismiss()
         }
@@ -118,6 +124,7 @@ export const AppConnectionAddAccountScreen = (): JSX.Element => {
             isUpdatingWallet
           }
         )
+        isHandlingCompleteRef.current = false
         resetSetup()
         dismiss()
       }

--- a/packages/core-mobile/app/new/features/ledger/screens/AppConnectionAddAccountScreen.tsx
+++ b/packages/core-mobile/app/new/features/ledger/screens/AppConnectionAddAccountScreen.tsx
@@ -35,6 +35,10 @@ export const AppConnectionAddAccountScreen = (): JSX.Element => {
     return getLedgerInfoByWalletId(walletId)
   }, [getLedgerInfoByWalletId, walletId])
 
+  // useRef instead of useState: the ref flips synchronously, so a second tap
+  // cannot enter handleComplete before the first invocation finishes. useState
+  // is async — rapid taps could race past the isUpdatingWallet guard before
+  // React re-renders with the updated value.
   const isHandlingCompleteRef = useRef(false)
 
   const {

--- a/packages/core-mobile/app/new/features/ledger/screens/AppConnectionOnboardingScreen.tsx
+++ b/packages/core-mobile/app/new/features/ledger/screens/AppConnectionOnboardingScreen.tsx
@@ -35,6 +35,10 @@ export const AppConnectionOnboardingScreen = ({
   const { canGoBack, back } = useRouter()
   const dispatch = useDispatch()
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
+  // useRef instead of useState: the ref flips synchronously, so a second tap
+  // cannot enter handleComplete before the first invocation finishes. useState
+  // is async — rapid taps could race past the isUpdatingWallet guard before
+  // React re-renders with the updated value.
   const isHandlingCompleteRef = useRef(false)
 
   const {

--- a/packages/core-mobile/app/new/features/ledger/screens/AppConnectionOnboardingScreen.tsx
+++ b/packages/core-mobile/app/new/features/ledger/screens/AppConnectionOnboardingScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import Logger from 'utils/Logger'
@@ -35,6 +35,7 @@ export const AppConnectionOnboardingScreen = ({
   const { canGoBack, back } = useRouter()
   const dispatch = useDispatch()
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
+  const isHandlingCompleteRef = useRef(false)
 
   const {
     connectedDeviceId,
@@ -54,6 +55,9 @@ export const AppConnectionOnboardingScreen = ({
 
   const handleComplete = useCallback(
     async (multiIndexKeys: LedgerMultiIndexKeys) => {
+      if (isHandlingCompleteRef.current) return
+      isHandlingCompleteRef.current = true
+
       // Account 0's keys are at index 0 in the multi-index map.
       // Additional indices hold xpubs/pubkeys that will be used for
       // background discovery after onboarding completes.
@@ -82,6 +86,7 @@ export const AppConnectionOnboardingScreen = ({
       ) {
         Logger.info('Ledger wallet already exists, skipping duplicate import')
         LedgerService.stopAppPolling()
+        isHandlingCompleteRef.current = false
         onNavigateToComplete()
         return
       }
@@ -97,6 +102,7 @@ export const AppConnectionOnboardingScreen = ({
           hasSelectedDerivationPath: !!selectedDerivationPath,
           isUpdatingWallet
         })
+        isHandlingCompleteRef.current = false
         Alert.alert(
           'Wallet setup failed',
           'Unable to complete Ledger wallet setup. Please restart the setup process.',
@@ -168,6 +174,7 @@ export const AppConnectionOnboardingScreen = ({
         )
       } finally {
         setIsUpdatingWallet(false)
+        isHandlingCompleteRef.current = false
       }
     },
     [

--- a/packages/core-mobile/app/new/features/ledger/screens/SolanaConnectionScreen.tsx
+++ b/packages/core-mobile/app/new/features/ledger/screens/SolanaConnectionScreen.tsx
@@ -30,6 +30,10 @@ export default function SolanaConnectionScreen(): JSX.Element {
     AppConnectionStep.SOLANA_CONNECT | AppConnectionStep.SOLANA_LOADING
   >(AppConnectionStep.SOLANA_CONNECT)
 
+  // useRef instead of useState: the ref flips synchronously, so a second tap
+  // cannot enter handleConnectSolana before the first invocation finishes.
+  // useState is async — rapid taps could race past the isUpdatingWallet guard
+  // before React re-renders with the updated value.
   const isHandlingCompleteRef = useRef(false)
 
   const {

--- a/packages/core-mobile/app/new/features/ledger/screens/SolanaConnectionScreen.tsx
+++ b/packages/core-mobile/app/new/features/ledger/screens/SolanaConnectionScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect, useMemo } from 'react'
+import React, { useCallback, useState, useEffect, useMemo, useRef } from 'react'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { Alert } from 'react-native'
 import { ScrollScreen } from 'common/components/ScrollScreen'
@@ -30,6 +30,8 @@ export default function SolanaConnectionScreen(): JSX.Element {
     AppConnectionStep.SOLANA_CONNECT | AppConnectionStep.SOLANA_LOADING
   >(AppConnectionStep.SOLANA_CONNECT)
 
+  const isHandlingCompleteRef = useRef(false)
+
   const {
     connectedDeviceId,
     connectedDeviceName,
@@ -54,6 +56,9 @@ export default function SolanaConnectionScreen(): JSX.Element {
   }, [])
 
   const handleConnectSolana = useCallback(async () => {
+    if (isHandlingCompleteRef.current) return
+    isHandlingCompleteRef.current = true
+
     try {
       if (!account) {
         throw new Error('Account not found')
@@ -106,6 +111,7 @@ export default function SolanaConnectionScreen(): JSX.Element {
       )
     } finally {
       setIsUpdatingWallet(false)
+      isHandlingCompleteRef.current = false
     }
   }, [
     account,


### PR DESCRIPTION
## Description

iOS: 8213
Android: 8214

**Ticket: [CP-14070]**

Under slow performance, a user could rapidly tap "Complete setup" (or "Connect" on the Solana screen) multiple times before the async `isUpdatingWallet` state had a chance to update, causing duplicate wallet/account creation flows to execute concurrently.

- Added a synchronous `isHandlingCompleteRef = useRef(false)` guard to `handleComplete` / `handleConnectSolana` on `AppConnectionOnboardingScreen`, `AppConnectionAddAccountScreen`, and `SolanaConnectionScreen`
- The ref is checked and set at the very top of each handler before any async work begins — unlike React state, ref mutations are synchronous so no second invocation can enter the critical section
- The ref is reset on every exit path: early returns, the conditions-not-met branch, and the `finally` block
- `isUpdatingWallet` / `setIsUpdatingWallet` from context are retained for UI loading state (button disabled / spinner)

## Screenshots/Videos

N/A — logic-only change, no UI difference under normal conditions.

## Testing

**Dev Testing (if applicable)**

- On a slow device or with an artificially delayed JS thread, open Ledger onboarding and tap "Complete setup" rapidly 2–3 times
- Verify only one wallet is created (check Wallets screen)
- Repeat for the "Add Account" flow — verify only one account is added
- Repeat for the Solana connection screen — verify only one Solana key update fires
- Verify the button correctly shows loading state and re-enables on error

**QA Testing (if applicable)**

- Happy path: single tap completes wallet setup normally on iOS and Android
- Edge case: multiple rapid taps → only one wallet/account created, no crash or duplicate entry

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14061]: https://ava-labs.atlassian.net/browse/CP-14061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CP-14070]: https://ava-labs.atlassian.net/browse/CP-14070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ