### PR TITLE
CP-14069: Fix non-dismissible Ledger scan error alert

### DIFF
--- a/packages/core-mobile/app/new/features/ledger/screens/DeviceConnectionScreen.tsx
+++ b/packages/core-mobile/app/new/features/ledger/screens/DeviceConnectionScreen.tsx
@@ -72,6 +72,30 @@ export default function DeviceConnectionScreen({
     }
   }, [])
 
+  const handleCancel = useCallback(() => {
+    resetSetup()
+    back()
+  }, [resetSetup, back])
+
+  useEffect(() => {
+    const onScanError = ({
+      title,
+      message
+    }: {
+      title: string
+      message: string
+    }): void => {
+      Alert.alert(title, message, [
+        {
+          text: 'OK',
+          onPress: resetSetup
+        }
+      ])
+    }
+    LedgerService.addScanErrorListener(onScanError)
+    return () => LedgerService.removeScanErrorListener(onScanError)
+  }, [resetSetup, back])
+
   // Scan for devices
   const scanForDevices = useCallback(async () => {
     try {
@@ -85,10 +109,11 @@ export default function DeviceConnectionScreen({
         'Scan Error',
         `Failed to scan for devices: ${
           error instanceof Error ? error.message : 'Unknown error'
-        }`
+        }`,
+        [{ text: 'OK', onPress: resetSetup }]
       )
     }
-  }, [])
+  }, [resetSetup])
 
   // Handle device connection
   const handleDeviceConnection = useCallback(
@@ -145,11 +170,6 @@ export default function DeviceConnectionScreen({
       walletState
     ]
   )
-
-  const handleCancel = useCallback(() => {
-    resetSetup()
-    back()
-  }, [resetSetup, back])
 
   const renderBluetoothPermissionError = useCallback(() => {
     if (isBluetoothOnAndPermissionGranted || isInitializingBluetooth)

--- a/packages/core-mobile/app/new/features/ledger/screens/DeviceConnectionScreen.tsx
+++ b/packages/core-mobile/app/new/features/ledger/screens/DeviceConnectionScreen.tsx
@@ -77,29 +77,17 @@ export default function DeviceConnectionScreen({
     back()
   }, [resetSetup, back])
 
-  useEffect(() => {
-    const onScanError = ({
-      title,
-      message
-    }: {
-      title: string
-      message: string
-    }): void => {
-      Alert.alert(title, message, [
-        {
-          text: 'OK',
-          onPress: resetSetup
-        }
-      ])
-    }
-    LedgerService.addScanErrorListener(onScanError)
-    return () => LedgerService.removeScanErrorListener(onScanError)
-  }, [resetSetup])
+  const onScanError = useCallback(
+    ({ title, message }: { title: string; message: string }): void => {
+      Alert.alert(title, message, [{ text: 'OK', onPress: resetSetup }])
+    },
+    [resetSetup]
+  )
 
   // Scan for devices
   const scanForDevices = useCallback(async () => {
     try {
-      await LedgerService.startDeviceScanning()
+      await LedgerService.startDeviceScanning(onScanError)
     } catch (error) {
       if (isLedgerBluetoothError(error)) {
         showBluetoothErrorAlert(error)
@@ -113,7 +101,7 @@ export default function DeviceConnectionScreen({
         [{ text: 'OK', onPress: resetSetup }]
       )
     }
-  }, [resetSetup])
+  }, [resetSetup, onScanError])
 
   // Handle device connection
   const handleDeviceConnection = useCallback(

--- a/packages/core-mobile/app/new/features/ledger/screens/DeviceConnectionScreen.tsx
+++ b/packages/core-mobile/app/new/features/ledger/screens/DeviceConnectionScreen.tsx
@@ -94,7 +94,7 @@ export default function DeviceConnectionScreen({
     }
     LedgerService.addScanErrorListener(onScanError)
     return () => LedgerService.removeScanErrorListener(onScanError)
-  }, [resetSetup, back])
+  }, [resetSetup])
 
   // Scan for devices
   const scanForDevices = useCallback(async () => {

--- a/packages/core-mobile/app/services/ledger/LedgerService.test.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.test.ts
@@ -674,12 +674,10 @@ describe('LedgerService', () => {
       const onScanError = jest.fn()
 
       const scanError = new Error('Hardware failure')
-      transportBLEMock.listen.mockImplementation(
-        (observer: { error: (e: Error) => void }) => {
-          observer.error(scanError)
-          return { unsubscribe: jest.fn() }
-        }
-      )
+      transportBLEMock.listen.mockImplementation(observer => {
+        observer.error(scanError)
+        return { unsubscribe: jest.fn() }
+      })
 
       await LedgerService.startDeviceScanning(onScanError)
 
@@ -695,12 +693,10 @@ describe('LedgerService', () => {
       const onScanError = jest.fn()
 
       const bleError = ledgerBluetoothErrors.radioOff()
-      transportBLEMock.listen.mockImplementation(
-        (observer: { error: (e: Error) => void }) => {
-          observer.error(bleError)
-          return { unsubscribe: jest.fn() }
-        }
-      )
+      transportBLEMock.listen.mockImplementation(observer => {
+        observer.error(bleError)
+        return { unsubscribe: jest.fn() }
+      })
 
       await LedgerService.startDeviceScanning(onScanError)
 
@@ -725,20 +721,14 @@ describe('LedgerService', () => {
     it('does not call onScanError when scan times out after devices were found', async () => {
       const onScanError = jest.fn()
 
-      transportBLEMock.listen.mockImplementation(
-        (observer: {
-          next: (event: {
-            type: string
-            descriptor: { id: string; name: string }
-          }) => void
-        }) => {
-          observer.next({
-            type: 'add',
-            descriptor: { id: 'device-1', name: 'Ledger Nano X' }
-          })
-          return { unsubscribe: jest.fn() }
-        }
-      )
+      transportBLEMock.listen.mockImplementation(observer => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ;(observer as any).next({
+          type: 'add',
+          descriptor: { id: 'device-1', name: 'Ledger Nano X' }
+        })
+        return { unsubscribe: jest.fn() }
+      })
 
       await LedgerService.startDeviceScanning(onScanError)
 

--- a/packages/core-mobile/app/services/ledger/LedgerService.test.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.test.ts
@@ -4,7 +4,12 @@ import TransportBLE from '@ledgerhq/react-native-hw-transport-ble'
 import { LEDGER_TIMEOUTS } from 'new/features/ledger/consts'
 import Logger from 'utils/Logger'
 import LedgerService from './LedgerService'
-import { isLedgerBluetoothError } from './LedgerBluetoothError'
+import {
+  isLedgerBluetoothError,
+  ledgerBluetoothErrors,
+  LEDGER_SCAN_FAILED_TITLE,
+  LEDGER_SCAN_FAILED_ALREADY_CONNECTED_MESSAGE
+} from './LedgerBluetoothError'
 import { LedgerAppType, LEDGER_ERROR_CODES } from './types'
 
 jest.mock('@ledgerhq/react-native-hw-transport-ble', () => ({
@@ -609,6 +614,215 @@ describe('LedgerService', () => {
 
       isAppCompatibleSpy.mockRestore()
       checkAppSpy.mockRestore()
+    })
+  })
+
+  describe('scan error listeners', () => {
+    const transportBLEMock = TransportBLE as unknown as {
+      listen: jest.Mock
+      disconnectDevice: jest.Mock
+    }
+
+    const bluetoothPermissions = [
+      PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN,
+      PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
+      PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION
+    ].filter(
+      (
+        p
+      ): p is typeof PermissionsAndroid.PERMISSIONS[keyof typeof PermissionsAndroid.PERMISSIONS] =>
+        Boolean(p)
+    )
+
+    const grantedPermissions = Object.fromEntries(
+      bluetoothPermissions.map(p => [p, PermissionsAndroid.RESULTS.GRANTED])
+    )
+
+    const originalPlatformOS = Platform.OS
+
+    beforeEach(() => {
+      jest.useFakeTimers()
+      jest.spyOn(Logger, 'info').mockImplementation(jest.fn())
+      jest.spyOn(Logger, 'error').mockImplementation(jest.fn())
+      jest.spyOn(Alert, 'alert').mockImplementation(jest.fn())
+      jest.spyOn(PermissionsAndroid, 'check').mockResolvedValue(false as never)
+      jest
+        .spyOn(PermissionsAndroid, 'requestMultiple')
+        .mockResolvedValue(grantedPermissions as never)
+      Object.defineProperty(Platform, 'OS', {
+        configurable: true,
+        value: 'android'
+      })
+      transportBLEMock.listen.mockReturnValue({ unsubscribe: jest.fn() })
+      transportBLEMock.disconnectDevice.mockResolvedValue(undefined as never)
+    })
+
+    afterEach(async () => {
+      // Clear all listeners to prevent leakage between tests
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(LedgerService as any).scanErrorListeners.clear()
+      await LedgerService.disconnect().catch(() => undefined)
+      LedgerService.stopDeviceScanning()
+      LedgerService.stopAppPolling()
+      jest.runOnlyPendingTimers()
+      jest.useRealTimers()
+      Object.defineProperty(Platform, 'OS', {
+        configurable: true,
+        value: originalPlatformOS
+      })
+      jest.restoreAllMocks()
+    })
+
+    it('calls a registered listener with the correct title and message', () => {
+      const listener = jest.fn()
+      LedgerService.addScanErrorListener(listener)
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(LedgerService as any).notifyScanError('Test Title', 'Test message')
+
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(listener).toHaveBeenCalledWith({
+        title: 'Test Title',
+        message: 'Test message'
+      })
+    })
+
+    it('calls all registered listeners when an error is notified', () => {
+      const listener1 = jest.fn()
+      const listener2 = jest.fn()
+      LedgerService.addScanErrorListener(listener1)
+      LedgerService.addScanErrorListener(listener2)
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(LedgerService as any).notifyScanError('Title', 'Message')
+
+      expect(listener1).toHaveBeenCalledTimes(1)
+      expect(listener2).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not call a listener after it has been removed', () => {
+      const listener = jest.fn()
+      LedgerService.addScanErrorListener(listener)
+      LedgerService.removeScanErrorListener(listener)
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(LedgerService as any).notifyScanError('Title', 'Message')
+
+      expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('continues notifying remaining listeners when one listener throws', () => {
+      const throwingListener = jest.fn().mockImplementation(() => {
+        throw new Error('listener error')
+      })
+      const normalListener = jest.fn()
+      LedgerService.addScanErrorListener(throwingListener)
+      LedgerService.addScanErrorListener(normalListener)
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(LedgerService as any).notifyScanError('Title', 'Message')
+
+      expect(throwingListener).toHaveBeenCalledTimes(1)
+      expect(normalListener).toHaveBeenCalledTimes(1)
+    })
+
+    it('notifies scan error listeners (not Alert.alert) when TransportBLE.listen fires a non-BLE error', async () => {
+      const listener = jest.fn()
+      LedgerService.addScanErrorListener(listener)
+
+      const scanError = new Error('Hardware failure')
+      transportBLEMock.listen.mockImplementation(
+        (observer: { error: (e: Error) => void }) => {
+          observer.error(scanError)
+          return { unsubscribe: jest.fn() }
+        }
+      )
+
+      await LedgerService.startDeviceScanning()
+
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(listener).toHaveBeenCalledWith({
+        title: 'Scan Error',
+        message: `Failed to scan for devices: ${scanError.message}`
+      })
+      expect(Alert.alert).not.toHaveBeenCalled()
+    })
+
+    it('calls showBluetoothErrorAlert (not scan error listeners) when TransportBLE.listen fires a BLE error', async () => {
+      const listener = jest.fn()
+      LedgerService.addScanErrorListener(listener)
+
+      const bleError = ledgerBluetoothErrors.radioOff()
+      transportBLEMock.listen.mockImplementation(
+        (observer: { error: (e: Error) => void }) => {
+          observer.error(bleError)
+          return { unsubscribe: jest.fn() }
+        }
+      )
+
+      await LedgerService.startDeviceScanning()
+
+      expect(listener).not.toHaveBeenCalled()
+      expect(Alert.alert).toHaveBeenCalledTimes(1)
+    })
+
+    it('notifies scan error listeners with LEDGER_SCAN_FAILED title when scan times out with no devices', async () => {
+      const listener = jest.fn()
+      LedgerService.addScanErrorListener(listener)
+
+      await LedgerService.startDeviceScanning()
+
+      jest.advanceTimersByTime(LEDGER_TIMEOUTS.SCAN_TIMEOUT + 100)
+
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(listener).toHaveBeenCalledWith({
+        title: LEDGER_SCAN_FAILED_TITLE,
+        message: LEDGER_SCAN_FAILED_ALREADY_CONNECTED_MESSAGE
+      })
+    })
+
+    it('does not notify scan error listeners when scan times out after devices were found', async () => {
+      const listener = jest.fn()
+      LedgerService.addScanErrorListener(listener)
+
+      transportBLEMock.listen.mockImplementation(
+        (observer: {
+          next: (event: {
+            type: string
+            descriptor: { id: string; name: string }
+          }) => void
+        }) => {
+          observer.next({
+            type: 'add',
+            descriptor: { id: 'device-1', name: 'Ledger Nano X' }
+          })
+          return { unsubscribe: jest.fn() }
+        }
+      )
+
+      await LedgerService.startDeviceScanning()
+
+      jest.advanceTimersByTime(LEDGER_TIMEOUTS.SCAN_TIMEOUT + 100)
+
+      expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('notifies scan error listeners when TransportBLE.listen throws synchronously', async () => {
+      const listener = jest.fn()
+      LedgerService.addScanErrorListener(listener)
+
+      const syncError = new Error('Listen threw synchronously')
+      transportBLEMock.listen.mockImplementation(() => {
+        throw syncError
+      })
+
+      await LedgerService.startDeviceScanning()
+
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(listener).toHaveBeenCalledWith({
+        title: 'Scan Error',
+        message: `Failed to scan for devices: ${syncError.message}`
+      })
     })
   })
 

--- a/packages/core-mobile/app/services/ledger/LedgerService.test.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.test.ts
@@ -675,7 +675,8 @@ describe('LedgerService', () => {
 
       const scanError = new Error('Hardware failure')
       transportBLEMock.listen.mockImplementation(observer => {
-        observer.error(scanError)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ;(observer as any).error(scanError)
         return { unsubscribe: jest.fn() }
       })
 
@@ -694,7 +695,8 @@ describe('LedgerService', () => {
 
       const bleError = ledgerBluetoothErrors.radioOff()
       transportBLEMock.listen.mockImplementation(observer => {
-        observer.error(bleError)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ;(observer as any).error(bleError)
         return { unsubscribe: jest.fn() }
       })
 

--- a/packages/core-mobile/app/services/ledger/LedgerService.test.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.test.ts
@@ -401,7 +401,7 @@ describe('LedgerService', () => {
     })
 
     it('requests permissions when scanning for devices', async () => {
-      await LedgerService.startDeviceScanning()
+      await LedgerService.startDeviceScanning(jest.fn())
 
       expect(PermissionsAndroid.check).toHaveBeenCalledTimes(
         bluetoothPermissions.length
@@ -418,7 +418,7 @@ describe('LedgerService', () => {
       )
 
       try {
-        await LedgerService.startDeviceScanning()
+        await LedgerService.startDeviceScanning(jest.fn())
         throw new Error('Expected startDeviceScanning to fail')
       } catch (error) {
         expect(
@@ -617,7 +617,7 @@ describe('LedgerService', () => {
     })
   })
 
-  describe('scan error listeners', () => {
+  describe('scan errors', () => {
     const transportBLEMock = TransportBLE as unknown as {
       listen: jest.Mock
       disconnectDevice: jest.Mock
@@ -658,9 +658,6 @@ describe('LedgerService', () => {
     })
 
     afterEach(async () => {
-      // Clear all listeners to prevent leakage between tests
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(LedgerService as any).scanErrorListeners.clear()
       await LedgerService.disconnect().catch(() => undefined)
       LedgerService.stopDeviceScanning()
       LedgerService.stopAppPolling()
@@ -673,62 +670,8 @@ describe('LedgerService', () => {
       jest.restoreAllMocks()
     })
 
-    it('calls a registered listener with the correct title and message', () => {
-      const listener = jest.fn()
-      LedgerService.addScanErrorListener(listener)
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(LedgerService as any).notifyScanError('Test Title', 'Test message')
-
-      expect(listener).toHaveBeenCalledTimes(1)
-      expect(listener).toHaveBeenCalledWith({
-        title: 'Test Title',
-        message: 'Test message'
-      })
-    })
-
-    it('calls all registered listeners when an error is notified', () => {
-      const listener1 = jest.fn()
-      const listener2 = jest.fn()
-      LedgerService.addScanErrorListener(listener1)
-      LedgerService.addScanErrorListener(listener2)
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(LedgerService as any).notifyScanError('Title', 'Message')
-
-      expect(listener1).toHaveBeenCalledTimes(1)
-      expect(listener2).toHaveBeenCalledTimes(1)
-    })
-
-    it('does not call a listener after it has been removed', () => {
-      const listener = jest.fn()
-      LedgerService.addScanErrorListener(listener)
-      LedgerService.removeScanErrorListener(listener)
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(LedgerService as any).notifyScanError('Title', 'Message')
-
-      expect(listener).not.toHaveBeenCalled()
-    })
-
-    it('continues notifying remaining listeners when one listener throws', () => {
-      const throwingListener = jest.fn().mockImplementation(() => {
-        throw new Error('listener error')
-      })
-      const normalListener = jest.fn()
-      LedgerService.addScanErrorListener(throwingListener)
-      LedgerService.addScanErrorListener(normalListener)
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(LedgerService as any).notifyScanError('Title', 'Message')
-
-      expect(throwingListener).toHaveBeenCalledTimes(1)
-      expect(normalListener).toHaveBeenCalledTimes(1)
-    })
-
-    it('notifies scan error listeners (not Alert.alert) when TransportBLE.listen fires a non-BLE error', async () => {
-      const listener = jest.fn()
-      LedgerService.addScanErrorListener(listener)
+    it('calls onScanError (not Alert.alert) when TransportBLE.listen fires a non-BLE error', async () => {
+      const onScanError = jest.fn()
 
       const scanError = new Error('Hardware failure')
       transportBLEMock.listen.mockImplementation(
@@ -738,19 +681,18 @@ describe('LedgerService', () => {
         }
       )
 
-      await LedgerService.startDeviceScanning()
+      await LedgerService.startDeviceScanning(onScanError)
 
-      expect(listener).toHaveBeenCalledTimes(1)
-      expect(listener).toHaveBeenCalledWith({
+      expect(onScanError).toHaveBeenCalledTimes(1)
+      expect(onScanError).toHaveBeenCalledWith({
         title: 'Scan Error',
         message: `Failed to scan for devices: ${scanError.message}`
       })
       expect(Alert.alert).not.toHaveBeenCalled()
     })
 
-    it('calls showBluetoothErrorAlert (not scan error listeners) when TransportBLE.listen fires a BLE error', async () => {
-      const listener = jest.fn()
-      LedgerService.addScanErrorListener(listener)
+    it('calls showBluetoothErrorAlert (not onScanError) when TransportBLE.listen fires a BLE error', async () => {
+      const onScanError = jest.fn()
 
       const bleError = ledgerBluetoothErrors.radioOff()
       transportBLEMock.listen.mockImplementation(
@@ -760,30 +702,28 @@ describe('LedgerService', () => {
         }
       )
 
-      await LedgerService.startDeviceScanning()
+      await LedgerService.startDeviceScanning(onScanError)
 
-      expect(listener).not.toHaveBeenCalled()
+      expect(onScanError).not.toHaveBeenCalled()
       expect(Alert.alert).toHaveBeenCalledTimes(1)
     })
 
-    it('notifies scan error listeners with LEDGER_SCAN_FAILED title when scan times out with no devices', async () => {
-      const listener = jest.fn()
-      LedgerService.addScanErrorListener(listener)
+    it('calls onScanError with LEDGER_SCAN_FAILED title when scan times out with no devices', async () => {
+      const onScanError = jest.fn()
 
-      await LedgerService.startDeviceScanning()
+      await LedgerService.startDeviceScanning(onScanError)
 
       jest.advanceTimersByTime(LEDGER_TIMEOUTS.SCAN_TIMEOUT + 100)
 
-      expect(listener).toHaveBeenCalledTimes(1)
-      expect(listener).toHaveBeenCalledWith({
+      expect(onScanError).toHaveBeenCalledTimes(1)
+      expect(onScanError).toHaveBeenCalledWith({
         title: LEDGER_SCAN_FAILED_TITLE,
         message: LEDGER_SCAN_FAILED_ALREADY_CONNECTED_MESSAGE
       })
     })
 
-    it('does not notify scan error listeners when scan times out after devices were found', async () => {
-      const listener = jest.fn()
-      LedgerService.addScanErrorListener(listener)
+    it('does not call onScanError when scan times out after devices were found', async () => {
+      const onScanError = jest.fn()
 
       transportBLEMock.listen.mockImplementation(
         (observer: {
@@ -800,26 +740,25 @@ describe('LedgerService', () => {
         }
       )
 
-      await LedgerService.startDeviceScanning()
+      await LedgerService.startDeviceScanning(onScanError)
 
       jest.advanceTimersByTime(LEDGER_TIMEOUTS.SCAN_TIMEOUT + 100)
 
-      expect(listener).not.toHaveBeenCalled()
+      expect(onScanError).not.toHaveBeenCalled()
     })
 
-    it('notifies scan error listeners when TransportBLE.listen throws synchronously', async () => {
-      const listener = jest.fn()
-      LedgerService.addScanErrorListener(listener)
+    it('calls onScanError when TransportBLE.listen throws synchronously', async () => {
+      const onScanError = jest.fn()
 
       const syncError = new Error('Listen threw synchronously')
       transportBLEMock.listen.mockImplementation(() => {
         throw syncError
       })
 
-      await LedgerService.startDeviceScanning()
+      await LedgerService.startDeviceScanning(onScanError)
 
-      expect(listener).toHaveBeenCalledTimes(1)
-      expect(listener).toHaveBeenCalledWith({
+      expect(onScanError).toHaveBeenCalledTimes(1)
+      expect(onScanError).toHaveBeenCalledWith({
         title: 'Scan Error',
         message: `Failed to scan for devices: ${syncError.message}`
       })

--- a/packages/core-mobile/app/services/ledger/LedgerService.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.ts
@@ -99,9 +99,6 @@ class LedgerService {
   private scanSubscription: { unsubscribe: () => void } | null = null
   private scanInterval: ReturnType<typeof setInterval> | null = null
   private deviceListeners: Set<(devices: LedgerDevice[]) => void> = new Set()
-  private scanErrorListeners: Set<
-    (error: { title: string; message: string }) => void
-  > = new Set()
   private currentDevices: LedgerDevice[] = []
   private isScanning = false
 
@@ -269,7 +266,10 @@ class LedgerService {
   }
 
   // Handle scan errors (matching original implementation)
-  private handleScanError(error: Error): void {
+  private handleScanError(
+    error: Error,
+    onScanError: (error: { title: string; message: string }) => void
+  ): void {
     Logger.error('Scan error:', error)
     this.stopDeviceScanning()
 
@@ -277,14 +277,16 @@ class LedgerService {
       showBluetoothErrorAlert(error)
       return
     }
-    this.notifyScanError(
-      'Scan Error',
-      `Failed to scan for devices: ${error.message}`
-    )
+    onScanError({
+      title: 'Scan Error',
+      message: `Failed to scan for devices: ${error.message}`
+    })
   }
 
   // Device scanning methods (matching original implementation)
-  async startDeviceScanning(): Promise<void> {
+  async startDeviceScanning(
+    onScanError: (error: { title: string; message: string }) => void
+  ): Promise<void> {
     if (this.isScanning) {
       Logger.info('Device scanning already in progress')
       return
@@ -326,7 +328,7 @@ class LedgerService {
           }
         },
         error: (error: Error) => {
-          this.handleScanError(error)
+          this.handleScanError(error, onScanError)
         },
 
         complete: () => {
@@ -340,16 +342,16 @@ class LedgerService {
         this.stopDeviceScanning()
 
         if (!this.currentDevices || this.currentDevices.length === 0) {
-          this.notifyScanError(
-            LEDGER_SCAN_FAILED_TITLE,
-            LEDGER_SCAN_FAILED_ALREADY_CONNECTED_MESSAGE
-          )
+          onScanError({
+            title: LEDGER_SCAN_FAILED_TITLE,
+            message: LEDGER_SCAN_FAILED_ALREADY_CONNECTED_MESSAGE
+          })
         }
       }, LEDGER_TIMEOUTS.SCAN_TIMEOUT)
     } catch (error) {
       Logger.error('Failed to start device scanning:', error)
       this.isScanning = false
-      this.handleScanError(error as Error)
+      this.handleScanError(error as Error, onScanError)
     }
   }
 
@@ -369,28 +371,6 @@ class LedgerService {
     }
 
     this.isScanning = false
-  }
-
-  addScanErrorListener(
-    callback: (error: { title: string; message: string }) => void
-  ): void {
-    this.scanErrorListeners.add(callback)
-  }
-
-  removeScanErrorListener(
-    callback: (error: { title: string; message: string }) => void
-  ): void {
-    this.scanErrorListeners.delete(callback)
-  }
-
-  private notifyScanError(title: string, message: string): void {
-    this.scanErrorListeners.forEach(callback => {
-      try {
-        callback({ title, message })
-      } catch (error) {
-        Logger.error('Error in scan error listener callback:', error)
-      }
-    })
   }
 
   addDeviceListener(callback: (devices: LedgerDevice[]) => void): void {

--- a/packages/core-mobile/app/services/ledger/LedgerService.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.ts
@@ -1,6 +1,6 @@
 import TransportBLE from '@ledgerhq/react-native-hw-transport-ble'
 import Transport from '@ledgerhq/hw-transport'
-import { Alert, AppState, AppStateStatus } from 'react-native'
+import { AppState, AppStateStatus } from 'react-native'
 import AppAvalanche from '@avalabs/hw-app-avalanche'
 import AppSolana from '@ledgerhq/hw-app-solana'
 import { NetworkVMType } from '@avalabs/core-chains-sdk'
@@ -99,6 +99,9 @@ class LedgerService {
   private scanSubscription: { unsubscribe: () => void } | null = null
   private scanInterval: ReturnType<typeof setInterval> | null = null
   private deviceListeners: Set<(devices: LedgerDevice[]) => void> = new Set()
+  private scanErrorListeners: Set<
+    (error: { title: string; message: string }) => void
+  > = new Set()
   private currentDevices: LedgerDevice[] = []
   private isScanning = false
 
@@ -274,7 +277,10 @@ class LedgerService {
       showBluetoothErrorAlert(error)
       return
     }
-    Alert.alert('Scan Error', `Failed to scan for devices: ${error.message}`)
+    this.notifyScanError(
+      'Scan Error',
+      `Failed to scan for devices: ${error.message}`
+    )
   }
 
   // Device scanning methods (matching original implementation)
@@ -334,10 +340,9 @@ class LedgerService {
         this.stopDeviceScanning()
 
         if (!this.currentDevices || this.currentDevices.length === 0) {
-          Alert.alert(
+          this.notifyScanError(
             LEDGER_SCAN_FAILED_TITLE,
-            LEDGER_SCAN_FAILED_ALREADY_CONNECTED_MESSAGE,
-            [{ text: 'OK' }]
+            LEDGER_SCAN_FAILED_ALREADY_CONNECTED_MESSAGE
           )
         }
       }, LEDGER_TIMEOUTS.SCAN_TIMEOUT)
@@ -364,6 +369,28 @@ class LedgerService {
     }
 
     this.isScanning = false
+  }
+
+  addScanErrorListener(
+    callback: (error: { title: string; message: string }) => void
+  ): void {
+    this.scanErrorListeners.add(callback)
+  }
+
+  removeScanErrorListener(
+    callback: (error: { title: string; message: string }) => void
+  ): void {
+    this.scanErrorListeners.delete(callback)
+  }
+
+  private notifyScanError(title: string, message: string): void {
+    this.scanErrorListeners.forEach(callback => {
+      try {
+        callback({ title, message })
+      } catch (error) {
+        Logger.error('Error in scan error listener callback:', error)
+      }
+    })
   }
 
   addDeviceListener(callback: (devices: LedgerDevice[]) => void): void {


### PR DESCRIPTION
## Description

iOS: 8216
Android: 8217

**Ticket: [CP-14069]**

`LedgerService` was calling `Alert.alert` directly with no buttons array.
On Android, an alert with no buttons renders without any dismiss control,
forcing the user to kill and reopen the app. The scan timeout path also
had an OK button but no `onPress` action, leaving state uncleaned.

**Root cause:** A service class showed UI alerts it had no ability to
navigate away from or clean up after.

**Fix:**
- Added `scanErrorListeners` to `LedgerService` (mirrors the existing
  `deviceListeners` pattern) with `addScanErrorListener`,
  `removeScanErrorListener`, and `notifyScanError`
- Replaced both `Alert.alert` calls in `LedgerService` with
  `notifyScanError` — the service now emits the error, not the UI
- Removed `Alert` import from `LedgerService`
- `DeviceConnectionScreen` subscribes via `useEffect`; the alert OK
  button calls `resetSetup()` to clean up scan state on dismiss

## Screenshots/Videos

N/A — logic-only change.

## Testing

**Dev Testing (if applicable)**

- Start Ledger onboarding with no Ledger device nearby
- Wait for the scan timeout (~30 seconds) — confirm the "Scan failed"
  alert appears with an OK button that dismisses and resets state
- Force a BLE scan error (e.g. toggle Bluetooth mid-scan) — confirm the
  "Scan Error" alert is dismissible and cleans up state
- Verify the above on both iOS and Android (Android was the platform
  where the non-dismissible alert occurred)

**QA Testing (if applicable)**

- Scan for Ledger with no device in range → alert dismisses cleanly,
  user can retry or cancel without killing the app

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14069]: https://ava-labs.atlassian.net/browse/CP-14069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ