### PR TITLE
CP-14074: Only derive missing seedless session keys when seedless wallet accounts are missing addressSVM

### DIFF
--- a/packages/core-mobile/app/store/account/listeners.ts
+++ b/packages/core-mobile/app/store/account/listeners.ts
@@ -297,17 +297,17 @@ const migrateSolanaAddressesIfNeeded = async (
   const isSolanaSupportBlocked = selectIsSolanaSupportBlocked(state)
   const accounts = selectAccounts(state)
   const entries = Object.values(accounts)
+  const seedlessWallet = selectSeedlessWallet(state)
+  const hasAccountsWithoutSVM = entries.some(account => !account.addressSVM)
+  const hasSeedlessAccountsWithoutSVM = entries.some(
+    account =>
+      account.addressSVM === undefined &&
+      account.walletId === seedlessWallet?.id
+  )
 
   // Only migrate Solana addresses if Solana support is enabled
-  if (!isSolanaSupportBlocked && entries.some(account => !account.addressSVM)) {
-    const seedlessWallet = selectSeedlessWallet(state)
-    const seedlessAccounts = seedlessWallet
-      ? selectAccountsByWalletId(state, seedlessWallet.id)
-      : []
-    if (
-      seedlessWallet &&
-      seedlessAccounts.some(account => !account.addressSVM)
-    ) {
+  if (!isSolanaSupportBlocked && hasAccountsWithoutSVM) {
+    if (seedlessWallet && hasSeedlessAccountsWithoutSVM) {
       await deriveMissingSeedlessSessionKeys(seedlessWallet.id)
     }
     // reload only when there are accounts without Solana addresses

--- a/packages/core-mobile/app/store/account/listeners.ts
+++ b/packages/core-mobile/app/store/account/listeners.ts
@@ -298,10 +298,12 @@ const migrateSolanaAddressesIfNeeded = async (
   const accounts = selectAccounts(state)
   const entries = Object.values(accounts)
   const seedlessWallet = selectSeedlessWallet(state)
-  const hasAccountsWithoutSVM = entries.some(account => !account.addressSVM)
+  const hasAccountsWithoutSVM = entries.some(account =>
+    isAddressMissing(account.addressSVM)
+  )
   const hasSeedlessAccountsWithoutSVM = entries.some(
     account =>
-      account.addressSVM === undefined &&
+      isAddressMissing(account.addressSVM) &&
       account.walletId === seedlessWallet?.id
   )
 

--- a/packages/core-mobile/app/store/account/listeners.ts
+++ b/packages/core-mobile/app/store/account/listeners.ts
@@ -301,7 +301,13 @@ const migrateSolanaAddressesIfNeeded = async (
   // Only migrate Solana addresses if Solana support is enabled
   if (!isSolanaSupportBlocked && entries.some(account => !account.addressSVM)) {
     const seedlessWallet = selectSeedlessWallet(state)
-    if (seedlessWallet) {
+    const seedlessAccounts = seedlessWallet
+      ? selectAccountsByWalletId(state, seedlessWallet.id)
+      : []
+    if (
+      seedlessWallet &&
+      seedlessAccounts.some(account => !account.addressSVM)
+    ) {
       await deriveMissingSeedlessSessionKeys(seedlessWallet.id)
     }
     // reload only when there are accounts without Solana addresses


### PR DESCRIPTION
## Description

**Ticket: [CP-14074]**

- Adds a guard in `migrateSolanaAddressesIfNeeded` so that `deriveMissingSeedlessSessionKeys` is only called when the seedless wallet's own accounts are actually missing `addressSVM`.
- Previously, the function would call `deriveMissingSeedlessSessionKeys` whenever *any* account across all wallets was missing a Solana address — even if those accounts belonged to a non-seedless wallet. This narrows the check to only accounts belonging to the seedless wallet.

## Screenshots/Videos

N/A — logic-only change, no UI impact.

## Testing

**Dev Testing (if applicable)**

- Have a seedless wallet and a non-seedless wallet (e.g. Ledger or mnemonic) in the app
- Ensure the non-seedless wallet has an account missing `addressSVM`
- Confirm that `deriveMissingSeedlessSessionKeys` is **not** called (no unnecessary key derivation triggered)
- Ensure the seedless wallet still derives missing session keys when its own accounts are missing `addressSVM`
- Trigger a build on Bitrise and reference it here
- Move the ticket into the "Testing" column on Jira

iOS: 8217
Android: 8218

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14074]: https://ava-labs.atlassian.net/browse/CP-14074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ