### PR TITLE
CP-13974: Fix Ledger auto-import toast timing

### DIFF
--- a/packages/core-mobile/app/new/features/ledger/screens/AppConnectionOnboardingScreen.tsx
+++ b/packages/core-mobile/app/new/features/ledger/screens/AppConnectionOnboardingScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import Logger from 'utils/Logger'
 import { Alert } from 'react-native'
@@ -10,8 +10,6 @@ import {
   PublicKeyInfo
 } from 'services/ledger/types'
 import { useRouter } from 'expo-router'
-import { WalletType } from 'services/wallet/types'
-import { onWalletImported } from 'store/app/slice'
 import { useLedgerWallet } from '../hooks/useLedgerWallet'
 import { useLedgerSetupContext } from '../contexts/LedgerSetupContext'
 import { useSetLedgerAddress } from '../hooks/useSetLedgerAddress'
@@ -19,7 +17,7 @@ import { useCheckIfLedgerWalletExists } from '../hooks/useCheckIfLedgerWalletExi
 import AppConnectionScreen from './AppConnectionScreen'
 
 interface AppConnectionOnboardingScreenProps {
-  onNavigateToComplete: () => void
+  onNavigateToComplete: (walletId?: string) => void
   showConnectionToasts: boolean
   showCancelOnComplete: boolean
 }
@@ -33,7 +31,6 @@ export const AppConnectionOnboardingScreen = ({
   const { setLedgerAddress } = useSetLedgerAddress()
   const checkIfLedgerWalletExists = useCheckIfLedgerWalletExists()
   const { canGoBack, back } = useRouter()
-  const dispatch = useDispatch()
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   // useRef instead of useState: the ref flips synchronously, so a second tap
   // cannot enter handleComplete before the first invocation finishes. useState
@@ -155,18 +152,7 @@ export const AppConnectionOnboardingScreen = ({
         })
 
         LedgerService.stopAppPolling()
-        onNavigateToComplete()
-
-        // Trigger background discovery for accounts 1-9.
-        // This runs after navigation — the user doesn't wait.
-        const walletType =
-          derivationPath === LedgerDerivationPathType.BIP44
-            ? WalletType.LEDGER
-            : WalletType.LEDGER_LIVE
-
-        setTimeout(() => {
-          dispatch(onWalletImported({ walletId, walletType }))
-        }, 1500)
+        onNavigateToComplete(walletId)
       } catch (error) {
         Logger.error('Wallet creation failed', error)
         Alert.alert(
@@ -192,7 +178,6 @@ export const AppConnectionOnboardingScreen = ({
       isDeveloperMode,
       onNavigateToComplete,
       handleCancel,
-      dispatch,
       checkIfLedgerWalletExists
     ]
   )

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/ledger/appConnection.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/ledger/appConnection.tsx
@@ -1,13 +1,35 @@
 import React, { useCallback } from 'react'
 import { useRouter } from 'expo-router'
 import { AppConnectionOnboardingScreen } from 'new/features/ledger/screens/AppConnectionOnboardingScreen'
+import { LedgerDerivationPathType } from 'services/ledger/types'
+import { WalletType } from 'services/wallet/types'
+import { onWalletImported } from 'store/app/slice'
+import { useDispatch } from 'react-redux'
+import { useLedgerSetupContext } from 'features/ledger'
 
 export default function AppConnection(): JSX.Element {
   const { navigate } = useRouter()
+  const dispatch = useDispatch()
+  const { selectedDerivationPath } = useLedgerSetupContext()
 
-  const handleNavigateToComplete = useCallback(() => {
-    navigate('/accountSettings/ledger/complete')
-  }, [navigate])
+  const handleNavigateToComplete = useCallback(
+    (walletId?: string) => {
+      if (!walletId) {
+        navigate('/accountSettings/ledger/complete')
+        return
+      }
+      // Trigger background discovery for accounts 1-9.
+      // This runs after navigation — the user doesn't wait.
+      const walletType =
+        selectedDerivationPath === LedgerDerivationPathType.BIP44
+          ? WalletType.LEDGER
+          : WalletType.LEDGER_LIVE
+
+      dispatch(onWalletImported({ walletId, walletType }))
+      navigate('/accountSettings/ledger/complete')
+    },
+    [selectedDerivationPath, navigate, dispatch]
+  )
 
   return (
     <AppConnectionOnboardingScreen

--- a/packages/core-mobile/app/new/routes/onboarding/ledger/confirmation.tsx
+++ b/packages/core-mobile/app/new/routes/onboarding/ledger/confirmation.tsx
@@ -4,20 +4,31 @@ import { useLedgerSetupContext } from 'features/ledger'
 import { LedgerDerivationPathType } from 'services/ledger/types'
 import { WalletType } from 'services/wallet/types'
 import Logger from 'utils/Logger'
-import React from 'react'
+import React, { useCallback } from 'react'
+import { onWalletImported } from 'store/app'
+import { useDispatch, useSelector } from 'react-redux'
+import { selectActiveWalletId } from 'store/wallet/slice'
 
 export default function Confirmation(): JSX.Element {
   const { login } = useWallet()
+  const walletId = useSelector(selectActiveWalletId)
+  const dispatch = useDispatch()
   const { selectedDerivationPath } = useLedgerSetupContext()
 
-  const walletType =
-    selectedDerivationPath === LedgerDerivationPathType.LedgerLive
-      ? WalletType.LEDGER_LIVE
-      : WalletType.LEDGER
+  const handleNext = useCallback((): void => {
+    if (!walletId) {
+      Logger.error('No wallet ID found for Ledger wallet after creation')
+      return
+    }
+    const walletType =
+      selectedDerivationPath === LedgerDerivationPathType.LedgerLive
+        ? WalletType.LEDGER_LIVE
+        : WalletType.LEDGER
 
-  const handleNext = (): void => {
+    dispatch(onWalletImported({ walletId, walletType }))
+
     login(walletType).catch(Logger.error)
-  }
+  }, [dispatch, login, walletId, selectedDerivationPath])
 
   return <Component onNext={handleNext} />
 }


### PR DESCRIPTION
## Description

**Ticket: [CP-13974](https://ava-labs.atlassian.net/browse/CP-13974)**

Fixes two issues with Ledger background account discovery (`onWalletImported`):

1. **Too-early toast during onboarding** — The "1 account added" toast appeared mid-onboarding (before the user reached portfolio) because `onWalletImported` was dispatched via a 1.5s `setTimeout` in `AppConnectionOnboardingScreen`, while the user still had 3 screens to go (setWalletName → selectAvatar → confirmation). Now deferred to the confirmation screen, right before `login()`.

### Changes
- `AppConnectionOnboardingScreen` no longer dispatches `onWalletImported` — it passes `walletId` to the caller via `onNavigateToComplete(walletId)`
- Signed-in route receives `walletId` from the callback and dispatches `onWalletImported` with the correct ID
- Onboarding `confirmation.tsx` dispatches `onWalletImported` at the confirmation step (right before login)

## Screenshots/Videos

N/A — behavioral fix, no UI changes.

## Testing

**Dev Testing**

- Onboard with Ledger that has multiple active accounts → verify toast does NOT appear during onboarding screens, accounts appear on portfolio
- Onboard with mnemonic first, then import Ledger wallet with multiple active accounts → verify additional accounts are discovered and appear in the wallet
- Import Ledger wallet (BIP44 and LedgerLive paths) → verify discovery works correctly

**QA Testing**

- Verify no "X account added" toast during Ledger onboarding flow
- Verify Ledger account discovery works when importing Ledger as a second wallet

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

iOS: 8232
Android: 8233

[CP-13974]: https://ava-labs.atlassian.net/browse/CP-13974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ