### PR TITLE
Extract EVM injected provider dispatch into router module

### DIFF
--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -1,0 +1,477 @@
+import { setTabChainId } from 'store/browser/slices/tabs'
+import type { Networks } from 'store/network/types'
+import { createInjectedProviderRouter } from './router'
+import { BrowserNetwork, RouterDeps } from './types'
+
+jest.mock('store/browser/slices/tabs', () => ({
+  setTabChainId: jest.fn(
+    (payload: { tabId: string; chainId: number }) => ({
+      type: 'browser/tabs/setTabChainId',
+      payload
+    })
+  )
+}))
+
+jest.mock('utils/caip2ChainIds', () => ({
+  getEvmCaip2ChainId: (chainId: number) => `eip155:${chainId}`
+}))
+
+jest.mock('utils/Logger', () => ({
+  __esModule: true,
+  default: {
+    trace: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}))
+
+type MockDeps = {
+  deps: RouterDeps
+  sendResponse: jest.Mock
+  emitEvent: jest.Mock
+  requestSigning: jest.Mock
+  dispatch: jest.Mock
+  trackPendingOrigin: jest.Mock
+  setBrowserNetworkSpy: jest.Mock
+  currentNetwork: { value: BrowserNetwork }
+}
+
+function makeDeps(overrides?: {
+  browserNetwork?: BrowserNetwork
+  allNetworks?: Networks
+  nativeOrigin?: string | undefined
+  tabId?: string
+}): MockDeps {
+  const currentNetwork = {
+    value: overrides?.browserNetwork ?? {
+      chainId: 43114,
+      rpcUrl: 'https://api.avax.network/ext/bc/C/rpc'
+    }
+  }
+  const allNetworks = overrides?.allNetworks ?? ({
+    43114: {
+      chainId: 43114,
+      rpcUrl: 'https://api.avax.network/ext/bc/C/rpc'
+    },
+    1: {
+      chainId: 1,
+      rpcUrl: 'https://eth.llamarpc.com'
+    }
+  } as unknown as Networks)
+
+  const sendResponse = jest.fn()
+  const emitEvent = jest.fn()
+  const requestSigning = jest.fn()
+  const dispatch = jest.fn()
+  const trackPendingOrigin = jest.fn()
+  const setBrowserNetworkSpy = jest.fn((net: BrowserNetwork) => {
+    currentNetwork.value = net
+  })
+
+  const deps: RouterDeps = {
+    getBrowserNetwork: () => currentNetwork.value,
+    setBrowserNetwork: setBrowserNetworkSpy,
+    getAllNetworks: () => allNetworks,
+    tabId: overrides?.tabId ?? 'tab-1',
+    dispatch,
+    requestSigning,
+    sendResponse,
+    emitEvent,
+    getNativeOrigin: () =>
+      overrides && 'nativeOrigin' in overrides
+        ? overrides.nativeOrigin
+        : 'https://example.com',
+    trackPendingOrigin,
+    getPeerMeta: () => ({
+      name: 'example',
+      description: '',
+      url: 'https://example.com',
+      icons: []
+    })
+  }
+
+  return {
+    deps,
+    sendResponse,
+    emitEvent,
+    requestSigning,
+    dispatch,
+    trackPendingOrigin,
+    setBrowserNetworkSpy,
+    currentNetwork
+  }
+}
+
+function send(
+  router: ReturnType<typeof createInjectedProviderRouter>,
+  id: number,
+  method: string,
+  params: unknown[] = []
+): void {
+  router.handleProviderMessage(
+    JSON.stringify({ id, request: { method, params } })
+  )
+}
+
+describe('createInjectedProviderRouter', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  describe('dispatch', () => {
+    it('rejects unknown methods with methodNotFound', () => {
+      const { deps, sendResponse } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'totally_fake_method')
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: -32601 }),
+        undefined
+      )
+    })
+
+    it('tracks native origin for allowed methods', () => {
+      const { deps, trackPendingOrigin } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'eth_blockNumber')
+
+      expect(trackPendingOrigin).toHaveBeenCalledWith(
+        1,
+        'https://example.com'
+      )
+    })
+
+    it('rejects signing methods when native origin is unavailable', () => {
+      const { deps, sendResponse } = makeDeps({ nativeOrigin: undefined })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'personal_sign', ['0xMsg', '0xAddr'])
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          code: -32603,
+          message: expect.stringContaining('Origin unavailable')
+        }),
+        undefined
+      )
+    })
+  })
+
+  describe('payload parsing', () => {
+    it('ignores invalid JSON', () => {
+      const { deps, sendResponse } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      router.handleProviderMessage('not-json')
+
+      expect(sendResponse).not.toHaveBeenCalled()
+    })
+
+    it('responds invalidRequest for malformed request with numeric id', () => {
+      const { deps, sendResponse } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      router.handleProviderMessage(JSON.stringify({ id: 7, request: null }))
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        7,
+        expect.objectContaining({ code: -32600 }),
+        undefined
+      )
+    })
+
+    it('responds invalidRequest when payload exceeds size limit', () => {
+      const { deps, sendResponse } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      const big = 'x'.repeat(2_000_000)
+      router.handleProviderMessage(
+        JSON.stringify({ id: 9, request: { method: 'eth_call' }, big })
+      )
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        9,
+        expect.objectContaining({ code: -32600 }),
+        undefined
+      )
+    })
+  })
+
+  describe('wallet_switchEthereumChain', () => {
+    it('returns invalidParams when chainId missing', () => {
+      const { deps, sendResponse } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'wallet_switchEthereumChain', [{}])
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: -32602 }),
+        undefined
+      )
+    })
+
+    it('returns 4902 for unknown chain (triggers addEthereumChain flow)', () => {
+      const { deps, sendResponse } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'wallet_switchEthereumChain', [{ chainId: '0x2a' }]) // 42
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        { code: 4902, message: expect.stringContaining('Chain 42') },
+        undefined
+      )
+    })
+
+    it('no-ops when already on requested chain', () => {
+      const { deps, sendResponse, dispatch, setBrowserNetworkSpy } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'wallet_switchEthereumChain', [{ chainId: '0xa86a' }])
+
+      expect(dispatch).not.toHaveBeenCalled()
+      expect(setBrowserNetworkSpy).not.toHaveBeenCalled()
+      expect(sendResponse).toHaveBeenCalledWith(1, null, null)
+    })
+
+    it('updates browser network and dispatches setTabChainId on known chain switch', () => {
+      const { deps, sendResponse, dispatch, setBrowserNetworkSpy } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'wallet_switchEthereumChain', [{ chainId: '0x1' }]) // 1
+
+      expect(dispatch).toHaveBeenCalledWith(
+        setTabChainId({ tabId: 'tab-1', chainId: 1 })
+      )
+      expect(setBrowserNetworkSpy).toHaveBeenCalledWith({
+        chainId: 1,
+        rpcUrl: 'https://eth.llamarpc.com'
+      })
+      expect(sendResponse).toHaveBeenCalledWith(1, null, null)
+    })
+  })
+
+  describe('wallet_addEthereumChain', () => {
+    it('on approval, updates browser network, dispatches setTabChainId, emits chainChanged', async () => {
+      const { deps, sendResponse, dispatch, setBrowserNetworkSpy, emitEvent, requestSigning } =
+        makeDeps()
+      requestSigning.mockResolvedValueOnce('')
+      const router = createInjectedProviderRouter(deps)
+
+      router.handleProviderMessage(
+        JSON.stringify({
+          id: 1,
+          request: {
+            method: 'wallet_addEthereumChain',
+            params: [
+              { chainId: '0x1', rpcUrls: ['https://eth.llamarpc.com'] }
+            ]
+          }
+        })
+      )
+      await new Promise(r => setImmediate(r))
+
+      expect(setBrowserNetworkSpy).toHaveBeenCalledWith({
+        chainId: 1,
+        rpcUrl: 'https://eth.llamarpc.com'
+      })
+      expect(dispatch).toHaveBeenCalledWith(
+        setTabChainId({ tabId: 'tab-1', chainId: 1 })
+      )
+      expect(emitEvent).toHaveBeenCalledWith('chainChanged', '0x1')
+      expect(sendResponse).toHaveBeenCalledWith(1, null, null)
+    })
+
+    it('on rejection, propagates the error', async () => {
+      const { deps, sendResponse, requestSigning } = makeDeps()
+      const rejection = { code: 4001, message: 'User rejected' }
+      requestSigning.mockRejectedValueOnce(rejection)
+      const router = createInjectedProviderRouter(deps)
+
+      router.handleProviderMessage(
+        JSON.stringify({
+          id: 1,
+          request: {
+            method: 'wallet_addEthereumChain',
+            params: [
+              { chainId: '0x1', rpcUrls: ['https://eth.llamarpc.com'] }
+            ]
+          }
+        })
+      )
+      await new Promise(r => setImmediate(r))
+
+      expect(sendResponse).toHaveBeenCalledWith(1, rejection, undefined)
+    })
+  })
+
+  describe('wallet_revokePermissions', () => {
+    it('emits accountsChanged([]) and responds null — does NOT emit disconnect', () => {
+      const { deps, sendResponse, emitEvent } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'wallet_revokePermissions')
+
+      expect(emitEvent).toHaveBeenCalledWith('accountsChanged', [])
+      expect(emitEvent).not.toHaveBeenCalledWith(
+        'disconnect',
+        expect.anything()
+      )
+      expect(sendResponse).toHaveBeenCalledWith(1, null, null)
+    })
+  })
+
+  describe('wallet_watchAsset', () => {
+    it('on 4001 rejection, responds with (null, false) per EIP-747', async () => {
+      const { deps, sendResponse, requestSigning } = makeDeps()
+      requestSigning.mockRejectedValueOnce({ code: 4001 })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'wallet_watchAsset', [
+        { type: 'ERC20', options: { address: '0xAA' } }
+      ])
+      await new Promise(r => setImmediate(r))
+
+      expect(sendResponse).toHaveBeenCalledWith(1, null, false)
+    })
+
+    it('on non-4001 error, propagates as real error', async () => {
+      const { deps, sendResponse, requestSigning } = makeDeps()
+      const internalErr = { code: -32603, message: 'internal' }
+      requestSigning.mockRejectedValueOnce(internalErr)
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'wallet_watchAsset', [
+        { type: 'ERC20', options: { address: '0xAA' } }
+      ])
+      await new Promise(r => setImmediate(r))
+
+      expect(sendResponse).toHaveBeenCalledWith(1, internalErr, undefined)
+    })
+
+    it('accepts object-form params and normalizes to array', async () => {
+      const { deps, requestSigning } = makeDeps()
+      requestSigning.mockResolvedValueOnce(true)
+      const router = createInjectedProviderRouter(deps)
+
+      router.handleProviderMessage(
+        JSON.stringify({
+          id: 1,
+          request: {
+            method: 'wallet_watchAsset',
+            params: { type: 'ERC20', options: { address: '0xAA' } }
+          }
+        })
+      )
+      await new Promise(r => setImmediate(r))
+
+      expect(requestSigning).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: [{ type: 'ERC20', options: { address: '0xAA' } }]
+        })
+      )
+    })
+  })
+
+  describe('signing methods', () => {
+    it('calls requestSigning with caip2 chain and peer meta, resolves with result', async () => {
+      const { deps, sendResponse, requestSigning } = makeDeps()
+      requestSigning.mockResolvedValueOnce('0xSig')
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'personal_sign', ['0xMsg', '0xAddr'])
+      await new Promise(r => setImmediate(r))
+
+      expect(requestSigning).toHaveBeenCalledWith({
+        method: 'personal_sign',
+        params: ['0xMsg', '0xAddr'],
+        chainId: 'eip155:43114',
+        peerMeta: expect.objectContaining({ name: 'example' })
+      })
+      expect(sendResponse).toHaveBeenCalledWith(1, null, '0xSig')
+    })
+
+    it('propagates rejection from requestSigning', async () => {
+      const { deps, sendResponse, requestSigning } = makeDeps()
+      const err = { code: 4001, message: 'User rejected' }
+      requestSigning.mockRejectedValueOnce(err)
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'personal_sign', ['0xMsg', '0xAddr'])
+      await new Promise(r => setImmediate(r))
+
+      expect(sendResponse).toHaveBeenCalledWith(1, err, undefined)
+    })
+  })
+
+  describe('proxyToRpc', () => {
+    const originalFetch = global.fetch
+
+    afterEach(() => {
+      global.fetch = originalFetch
+    })
+
+    it('returns internal error when rpcUrl is empty', async () => {
+      const { deps, sendResponse } = makeDeps({
+        browserNetwork: { chainId: 1, rpcUrl: '' }
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'eth_blockNumber')
+      await new Promise(r => setImmediate(r))
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: -32603 }),
+        undefined
+      )
+    })
+
+    it('proxies result on successful RPC fetch', async () => {
+      const { deps, sendResponse } = makeDeps()
+      global.fetch = jest.fn().mockResolvedValue({
+        json: async () => ({ result: '0xabc' })
+      }) as unknown as typeof fetch
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'eth_blockNumber')
+      await new Promise(r => setImmediate(r))
+
+      expect(sendResponse).toHaveBeenCalledWith(1, null, '0xabc')
+    })
+
+    it('surfaces RPC error field', async () => {
+      const { deps, sendResponse } = makeDeps()
+      const rpcErr = { code: -32000, message: 'node error' }
+      global.fetch = jest.fn().mockResolvedValue({
+        json: async () => ({ error: rpcErr })
+      }) as unknown as typeof fetch
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'eth_blockNumber')
+      await new Promise(r => setImmediate(r))
+
+      expect(sendResponse).toHaveBeenCalledWith(1, rpcErr, undefined)
+    })
+
+    it('returns internal error on fetch failure', async () => {
+      const { deps, sendResponse } = makeDeps()
+      global.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error('network down')) as unknown as typeof fetch
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'eth_blockNumber')
+      await new Promise(r => setImmediate(r))
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: -32603 }),
+        undefined
+      )
+    })
+  })
+})

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -1,0 +1,378 @@
+import { rpcErrors } from '@metamask/rpc-errors'
+import { RpcMethod } from '@avalabs/vm-module-types'
+import Logger from 'utils/Logger'
+import { getEvmCaip2ChainId } from 'utils/caip2ChainIds'
+import { setTabChainId } from 'store/browser/slices/tabs'
+import {
+  MAX_MESSAGE_SIZE,
+  ProviderRequest,
+  RouterDeps
+} from './types'
+
+const READ_ONLY_METHODS = new Set([
+  'eth_blockNumber',
+  'eth_call',
+  'eth_estimateGas',
+  'eth_gasPrice',
+  'eth_getBalance',
+  'eth_getBlockByHash',
+  'eth_getBlockByNumber',
+  'eth_getCode',
+  'eth_getLogs',
+  'eth_getStorageAt',
+  'eth_getTransactionByHash',
+  'eth_getTransactionCount',
+  'eth_getTransactionReceipt',
+  'eth_maxPriorityFeePerGas',
+  'eth_feeHistory',
+  'web3_clientVersion',
+  'web3_sha3',
+  'eth_getBlockTransactionCountByHash',
+  'eth_getBlockTransactionCountByNumber'
+])
+
+const SIGNING_METHODS: Record<string, RpcMethod> = {
+  [RpcMethod.ETH_SEND_TRANSACTION]: RpcMethod.ETH_SEND_TRANSACTION,
+  [RpcMethod.PERSONAL_SIGN]: RpcMethod.PERSONAL_SIGN,
+  [RpcMethod.ETH_SIGN]: RpcMethod.ETH_SIGN,
+  [RpcMethod.SIGN_TYPED_DATA]: RpcMethod.SIGN_TYPED_DATA,
+  [RpcMethod.SIGN_TYPED_DATA_V1]: RpcMethod.SIGN_TYPED_DATA_V1,
+  [RpcMethod.SIGN_TYPED_DATA_V3]: RpcMethod.SIGN_TYPED_DATA_V3,
+  [RpcMethod.SIGN_TYPED_DATA_V4]: RpcMethod.SIGN_TYPED_DATA_V4
+}
+
+const ALLOWED_METHODS = new Set([
+  ...READ_ONLY_METHODS,
+  ...Object.keys(SIGNING_METHODS),
+  'wallet_switchEthereumChain',
+  'wallet_addEthereumChain',
+  'wallet_revokePermissions',
+  'wallet_watchAsset'
+])
+
+function validateProviderRequest(data: unknown): data is ProviderRequest {
+  if (typeof data !== 'object' || data === null) return false
+  const obj = data as Record<string, unknown>
+  if (typeof obj.id !== 'number') return false
+  if (typeof obj.request !== 'object' || obj.request === null) return false
+  const req = obj.request as Record<string, unknown>
+  return typeof req.method === 'string'
+}
+
+function parseProviderPayload(
+  payload: string,
+  respondWithError: (id: number, error: unknown) => void
+): ProviderRequest | undefined {
+  if (payload.length > MAX_MESSAGE_SIZE) {
+    Logger.warn(
+      `[InjectedProvider] Message exceeds ${MAX_MESSAGE_SIZE} byte limit`
+    )
+    try {
+      const { id } = JSON.parse(payload) as { id?: unknown }
+      if (typeof id === 'number') {
+        respondWithError(
+          id,
+          rpcErrors.invalidRequest('Message exceeds size limit')
+        )
+      }
+    } catch {
+      /* oversized and unparseable */
+    }
+    return undefined
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(payload)
+  } catch {
+    Logger.error('[InjectedProvider] Invalid JSON payload')
+    return undefined
+  }
+
+  if (!validateProviderRequest(parsed)) {
+    Logger.error('[InjectedProvider] Malformed provider_request')
+    const maybeId = (parsed as Record<string, unknown>)?.id
+    if (typeof maybeId === 'number') {
+      respondWithError(maybeId, rpcErrors.invalidRequest('Malformed request'))
+    }
+    return undefined
+  }
+
+  return parsed
+}
+
+export type InjectedProviderRouter = {
+  handleProviderMessage: (payload: string) => void
+}
+
+export function createInjectedProviderRouter(
+  deps: RouterDeps
+): InjectedProviderRouter {
+  const {
+    getBrowserNetwork,
+    setBrowserNetwork,
+    getAllNetworks,
+    tabId,
+    dispatch,
+    requestSigning,
+    sendResponse,
+    emitEvent,
+    getNativeOrigin,
+    trackPendingOrigin,
+    getPeerMeta
+  } = deps
+
+  const proxyToRpc = async (
+    id: number,
+    method: string,
+    params: unknown[]
+  ): Promise<void> => {
+    try {
+      const rpcUrl = getBrowserNetwork().rpcUrl
+      if (!rpcUrl) {
+        sendResponse(
+          id,
+          rpcErrors.internal('No RPC URL configured'),
+          undefined
+        )
+        return
+      }
+
+      const body = JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        method,
+        params
+      })
+
+      const response = await fetch(rpcUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body
+      })
+
+      const json = await response.json()
+
+      if (json.error) {
+        sendResponse(id, json.error, undefined)
+      } else {
+        sendResponse(id, null, json.result)
+      }
+    } catch (e) {
+      Logger.error('[InjectedProvider] RPC proxy error', e)
+      sendResponse(id, rpcErrors.internal('RPC request failed'), undefined)
+    }
+  }
+
+  const dispatchSigningRequest = async (
+    id: number,
+    method: string,
+    params: unknown[]
+  ): Promise<void> => {
+    const rpcMethod = SIGNING_METHODS[method]
+    if (!rpcMethod) {
+      sendResponse(
+        id,
+        rpcErrors.methodNotFound(`Method not supported: ${method}`),
+        undefined
+      )
+      return
+    }
+
+    const caip2ChainId = getEvmCaip2ChainId(getBrowserNetwork().chainId)
+
+    try {
+      const result = await requestSigning({
+        method: rpcMethod,
+        params,
+        chainId: caip2ChainId,
+        peerMeta: getPeerMeta()
+      })
+      sendResponse(id, null, result)
+    } catch (e) {
+      sendResponse(id, e, undefined)
+    }
+  }
+
+  const handleSwitchEthereumChain = (id: number, params: unknown[]): void => {
+    const param = params[0] as { chainId?: string } | undefined
+    const hexChainId = param?.chainId
+    if (!hexChainId) {
+      sendResponse(
+        id,
+        rpcErrors.invalidParams('Missing chainId param'),
+        undefined
+      )
+      return
+    }
+    const requestedChainId = parseInt(hexChainId, 16)
+    if (isNaN(requestedChainId)) {
+      sendResponse(id, rpcErrors.invalidParams('Invalid chainId'), undefined)
+      return
+    }
+    const allNetworks = getAllNetworks()
+    if (!(String(requestedChainId) in allNetworks)) {
+      // Return 4902 (unrecognized chain) so ConnectKit/wagmi can trigger the
+      // wallet_addEthereumChain flow instead. The shim already fired
+      // chainChanged(target) optimistically and will not roll it back, so
+      // wagmi's chain state stays at target — preventing ConnectKit from
+      // re-triggering switchChain in a loop (React error #185).
+      sendResponse(
+        id,
+        {
+          code: 4902,
+          message: `Chain ${requestedChainId} has not been added to your wallet.`
+        },
+        undefined
+      )
+      return
+    }
+    if (requestedChainId === getBrowserNetwork().chainId) {
+      sendResponse(id, null, null)
+      return
+    }
+    // Persist the chain switch for this tab only (survives tab eviction/remount).
+    // The browser network ensures all subsequent RPC calls in this session are
+    // routed to the correct chain. The shim already fired chainChanged
+    // synchronously before the round-trip (prevents React #185 loop), so we
+    // do NOT re-emit it here.
+    const switchedNetwork = allNetworks[requestedChainId]
+    dispatch(setTabChainId({ tabId, chainId: requestedChainId }))
+    setBrowserNetwork({
+      chainId: requestedChainId,
+      rpcUrl: switchedNetwork?.rpcUrl ?? ''
+    })
+    sendResponse(id, null, null)
+  }
+
+  const handleAddEthereumChain = async (
+    id: number,
+    params: unknown[]
+  ): Promise<void> => {
+    const addParam = params[0] as
+      | { chainId?: string; rpcUrls?: string[] }
+      | undefined
+    const addHexChainId = addParam?.chainId
+    const addRpcUrl = addParam?.rpcUrls?.[0]
+    try {
+      await requestSigning({
+        method: 'wallet_addEthereumChain' as unknown as RpcMethod,
+        params,
+        chainId: getEvmCaip2ChainId(getBrowserNetwork().chainId),
+        peerMeta: getPeerMeta()
+      })
+      // User approved — switch browser chain to the new network and notify dApp
+      if (addHexChainId) {
+        const newChainId = parseInt(addHexChainId, 16)
+        if (!isNaN(newChainId)) {
+          const addedNetwork = getAllNetworks()[newChainId]
+          setBrowserNetwork({
+            chainId: newChainId,
+            rpcUrl: addedNetwork?.rpcUrl ?? addRpcUrl ?? ''
+          })
+          dispatch(setTabChainId({ tabId, chainId: newChainId }))
+          emitEvent('chainChanged', addHexChainId)
+        }
+      }
+      sendResponse(id, null, null)
+    } catch (e) {
+      sendResponse(id, e, undefined)
+    }
+  }
+
+  const handleRevokePermissions = (id: number): void => {
+    // Only emit accountsChanged([]) — NOT disconnect. Per EIP-1193,
+    // 'disconnect' means the provider lost network connectivity, not
+    // that the user revoked access. Emitting disconnect causes wagmi
+    // to mark the provider as offline and refuse to auto-reconnect.
+    emitEvent('accountsChanged', [])
+    sendResponse(id, null, null)
+  }
+
+  const handleWatchAsset = async (
+    id: number,
+    params: unknown[] | unknown
+  ): Promise<void> => {
+    // Normalize: some dApps send object form { type, options } instead of array
+    const normalizedParams = Array.isArray(params) ? params : [params]
+    try {
+      const result = await requestSigning({
+        method: 'wallet_watchAsset' as unknown as RpcMethod,
+        params: normalizedParams,
+        chainId: getEvmCaip2ChainId(getBrowserNetwork().chainId),
+        peerMeta: getPeerMeta()
+      })
+      sendResponse(id, null, result)
+    } catch (e) {
+      // EIP-747: explicit user rejection (4001) returns false; all other
+      // errors (invalid params, internal) are surfaced as real RPC errors
+      if ((e as { code?: number })?.code === 4001) {
+        sendResponse(id, null, false)
+      } else {
+        sendResponse(id, e, undefined)
+      }
+    }
+  }
+
+  const handleProviderMessage = (payload: string): void => {
+    const respondWithError = (reqId: number, error: unknown): void =>
+      sendResponse(reqId, error, undefined)
+
+    const parsed = parseProviderPayload(payload, respondWithError)
+    if (!parsed) return
+
+    const { id, origin: pageOrigin, request: rpc } = parsed
+    const { method, params } = rpc
+
+    const nativeOrigin = getNativeOrigin()
+    if (pageOrigin && nativeOrigin && pageOrigin !== nativeOrigin) {
+      Logger.warn(
+        `[InjectedProvider] Origin mismatch: page=${pageOrigin} native=${nativeOrigin}`
+      )
+    }
+
+    Logger.trace(`[InjectedProvider] ${method}`, params)
+
+    if (!ALLOWED_METHODS.has(method)) {
+      sendResponse(
+        id,
+        rpcErrors.methodNotFound(`Unsupported method: ${method}`),
+        undefined
+      )
+      return
+    }
+
+    if (nativeOrigin) {
+      trackPendingOrigin(id, nativeOrigin)
+    } else if (method in SIGNING_METHODS) {
+      // Signing methods require a verified page origin — reject without one.
+      sendResponse(
+        id,
+        rpcErrors.internal('Origin unavailable — cannot sign'),
+        undefined
+      )
+      return
+    }
+
+    // Ensure params is always an array for handlers that expect one.
+    // wallet_watchAsset is the only method that legitimately accepts object-form
+    // params (some dApps send { type, options } instead of [{ type, options }]);
+    // its handler normalizes internally.
+    const safeParams = Array.isArray(params) ? params : []
+    if (method === 'wallet_switchEthereumChain') {
+      handleSwitchEthereumChain(id, safeParams)
+    } else if (method === 'wallet_addEthereumChain') {
+      handleAddEthereumChain(id, safeParams)
+    } else if (method === 'wallet_revokePermissions') {
+      handleRevokePermissions(id)
+    } else if (method === 'wallet_watchAsset') {
+      handleWatchAsset(id, params)
+    } else if (method in SIGNING_METHODS) {
+      dispatchSigningRequest(id, method, safeParams)
+    } else if (READ_ONLY_METHODS.has(method)) {
+      proxyToRpc(id, method, safeParams)
+    }
+  }
+
+  return { handleProviderMessage }
+}

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/types.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/types.ts
@@ -1,0 +1,47 @@
+import type { Dispatch } from '@reduxjs/toolkit'
+import type { Networks } from 'store/network/types'
+import type { TabId } from 'store/browser/types'
+import type { PeerMeta } from 'store/rpc/types'
+import type { Request as InAppRequest } from 'store/rpc/utils/createInAppRequest'
+
+export const MAX_MESSAGE_SIZE = 1_048_576
+
+export type ProviderRequest = {
+  id: number
+  origin?: string
+  request: {
+    method: string
+    params: unknown[]
+  }
+}
+
+export type DomainMetadata = {
+  domain: string
+  name: string
+  icon: string
+  url: string
+}
+
+export type BrowserNetwork = {
+  chainId: number
+  rpcUrl: string
+}
+
+export type RouterDeps = {
+  getBrowserNetwork: () => BrowserNetwork
+  setBrowserNetwork: (net: BrowserNetwork) => void
+  getAllNetworks: () => Networks
+
+  tabId: TabId
+
+  dispatch: Dispatch
+  requestSigning: InAppRequest
+
+  sendResponse: (id: number, error: unknown, result: unknown) => void
+  emitEvent: (eventName: string, data: unknown) => void
+
+  getNativeOrigin: () => string | undefined
+  trackPendingOrigin: (id: number, origin: string) => void
+
+  getPeerMeta: () => PeerMeta | undefined
+}

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -2,86 +2,24 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { shallowEqual, useDispatch, useSelector } from 'react-redux'
 import { selectActiveAccount } from 'store/account/slice'
 import { selectActiveNetwork, selectAllNetworks } from 'store/network/slice'
-import { selectTabChainId, setTabChainId } from 'store/browser/slices/tabs'
+import { selectTabChainId } from 'store/browser/slices/tabs'
 import { TabId } from 'store/browser/types'
 import { NetworkVMType } from '@avalabs/core-chains-sdk'
 import RNWebView from 'react-native-webview'
 import Logger from 'utils/Logger'
 import { createInAppRequest } from 'store/rpc/utils/createInAppRequest'
 import { PeerMeta } from 'store/rpc/types'
-import { RpcMethod } from '@avalabs/vm-module-types'
-import { getEvmCaip2ChainId } from 'utils/caip2ChainIds'
-import { rpcErrors, serializeError } from '@metamask/rpc-errors'
+import { serializeError } from '@metamask/rpc-errors'
 import { buildEvmProviderShim } from './evmProviderShim'
 import { getInjectedProviderUuid } from './getInjectedProviderUuid'
+import { createInjectedProviderRouter } from './injectedProvider/router'
+import {
+  BrowserNetwork,
+  DomainMetadata,
+  MAX_MESSAGE_SIZE as ROUTER_MAX_MESSAGE_SIZE
+} from './injectedProvider/types'
 
-export const MAX_MESSAGE_SIZE = 1_048_576
-
-type ProviderRequest = {
-  id: number
-  origin?: string
-  request: {
-    method: string
-    params: unknown[]
-  }
-}
-
-type DomainMetadata = {
-  domain: string
-  name: string
-  icon: string
-  url: string
-}
-
-const READ_ONLY_METHODS = new Set([
-  'eth_blockNumber',
-  'eth_call',
-  'eth_estimateGas',
-  'eth_gasPrice',
-  'eth_getBalance',
-  'eth_getBlockByHash',
-  'eth_getBlockByNumber',
-  'eth_getCode',
-  'eth_getLogs',
-  'eth_getStorageAt',
-  'eth_getTransactionByHash',
-  'eth_getTransactionCount',
-  'eth_getTransactionReceipt',
-  'eth_maxPriorityFeePerGas',
-  'eth_feeHistory',
-  'web3_clientVersion',
-  'web3_sha3',
-  'eth_getBlockTransactionCountByHash',
-  'eth_getBlockTransactionCountByNumber'
-])
-
-const SIGNING_METHODS: Record<string, RpcMethod> = {
-  [RpcMethod.ETH_SEND_TRANSACTION]: RpcMethod.ETH_SEND_TRANSACTION,
-  [RpcMethod.PERSONAL_SIGN]: RpcMethod.PERSONAL_SIGN,
-  [RpcMethod.ETH_SIGN]: RpcMethod.ETH_SIGN,
-  [RpcMethod.SIGN_TYPED_DATA]: RpcMethod.SIGN_TYPED_DATA,
-  [RpcMethod.SIGN_TYPED_DATA_V1]: RpcMethod.SIGN_TYPED_DATA_V1,
-  [RpcMethod.SIGN_TYPED_DATA_V3]: RpcMethod.SIGN_TYPED_DATA_V3,
-  [RpcMethod.SIGN_TYPED_DATA_V4]: RpcMethod.SIGN_TYPED_DATA_V4
-}
-
-const ALLOWED_METHODS = new Set([
-  ...READ_ONLY_METHODS,
-  ...Object.keys(SIGNING_METHODS),
-  'wallet_switchEthereumChain',
-  'wallet_addEthereumChain',
-  'wallet_revokePermissions',
-  'wallet_watchAsset'
-])
-
-function validateProviderRequest(data: unknown): data is ProviderRequest {
-  if (typeof data !== 'object' || data === null) return false
-  const obj = data as Record<string, unknown>
-  if (typeof obj.id !== 'number') return false
-  if (typeof obj.request !== 'object' || obj.request === null) return false
-  const req = obj.request as Record<string, unknown>
-  return typeof req.method === 'string'
-}
+export const MAX_MESSAGE_SIZE = ROUTER_MAX_MESSAGE_SIZE
 
 function getOriginFromUrl(url: string): string | undefined {
   if (!url) return undefined
@@ -91,48 +29,6 @@ function getOriginFromUrl(url: string): string | undefined {
   } catch {
     return undefined
   }
-}
-
-function parseProviderPayload(
-  payload: string,
-  respondWithError: (id: number, error: unknown) => void
-): ProviderRequest | undefined {
-  if (payload.length > MAX_MESSAGE_SIZE) {
-    Logger.warn(
-      `[InjectedProvider] Message exceeds ${MAX_MESSAGE_SIZE} byte limit`
-    )
-    try {
-      const { id } = JSON.parse(payload) as { id?: unknown }
-      if (typeof id === 'number') {
-        respondWithError(
-          id,
-          rpcErrors.invalidRequest('Message exceeds size limit')
-        )
-      }
-    } catch {
-      /* oversized and unparseable */
-    }
-    return undefined
-  }
-
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(payload)
-  } catch {
-    Logger.error('[InjectedProvider] Invalid JSON payload')
-    return undefined
-  }
-
-  if (!validateProviderRequest(parsed)) {
-    Logger.error('[InjectedProvider] Malformed provider_request')
-    const maybeId = (parsed as Record<string, unknown>)?.id
-    if (typeof maybeId === 'number') {
-      respondWithError(maybeId, rpcErrors.invalidRequest('Malformed request'))
-    }
-    return undefined
-  }
-
-  return parsed
 }
 
 /**
@@ -156,10 +52,16 @@ export function useEvmInjectedProvider(
   const pendingOrigins = useRef<Map<number, string>>(new Map())
   const initialChainId = tabChainId ?? activeNetwork.chainId
   const initialNetwork = allNetworks[initialChainId] ?? activeNetwork
-  const browserNetworkRef = useRef({
+  const browserNetworkRef = useRef<BrowserNetwork>({
     chainId: initialChainId,
     rpcUrl: initialNetwork.rpcUrl
   })
+
+  // Refs kept current so the stable router can read latest values via getters
+  const allNetworksRef = useRef(allNetworks)
+  useEffect(() => {
+    allNetworksRef.current = allNetworks
+  }, [allNetworks])
 
   // When the tab has no persisted chainId, keep browserNetworkRef in sync with
   // the global active network so read-only RPC and signing requests are routed
@@ -250,48 +152,7 @@ export function useEvmInjectedProvider(
     [webViewRef]
   )
 
-  const proxyToRpc = useCallback(
-    async (id: number, method: string, params: unknown[]) => {
-      try {
-        const rpcUrl = browserNetworkRef.current.rpcUrl
-        if (!rpcUrl) {
-          sendResponse(
-            id,
-            rpcErrors.internal('No RPC URL configured'),
-            undefined
-          )
-          return
-        }
-
-        const body = JSON.stringify({
-          jsonrpc: '2.0',
-          id,
-          method,
-          params
-        })
-
-        const response = await fetch(rpcUrl, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body
-        })
-
-        const json = await response.json()
-
-        if (json.error) {
-          sendResponse(id, json.error, undefined)
-        } else {
-          sendResponse(id, null, json.result)
-        }
-      } catch (e) {
-        Logger.error('[InjectedProvider] RPC proxy error', e)
-        sendResponse(id, rpcErrors.internal('RPC request failed'), undefined)
-      }
-    },
-    [sendResponse]
-  )
-
-  const buildDappPeerMeta = useCallback((): PeerMeta | undefined => {
+  const getPeerMeta = useCallback((): PeerMeta | undefined => {
     const meta = dappMetadata.current
     const nativeUrl = currentUrlRef.current
     if (!meta && !nativeUrl) return undefined
@@ -304,232 +165,33 @@ export function useEvmInjectedProvider(
     }
   }, [])
 
-  const dispatchSigningRequest = useCallback(
-    async (id: number, method: string, params: unknown[]) => {
-      const rpcMethod = SIGNING_METHODS[method]
-      if (!rpcMethod) {
-        sendResponse(
-          id,
-          rpcErrors.methodNotFound(`Method not supported: ${method}`),
-          undefined
-        )
-        return
-      }
-
-      const caip2ChainId = getEvmCaip2ChainId(browserNetworkRef.current.chainId)
-      const request = createInAppRequest(dispatch)
-
-      try {
-        const result = await request({
-          method: rpcMethod,
-          params,
-          chainId: caip2ChainId,
-          peerMeta: buildDappPeerMeta()
-        })
-        sendResponse(id, null, result)
-      } catch (e) {
-        sendResponse(id, e, undefined)
-      }
-    },
-    [dispatch, sendResponse, buildDappPeerMeta]
-  )
-
-  const handleSwitchEthereumChain = useCallback(
-    (id: number, params: unknown[]) => {
-      const param = params[0] as { chainId?: string } | undefined
-      const hexChainId = param?.chainId
-      if (!hexChainId) {
-        sendResponse(
-          id,
-          rpcErrors.invalidParams('Missing chainId param'),
-          undefined
-        )
-        return
-      }
-      const requestedChainId = parseInt(hexChainId, 16)
-      if (isNaN(requestedChainId)) {
-        sendResponse(id, rpcErrors.invalidParams('Invalid chainId'), undefined)
-        return
-      }
-      if (!(String(requestedChainId) in allNetworks)) {
-        // Return 4902 (unrecognized chain) so ConnectKit/wagmi can trigger the
-        // wallet_addEthereumChain flow instead. The shim already fired
-        // chainChanged(target) optimistically and will not roll it back, so
-        // wagmi's chain state stays at target — preventing ConnectKit from
-        // re-triggering switchChain in a loop (React error #185).
-        sendResponse(
-          id,
-          {
-            code: 4902,
-            message: `Chain ${requestedChainId} has not been added to your wallet.`
-          },
-          undefined
-        )
-        return
-      }
-      if (requestedChainId === browserNetworkRef.current.chainId) {
-        sendResponse(id, null, null)
-        return
-      }
-      // Persist the chain switch for this tab only (survives tab eviction/remount).
-      // browserNetworkRef ensures all subsequent RPC calls in this session are
-      // routed to the correct chain. The shim already fired chainChanged
-      // synchronously before the round-trip (prevents React #185 loop), so we
-      // do NOT re-emit it here.
-      const switchedNetwork = allNetworks[requestedChainId]
-      dispatch(setTabChainId({ tabId, chainId: requestedChainId }))
-      browserNetworkRef.current = {
-        chainId: requestedChainId,
-        rpcUrl: switchedNetwork?.rpcUrl ?? ''
-      }
-      sendResponse(id, null, null)
-    },
-    [sendResponse, allNetworks, dispatch, tabId]
-  )
-
-  const handleAddEthereumChain = useCallback(
-    async (id: number, params: unknown[]) => {
-      const addParam = params[0] as
-        | { chainId?: string; rpcUrls?: string[] }
-        | undefined
-      const addHexChainId = addParam?.chainId
-      const addRpcUrl = addParam?.rpcUrls?.[0]
-      const inAppRequest = createInAppRequest(dispatch)
-      try {
-        await inAppRequest({
-          method: 'wallet_addEthereumChain' as unknown as RpcMethod,
-          params,
-          chainId: getEvmCaip2ChainId(browserNetworkRef.current.chainId),
-          peerMeta: buildDappPeerMeta()
-        })
-        // User approved — switch browser chain to the new network and notify dApp
-        if (addHexChainId) {
-          const newChainId = parseInt(addHexChainId, 16)
-          if (!isNaN(newChainId)) {
-            const addedNetwork = allNetworks[newChainId]
-            browserNetworkRef.current = {
-              chainId: newChainId,
-              rpcUrl: addedNetwork?.rpcUrl ?? addRpcUrl ?? ''
-            }
-            dispatch(setTabChainId({ tabId, chainId: newChainId }))
-            emitEvent('chainChanged', addHexChainId)
-          }
-        }
-        sendResponse(id, null, null)
-      } catch (e) {
-        sendResponse(id, e, undefined)
-      }
-    },
-    [sendResponse, allNetworks, dispatch, emitEvent, buildDappPeerMeta, tabId]
-  )
-
-  const handleRevokePermissions = useCallback(
-    (id: number) => {
-      // Only emit accountsChanged([]) — NOT disconnect. Per EIP-1193,
-      // 'disconnect' means the provider lost network connectivity, not
-      // that the user revoked access. Emitting disconnect causes wagmi
-      // to mark the provider as offline and refuse to auto-reconnect.
-      emitEvent('accountsChanged', [])
-      sendResponse(id, null, null)
-    },
-    [emitEvent, sendResponse]
-  )
-
-  const handleWatchAsset = useCallback(
-    async (id: number, params: unknown[] | unknown) => {
-      // Normalize: some dApps send object form { type, options } instead of array
-      const normalizedParams = Array.isArray(params) ? params : [params]
-      const inAppRequest = createInAppRequest(dispatch)
-      try {
-        const result = await inAppRequest({
-          method: 'wallet_watchAsset' as unknown as RpcMethod,
-          params: normalizedParams,
-          chainId: getEvmCaip2ChainId(browserNetworkRef.current.chainId),
-          peerMeta: buildDappPeerMeta()
-        })
-        sendResponse(id, null, result)
-      } catch (e) {
-        // EIP-747: explicit user rejection (4001) returns false; all other
-        // errors (invalid params, internal) are surfaced as real RPC errors
-        if ((e as { code?: number })?.code === 4001) {
-          sendResponse(id, null, false)
-        } else {
-          sendResponse(id, e, undefined)
-        }
-      }
-    },
-    [sendResponse, dispatch, buildDappPeerMeta]
-  )
+  const router = useMemo(() => {
+    // requestSigning closes over dispatch; keep its construction inside the
+    // memo so it always uses the latest dispatch and re-builds when dispatch
+    // changes (gated via the dep array below).
+    const requestSigning = createInAppRequest(dispatch)
+    return createInjectedProviderRouter({
+      getBrowserNetwork: () => browserNetworkRef.current,
+      setBrowserNetwork: net => {
+        browserNetworkRef.current = net
+      },
+      getAllNetworks: () => allNetworksRef.current,
+      tabId,
+      dispatch,
+      requestSigning,
+      sendResponse,
+      emitEvent,
+      getNativeOrigin: () => getOriginFromUrl(currentUrlRef.current),
+      trackPendingOrigin: (id, origin) => {
+        pendingOrigins.current.set(id, origin)
+      },
+      getPeerMeta
+    })
+  }, [dispatch, tabId, sendResponse, emitEvent, getPeerMeta])
 
   const handleProviderMessage = useCallback(
-    (payload: string) => {
-      const respondWithError = (id: number, error: unknown): void =>
-        sendResponse(id, error, undefined)
-
-      const parsed = parseProviderPayload(payload, respondWithError)
-      if (!parsed) return
-
-      const { id, origin: pageOrigin, request: rpc } = parsed
-      const { method, params } = rpc
-
-      const nativeOrigin = getOriginFromUrl(currentUrlRef.current)
-      if (pageOrigin && nativeOrigin && pageOrigin !== nativeOrigin) {
-        Logger.warn(
-          `[InjectedProvider] Origin mismatch: page=${pageOrigin} native=${nativeOrigin}`
-        )
-      }
-
-      Logger.trace(`[InjectedProvider] ${method}`, params)
-
-      if (!ALLOWED_METHODS.has(method)) {
-        sendResponse(
-          id,
-          rpcErrors.methodNotFound(`Unsupported method: ${method}`),
-          undefined
-        )
-        return
-      }
-
-      if (nativeOrigin) {
-        pendingOrigins.current.set(id, nativeOrigin)
-      } else if (method in SIGNING_METHODS) {
-        // Signing methods require a verified page origin — reject without one.
-        sendResponse(
-          id,
-          rpcErrors.internal('Origin unavailable — cannot sign'),
-          undefined
-        )
-        return
-      }
-
-      // Ensure params is always an array for handlers that expect one.
-      // wallet_watchAsset is the only method that legitimately accepts object-form
-      // params (some dApps send { type, options } instead of [{ type, options }]);
-      // its handler normalizes internally.
-      const safeParams = Array.isArray(params) ? params : []
-      if (method === 'wallet_switchEthereumChain') {
-        handleSwitchEthereumChain(id, safeParams)
-      } else if (method === 'wallet_addEthereumChain') {
-        handleAddEthereumChain(id, safeParams)
-      } else if (method === 'wallet_revokePermissions') {
-        handleRevokePermissions(id)
-      } else if (method === 'wallet_watchAsset') {
-        handleWatchAsset(id, params)
-      } else if (method in SIGNING_METHODS) {
-        dispatchSigningRequest(id, method, safeParams)
-      } else if (READ_ONLY_METHODS.has(method)) {
-        proxyToRpc(id, method, safeParams)
-      }
-    },
-    [
-      sendResponse,
-      proxyToRpc,
-      dispatchSigningRequest,
-      handleSwitchEthereumChain,
-      handleAddEthereumChain,
-      handleRevokePermissions,
-      handleWatchAsset
-    ]
+    (payload: string) => router.handleProviderMessage(payload),
+    [router]
   )
 
   const handleDomainMetadata = useCallback((payload: string) => {


### PR DESCRIPTION
## Description

**Ticket: [CP-]**

Extracts EVM injected-provider dispatch logic out of a 552-line React hook (`useEvmInjectedProvider`) into a plain `InjectedProviderRouter` module. The hook becomes a thin ~210-line adapter that wires Redux state and refs into the router; per-method handlers move to a dependency-injected module that can be unit-tested without mounting React. Zero behavior change — every error code, origin gate, optimistic `chainChanged`, and EIP-1193/2255/747 nuance is preserved.

This is Phase 1(a) of the broader injected-provider modernization plan. Phase 1(b) (making `eth_requestAccounts` / `wallet_requestPermissions` round-trip to native with a real approval UI) builds on this module.

**Summary of changes:**
- NEW `app/hooks/browser/injectedProvider/router.ts` — `createInjectedProviderRouter` factory + 6 per-method handlers + payload parsing.
- NEW `app/hooks/browser/injectedProvider/types.ts` — `RouterDeps`, `ProviderRequest`, `BrowserNetwork`.
- NEW `app/hooks/browser/injectedProvider/router.test.ts` — 22 unit tests covering dispatch, origin gating, switch/add chain, signing, watchAsset, proxy, oversized payload, malformed JSON.
- MODIFIED `app/hooks/browser/useEvmInjectedProvider.ts` — shrunk 552 → 213 LOC; React glue only (selectors, refs, `injectJavaScript`-backed `sendResponse`/`emitEvent`, tab-chain sync effect).

**Motivation:** Prepares for Phase 1(b) (connect approval UI + per-origin permissions) and later phases (Solana, BTC, X/P). Handlers trapped inside a React hook coupled to Redux selectors can't be DI'd or tested in isolation.

**Dependencies:** none.
**Breaking:** no — feature is behind a feature flag and has never shipped to production users.

## Screenshots/Videos

N/A — pure refactor, no user-visible change.

## Testing

**Dev Testing:**

End-to-end validated on real dApps in the in-app browser:
- OpenSea — `eth_requestAccounts`, `eth_signTypedData_v4`
- Etherscan (Verified Signature tool) — `personal_sign`
- app.uniswap.org — `wallet_switchEthereumChain` (confirmed no ConnectKit React #185 loop)
- chainlist.org → Gnosis Chain — `wallet_addEthereumChain` full approval flow

Static:
- `yarn tsc` — passes
- `yarn lint` — clean on touched files
- `yarn test app/hooks/browser/` — 22 new router tests + 66 existing hook tests all pass

**Steps to verify locally:**
1. `yarn core start && yarn core ios`
2. Open the in-app browser (flip the injected-provider feature flag if needed).
3. Visit a dApp and connect: OpenSea / Etherscan / Uniswap / chainlist.
4. Exercise at least one read path (balance), one signing path (sign a message), one chain switch, one add-chain.
5. Confirm behavior matches pre-refactor — no new approval popups should appear for `eth_requestAccounts` (that comes in Phase 1(b)).

**QA Testing:** N/A for this PR. Refactor is behavior-preserving; QA cycles begin with Phase 1(b).

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios (N/A — no UI change)
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation (modernization plan is draft; separate PR)