### PR TITLE
CP-14077: Hide Solana features when address is not derived

### DIFF
--- a/packages/core-mobile/app/new/common/hooks/useCombinedPrimaryNetworks.ts
+++ b/packages/core-mobile/app/new/common/hooks/useCombinedPrimaryNetworks.ts
@@ -7,9 +7,8 @@ import {
   NETWORK_SOLANA_DEVNET,
   TEST_PRIMARY_NETWORKS
 } from 'services/network/consts'
-import { selectIsSolanaSupportBlocked } from 'store/posthog/slice'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
-import { selectActiveAccount } from 'store/account'
+import { selectHasSolanaAddress } from 'store/account'
 import { useHasXpAddresses } from './useHasXpAddresses'
 
 /**
@@ -27,26 +26,23 @@ export function useCombinedPrimaryNetworks({
 } {
   const hasXpAddresses = useHasXpAddresses()
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
-  const isSolanaSupportBlocked = useSelector(selectIsSolanaSupportBlocked)
-  const account = useSelector(selectActiveAccount)
+  const hasSolanaAddress = useSelector(selectHasSolanaAddress)
 
-  const hideSolana = hideEmptySolana
-    ? account?.addressSVM === undefined || account?.addressSVM.length === 0
-    : false
+  const hideSolana = hideEmptySolana ? !hasSolanaAddress : false
 
   const networks = useMemo(() => {
     // Test networks
     if (isDeveloperMode) {
-      return isSolanaSupportBlocked || hideSolana
+      return hideSolana
         ? (TEST_PRIMARY_NETWORKS as Network[])
         : [...TEST_PRIMARY_NETWORKS, NETWORK_SOLANA_DEVNET]
     }
 
     // Main networks
-    return isSolanaSupportBlocked || hideSolana
+    return hideSolana
       ? (MAIN_PRIMARY_NETWORKS as Network[])
       : [...MAIN_PRIMARY_NETWORKS, NETWORK_SOLANA]
-  }, [hideSolana, isDeveloperMode, isSolanaSupportBlocked])
+  }, [hideSolana, isDeveloperMode])
 
   // filter out networks that are missing XP addresses
   const filteredNetworks = useMemo(() => {

--- a/packages/core-mobile/app/new/common/hooks/useCombinedPrimaryNetworks.ts
+++ b/packages/core-mobile/app/new/common/hooks/useCombinedPrimaryNetworks.ts
@@ -8,7 +8,7 @@ import {
   TEST_PRIMARY_NETWORKS
 } from 'services/network/consts'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
-import { selectHasSolanaAddress } from 'store/account'
+import { selectActiveAccountHasSolanaAddress } from 'store/account'
 import { useHasXpAddresses } from './useHasXpAddresses'
 
 /**
@@ -26,7 +26,7 @@ export function useCombinedPrimaryNetworks({
 } {
   const hasXpAddresses = useHasXpAddresses()
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
-  const hasSolanaAddress = useSelector(selectHasSolanaAddress)
+  const hasSolanaAddress = useSelector(selectActiveAccountHasSolanaAddress)
 
   const hideSolana = hideEmptySolana ? !hasSolanaAddress : false
 

--- a/packages/core-mobile/app/new/features/ledger/hooks/useLedgerWallet.discovery.test.ts
+++ b/packages/core-mobile/app/new/features/ledger/hooks/useLedgerWallet.discovery.test.ts
@@ -41,7 +41,7 @@ jest.mock('store/account', () => ({
     payload: id
   })),
   selectActiveAccount: jest.fn(() => undefined),
-  selectHasSolanaAddress: jest.fn(() => false)
+  selectActiveAccountHasSolanaAddress: jest.fn(() => false)
 }))
 
 jest.mock('utils/uuid', () => ({

--- a/packages/core-mobile/app/new/features/ledger/hooks/useLedgerWallet.discovery.test.ts
+++ b/packages/core-mobile/app/new/features/ledger/hooks/useLedgerWallet.discovery.test.ts
@@ -40,7 +40,8 @@ jest.mock('store/account', () => ({
     type: 'account/setActiveAccountId',
     payload: id
   })),
-  selectActiveAccount: jest.fn(() => undefined)
+  selectActiveAccount: jest.fn(() => undefined),
+  selectHasSolanaAddress: jest.fn(() => false)
 }))
 
 jest.mock('utils/uuid', () => ({

--- a/packages/core-mobile/app/new/features/portfolio/assets/hooks/useAssetsFilterAndSort.ts
+++ b/packages/core-mobile/app/new/features/portfolio/assets/hooks/useAssetsFilterAndSort.ts
@@ -16,8 +16,6 @@ import { usePrevious } from 'common/hooks/usePrevious'
 import { ActivityNetworkFilter } from 'features/activity/hooks/useActivityFilterAndSearch'
 import { isEqual } from 'lodash'
 import { usePortfolioView } from 'features/portfolio/store'
-import { selectActiveAccount } from 'store/account'
-import { NetworkVMType } from '@avalabs/vm-module-types'
 
 export const useAssetsFilterAndSort = (): {
   onResetFilter: () => void
@@ -29,23 +27,10 @@ export const useAssetsFilterAndSort = (): {
   isRefetching: boolean
   isLoading: boolean
 } => {
-  const account = useSelector(selectActiveAccount)
   const { selectedView, setSelectedView } = usePortfolioView()
 
   const erc20ContractTokens = useErc20ContractTokens()
   const enabledNetworks = useSelector(selectEnabledNetworks)
-
-  // remove solana network from the list if account has no SVM address
-  const filteredEnabledNetworks = useMemo(() => {
-    const accountHasSvmAddress =
-      account?.addressSVM !== undefined && account?.addressSVM.length > 0
-    if (accountHasSvmAddress) {
-      return enabledNetworks
-    }
-    return enabledNetworks.filter(
-      network => network.vmName !== NetworkVMType.SVM
-    )
-  }, [account?.addressSVM, enabledNetworks])
 
   const { filteredTokenList, refetch, isRefetching, isLoading } =
     useSearchableTokenList({
@@ -53,7 +38,7 @@ export const useAssetsFilterAndSort = (): {
     })
 
   const networkFilters = useMemo(() => {
-    const enabledNetworksFilter = filteredEnabledNetworks.map(network => {
+    const enabledNetworksFilter = enabledNetworks.map(network => {
       return { filterName: network.chainName, chainId: network.chainId }
     })
     return [
@@ -63,7 +48,7 @@ export const useAssetsFilterAndSort = (): {
       },
       ...enabledNetworksFilter
     ]
-  }, [filteredEnabledNetworks])
+  }, [enabledNetworks])
 
   const [selectedNetworkFilters, setSelectedNetworkFilters] =
     useState<ActivityNetworkFilter[]>(networkFilters)

--- a/packages/core-mobile/app/new/features/swap/hooks/useSupportedChains.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useSupportedChains.ts
@@ -10,6 +10,7 @@ import { isAvalancheChainId } from 'services/network/utils/isAvalancheNetwork'
 import { isSolanaNetwork } from 'utils/network/isSolanaNetwork'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { selectActiveAccountHasSolanaAddress } from 'store/account'
+import { selectIsSolanaSwapBlocked } from 'store/posthog'
 import FusionService from '../services/FusionService'
 import { logSdkError } from '../utils/fusionLogger'
 import { useIsFusionServiceReady } from './useZustandStore'
@@ -69,7 +70,8 @@ export function useSupportedChains(sourceChainId?: number): {
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const [isFusionServiceReady] = useIsFusionServiceReady()
   const hasSolanaAddress = useSelector(selectActiveAccountHasSolanaAddress)
-  const hideSolana = !hasSolanaAddress
+  const isSolanaSwapBlocked = useSelector(selectIsSolanaSwapBlocked)
+  const hideSolana = !hasSolanaAddress || isSolanaSwapBlocked
 
   // Fetch supported chains Map from Fusion Service
   const {

--- a/packages/core-mobile/app/new/features/swap/hooks/useSupportedChains.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useSupportedChains.ts
@@ -9,7 +9,7 @@ import { getCaip2ChainId } from 'utils/caip2ChainIds'
 import { isAvalancheChainId } from 'services/network/utils/isAvalancheNetwork'
 import { isSolanaNetwork } from 'utils/network/isSolanaNetwork'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
-import { selectHasSolanaAddress } from 'store/account'
+import { selectActiveAccountHasSolanaAddress } from 'store/account'
 import FusionService from '../services/FusionService'
 import { logSdkError } from '../utils/fusionLogger'
 import { useIsFusionServiceReady } from './useZustandStore'
@@ -68,7 +68,7 @@ export function useSupportedChains(sourceChainId?: number): {
   const { getEnabledNetworkByCaip2ChainId } = useNetworks()
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const [isFusionServiceReady] = useIsFusionServiceReady()
-  const hasSolanaAddress = useSelector(selectHasSolanaAddress)
+  const hasSolanaAddress = useSelector(selectActiveAccountHasSolanaAddress)
   const hideSolana = !hasSolanaAddress
 
   // Fetch supported chains Map from Fusion Service

--- a/packages/core-mobile/app/new/features/swap/hooks/useSupportedChains.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useSupportedChains.ts
@@ -8,8 +8,8 @@ import Logger from 'utils/Logger'
 import { getCaip2ChainId } from 'utils/caip2ChainIds'
 import { isAvalancheChainId } from 'services/network/utils/isAvalancheNetwork'
 import { isSolanaNetwork } from 'utils/network/isSolanaNetwork'
-import { selectIsSolanaSwapBlocked } from 'store/posthog'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
+import { selectHasSolanaAddress } from 'store/account'
 import FusionService from '../services/FusionService'
 import { logSdkError } from '../utils/fusionLogger'
 import { useIsFusionServiceReady } from './useZustandStore'
@@ -21,17 +21,17 @@ const STALE_TIME = 2 * 60 * 1000 // 2 minutes
 
 /**
  * Helper function to filter and sort networks
- * - Filters out Solana networks if blocked
+ * - Filters out Solana networks if blocked or not derived
  * - Sorts with Avalanche C-Chain first
  */
 function filterAndSortNetworks(
   networks: Network[],
-  isSolanaSwapBlocked: boolean
+  hideSolana: boolean
 ): Network[] {
   return networks
     .filter(network => {
-      // Filter out Solana networks if Solana swap is blocked
-      return !(isSolanaSwapBlocked && isSolanaNetwork(network))
+      // Filter out Solana networks if blocked or account has no Solana address
+      return !(hideSolana && isSolanaNetwork(network))
     })
     .sort((a, b) => {
       // Avalanche C-Chain always first
@@ -66,9 +66,10 @@ export function useSupportedChains(sourceChainId?: number): {
   error: Error | null
 } {
   const { getEnabledNetworkByCaip2ChainId } = useNetworks()
-  const isSolanaSwapBlocked = useSelector(selectIsSolanaSwapBlocked)
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const [isFusionServiceReady] = useIsFusionServiceReady()
+  const hasSolanaAddress = useSelector(selectHasSolanaAddress)
+  const hideSolana = !hasSolanaAddress
 
   // Fetch supported chains Map from Fusion Service
   const {
@@ -98,10 +99,7 @@ export function useSupportedChains(sourceChainId?: number): {
       .map(caip2Id => getEnabledNetworkByCaip2ChainId(caip2Id))
       .filter((network): network is Network => network !== undefined)
 
-    const supportedNetworks = filterAndSortNetworks(
-      networks,
-      isSolanaSwapBlocked
-    )
+    const supportedNetworks = filterAndSortNetworks(networks, hideSolana)
 
     Logger.info(
       `Mapped to ${supportedNetworks.length} supported networks:`,
@@ -109,7 +107,7 @@ export function useSupportedChains(sourceChainId?: number): {
     )
 
     return supportedNetworks
-  }, [chainsMap, getEnabledNetworkByCaip2ChainId, isSolanaSwapBlocked])
+  }, [chainsMap, getEnabledNetworkByCaip2ChainId, hideSolana])
 
   // Convert source chainId to CAIP-2 and look up destinations (optional)
   const destinations = useMemo(() => {
@@ -138,7 +136,7 @@ export function useSupportedChains(sourceChainId?: number): {
       .map(caip2Id => getEnabledNetworkByCaip2ChainId(caip2Id))
       .filter((network): network is Network => network !== undefined)
 
-    const destNetworks = filterAndSortNetworks(networks, isSolanaSwapBlocked)
+    const destNetworks = filterAndSortNetworks(networks, hideSolana)
 
     Logger.info(
       `Source chain ${sourceChainId} (${sourceCaip2}) can swap to ${destNetworks.length} destination networks:`,
@@ -146,12 +144,7 @@ export function useSupportedChains(sourceChainId?: number): {
     )
 
     return destNetworks
-  }, [
-    sourceChainId,
-    chainsMap,
-    getEnabledNetworkByCaip2ChainId,
-    isSolanaSwapBlocked
-  ])
+  }, [sourceChainId, chainsMap, getEnabledNetworkByCaip2ChainId, hideSolana])
 
   // Function to check if a destination chain is valid for a source chain
   const isValidDestination = useCallback(
@@ -172,10 +165,10 @@ export function useSupportedChains(sourceChainId?: number): {
       const destNetwork = getEnabledNetworkByCaip2ChainId(destCaip2)
       if (!destNetwork) return false
 
-      // Check Solana blocking - return true if not blocked
-      return !(isSolanaSwapBlocked && isSolanaNetwork(destNetwork))
+      // Check Solana blocking - return true if not blocked/missing
+      return !(hideSolana && isSolanaNetwork(destNetwork))
     },
-    [chainsMap, getEnabledNetworkByCaip2ChainId, isSolanaSwapBlocked]
+    [chainsMap, getEnabledNetworkByCaip2ChainId, hideSolana]
   )
 
   useEffect(() => {

--- a/packages/core-mobile/app/new/features/swap/hooks/useSwapTokens.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useSwapTokens.ts
@@ -11,6 +11,7 @@ import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { isAddressLikeSearch } from 'common/utils/isAddressLikeSearch'
 import { selectActiveAccountHasSolanaAddress } from 'store/account'
+import { selectIsSolanaSwapBlocked } from 'store/posthog'
 import { mapApiTokenToLocal } from '../utils/mapApiTokenToLocal'
 import { getLocalTokenIdFromApi } from '../utils/getLocalTokenIdFromApi'
 
@@ -46,10 +47,11 @@ export const useSwapTokens = (
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const activeAccount = useSelector(selectActiveAccount)
   const hasSolanaAddress = useSelector(selectActiveAccountHasSolanaAddress)
+  const isSolanaSwapBlocked = useSelector(selectIsSolanaSwapBlocked)
 
   const isSolanaBlocked = useMemo(
-    () => isSvmChainId(caip2Id) && !hasSolanaAddress,
-    [caip2Id, hasSolanaAddress]
+    () => isSvmChainId(caip2Id) && (!hasSolanaAddress || isSolanaSwapBlocked),
+    [caip2Id, hasSolanaAddress, isSolanaSwapBlocked]
   )
 
   const chainId = useMemo(() => getChainIdFromCaip2(caip2Id), [caip2Id])

--- a/packages/core-mobile/app/new/features/swap/hooks/useSwapTokens.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useSwapTokens.ts
@@ -10,7 +10,7 @@ import { useTokensWithBalanceByNetworkForAccount } from 'features/portfolio/hook
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { isAddressLikeSearch } from 'common/utils/isAddressLikeSearch'
-import { selectHasSolanaAddress } from 'store/account'
+import { selectActiveAccountHasSolanaAddress } from 'store/account'
 import { mapApiTokenToLocal } from '../utils/mapApiTokenToLocal'
 import { getLocalTokenIdFromApi } from '../utils/getLocalTokenIdFromApi'
 
@@ -45,7 +45,7 @@ export const useSwapTokens = (
 ): UseSwapTokensResult => {
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const activeAccount = useSelector(selectActiveAccount)
-  const hasSolanaAddress = useSelector(selectHasSolanaAddress)
+  const hasSolanaAddress = useSelector(selectActiveAccountHasSolanaAddress)
 
   const isSolanaBlocked = useMemo(
     () => isSvmChainId(caip2Id) && !hasSolanaAddress,

--- a/packages/core-mobile/app/new/features/swap/hooks/useSwapTokens.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useSwapTokens.ts
@@ -8,9 +8,9 @@ import { getChainIdFromCaip2, isSvmChainId } from 'utils/caip2ChainIds'
 import { selectActiveAccount } from 'store/account'
 import { useTokensWithBalanceByNetworkForAccount } from 'features/portfolio/hooks/useTokensWithBalanceByNetworkForAccount'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
-import { selectIsSolanaSwapBlocked } from 'store/posthog'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { isAddressLikeSearch } from 'common/utils/isAddressLikeSearch'
+import { selectHasSolanaAddress } from 'store/account'
 import { mapApiTokenToLocal } from '../utils/mapApiTokenToLocal'
 import { getLocalTokenIdFromApi } from '../utils/getLocalTokenIdFromApi'
 
@@ -43,16 +43,16 @@ export const useSwapTokens = (
   caip2Id: string,
   searchText?: string
 ): UseSwapTokensResult => {
-  const isSolanaSwapBlocked = useSelector(selectIsSolanaSwapBlocked)
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
+  const activeAccount = useSelector(selectActiveAccount)
+  const hasSolanaAddress = useSelector(selectHasSolanaAddress)
 
   const isSolanaBlocked = useMemo(
-    () => isSvmChainId(caip2Id) && isSolanaSwapBlocked,
-    [caip2Id, isSolanaSwapBlocked]
+    () => isSvmChainId(caip2Id) && !hasSolanaAddress,
+    [caip2Id, hasSolanaAddress]
   )
 
   const chainId = useMemo(() => getChainIdFromCaip2(caip2Id), [caip2Id])
-  const activeAccount = useSelector(selectActiveAccount)
 
   const { tokens: balances } = useTokensWithBalanceByNetworkForAccount(
     activeAccount,

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -45,6 +45,7 @@ import { tokenIds } from 'consts/tokenIds'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { useTokensWithBalanceForAccount } from 'features/portfolio/hooks/useTokensWithBalanceForAccount'
 import { caip2ChainIds } from 'consts/caip2ChainIds'
+import { selectHasSolanaAddress } from 'store/account'
 import { AdditiveFeesNotice } from '../components/AdditiveFeesNotice'
 import { FeeDebugTable } from '../components/FeeDebugTable'
 import { useFusionTokenLookup } from '../hooks/useFusionTokenLookup'
@@ -171,11 +172,14 @@ export const SwapScreen = (): JSX.Element => {
     setToToken
   })
 
+  const hasSolanaAddress = useSelector(selectHasSolanaAddress)
+
   const tokensWithZeroBalance = useTokensWithZeroBalanceByNetworksForAccount(
     activeAccount,
-    [cChainNetwork?.chainId, solanaNetwork?.chainId].filter(
-      chainId => chainId !== undefined
-    ) as number[]
+    [
+      cChainNetwork?.chainId,
+      hasSolanaAddress ? solanaNetwork?.chainId : undefined
+    ].filter(chainId => chainId !== undefined) as number[]
   )
 
   const { getNetwork } = useNetworks()

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -46,6 +46,7 @@ import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { useTokensWithBalanceForAccount } from 'features/portfolio/hooks/useTokensWithBalanceForAccount'
 import { caip2ChainIds } from 'consts/caip2ChainIds'
 import { selectActiveAccountHasSolanaAddress } from 'store/account'
+import { selectIsSolanaSwapBlocked } from 'store/posthog'
 import { AdditiveFeesNotice } from '../components/AdditiveFeesNotice'
 import { FeeDebugTable } from '../components/FeeDebugTable'
 import { useFusionTokenLookup } from '../hooks/useFusionTokenLookup'
@@ -173,12 +174,14 @@ export const SwapScreen = (): JSX.Element => {
   })
 
   const hasSolanaAddress = useSelector(selectActiveAccountHasSolanaAddress)
+  const isSolanaSwapBlocked = useSelector(selectIsSolanaSwapBlocked)
+  const showSolanaSwap = hasSolanaAddress && !isSolanaSwapBlocked
 
   const tokensWithZeroBalance = useTokensWithZeroBalanceByNetworksForAccount(
     activeAccount,
     [
       cChainNetwork?.chainId,
-      hasSolanaAddress ? solanaNetwork?.chainId : undefined
+      showSolanaSwap ? solanaNetwork?.chainId : undefined
     ].filter(chainId => chainId !== undefined) as number[]
   )
 

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -45,7 +45,7 @@ import { tokenIds } from 'consts/tokenIds'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { useTokensWithBalanceForAccount } from 'features/portfolio/hooks/useTokensWithBalanceForAccount'
 import { caip2ChainIds } from 'consts/caip2ChainIds'
-import { selectHasSolanaAddress } from 'store/account'
+import { selectActiveAccountHasSolanaAddress } from 'store/account'
 import { AdditiveFeesNotice } from '../components/AdditiveFeesNotice'
 import { FeeDebugTable } from '../components/FeeDebugTable'
 import { useFusionTokenLookup } from '../hooks/useFusionTokenLookup'
@@ -172,7 +172,7 @@ export const SwapScreen = (): JSX.Element => {
     setToToken
   })
 
-  const hasSolanaAddress = useSelector(selectHasSolanaAddress)
+  const hasSolanaAddress = useSelector(selectActiveAccountHasSolanaAddress)
 
   const tokensWithZeroBalance = useTokensWithZeroBalanceByNetworksForAccount(
     activeAccount,

--- a/packages/core-mobile/app/store/account/slice.ts
+++ b/packages/core-mobile/app/store/account/slice.ts
@@ -166,7 +166,7 @@ export const selectAccountsCount = createSelector(
   (accounts): number => Object.keys(accounts).length
 )
 
-export const selectHasSolanaAddress = createSelector(
+export const selectActiveAccountHasSolanaAddress = createSelector(
   [selectActiveAccount, selectIsSolanaSupportBlocked],
   (activeAccount, isSolanaSupportBlocked) => {
     if (isSolanaSupportBlocked) return false

--- a/packages/core-mobile/app/store/account/slice.ts
+++ b/packages/core-mobile/app/store/account/slice.ts
@@ -2,7 +2,10 @@ import { createSlice, PayloadAction, createSelector } from '@reduxjs/toolkit'
 import { RootState } from 'store/types'
 import { WalletType } from 'services/wallet/types'
 import { CoreAccountType } from '@avalabs/types'
-import { selectIsLedgerSupportBlocked } from 'store/posthog'
+import {
+  selectIsLedgerSupportBlocked,
+  selectIsSolanaSupportBlocked
+} from 'store/posthog'
 import {
   Account,
   AccountsState,
@@ -161,6 +164,17 @@ export const selectImportedAccounts = createSelector(
 export const selectAccountsCount = createSelector(
   [selectAccounts],
   (accounts): number => Object.keys(accounts).length
+)
+
+export const selectHasSolanaAddress = createSelector(
+  [selectActiveAccount, selectIsSolanaSupportBlocked],
+  (activeAccount, isSolanaSupportBlocked) => {
+    if (isSolanaSupportBlocked) return false
+    return (
+      activeAccount?.addressSVM !== undefined &&
+      activeAccount.addressSVM.length > 0
+    )
+  }
 )
 
 // actions

--- a/packages/core-mobile/app/store/network/slice.ts
+++ b/packages/core-mobile/app/store/network/slice.ts
@@ -13,7 +13,7 @@ import {
 import { getNetworksFromCache } from 'hooks/networks/utils/getNetworksFromCache'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { selectIsSolanaSupportBlocked } from 'store/posthog'
-import { selectActiveAccount } from 'store/account'
+import { selectHasSolanaAddress } from 'store/account'
 import { defaultEnabledL2ChainIds } from 'services/network/consts'
 import { RootState } from '../types'
 import { ChainID, Networks, NetworkState } from './types'
@@ -206,18 +206,15 @@ export const selectEnabledNetworks = createSelector(
     selectEnabledChainIds,
     selectIsDeveloperMode,
     selectNetworks,
-    selectActiveAccount
+    selectHasSolanaAddress
   ],
   // eslint-disable-next-line max-params
-  (enabledChainIds, isDeveloperMode, networks, activeAccount) => {
+  (enabledChainIds, isDeveloperMode, networks, hasSolanaAddress) => {
     return enabledChainIds.reduce((acc, chainId) => {
       const network = networks[chainId]
       if (network && network.isTestnet === isDeveloperMode) {
         if (network.vmName === NetworkVMType.SVM) {
-          if (
-            activeAccount?.addressSVM !== undefined &&
-            activeAccount.addressSVM.length > 0
-          ) {
+          if (hasSolanaAddress) {
             acc.push(network)
           }
         } else {
@@ -234,18 +231,15 @@ export const selectEnabledNetworksMap = createSelector(
     selectEnabledChainIds,
     selectIsDeveloperMode,
     selectNetworks,
-    selectActiveAccount
+    selectHasSolanaAddress
   ],
   // eslint-disable-next-line max-params
-  (enabledChainIds, isDeveloperMode, networks, activeAccount) => {
+  (enabledChainIds, isDeveloperMode, networks, hasSolanaAddress) => {
     return enabledChainIds.reduce<Networks>((acc, chainId) => {
       const network = networks[chainId]
       if (network && network.isTestnet === isDeveloperMode) {
         if (network.vmName === NetworkVMType.SVM) {
-          if (
-            activeAccount?.addressSVM !== undefined &&
-            activeAccount.addressSVM.length > 0
-          ) {
+          if (hasSolanaAddress) {
             acc[chainId] = network
           }
         } else {
@@ -261,17 +255,14 @@ export const selectEnabledNetworksByTestnet =
   (isTestnet: boolean) => (state: RootState) => {
     const networks = selectNetworks(state)
     const enabledChainIds = selectEnabledChainIds(state)
-    const activeAccount = selectActiveAccount(state)
+    const hasSolanaAddress = selectHasSolanaAddress(state)
 
     const results: Network[] = []
     for (const chainId of enabledChainIds) {
       const network = networks[chainId]
       if (network && network.isTestnet === isTestnet) {
         if (network.vmName === NetworkVMType.SVM) {
-          if (
-            activeAccount?.addressSVM !== undefined &&
-            activeAccount.addressSVM.length > 0
-          ) {
+          if (hasSolanaAddress) {
             results.push(network)
           }
         } else {

--- a/packages/core-mobile/app/store/network/slice.ts
+++ b/packages/core-mobile/app/store/network/slice.ts
@@ -13,7 +13,7 @@ import {
 import { getNetworksFromCache } from 'hooks/networks/utils/getNetworksFromCache'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { selectIsSolanaSupportBlocked } from 'store/posthog'
-import { selectHasSolanaAddress } from 'store/account'
+import { selectActiveAccountHasSolanaAddress } from 'store/account'
 import { defaultEnabledL2ChainIds } from 'services/network/consts'
 import { RootState } from '../types'
 import { ChainID, Networks, NetworkState } from './types'
@@ -206,7 +206,7 @@ export const selectEnabledNetworks = createSelector(
     selectEnabledChainIds,
     selectIsDeveloperMode,
     selectNetworks,
-    selectHasSolanaAddress
+    selectActiveAccountHasSolanaAddress
   ],
   // eslint-disable-next-line max-params
   (enabledChainIds, isDeveloperMode, networks, hasSolanaAddress) => {
@@ -231,7 +231,7 @@ export const selectEnabledNetworksMap = createSelector(
     selectEnabledChainIds,
     selectIsDeveloperMode,
     selectNetworks,
-    selectHasSolanaAddress
+    selectActiveAccountHasSolanaAddress
   ],
   // eslint-disable-next-line max-params
   (enabledChainIds, isDeveloperMode, networks, hasSolanaAddress) => {
@@ -255,7 +255,7 @@ export const selectEnabledNetworksByTestnet =
   (isTestnet: boolean) => (state: RootState) => {
     const networks = selectNetworks(state)
     const enabledChainIds = selectEnabledChainIds(state)
-    const hasSolanaAddress = selectHasSolanaAddress(state)
+    const hasSolanaAddress = selectActiveAccountHasSolanaAddress(state)
 
     const results: Network[] = []
     for (const chainId of enabledChainIds) {

--- a/packages/core-mobile/tests/jestSetup/posthog.js
+++ b/packages/core-mobile/tests/jestSetup/posthog.js
@@ -1,23 +1,30 @@
 /**
  * Break the circular dependency between store/account/slice.ts and store/posthog.
  *
- * store/account/slice.ts imports selectIsLedgerSupportBlocked from store/posthog,
- * but store/posthog → store/wallet → ... → store/account creates a cycle that
- * causes the export to be undefined at module-load time in Jest.
+ * store/account/slice.ts imports selectIsLedgerSupportBlocked and
+ * selectIsSolanaSupportBlocked from store/posthog, but
+ * store/posthog → store/wallet → ... → store/account creates a cycle that
+ * causes the exports to be undefined at module-load time in Jest.
  *
- * This setup file provides a standalone implementation of selectIsLedgerSupportBlocked
- * so the createSelector call in store/account/slice.ts receives a real function
+ * This setup file provides standalone implementations of those selectors
+ * so the createSelector calls in store/account/slice.ts receive real functions
  * instead of undefined. All other exports are forwarded from the real module.
  */
 jest.mock('store/posthog', () => {
   return new Proxy(
     {
       // Inline implementation matching the real selectIsLedgerSupportBlocked.
-      // This is the only export store/account/slice.ts needs at load time.
       selectIsLedgerSupportBlocked: state => {
         const featureFlags = state?.posthog?.featureFlags
         return (
           !featureFlags?.['ledger-support'] || !featureFlags?.['everything']
+        )
+      },
+      // Inline implementation matching the real selectIsSolanaSupportBlocked.
+      selectIsSolanaSupportBlocked: state => {
+        const featureFlags = state?.posthog?.featureFlags
+        return (
+          !featureFlags?.['solana-support'] || !featureFlags?.['everything']
         )
       }
     },


### PR DESCRIPTION
## Summary

iOS: 8263
Android: 8264

- Add `selectHasSolanaAddress` selector in `account/slice.ts` combining `selectIsSolanaSupportBlocked` + `addressSVM` derivation check
- Use it across swap (`useSupportedChains`, `useSwapTokens`, `SwapScreen`), portfolio (`useAssetsFilterAndSort`), network selectors (`selectEnabledNetworks`, `selectEnabledNetworksMap`, `selectEnabledNetworksByTestnet`), and `useCombinedPrimaryNetworks` to hide Solana for Ledger wallets without a derived Solana account
- Fix circular dependency in Jest mock setup for `store/posthog`

## Test plan
- [ ] Ledger wallet without Solana derived: verify Solana does not appear in swap chain/token selection
- [ ] Ledger wallet with Solana derived: verify Solana still appears in swap
- [ ] Non-Ledger wallet: verify Solana behavior unchanged
- [ ] Portfolio asset filter: Solana network hidden when address not derived
- [ ] Account addresses screen: Solana still shows "Enable" button for Ledger without derivation

