### PR TITLE
CP-14078: Fix gasless flow to sign before funding

### DIFF
--- a/packages/core-mobile/app/hooks/useGasless.ts
+++ b/packages/core-mobile/app/hooks/useGasless.ts
@@ -16,6 +16,9 @@ import AnalyticsService from 'services/analytics/AnalyticsService'
 
 type Params = {
   maxFeePerGas: bigint | undefined
+  maxPriorityFeePerGas: bigint | undefined
+  gasLimit: number | undefined
+  overrideData: string | undefined
   signingData: SigningData
   caip2ChainId: string
 }
@@ -31,6 +34,9 @@ type Return = {
 export const useGasless = ({
   signingData,
   maxFeePerGas,
+  maxPriorityFeePerGas,
+  gasLimit,
+  overrideData,
   caip2ChainId
 }: Params): Return => {
   const { getNetwork } = useNetworks()
@@ -91,7 +97,7 @@ export const useGasless = ({
     let attempts = 0
     const MAX_ATTEMPTS = 1
 
-    if (!network) {
+    if (!network || !chainId) {
       showGaslessError()
       return undefined
     }
@@ -106,7 +112,11 @@ export const useGasless = ({
         GaslessService.fundTx({
           signingData,
           addressFrom,
+          chainId,
           maxFeePerGas,
+          maxPriorityFeePerGas,
+          gasLimit,
+          overrideData,
           provider,
           waitForConfirmation: isGaslessInstantBlocked
         })

--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
@@ -37,6 +37,7 @@ import { NetworkFeeSelectorWithGasless } from '../../components/NetworkFeeSelect
 import { SpendLimits } from '../../components/SpendLimits/SpendLimits'
 import {
   getAccountSelector,
+  getHasBalanceChange,
   getInitialGasLimit,
   overrideContractItem,
   removeWebsiteItemIfNecessary
@@ -116,9 +117,7 @@ const ApprovalScreen = ({
   }, [displayData.details, request])
 
   const balanceChange = displayData.balanceChange
-  const hasBalanceChange =
-    balanceChange &&
-    (balanceChange.ins.length > 0 || balanceChange.outs.length > 0)
+  const hasBalanceChange = getHasBalanceChange(balanceChange)
 
   const rejectAndClose = useCallback(
     (message?: string) => {
@@ -384,7 +383,7 @@ const ApprovalScreen = ({
   }, [filteredSections, symbol])
 
   const renderBalanceChange = useCallback((): JSX.Element | null => {
-    if (!hasBalanceChange) return null
+    if (!hasBalanceChange || !balanceChange) return null
 
     return <BalanceChange balanceChange={balanceChange} />
   }, [balanceChange, hasBalanceChange])

--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
@@ -74,6 +74,10 @@ const ApprovalScreen = ({
   const [maxPriorityFeePerGas, setMaxPriorityFeePerGas] = useState<
     bigint | undefined
   >()
+
+  const { spendLimits, canEdit, updateSpendLimit, hashedCustomSpend } =
+    useSpendLimits(displayData.tokenApprovals)
+
   const {
     gaslessEnabled,
     setGaslessEnabled,
@@ -83,6 +87,9 @@ const ApprovalScreen = ({
   } = useGasless({
     signingData,
     maxFeePerGas,
+    maxPriorityFeePerGas,
+    gasLimit,
+    overrideData: hashedCustomSpend,
     caip2ChainId
   })
 
@@ -93,9 +100,6 @@ const ApprovalScreen = ({
     (displayData.networkFeeSelector && maxPriorityFeePerGas === undefined) ||
     submitting ||
     amountError !== undefined
-
-  const { spendLimits, canEdit, updateSpendLimit, hashedCustomSpend } =
-    useSpendLimits(displayData.tokenApprovals)
 
   const filteredSections = useMemo(() => {
     return displayData.details.map(detailSection => {
@@ -133,37 +137,11 @@ const ApprovalScreen = ({
     onReject()
   }, [cancelLedger, isLedger, onReject])
 
-  const handleGaslessPreApprove = useCallback(async (): Promise<boolean> => {
-    if (!shouldShowGaslessSwitch || !gaslessEnabled) return true
-
-    if (!account) return false
-    const txHash = await handleGaslessTx(account.addressC)
-    if (!txHash) return false
-
-    // flag VM-module retry via request context instead of mutating tx data
-    request.context = {
-      ...request.context,
-      [RequestContext.SHOULD_RETRY]: !isGaslessInstantBlocked
-    }
-    return true
-  }, [
-    shouldShowGaslessSwitch,
-    gaslessEnabled,
-    handleGaslessTx,
-    account,
-    request,
-    isGaslessInstantBlocked
-  ])
-
   const handleApprove = useCallback(async (): Promise<void> => {
     if (approveDisabled) return
     setSubmitting(true)
 
-    const canProceed = await handleGaslessPreApprove()
-    if (!canProceed) {
-      setSubmitting(false)
-      return
-    }
+    const isGasless = shouldShowGaslessSwitch && gaslessEnabled
 
     try {
       await onApprove({
@@ -174,7 +152,21 @@ const ApprovalScreen = ({
         maxFeePerGas,
         maxPriorityFeePerGas,
         gasLimit,
-        overrideData: hashedCustomSpend
+        overrideData: hashedCustomSpend,
+        // For gasless: fund after signing but before broadcasting.
+        // This ensures the gas station is only called once we have
+        // a signed tx, preventing wasted funding on rejected signs.
+        onSigned: isGasless
+          ? async () => {
+              if (!account) return false
+              request.context = {
+                ...request.context,
+                [RequestContext.SHOULD_RETRY]: !isGaslessInstantBlocked
+              }
+              const txHash = await handleGaslessTx(account.addressC)
+              return !!txHash
+            }
+          : undefined
       })
       // For Ledger, the controller sets the store and navigation is handled
       // by ApprovalController.handleGoBackIfNeeded after signing completes
@@ -188,7 +180,8 @@ const ApprovalScreen = ({
     }
   }, [
     approveDisabled,
-    handleGaslessPreApprove,
+    shouldShowGaslessSwitch,
+    gaslessEnabled,
     onApprove,
     activeWallet.id,
     activeWallet.type,
@@ -198,6 +191,9 @@ const ApprovalScreen = ({
     maxPriorityFeePerGas,
     gasLimit,
     hashedCustomSpend,
+    isGaslessInstantBlocked,
+    handleGaslessTx,
+    request,
     isLedger
   ])
 

--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
@@ -2,8 +2,6 @@ import { Separator, showAlert, Text, View } from '@avalabs/k2-alpine'
 import { RpcMethod } from '@avalabs/vm-module-types'
 import { NetworkTokenSymbols } from 'common/components/TokenIcon'
 import { withWalletConnectCache } from 'common/components/withWalletConnectCache'
-import { validateFee } from 'common/hooks/send/utils/evm/validate'
-import { SendErrorMessage } from 'common/hooks/send/utils/types'
 import { useActiveWallet } from 'common/hooks/useActiveWallet'
 import { useLedgerApproval } from 'features/approval/hooks/useLedgerApproval'
 import { dismissKeyboardIfNeeded } from 'common/utils/dismissKeyboardIfNeeded'
@@ -37,6 +35,7 @@ import { NetworkFeeSelectorWithGasless } from '../../components/NetworkFeeSelect
 import { SpendLimits } from '../../components/SpendLimits/SpendLimits'
 import {
   getAccountSelector,
+  getEthSendTxValidationError,
   getHasBalanceChange,
   getInitialGasLimit,
   overrideContractItem,
@@ -211,28 +210,13 @@ const ApprovalScreen = ({
       return
     }
 
-    const ethSendTx = signingData.data
-
-    try {
-      const gasLimitToValidate = gasLimit ? BigInt(gasLimit) : 0n
-      const amount = ethSendTx.value ? BigInt(ethSendTx.value) : 0n
-
-      validateFee({
-        gasLimit: gasLimitToValidate,
-        maxFee: maxFeePerGas || 0n,
-        amount,
-        nativeToken,
-        token: nativeToken
-      })
-
-      setAmountError(undefined)
-    } catch (err) {
-      if (err instanceof Error) {
-        setAmountError(err.message)
-      } else {
-        setAmountError(SendErrorMessage.UNKNOWN_ERROR)
-      }
-    }
+    const error = getEthSendTxValidationError({
+      gasLimit,
+      maxFeePerGas,
+      sendValue: signingData.data.value,
+      nativeToken
+    })
+    setAmountError(error)
   }, [
     signingData,
     network?.networkToken,

--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/utils.ts
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/utils.ts
@@ -4,8 +4,11 @@ import {
   RpcMethod,
   DetailItemType,
   SigningData,
-  BalanceChange
+  BalanceChange,
+  NetworkTokenWithBalance
 } from '@avalabs/vm-module-types'
+import { validateFee } from 'common/hooks/send/utils/evm/validate'
+import { SendErrorMessage } from 'common/hooks/send/utils/types'
 import { RequestContext } from 'store/rpc/types'
 import { isInAppRequest } from 'store/rpc/utils/isInAppRequest'
 import {
@@ -88,4 +91,36 @@ export const getHasBalanceChange = (
     !!balanceChange &&
     (balanceChange.ins.length > 0 || balanceChange.outs.length > 0)
   )
+}
+
+export const getEthSendTxValidationError = ({
+  gasLimit,
+  maxFeePerGas,
+  sendValue,
+  nativeToken
+}: {
+  gasLimit: number | undefined
+  maxFeePerGas: bigint | undefined
+  sendValue?: string | number | bigint | null
+  nativeToken: NetworkTokenWithBalance
+}): string | undefined => {
+  try {
+    const gasLimitToValidate = gasLimit ? BigInt(gasLimit) : 0n
+    const amount = sendValue ? BigInt(sendValue) : 0n
+
+    validateFee({
+      gasLimit: gasLimitToValidate,
+      maxFee: maxFeePerGas || 0n,
+      amount,
+      nativeToken,
+      token: nativeToken
+    })
+
+    return undefined
+  } catch (err) {
+    if (err instanceof Error) {
+      return err.message
+    }
+    return SendErrorMessage.UNKNOWN_ERROR
+  }
 }

--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/utils.ts
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/utils.ts
@@ -3,7 +3,8 @@ import {
   DetailItem,
   RpcMethod,
   DetailItemType,
-  SigningData
+  SigningData,
+  BalanceChange
 } from '@avalabs/vm-module-types'
 import { RequestContext } from 'store/rpc/types'
 import { isInAppRequest } from 'store/rpc/utils/isInAppRequest'
@@ -78,4 +79,13 @@ export const getInitialGasLimit = (data: SigningData): number | undefined => {
     return Number(data.data.gasLimit || 0)
   }
   return undefined
+}
+
+export const getHasBalanceChange = (
+  balanceChange: BalanceChange | undefined
+): boolean => {
+  return (
+    !!balanceChange &&
+    (balanceChange.ins.length > 0 || balanceChange.outs.length > 0)
+  )
 }

--- a/packages/core-mobile/app/services/gasless/GaslessService.ts
+++ b/packages/core-mobile/app/services/gasless/GaslessService.ts
@@ -11,6 +11,7 @@ import { Transaction, TransactionLike } from 'ethers'
 import { JsonRpcBatchInternal } from '@avalabs/core-wallets-sdk'
 import { resolve } from '@avalabs/core-utils-sdk'
 import { FundTxParams } from 'services/gasless/types'
+import { buildEvmTransaction } from 'vmModule/utils/buildEvmTransaction'
 
 if (!Config.GAS_STATION_URL) {
   Logger.warn(
@@ -62,7 +63,11 @@ class GaslessService {
     signingData,
     addressFrom,
     provider,
+    chainId,
     maxFeePerGas,
+    maxPriorityFeePerGas,
+    gasLimit,
+    overrideData,
     waitForConfirmation
   }: FundTxParams): Promise<FundResult> => {
     const sdk = await this.getSdk()
@@ -87,9 +92,17 @@ class GaslessService {
     const { difficulty, challengeHex } = await sdk.fetchChallenge()
     const { solutionHex } = await sdk.solveChallenge(challengeHex, difficulty)
 
-    const txHex = Transaction.from({
-      ...signingData.data,
+    const transaction = buildEvmTransaction({
+      transactionRequest: signingData.data,
+      chainId,
       maxFeePerGas,
+      maxPriorityFeePerGas,
+      gasLimit,
+      overrideData
+    })
+
+    const txHex = Transaction.from({
+      ...transaction,
       from: null
     } as TransactionLike).unsignedSerialized
 

--- a/packages/core-mobile/app/services/gasless/types.ts
+++ b/packages/core-mobile/app/services/gasless/types.ts
@@ -5,6 +5,10 @@ export interface FundTxParams {
   signingData: SigningData
   addressFrom: string
   provider: JsonRpcBatchInternal
+  chainId: number
   maxFeePerGas?: bigint
+  maxPriorityFeePerGas?: bigint
+  gasLimit?: number
+  overrideData?: string
   waitForConfirmation: boolean
 }

--- a/packages/core-mobile/app/services/walletconnectv2/walletConnectCache/types.ts
+++ b/packages/core-mobile/app/services/walletconnectv2/walletConnectCache/types.ts
@@ -34,6 +34,7 @@ export type OnApproveParams = {
   maxPriorityFeePerGas?: bigint
   gasLimit?: number
   overrideData?: string
+  onSigned?: () => Promise<boolean>
 }
 
 export type ApprovalParams = {

--- a/packages/core-mobile/app/vmModule/ApprovalController/onApprove.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/onApprove.ts
@@ -24,6 +24,7 @@ export const onApprove = async ({
   maxPriorityFeePerGas,
   gasLimit,
   overrideData,
+  onSigned,
   signingData,
   resolve
 }: OnApproveParams & {
@@ -67,6 +68,7 @@ export const onApprove = async ({
         maxPriorityFeePerGas,
         gasLimit,
         overrideData,
+        onSigned,
         resolve
       })
       break

--- a/packages/core-mobile/app/vmModule/handlers/ethSendTransaction.ts
+++ b/packages/core-mobile/app/vmModule/handlers/ethSendTransaction.ts
@@ -6,6 +6,7 @@ import { Account } from 'store/account/types'
 import { TransactionRequest } from 'ethers'
 import { WalletType } from 'services/wallet/types'
 import Logger from 'utils/Logger'
+import { buildEvmTransaction } from 'vmModule/utils/buildEvmTransaction'
 
 export const ethSendTransaction = async ({
   transactionRequest,
@@ -17,6 +18,7 @@ export const ethSendTransaction = async ({
   maxPriorityFeePerGas,
   gasLimit,
   overrideData,
+  onSigned,
   resolve
 }: {
   transactionRequest: TransactionRequest
@@ -28,30 +30,17 @@ export const ethSendTransaction = async ({
   maxPriorityFeePerGas: bigint | undefined
   gasLimit: number | undefined
   overrideData: string | undefined
+  onSigned?: () => Promise<boolean>
   resolve: (value: ApprovalResponse) => void
 }): Promise<void> => {
-  const {
-    gasLimit: defaultGasLimit,
-    type,
-    nonce,
-    data,
-    from,
-    to,
-    value
-  } = transactionRequest
-
-  const transaction = {
-    nonce,
-    type,
+  const transaction = buildEvmTransaction({
+    transactionRequest,
     chainId: network.chainId,
     maxFeePerGas,
     maxPriorityFeePerGas,
-    gasLimit: gasLimit ? BigInt(gasLimit) : defaultGasLimit,
-    data: overrideData ?? data,
-    from,
-    to,
-    value
-  }
+    gasLimit,
+    overrideData
+  })
 
   try {
     const signedTx = await WalletService.sign({
@@ -61,6 +50,14 @@ export const ethSendTransaction = async ({
       accountIndex: account.index,
       network
     })
+
+    // If onSigned is provided (gasless flow), call it after signing
+    // but before broadcasting. If it returns false (funding failed),
+    // don't broadcast — the caller handles the error UI.
+    if (onSigned) {
+      const shouldBroadcast = await onSigned()
+      if (!shouldBroadcast) return
+    }
 
     resolve({
       signedData: signedTx

--- a/packages/core-mobile/app/vmModule/handlers/ethSendTransaction.ts
+++ b/packages/core-mobile/app/vmModule/handlers/ethSendTransaction.ts
@@ -52,11 +52,27 @@ export const ethSendTransaction = async ({
     })
 
     // If onSigned is provided (gasless flow), call it after signing
-    // but before broadcasting. If it returns false (funding failed),
-    // don't broadcast — the caller handles the error UI.
+    // but before broadcasting. If it returns false or throws (funding
+    // failed), don't broadcast — the caller handles the error UI.
     if (onSigned) {
-      const shouldBroadcast = await onSigned()
-      if (!shouldBroadcast) return
+      try {
+        const shouldBroadcast = await onSigned()
+        if (!shouldBroadcast) return
+      } catch (error) {
+        Logger.error(
+          `[ethSendTransaction] onSigned FAILED: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          error
+        )
+        resolve({
+          error: rpcErrors.internal({
+            message: 'Failed to complete gasless transaction funding',
+            data: { cause: error }
+          })
+        })
+        return
+      }
     }
 
     resolve({

--- a/packages/core-mobile/app/vmModule/utils/buildEvmTransaction.ts
+++ b/packages/core-mobile/app/vmModule/utils/buildEvmTransaction.ts
@@ -1,0 +1,47 @@
+import { TransactionRequest } from 'ethers'
+
+export interface BuildEvmTransactionParams {
+  transactionRequest: TransactionRequest
+  chainId: number
+  maxFeePerGas: bigint | undefined
+  maxPriorityFeePerGas: bigint | undefined
+  gasLimit: number | undefined
+  overrideData: string | undefined
+}
+
+/**
+ * Builds a canonical EVM transaction object from the original request
+ * and user-selected fee parameters. Used by both the gasless funding
+ * path and the actual signing path to ensure the two match.
+ */
+export function buildEvmTransaction({
+  transactionRequest,
+  chainId,
+  maxFeePerGas,
+  maxPriorityFeePerGas,
+  gasLimit,
+  overrideData
+}: BuildEvmTransactionParams): TransactionRequest {
+  const {
+    gasLimit: defaultGasLimit,
+    type,
+    nonce,
+    data,
+    from,
+    to,
+    value
+  } = transactionRequest
+
+  return {
+    nonce,
+    type,
+    chainId,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+    gasLimit: gasLimit ? BigInt(gasLimit) : defaultGasLimit,
+    data: overrideData ?? data,
+    from,
+    to,
+    value
+  }
+}


### PR DESCRIPTION
## Summary
- Reorders gasless flow from **fund→sign→broadcast** to **sign→fund→broadcast**, preventing wasted gas station funding when users reject on Ledger (which burned the nonce and caused a 12-hour gasless cooldown)
- Fixes transaction field mismatch between gasless funding and signing paths by introducing a shared `buildEvmTransaction` utility
- Adds `onSigned` callback to `ethSendTransaction` that runs between signing and broadcasting — gasless funding hooks in here

## Build
- iOS: 8285
- Android: 8286

## Test plan
- [ ] Verify gasless toggle appears on C-chain send
- [ ] Enable gasless, approve tx — confirm funding happens after signing, tx broadcasts successfully
- [ ] Enable gasless on Ledger, reject on device — confirm gasless toggle still appears on next attempt (nonce not burned)
- [ ] Enable gasless on Ledger, approve on device — confirm tx completes end-to-end
- [ ] WalletConnect + Ledger + gasless flow
- [ ] Non-gasless transactions still work normally (no regression)
- [ ] Custom spend limits with gasless enabled

