### PR TITLE
CP-13892: fix collectibles NFT loading and masonry glitches

### DIFF
--- a/packages/core-mobile/app/new/features/portfolio/collectibles/CollectiblesContext.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/CollectiblesContext.tsx
@@ -17,7 +17,6 @@ import {
   NftLocalStatus,
   UnprocessedNftItem
 } from 'services/nft/types'
-import { isUnreachableNftIndexStatus } from 'services/nft/indexStatus'
 import { getTokenUri } from 'services/nft/utils'
 import { isPositiveNumber } from 'utils/isPositiveNumber/isPositiveNumber'
 import Logger from 'utils/Logger'
@@ -174,14 +173,6 @@ export const CollectiblesProvider = ({
   const process = useCallback(
     (items: UnprocessedNftItem[]): void => {
       for (const item of items) {
-        if (isUnreachableNftIndexStatus(item.metadata?.indexStatus)) {
-          setStatusData(prevData => ({
-            ...prevData,
-            [item.localId]: NftLocalStatus.Unprocessable
-          }))
-          continue
-        }
-        // if logoUri is present, no need to fetch metadata
         if (item.logoUri) {
           processImageData(item.localId, item.logoUri)
         } else {

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleItem.tsx
@@ -8,7 +8,6 @@ import {
   useTheme,
   View
 } from '@avalabs/k2-alpine'
-import { getListItemEnteringAnimation } from 'common/utils/animations'
 import React, { memo, ReactNode } from 'react'
 import { Pressable, ViewStyle } from 'react-native'
 import { NftItem } from 'services/nft/types'
@@ -59,7 +58,6 @@ export const CollectibleItem = memo(
         index={index}
         onPress={onPress}
         onLoaded={onLoaded}
-        entering={getListItemEnteringAnimation(index)}
         rendererProps={{
           videoProps: {
             muted: true,

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/screens/CollectiblesScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/screens/CollectiblesScreen.tsx
@@ -316,7 +316,9 @@ export const CollectiblesScreen = ({
         onRefresh={pullToRefresh}
         numColumns={columns}
         extraData={{ view, sort, filter }}
-        listKey={`collectibles-list-${listType}`}
+        listKey={`collectibles-list-${listType}-${sort.selected}-${(
+          filter.selected ?? []
+        ).join('-')}`}
         columnItems={columnItems}
         nestedScrollEnabled
         removeClippedSubviews={Platform.OS === 'android'}


### PR DESCRIPTION
## Description

**Ticket: [CP-13892]**

- `CollectiblesContext.tsx`: remove `isUnreachableNftIndexStatus` gate from `process`; always attempt client-side fetch via `processImageData` / `processMetadata`.
- `CollectibleItem.tsx`: remove `entering={getListItemEnteringAnimation(index)}` prop on the grid path to avoid the reanimated stuck-animation race. (`CollectibleListItem` already did not use the entering animation, so consistency is preserved.)
- `CollectiblesScreen.tsx`: extend `listKey` to include `sort.selected` and `filter.selected` so the list remounts and re-measures when sort/filter change.

## Testing
iOS: 8274
Android: 8275

Regression check on Portfolio → Collectibles:
- Confirm NFT images that were visible in previous app versions still load and display correctly
- On initial load, NFT images and titles render in grid/list/detail.
- No blank or overlapping tiles at the top of the grid.
- Sort / Filter / View changes produce a stable masonry layout without stale heights.

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-13892]: https://ava-labs.atlassian.net/browse/CP-13892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ