### PR TITLE
CP-14082: Move chain ID fields to plaintext analytics properties

### DIFF
--- a/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
+++ b/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
@@ -34,7 +34,7 @@ export const useSendTransactionCallbacks = (): {
             txHash
           },
           {
-            chainId: getCaip2ChainId(selectedToken.networkChainId)
+            caip2ChainId: getCaip2ChainId(selectedToken.networkChainId)
           }
         )
       audioFeedback(Audios.Send)

--- a/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
+++ b/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
@@ -31,6 +31,7 @@ export const useSendTransactionCallbacks = (): {
         AnalyticsService.captureWithEncryption(
           'SendTransactionSucceeded',
           {
+            chainId: selectedToken.networkChainId,
             txHash
           },
           {

--- a/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
+++ b/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
@@ -4,6 +4,7 @@ import { useCallback } from 'react'
 import AnalyticsService from 'services/analytics/AnalyticsService'
 import { isUserRejectedError } from 'store/rpc/providers/walletConnect/utils'
 import { audioFeedback, Audios } from 'utils/AudioFeedback'
+import { getCaip2ChainId } from 'utils/caip2ChainIds'
 import { getJsonRpcErrorMessage } from 'utils/getJsonRpcErrorMessage/getJsonRpcErrorMessage'
 
 export const useSendTransactionCallbacks = (): {
@@ -27,10 +28,15 @@ export const useSendTransactionCallbacks = (): {
       onDismiss: () => void
     }): void => {
       selectedToken &&
-        AnalyticsService.captureWithEncryption('SendTransactionSucceeded', {
-          chainId: selectedToken.networkChainId,
-          txHash
-        })
+        AnalyticsService.captureWithEncryption(
+          'SendTransactionSucceeded',
+          {
+            txHash
+          },
+          {
+            chainId: getCaip2ChainId(selectedToken.networkChainId)
+          }
+        )
       audioFeedback(Audios.Send)
       setSelectedToken(undefined)
 

--- a/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
+++ b/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
@@ -52,7 +52,7 @@ export const SendScreen = (): JSX.Element => {
             txHash
           },
           {
-            chainId: getCaip2ChainId(network.chainId)
+            caip2ChainId: getCaip2ChainId(network.chainId)
           }
         )
       audioFeedback(Audios.Send)

--- a/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
+++ b/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
@@ -5,6 +5,7 @@ import { audioFeedback, Audios } from 'utils/AudioFeedback'
 import { isUserRejectedError } from 'store/rpc/providers/walletConnect/utils'
 import { transactionSnackbar } from 'common/utils/toast'
 import { getJsonRpcErrorMessage } from 'utils/getJsonRpcErrorMessage/getJsonRpcErrorMessage'
+import { getCaip2ChainId } from 'utils/caip2ChainIds'
 import { useDispatch, useSelector } from 'react-redux'
 import { selectActiveAccount } from 'store/account'
 import { View, ActivityIndicator } from '@avalabs/k2-alpine'
@@ -45,10 +46,15 @@ export const SendScreen = (): JSX.Element => {
   const handleSuccess = useCallback(
     (txHash: string): void => {
       network &&
-        AnalyticsService.captureWithEncryption('SendTransactionSucceeded', {
-          chainId: network.chainId,
-          txHash
-        })
+        AnalyticsService.captureWithEncryption(
+          'SendTransactionSucceeded',
+          {
+            txHash
+          },
+          {
+            chainId: getCaip2ChainId(network.chainId)
+          }
+        )
       audioFeedback(Audios.Send)
       resetAmount()
       setSelectedToken(undefined)

--- a/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
+++ b/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
@@ -49,6 +49,7 @@ export const SendScreen = (): JSX.Element => {
         AnalyticsService.captureWithEncryption(
           'SendTransactionSucceeded',
           {
+            chainId: network.chainId,
             txHash
           },
           {

--- a/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
+++ b/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
@@ -230,6 +230,8 @@ export const SwapContextProvider = ({
         {
           sourceAddress: address,
           targetAddress,
+          sourceChainId: quote.sourceChain.chainId,
+          targetChainId: quote.targetChain.chainId,
           sourceTxHash: transfer.source?.txHash,
           quoteSelectionMode,
           autoRetryAttempt

--- a/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
+++ b/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
@@ -225,15 +225,20 @@ export const SwapContextProvider = ({
         autoRetryAttempt
       } = params
       audioFeedback(Audios.Send)
-      AnalyticsService.captureWithEncryption('SwapConfirmed', {
-        sourceAddress: address,
-        targetAddress,
-        sourceChainId: quote.sourceChain.chainId,
-        targetChainId: quote.targetChain.chainId,
-        sourceTxHash: transfer.source?.txHash,
-        quoteSelectionMode,
-        autoRetryAttempt
-      })
+      AnalyticsService.captureWithEncryption(
+        'SwapConfirmed',
+        {
+          sourceAddress: address,
+          targetAddress,
+          sourceTxHash: transfer.source?.txHash,
+          quoteSelectionMode,
+          autoRetryAttempt
+        },
+        {
+          sourceChainId: quote.sourceChain.chainId,
+          targetChainId: quote.targetChain.chainId
+        }
+      )
 
       Logger.info('[SwapContext] transfer executed', {
         transfer

--- a/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
+++ b/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
@@ -235,8 +235,8 @@ export const SwapContextProvider = ({
           autoRetryAttempt
         },
         {
-          sourceChainId: quote.sourceChain.chainId,
-          targetChainId: quote.targetChain.chainId
+          caip2SourceChainId: quote.sourceChain.chainId,
+          caip2TargetChainId: quote.targetChain.chainId
         }
       )
 

--- a/packages/core-mobile/app/services/analytics/AnalyticsService.ts
+++ b/packages/core-mobile/app/services/analytics/AnalyticsService.ts
@@ -7,7 +7,8 @@ import { AnalyticsServiceNoop } from 'services/analytics/AnalyticsServiceNoop'
 import {
   AnalyticsEventName,
   AnalyticsServiceInterface,
-  CaptureEventProperties
+  CaptureEventProperties,
+  PlaintextProperties
 } from './types'
 
 if (!Config.ANALYTICS_ENCRYPTION_KEY) {
@@ -47,7 +48,8 @@ class AnalyticsService implements AnalyticsServiceInterface {
 
   async captureWithEncryption<E extends AnalyticsEventName>(
     eventName: E,
-    properties: AnalyticsEvents[E]
+    properties: AnalyticsEvents[E],
+    plaintextProperties?: PlaintextProperties<E>
   ): Promise<void> {
     if (!this.isEnabled) {
       return
@@ -64,7 +66,8 @@ class AnalyticsService implements AnalyticsServiceInterface {
       return PostHogService.capture(eventName, {
         data: encrypted,
         enc,
-        keyID: keyID
+        keyID: keyID,
+        ...plaintextProperties
       })
     } catch (error) {
       Logger.error(

--- a/packages/core-mobile/app/services/analytics/AnalyticsService.ts
+++ b/packages/core-mobile/app/services/analytics/AnalyticsService.ts
@@ -8,7 +8,7 @@ import {
   AnalyticsEventName,
   AnalyticsServiceInterface,
   CaptureEventProperties,
-  PlaintextProperties
+  PlaintextArgs
 } from './types'
 
 if (!Config.ANALYTICS_ENCRYPTION_KEY) {
@@ -49,7 +49,7 @@ class AnalyticsService implements AnalyticsServiceInterface {
   async captureWithEncryption<E extends AnalyticsEventName>(
     eventName: E,
     properties: AnalyticsEvents[E],
-    plaintextProperties?: PlaintextProperties<E>
+    ...plaintextProperties: PlaintextArgs<E>
   ): Promise<void> {
     if (!this.isEnabled) {
       return
@@ -67,7 +67,7 @@ class AnalyticsService implements AnalyticsServiceInterface {
         data: encrypted,
         enc,
         keyID: keyID,
-        ...plaintextProperties
+        ...(plaintextProperties[0] as Record<string, unknown>)
       })
     } catch (error) {
       Logger.error(

--- a/packages/core-mobile/app/services/analytics/types.ts
+++ b/packages/core-mobile/app/services/analytics/types.ts
@@ -7,10 +7,10 @@ export type CaptureEventProperties<E extends AnalyticsEventName> =
     ? [AnalyticsEvents[E]?]
     : [AnalyticsEvents[E]]
 
-export type PlaintextProperties<E extends AnalyticsEventName> =
+export type PlaintextArgs<E extends AnalyticsEventName> =
   E extends keyof AnalyticsPlaintextEvents
-    ? AnalyticsPlaintextEvents[E]
-    : undefined
+    ? [AnalyticsPlaintextEvents[E]]
+    : []
 
 export interface AnalyticsServiceInterface {
   setEnabled(isEnabled: boolean): void
@@ -21,6 +21,6 @@ export interface AnalyticsServiceInterface {
   captureWithEncryption<E extends AnalyticsEventName>(
     eventName: E,
     properties: AnalyticsEvents[E],
-    plaintextProperties?: PlaintextProperties<E>
+    ...plaintextProperties: PlaintextArgs<E>
   ): Promise<void>
 }

--- a/packages/core-mobile/app/services/analytics/types.ts
+++ b/packages/core-mobile/app/services/analytics/types.ts
@@ -1,4 +1,4 @@
-import { AnalyticsEvents } from 'types/analytics'
+import { AnalyticsEvents, AnalyticsPlaintextEvents } from 'types/analytics'
 
 export type AnalyticsEventName = keyof AnalyticsEvents
 
@@ -6,6 +6,11 @@ export type CaptureEventProperties<E extends AnalyticsEventName> =
   undefined extends AnalyticsEvents[E]
     ? [AnalyticsEvents[E]?]
     : [AnalyticsEvents[E]]
+
+export type PlaintextProperties<E extends AnalyticsEventName> =
+  E extends keyof AnalyticsPlaintextEvents
+    ? AnalyticsPlaintextEvents[E]
+    : undefined
 
 export interface AnalyticsServiceInterface {
   setEnabled(isEnabled: boolean): void
@@ -15,6 +20,7 @@ export interface AnalyticsServiceInterface {
   ): Promise<void>
   captureWithEncryption<E extends AnalyticsEventName>(
     eventName: E,
-    properties: AnalyticsEvents[E]
+    properties: AnalyticsEvents[E],
+    plaintextProperties?: PlaintextProperties<E>
   ): Promise<void>
 }

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -114,8 +114,6 @@ export type AnalyticsEvents = {
   SwapConfirmed: {
     sourceAddress: string
     targetAddress: string
-    sourceChainId: string
-    targetChainId: string
     sourceTxHash?: string
     quoteSelectionMode: 'manual' | 'auto'
     autoRetryAttempt?: number
@@ -206,7 +204,7 @@ export type AnalyticsEvents = {
       addressSVM: string
     }[]
   }
-  SendTransactionSucceeded: { txHash: string; chainId: number }
+  SendTransactionSucceeded: { txHash: string }
 
   StakeTransactionStarted: { txHash: string; chainId: number }
   BridgeTransactionStarted: {
@@ -365,4 +363,9 @@ export type AnalyticsEvents = {
   PredictionsSearched: { query: string; resultCount: number }
   PredictionsClicked: undefined
   PerpsClicked: undefined
+}
+
+export type AnalyticsPlaintextEvents = {
+  SendTransactionSucceeded: { chainId: string }
+  SwapConfirmed: { sourceChainId: string; targetChainId: string }
 }

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -114,6 +114,8 @@ export type AnalyticsEvents = {
   SwapConfirmed: {
     sourceAddress: string
     targetAddress: string
+    sourceChainId: string
+    targetChainId: string
     sourceTxHash?: string
     quoteSelectionMode: 'manual' | 'auto'
     autoRetryAttempt?: number
@@ -204,7 +206,7 @@ export type AnalyticsEvents = {
       addressSVM: string
     }[]
   }
-  SendTransactionSucceeded: { txHash: string }
+  SendTransactionSucceeded: { txHash: string; chainId: number }
 
   StakeTransactionStarted: { txHash: string; chainId: number }
   BridgeTransactionStarted: {

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -366,6 +366,6 @@ export type AnalyticsEvents = {
 }
 
 export type AnalyticsPlaintextEvents = {
-  SendTransactionSucceeded: { chainId: string }
-  SwapConfirmed: { sourceChainId: string; targetChainId: string }
+  SendTransactionSucceeded: { caip2ChainId: string }
+  SwapConfirmed: { caip2SourceChainId: string; caip2TargetChainId: string }
 }

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -15,6 +15,40 @@ type DappTxEventPayload = {
   txHash: string
 }
 
+/**
+ * Events sent via captureWithEncryption that also carry plaintext properties.
+ * Define the full shape here — both `encrypted` (goes into the encrypted blob)
+ * and `plaintext` (sent unencrypted, queryable in PostHog) — so the complete
+ * event schema is visible in one place.
+ *
+ * AnalyticsEvents and AnalyticsPlaintextEvents are derived automatically.
+ */
+export type EncryptedEventDefinitions = {
+  SendTransactionSucceeded: {
+    encrypted: { txHash: string; chainId: number }
+    plaintext: { caip2ChainId: string }
+  }
+  SwapConfirmed: {
+    encrypted: {
+      sourceAddress: string
+      targetAddress: string
+      sourceChainId: string
+      targetChainId: string
+      sourceTxHash?: string
+      quoteSelectionMode: 'manual' | 'auto'
+      autoRetryAttempt?: number
+    }
+    plaintext: {
+      caip2SourceChainId: string
+      caip2TargetChainId: string
+    }
+  }
+}
+
+export type AnalyticsPlaintextEvents = {
+  [K in keyof EncryptedEventDefinitions]: EncryptedEventDefinitions[K]['plaintext']
+}
+
 export type AnalyticsEvents = {
   AccountSelectorAddAccount: { accountNumber: number }
   ExplorerLinkClicked: undefined
@@ -111,15 +145,7 @@ export type AnalyticsEvents = {
     provider: string
     slippage: number
   }
-  SwapConfirmed: {
-    sourceAddress: string
-    targetAddress: string
-    sourceChainId: string
-    targetChainId: string
-    sourceTxHash?: string
-    quoteSelectionMode: 'manual' | 'auto'
-    autoRetryAttempt?: number
-  }
+  SwapConfirmed: EncryptedEventDefinitions['SwapConfirmed']['encrypted']
   SwapSuccessful: {
     sourceAddress: string
     targetAddress: string
@@ -206,7 +232,7 @@ export type AnalyticsEvents = {
       addressSVM: string
     }[]
   }
-  SendTransactionSucceeded: { txHash: string; chainId: number }
+  SendTransactionSucceeded: EncryptedEventDefinitions['SendTransactionSucceeded']['encrypted']
 
   StakeTransactionStarted: { txHash: string; chainId: number }
   BridgeTransactionStarted: {
@@ -365,9 +391,4 @@ export type AnalyticsEvents = {
   PredictionsSearched: { query: string; resultCount: number }
   PredictionsClicked: undefined
   PerpsClicked: undefined
-}
-
-export type AnalyticsPlaintextEvents = {
-  SendTransactionSucceeded: { caip2ChainId: string }
-  SwapConfirmed: { caip2SourceChainId: string; caip2TargetChainId: string }
 }

--- a/packages/core-mobile/app/utils/caip2ChainIds.ts
+++ b/packages/core-mobile/app/utils/caip2ChainIds.ts
@@ -24,15 +24,19 @@ export const SOLANA_LEGACY_CHAIN_ID = 'solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ'
  * @param properties
  */
 export function applyTempChainIdConversion(properties?: JsonMap): void {
-  if (properties?.chainId) {
+  if (properties?.chainId && !isCaip2Format(properties.chainId)) {
     properties.chainId = updateChainIdIfNeeded(Number(properties.chainId))
   }
 
-  if (properties?.networkChainId) {
+  if (properties?.networkChainId && !isCaip2Format(properties.networkChainId)) {
     properties.networkChainId = updateChainIdIfNeeded(
       Number(properties.networkChainId)
     )
   }
+}
+
+function isCaip2Format(value: unknown): boolean {
+  return typeof value === 'string' && value.includes(':')
 }
 
 function updateChainIdIfNeeded(original: number): string {


### PR DESCRIPTION
## Description

**Ticket: [CP-14082]**

- Add typed `PlaintextProperties<E>` conditional type to `captureWithEncryption` so plaintext fields are validated per event name at compile time
- Add `AnalyticsPlaintextEvents` type map in `analytics.ts` defining the plaintext shape for each event
- Guard `applyTempChainIdConversion` against double-converting values already in CAIP-2 format


<img width="639" height="198" alt="Screenshot 2026-04-23 at 10 14 44 AM" src="https://github.com/user-attachments/assets/9f44f32b-2a6d-43d5-98d6-0853373ac73d" />



<img width="774" height="210" alt="Screenshot 2026-04-23 at 10 15 26 AM" src="https://github.com/user-attachments/assets/56edd26d-8763-4eeb-bc3f-8d1bfc9daf65" />


## Testing
iOS: 8280
Android: 8281

- [ ] Verify `SendTransactionSucceeded` events include `chainId` as a top-level plaintext property (CAIP-2 format)
- [ ] Verify `SwapConfirmed` events include `sourceChainId` and `targetChainId` as top-level plaintext properties
- [ ] Verify encrypted `data` blob no longer contains chain ID fields for these events
- [ ] Verify existing analytics events without plaintext properties still work correctly
- [ ] TypeScript compiles cleanly (`yarn tsc`)

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14082]: https://ava-labs.atlassian.net/browse/CP-14082