### PR TITLE
CP-13944: Separate plaintext chain IDs from encrypted analytics payloads

### DIFF
--- a/packages/core-mobile/app/new/features/bridge/hooks/useBridgeTransfer.ts
+++ b/packages/core-mobile/app/new/features/bridge/hooks/useBridgeTransfer.ts
@@ -73,10 +73,12 @@ export const useBridgeTransfer = ({
     })
 
     AnalyticsService.captureWithEncryption('BridgeTransactionStarted', {
-      chainId: sourceNetwork.chainId,
-      sourceTxHash: pendingTransfer.sourceTxHash,
-      fromAddress: pendingTransfer.fromAddress,
-      toAddress: pendingTransfer.toAddress
+      encrypted: {
+        chainId: sourceNetwork.chainId,
+        sourceTxHash: pendingTransfer.sourceTxHash,
+        fromAddress: pendingTransfer.fromAddress,
+        toAddress: pendingTransfer.toAddress
+      }
     })
 
     dispatch(setPendingTransfer(pendingTransfer))

--- a/packages/core-mobile/app/new/features/bridge/hooks/useBridgeTransfer.ts
+++ b/packages/core-mobile/app/new/features/bridge/hooks/useBridgeTransfer.ts
@@ -72,7 +72,7 @@ export const useBridgeTransfer = ({
       targetChainId: targetNetwork.chainId
     })
 
-    AnalyticsService.captureWithEncryption('BridgeTransactionStarted', {
+    AnalyticsService.capture('BridgeTransactionStarted', {
       encrypted: {
         chainId: sourceNetwork.chainId,
         sourceTxHash: pendingTransfer.sourceTxHash,

--- a/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
+++ b/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
@@ -34,7 +34,7 @@ export const useSendTransactionCallbacks = (): {
             txHash
           },
           {
-            chainId: getCaip2ChainId(selectedToken.networkChainId)
+            caip2ChainId: getCaip2ChainId(selectedToken.networkChainId)
           }
         )
       audioFeedback(Audios.Send)

--- a/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
+++ b/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
@@ -31,6 +31,7 @@ export const useSendTransactionCallbacks = (): {
         AnalyticsService.captureWithEncryption(
           'SendTransactionSucceeded',
           {
+            chainId: selectedToken.networkChainId,
             txHash
           },
           {

--- a/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
+++ b/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
@@ -28,16 +28,13 @@ export const useSendTransactionCallbacks = (): {
       onDismiss: () => void
     }): void => {
       selectedToken &&
-        AnalyticsService.captureWithEncryption(
-          'SendTransactionSucceeded',
-          {
+        AnalyticsService.captureWithEncryption('SendTransactionSucceeded', {
+          encrypted: {
             chainId: selectedToken.networkChainId,
             txHash
           },
-          {
-            caip2ChainId: getCaip2ChainId(selectedToken.networkChainId)
-          }
-        )
+          caip2ChainId: getCaip2ChainId(selectedToken.networkChainId)
+        })
       audioFeedback(Audios.Send)
       setSelectedToken(undefined)
 

--- a/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
+++ b/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
@@ -28,7 +28,7 @@ export const useSendTransactionCallbacks = (): {
       onDismiss: () => void
     }): void => {
       selectedToken &&
-        AnalyticsService.captureWithEncryption('SendTransactionSucceeded', {
+        AnalyticsService.capture('SendTransactionSucceeded', {
           encrypted: {
             chainId: selectedToken.networkChainId,
             txHash

--- a/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
+++ b/packages/core-mobile/app/new/features/collectibleSend/hooks/useSendTransactionCallbacks.ts
@@ -4,6 +4,7 @@ import { useCallback } from 'react'
 import AnalyticsService from 'services/analytics/AnalyticsService'
 import { isUserRejectedError } from 'store/rpc/providers/walletConnect/utils'
 import { audioFeedback, Audios } from 'utils/AudioFeedback'
+import { getCaip2ChainId } from 'utils/caip2ChainIds'
 import { getJsonRpcErrorMessage } from 'utils/getJsonRpcErrorMessage/getJsonRpcErrorMessage'
 
 export const useSendTransactionCallbacks = (): {
@@ -27,10 +28,15 @@ export const useSendTransactionCallbacks = (): {
       onDismiss: () => void
     }): void => {
       selectedToken &&
-        AnalyticsService.captureWithEncryption('SendTransactionSucceeded', {
-          chainId: selectedToken.networkChainId,
-          txHash
-        })
+        AnalyticsService.captureWithEncryption(
+          'SendTransactionSucceeded',
+          {
+            txHash
+          },
+          {
+            chainId: getCaip2ChainId(selectedToken.networkChainId)
+          }
+        )
       audioFeedback(Audios.Send)
       setSelectedToken(undefined)
 

--- a/packages/core-mobile/app/new/features/nestEgg/screens/NestEggScreen.tsx
+++ b/packages/core-mobile/app/new/features/nestEgg/screens/NestEggScreen.tsx
@@ -56,7 +56,9 @@ function NestEggScreen(): JSX.Element {
 
   useEffect(() => {
     AnalyticsService.captureWithEncryption('NestEggCampaignModalViewed', {
-      addressC: currentAccount?.addressC ?? ''
+      encrypted: {
+        addressC: currentAccount?.addressC ?? ''
+      }
     })
     return () => {
       dispatch(setHasSeenCampaign(true))

--- a/packages/core-mobile/app/new/features/nestEgg/screens/NestEggScreen.tsx
+++ b/packages/core-mobile/app/new/features/nestEgg/screens/NestEggScreen.tsx
@@ -55,7 +55,7 @@ function NestEggScreen(): JSX.Element {
   const currentAccount = useSelector(selectActiveAccount)
 
   useEffect(() => {
-    AnalyticsService.captureWithEncryption('NestEggCampaignModalViewed', {
+    AnalyticsService.capture('NestEggCampaignModalViewed', {
       encrypted: {
         addressC: currentAccount?.addressC ?? ''
       }

--- a/packages/core-mobile/app/new/features/nestEgg/screens/NestEggSuccesScreen.tsx
+++ b/packages/core-mobile/app/new/features/nestEgg/screens/NestEggSuccesScreen.tsx
@@ -35,7 +35,7 @@ function NestEggSuccessScreen(): JSX.Element {
 
   useFocusEffect(
     useCallback(() => {
-      AnalyticsService.captureWithEncryption('NestEggSuccessModalViewed', {
+      AnalyticsService.capture('NestEggSuccessModalViewed', {
         encrypted: {
           addressC: currentAccount?.addressC ?? ''
         }

--- a/packages/core-mobile/app/new/features/nestEgg/screens/NestEggSuccesScreen.tsx
+++ b/packages/core-mobile/app/new/features/nestEgg/screens/NestEggSuccesScreen.tsx
@@ -36,7 +36,9 @@ function NestEggSuccessScreen(): JSX.Element {
   useFocusEffect(
     useCallback(() => {
       AnalyticsService.captureWithEncryption('NestEggSuccessModalViewed', {
-        addressC: currentAccount?.addressC ?? ''
+        encrypted: {
+          addressC: currentAccount?.addressC ?? ''
+        }
       })
     }, [currentAccount?.addressC])
   )

--- a/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
+++ b/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
@@ -46,16 +46,13 @@ export const SendScreen = (): JSX.Element => {
   const handleSuccess = useCallback(
     (txHash: string): void => {
       network &&
-        AnalyticsService.captureWithEncryption(
-          'SendTransactionSucceeded',
-          {
+        AnalyticsService.captureWithEncryption('SendTransactionSucceeded', {
+          encrypted: {
             chainId: network.chainId,
             txHash
           },
-          {
-            caip2ChainId: getCaip2ChainId(network.chainId)
-          }
-        )
+          caip2ChainId: getCaip2ChainId(network.chainId)
+        })
       audioFeedback(Audios.Send)
       resetAmount()
       setSelectedToken(undefined)

--- a/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
+++ b/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
@@ -46,7 +46,7 @@ export const SendScreen = (): JSX.Element => {
   const handleSuccess = useCallback(
     (txHash: string): void => {
       network &&
-        AnalyticsService.captureWithEncryption('SendTransactionSucceeded', {
+        AnalyticsService.capture('SendTransactionSucceeded', {
           encrypted: {
             chainId: network.chainId,
             txHash

--- a/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
+++ b/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
@@ -52,7 +52,7 @@ export const SendScreen = (): JSX.Element => {
             txHash
           },
           {
-            chainId: getCaip2ChainId(network.chainId)
+            caip2ChainId: getCaip2ChainId(network.chainId)
           }
         )
       audioFeedback(Audios.Send)

--- a/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
+++ b/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
@@ -5,6 +5,7 @@ import { audioFeedback, Audios } from 'utils/AudioFeedback'
 import { isUserRejectedError } from 'store/rpc/providers/walletConnect/utils'
 import { transactionSnackbar } from 'common/utils/toast'
 import { getJsonRpcErrorMessage } from 'utils/getJsonRpcErrorMessage/getJsonRpcErrorMessage'
+import { getCaip2ChainId } from 'utils/caip2ChainIds'
 import { useDispatch, useSelector } from 'react-redux'
 import { selectActiveAccount } from 'store/account'
 import { View, ActivityIndicator } from '@avalabs/k2-alpine'
@@ -45,10 +46,15 @@ export const SendScreen = (): JSX.Element => {
   const handleSuccess = useCallback(
     (txHash: string): void => {
       network &&
-        AnalyticsService.captureWithEncryption('SendTransactionSucceeded', {
-          chainId: network.chainId,
-          txHash
-        })
+        AnalyticsService.captureWithEncryption(
+          'SendTransactionSucceeded',
+          {
+            txHash
+          },
+          {
+            chainId: getCaip2ChainId(network.chainId)
+          }
+        )
       audioFeedback(Audios.Send)
       resetAmount()
       setSelectedToken(undefined)

--- a/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
+++ b/packages/core-mobile/app/new/features/send/screens/SendScreen.tsx
@@ -49,6 +49,7 @@ export const SendScreen = (): JSX.Element => {
         AnalyticsService.captureWithEncryption(
           'SendTransactionSucceeded',
           {
+            chainId: network.chainId,
             txHash
           },
           {

--- a/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
+++ b/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
@@ -225,7 +225,7 @@ export const SwapContextProvider = ({
         autoRetryAttempt
       } = params
       audioFeedback(Audios.Send)
-      AnalyticsService.captureWithEncryption('SwapConfirmed', {
+      AnalyticsService.capture('SwapConfirmed', {
         encrypted: {
           sourceAddress: address,
           targetAddress,

--- a/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
+++ b/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
@@ -230,6 +230,8 @@ export const SwapContextProvider = ({
         {
           sourceAddress: address,
           targetAddress,
+          sourceChainId: quote.sourceChain.chainId,
+          targetChainId: quote.targetChain.chainId,
           sourceTxHash: transfer.source?.txHash,
           quoteSelectionMode,
           autoRetryAttempt

--- a/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
+++ b/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
@@ -225,9 +225,8 @@ export const SwapContextProvider = ({
         autoRetryAttempt
       } = params
       audioFeedback(Audios.Send)
-      AnalyticsService.captureWithEncryption(
-        'SwapConfirmed',
-        {
+      AnalyticsService.captureWithEncryption('SwapConfirmed', {
+        encrypted: {
           sourceAddress: address,
           targetAddress,
           sourceChainId: quote.sourceChain.chainId,
@@ -236,11 +235,9 @@ export const SwapContextProvider = ({
           quoteSelectionMode,
           autoRetryAttempt
         },
-        {
-          caip2SourceChainId: quote.sourceChain.chainId,
-          caip2TargetChainId: quote.targetChain.chainId
-        }
-      )
+        caip2SourceChainId: quote.sourceChain.chainId,
+        caip2TargetChainId: quote.targetChain.chainId
+      })
 
       Logger.info('[SwapContext] transfer executed', {
         transfer

--- a/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
+++ b/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
@@ -225,15 +225,20 @@ export const SwapContextProvider = ({
         autoRetryAttempt
       } = params
       audioFeedback(Audios.Send)
-      AnalyticsService.captureWithEncryption('SwapConfirmed', {
-        sourceAddress: address,
-        targetAddress,
-        sourceChainId: quote.sourceChain.chainId,
-        targetChainId: quote.targetChain.chainId,
-        sourceTxHash: transfer.source?.txHash,
-        quoteSelectionMode,
-        autoRetryAttempt
-      })
+      AnalyticsService.captureWithEncryption(
+        'SwapConfirmed',
+        {
+          sourceAddress: address,
+          targetAddress,
+          sourceTxHash: transfer.source?.txHash,
+          quoteSelectionMode,
+          autoRetryAttempt
+        },
+        {
+          sourceChainId: quote.sourceChain.chainId,
+          targetChainId: quote.targetChain.chainId
+        }
+      )
 
       Logger.info('[SwapContext] transfer executed', {
         transfer

--- a/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
+++ b/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
@@ -235,8 +235,8 @@ export const SwapContextProvider = ({
           autoRetryAttempt
         },
         {
-          sourceChainId: quote.sourceChain.chainId,
-          targetChainId: quote.targetChain.chainId
+          caip2SourceChainId: quote.sourceChain.chainId,
+          caip2TargetChainId: quote.targetChain.chainId
         }
       )
 

--- a/packages/core-mobile/app/new/features/swap/store/listeners.ts
+++ b/packages/core-mobile/app/new/features/swap/store/listeners.ts
@@ -234,25 +234,31 @@ const captureSwapAnalytics = (
 
   if (isCompletedTransfer(concludedTransfer)) {
     AnalyticsService.captureWithEncryption('SwapSuccessful', {
-      ...addresses,
-      sourceTxHash: concludedTransfer.source.txHash,
-      targetTxHash: concludedTransfer.target?.txHash
+      encrypted: {
+        ...addresses,
+        sourceTxHash: concludedTransfer.source.txHash,
+        targetTxHash: concludedTransfer.target?.txHash
+      }
     })
   } else if (isFailedTransfer(concludedTransfer)) {
     // source is optional on FailedTransfer — tx may not have been submitted
     AnalyticsService.captureWithEncryption('SwapFailed', {
-      ...addresses,
-      sourceTxHash: concludedTransfer.source?.txHash,
-      targetTxHash: concludedTransfer.target?.txHash,
-      errorCode: concludedTransfer.errorCode?.toString(),
-      errorReason: concludedTransfer.errorReason ?? undefined
+      encrypted: {
+        ...addresses,
+        sourceTxHash: concludedTransfer.source?.txHash,
+        targetTxHash: concludedTransfer.target?.txHash,
+        errorCode: concludedTransfer.errorCode?.toString(),
+        errorReason: concludedTransfer.errorReason ?? undefined
+      }
     })
   } else if (isRefundedTransfer(concludedTransfer)) {
     AnalyticsService.captureWithEncryption('SwapRefunded', {
-      ...addresses,
-      sourceTxHash: concludedTransfer.source.txHash,
-      targetTxHash: concludedTransfer.target?.txHash,
-      refundTxHash: concludedTransfer.refund.txHash ?? undefined
+      encrypted: {
+        ...addresses,
+        sourceTxHash: concludedTransfer.source.txHash,
+        targetTxHash: concludedTransfer.target?.txHash,
+        refundTxHash: concludedTransfer.refund.txHash ?? undefined
+      }
     })
   }
 }

--- a/packages/core-mobile/app/new/features/swap/store/listeners.ts
+++ b/packages/core-mobile/app/new/features/swap/store/listeners.ts
@@ -233,7 +233,7 @@ const captureSwapAnalytics = (
   }
 
   if (isCompletedTransfer(concludedTransfer)) {
-    AnalyticsService.captureWithEncryption('SwapSuccessful', {
+    AnalyticsService.capture('SwapSuccessful', {
       encrypted: {
         ...addresses,
         sourceTxHash: concludedTransfer.source.txHash,
@@ -242,7 +242,7 @@ const captureSwapAnalytics = (
     })
   } else if (isFailedTransfer(concludedTransfer)) {
     // source is optional on FailedTransfer — tx may not have been submitted
-    AnalyticsService.captureWithEncryption('SwapFailed', {
+    AnalyticsService.capture('SwapFailed', {
       encrypted: {
         ...addresses,
         sourceTxHash: concludedTransfer.source?.txHash,
@@ -252,7 +252,7 @@ const captureSwapAnalytics = (
       }
     })
   } else if (isRefundedTransfer(concludedTransfer)) {
-    AnalyticsService.captureWithEncryption('SwapRefunded', {
+    AnalyticsService.capture('SwapRefunded', {
       encrypted: {
         ...addresses,
         sourceTxHash: concludedTransfer.source.txHash,

--- a/packages/core-mobile/app/services/analytics/AnalyticsService.ts
+++ b/packages/core-mobile/app/services/analytics/AnalyticsService.ts
@@ -1,11 +1,9 @@
 import PostHogService from 'services/posthog/PostHogService'
-import { AnalyticsEncryptedEvents } from 'types/analytics'
 import Config from 'react-native-config'
 import { encrypt } from 'utils/hpke'
 import Logger from 'utils/Logger'
 import { AnalyticsServiceNoop } from 'services/analytics/AnalyticsServiceNoop'
 import {
-  AnalyticsEncryptedEventName,
   AnalyticsEventName,
   AnalyticsServiceInterface,
   CaptureEventProperties
@@ -20,6 +18,16 @@ if (!Config.ANALYTICS_ENCRYPTION_KEY) {
 if (!Config.ANALYTICS_ENCRYPTION_KEY_ID) {
   Logger.warn(
     'ANALYTICS_ENCRYPTION_KEY_ID is missing in env file. Analytics are disabled.'
+  )
+}
+
+const hasEncryptedPayload = (
+  properties: unknown
+): properties is { encrypted: Record<string, unknown> } => {
+  return (
+    typeof properties === 'object' &&
+    properties !== null &&
+    'encrypted' in properties
   )
 }
 
@@ -43,23 +51,16 @@ class AnalyticsService implements AnalyticsServiceInterface {
       return
     }
 
-    return PostHogService.capture(eventName, properties[0])
-  }
+    const payload = properties[0]
 
-  async captureWithEncryption<E extends AnalyticsEncryptedEventName>(
-    eventName: E,
-    properties: AnalyticsEncryptedEvents[E]
-  ): Promise<void> {
-    if (!this.isEnabled) {
-      return
+    if (!hasEncryptedPayload(payload)) {
+      return PostHogService.capture(eventName, payload)
     }
 
-    const { encrypted: toEncrypt, ...plaintext } = properties
-
     try {
-      const stringifiedProperties = JSON.stringify(toEncrypt)
+      const { encrypted: toEncrypt, ...plaintext } = payload
       const { encrypted, enc, keyID } = await encrypt(
-        stringifiedProperties,
+        JSON.stringify(toEncrypt),
         this.analyticsEncryptionKey,
         this.analyticsEncryptionKeyId
       )

--- a/packages/core-mobile/app/services/analytics/AnalyticsService.ts
+++ b/packages/core-mobile/app/services/analytics/AnalyticsService.ts
@@ -65,10 +65,10 @@ class AnalyticsService implements AnalyticsServiceInterface {
       )
 
       return PostHogService.capture(eventName, {
+        ...plaintext,
         data: encrypted,
         enc,
-        keyID,
-        ...plaintext
+        keyID
       })
     } catch (error) {
       Logger.error(

--- a/packages/core-mobile/app/services/analytics/AnalyticsService.ts
+++ b/packages/core-mobile/app/services/analytics/AnalyticsService.ts
@@ -7,7 +7,8 @@ import { AnalyticsServiceNoop } from 'services/analytics/AnalyticsServiceNoop'
 import {
   AnalyticsEventName,
   AnalyticsServiceInterface,
-  CaptureEventProperties
+  CaptureEventProperties,
+  PlaintextProperties
 } from './types'
 
 if (!Config.ANALYTICS_ENCRYPTION_KEY) {
@@ -47,7 +48,8 @@ class AnalyticsService implements AnalyticsServiceInterface {
 
   async captureWithEncryption<E extends AnalyticsEventName>(
     eventName: E,
-    properties: AnalyticsEvents[E]
+    properties: AnalyticsEvents[E],
+    plaintextProperties?: PlaintextProperties<E>
   ): Promise<void> {
     if (!this.isEnabled) {
       return
@@ -64,7 +66,8 @@ class AnalyticsService implements AnalyticsServiceInterface {
       return PostHogService.capture(eventName, {
         data: encrypted,
         enc,
-        keyID: keyID
+        keyID: keyID,
+        ...plaintextProperties
       })
     } catch (error) {
       Logger.error(

--- a/packages/core-mobile/app/services/analytics/AnalyticsService.ts
+++ b/packages/core-mobile/app/services/analytics/AnalyticsService.ts
@@ -1,14 +1,14 @@
 import PostHogService from 'services/posthog/PostHogService'
-import { AnalyticsEvents } from 'types/analytics'
+import { AnalyticsEncryptedEvents } from 'types/analytics'
 import Config from 'react-native-config'
 import { encrypt } from 'utils/hpke'
 import Logger from 'utils/Logger'
 import { AnalyticsServiceNoop } from 'services/analytics/AnalyticsServiceNoop'
 import {
+  AnalyticsEncryptedEventName,
   AnalyticsEventName,
   AnalyticsServiceInterface,
-  CaptureEventProperties,
-  PlaintextProperties
+  CaptureEventProperties
 } from './types'
 
 if (!Config.ANALYTICS_ENCRYPTION_KEY) {
@@ -46,17 +46,18 @@ class AnalyticsService implements AnalyticsServiceInterface {
     return PostHogService.capture(eventName, properties[0])
   }
 
-  async captureWithEncryption<E extends AnalyticsEventName>(
+  async captureWithEncryption<E extends AnalyticsEncryptedEventName>(
     eventName: E,
-    properties: AnalyticsEvents[E],
-    plaintextProperties?: PlaintextProperties<E>
+    properties: AnalyticsEncryptedEvents[E]
   ): Promise<void> {
     if (!this.isEnabled) {
       return
     }
 
+    const { encrypted: toEncrypt, ...plaintext } = properties
+
     try {
-      const stringifiedProperties = JSON.stringify(properties)
+      const stringifiedProperties = JSON.stringify(toEncrypt)
       const { encrypted, enc, keyID } = await encrypt(
         stringifiedProperties,
         this.analyticsEncryptionKey,
@@ -66,8 +67,8 @@ class AnalyticsService implements AnalyticsServiceInterface {
       return PostHogService.capture(eventName, {
         data: encrypted,
         enc,
-        keyID: keyID,
-        ...plaintextProperties
+        keyID,
+        ...plaintext
       })
     } catch (error) {
       Logger.error(

--- a/packages/core-mobile/app/services/analytics/AnalyticsServiceNoop.ts
+++ b/packages/core-mobile/app/services/analytics/AnalyticsServiceNoop.ts
@@ -8,8 +8,4 @@ export class AnalyticsServiceNoop implements AnalyticsServiceInterface {
   async capture(): Promise<void> {
     //noop
   }
-
-  async captureWithEncryption(): Promise<void> {
-    //noop
-  }
 }

--- a/packages/core-mobile/app/services/analytics/types.ts
+++ b/packages/core-mobile/app/services/analytics/types.ts
@@ -1,16 +1,12 @@
-import { AnalyticsEvents, AnalyticsPlaintextEvents } from 'types/analytics'
+import { AnalyticsEncryptedEvents, AnalyticsEvents } from 'types/analytics'
 
 export type AnalyticsEventName = keyof AnalyticsEvents
+export type AnalyticsEncryptedEventName = keyof AnalyticsEncryptedEvents
 
 export type CaptureEventProperties<E extends AnalyticsEventName> =
   undefined extends AnalyticsEvents[E]
     ? [AnalyticsEvents[E]?]
     : [AnalyticsEvents[E]]
-
-export type PlaintextProperties<E extends AnalyticsEventName> =
-  E extends keyof AnalyticsPlaintextEvents
-    ? AnalyticsPlaintextEvents[E]
-    : undefined
 
 export interface AnalyticsServiceInterface {
   setEnabled(isEnabled: boolean): void
@@ -18,9 +14,8 @@ export interface AnalyticsServiceInterface {
     eventName: E,
     ...properties: CaptureEventProperties<E>
   ): Promise<void>
-  captureWithEncryption<E extends AnalyticsEventName>(
+  captureWithEncryption<E extends AnalyticsEncryptedEventName>(
     eventName: E,
-    properties: AnalyticsEvents[E],
-    plaintextProperties?: PlaintextProperties<E>
+    properties: AnalyticsEncryptedEvents[E]
   ): Promise<void>
 }

--- a/packages/core-mobile/app/services/analytics/types.ts
+++ b/packages/core-mobile/app/services/analytics/types.ts
@@ -1,4 +1,4 @@
-import { AnalyticsEvents } from 'types/analytics'
+import { AnalyticsEvents, AnalyticsPlaintextEvents } from 'types/analytics'
 
 export type AnalyticsEventName = keyof AnalyticsEvents
 
@@ -6,6 +6,11 @@ export type CaptureEventProperties<E extends AnalyticsEventName> =
   undefined extends AnalyticsEvents[E]
     ? [AnalyticsEvents[E]?]
     : [AnalyticsEvents[E]]
+
+export type PlaintextProperties<E extends AnalyticsEventName> =
+  E extends keyof AnalyticsPlaintextEvents
+    ? AnalyticsPlaintextEvents[E]
+    : undefined
 
 export interface AnalyticsServiceInterface {
   setEnabled(isEnabled: boolean): void
@@ -15,6 +20,7 @@ export interface AnalyticsServiceInterface {
   ): Promise<void>
   captureWithEncryption<E extends AnalyticsEventName>(
     eventName: E,
-    properties: AnalyticsEvents[E]
+    properties: AnalyticsEvents[E],
+    plaintextProperties?: PlaintextProperties<E>
   ): Promise<void>
 }

--- a/packages/core-mobile/app/services/analytics/types.ts
+++ b/packages/core-mobile/app/services/analytics/types.ts
@@ -1,24 +1,11 @@
-import { AnalyticsEncryptedEvents, AnalyticsEvents } from 'types/analytics'
+import { AnalyticsEvents } from 'types/analytics'
 
-/**
- * Union of all analytics event names. The payload shape is resolved per
- * event via `CaptureEventProperties<E>` — events declared in
- * `AnalyticsEncryptedEvents` use the `{ encrypted, ...plaintextSiblings }`
- * shape and are transparently encrypted by `AnalyticsService.capture`.
- */
-export type AnalyticsEventName =
-  | keyof AnalyticsEvents
-  | keyof AnalyticsEncryptedEvents
-
-type EventPayload<E extends AnalyticsEventName> =
-  E extends keyof AnalyticsEncryptedEvents
-    ? AnalyticsEncryptedEvents[E]
-    : E extends keyof AnalyticsEvents
-    ? AnalyticsEvents[E]
-    : never
+export type AnalyticsEventName = keyof AnalyticsEvents
 
 export type CaptureEventProperties<E extends AnalyticsEventName> =
-  undefined extends EventPayload<E> ? [EventPayload<E>?] : [EventPayload<E>]
+  undefined extends AnalyticsEvents[E]
+    ? [AnalyticsEvents[E]?]
+    : [AnalyticsEvents[E]]
 
 export interface AnalyticsServiceInterface {
   setEnabled(isEnabled: boolean): void

--- a/packages/core-mobile/app/services/analytics/types.ts
+++ b/packages/core-mobile/app/services/analytics/types.ts
@@ -1,21 +1,29 @@
 import { AnalyticsEncryptedEvents, AnalyticsEvents } from 'types/analytics'
 
-export type AnalyticsEventName = keyof AnalyticsEvents
-export type AnalyticsEncryptedEventName = keyof AnalyticsEncryptedEvents
+/**
+ * Union of all analytics event names. The payload shape is resolved per
+ * event via `CaptureEventProperties<E>` — events declared in
+ * `AnalyticsEncryptedEvents` use the `{ encrypted, ...plaintextSiblings }`
+ * shape and are transparently encrypted by `AnalyticsService.capture`.
+ */
+export type AnalyticsEventName =
+  | keyof AnalyticsEvents
+  | keyof AnalyticsEncryptedEvents
+
+type EventPayload<E extends AnalyticsEventName> =
+  E extends keyof AnalyticsEncryptedEvents
+    ? AnalyticsEncryptedEvents[E]
+    : E extends keyof AnalyticsEvents
+    ? AnalyticsEvents[E]
+    : never
 
 export type CaptureEventProperties<E extends AnalyticsEventName> =
-  undefined extends AnalyticsEvents[E]
-    ? [AnalyticsEvents[E]?]
-    : [AnalyticsEvents[E]]
+  undefined extends EventPayload<E> ? [EventPayload<E>?] : [EventPayload<E>]
 
 export interface AnalyticsServiceInterface {
   setEnabled(isEnabled: boolean): void
   capture<E extends AnalyticsEventName>(
     eventName: E,
     ...properties: CaptureEventProperties<E>
-  ): Promise<void>
-  captureWithEncryption<E extends AnalyticsEncryptedEventName>(
-    eventName: E,
-    properties: AnalyticsEncryptedEvents[E]
   ): Promise<void>
 }

--- a/packages/core-mobile/app/services/earn/EarnService.ts
+++ b/packages/core-mobile/app/services/earn/EarnService.ts
@@ -311,7 +311,7 @@ class EarnService {
       network: avaxXPNetwork
     })
 
-    AnalyticsService.captureWithEncryption('StakeTransactionStarted', {
+    AnalyticsService.capture('StakeTransactionStarted', {
       encrypted: {
         txHash: txID,
         chainId: avaxXPNetwork.chainId

--- a/packages/core-mobile/app/services/earn/EarnService.ts
+++ b/packages/core-mobile/app/services/earn/EarnService.ts
@@ -312,8 +312,10 @@ class EarnService {
     })
 
     AnalyticsService.captureWithEncryption('StakeTransactionStarted', {
-      txHash: txID,
-      chainId: avaxXPNetwork.chainId
+      encrypted: {
+        txHash: txID,
+        chainId: avaxXPNetwork.chainId
+      }
     })
     Logger.trace('txID', txID)
 

--- a/packages/core-mobile/app/store/account/listeners.ts
+++ b/packages/core-mobile/app/store/account/listeners.ts
@@ -191,7 +191,7 @@ const initAccounts = async (
   }
 
   if (isDeveloperMode === false) {
-    AnalyticsService.captureWithEncryption('AccountAddressesUpdated', {
+    AnalyticsService.capture('AccountAddressesUpdated', {
       encrypted: {
         addresses: accountValues.map(account => ({
           address: account.addressC,

--- a/packages/core-mobile/app/store/account/listeners.ts
+++ b/packages/core-mobile/app/store/account/listeners.ts
@@ -199,7 +199,7 @@ const initAccounts = async (
           addressAVM: account.addressAVM ?? '',
           addressPVM: account.addressPVM ?? '',
           addressCoreEth: account.addressCoreEth ?? '',
-          addressSVM: acc.addressSVM ?? ''
+          addressSVM: account.addressSVM ?? ''
         }))
       }
     })

--- a/packages/core-mobile/app/store/account/listeners.ts
+++ b/packages/core-mobile/app/store/account/listeners.ts
@@ -192,14 +192,16 @@ const initAccounts = async (
 
   if (isDeveloperMode === false) {
     AnalyticsService.captureWithEncryption('AccountAddressesUpdated', {
-      addresses: accountValues.map(account => ({
-        address: account.addressC,
-        addressBtc: account.addressBTC,
-        addressAVM: account.addressAVM ?? '',
-        addressPVM: account.addressPVM ?? '',
-        addressCoreEth: account.addressCoreEth ?? '',
-        addressSVM: acc.addressSVM ?? ''
-      }))
+      encrypted: {
+        addresses: accountValues.map(account => ({
+          address: account.addressC,
+          addressBtc: account.addressBTC,
+          addressAVM: account.addressAVM ?? '',
+          addressPVM: account.addressPVM ?? '',
+          addressCoreEth: account.addressCoreEth ?? '',
+          addressSVM: acc.addressSVM ?? ''
+        }))
+      }
     })
   }
 

--- a/packages/core-mobile/app/store/account/thunks.ts
+++ b/packages/core-mobile/app/store/account/thunks.ts
@@ -125,7 +125,7 @@ export const addAccount = createAsyncThunk<void, string, ThunkApi>(
     if (isDeveloperMode === false) {
       const allAccountsByWalletId = [...Object.values(accountsByWalletId), acc]
 
-      AnalyticsService.captureWithEncryption('AccountAddressesUpdated', {
+      AnalyticsService.capture('AccountAddressesUpdated', {
         encrypted: {
           addresses: allAccountsByWalletId.map(account => ({
             address: account.addressC,

--- a/packages/core-mobile/app/store/account/thunks.ts
+++ b/packages/core-mobile/app/store/account/thunks.ts
@@ -126,14 +126,16 @@ export const addAccount = createAsyncThunk<void, string, ThunkApi>(
       const allAccountsByWalletId = [...Object.values(accountsByWalletId), acc]
 
       AnalyticsService.captureWithEncryption('AccountAddressesUpdated', {
-        addresses: allAccountsByWalletId.map(account => ({
-          address: account.addressC,
-          addressBtc: account.addressBTC,
-          addressAVM: account.addressAVM ?? '',
-          addressPVM: account.addressPVM ?? '',
-          addressCoreEth: account.addressCoreEth ?? '',
-          addressSVM: account.addressSVM ?? ''
-        }))
+        encrypted: {
+          addresses: allAccountsByWalletId.map(account => ({
+            address: account.addressC,
+            addressBtc: account.addressBTC,
+            addressAVM: account.addressAVM ?? '',
+            addressPVM: account.addressPVM ?? '',
+            addressCoreEth: account.addressCoreEth ?? '',
+            addressSVM: account.addressSVM ?? ''
+          }))
+        }
       })
     }
   }

--- a/packages/core-mobile/app/store/nestEgg/listeners.test.ts
+++ b/packages/core-mobile/app/store/nestEgg/listeners.test.ts
@@ -17,8 +17,7 @@ jest.mock('common/utils/waitForInteractions', () => ({
 }))
 
 jest.mock('services/analytics/AnalyticsService', () => ({
-  capture: jest.fn(),
-  captureWithEncryption: jest.fn()
+  capture: jest.fn()
 }))
 
 jest.mock('services/network/utils/isAvalancheNetwork', () => ({

--- a/packages/core-mobile/app/store/nestEgg/listeners.ts
+++ b/packages/core-mobile/app/store/nestEgg/listeners.ts
@@ -64,7 +64,7 @@ const handleSwapForNestEgg = async (
   const timestamp = Date.now()
   dispatch(setQualified({ txHash, timestamp }))
 
-  AnalyticsService.captureWithEncryption('NestEggQualified', {
+  AnalyticsService.capture('NestEggQualified', {
     encrypted: {
       addressC: currentAccount?.addressC ?? '',
       txHash,

--- a/packages/core-mobile/app/store/nestEgg/listeners.ts
+++ b/packages/core-mobile/app/store/nestEgg/listeners.ts
@@ -65,13 +65,15 @@ const handleSwapForNestEgg = async (
   dispatch(setQualified({ txHash, timestamp }))
 
   AnalyticsService.captureWithEncryption('NestEggQualified', {
-    addressC: currentAccount?.addressC ?? '',
-    txHash,
-    chainId,
-    fromTokenSymbol,
-    toTokenSymbol,
-    fromAmountUsd,
-    timestamp
+    encrypted: {
+      addressC: currentAccount?.addressC ?? '',
+      txHash,
+      chainId,
+      fromTokenSymbol,
+      toTokenSymbol,
+      fromAmountUsd,
+      timestamp
+    }
   })
 
   // Show success modal

--- a/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.test.ts
+++ b/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.test.ts
@@ -89,7 +89,7 @@ describe('walletConnectProvider', () => {
           listenerApi: mockListenerApi
         })
 
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_success',
           {
             encrypted: {
@@ -114,7 +114,7 @@ describe('walletConnectProvider', () => {
           listenerApi: mockListenerApi
         })
 
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'avalanche_sendTransaction_success',
           {
             encrypted: expect.objectContaining({
@@ -138,7 +138,7 @@ describe('walletConnectProvider', () => {
           listenerApi: mockListenerApi
         })
 
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'avalanche_sendTransaction_success',
           {
             encrypted: expect.objectContaining({
@@ -160,7 +160,7 @@ describe('walletConnectProvider', () => {
           listenerApi: mockListenerApi
         })
 
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'avalanche_sendTransaction_success',
           {
             encrypted: expect.objectContaining({
@@ -182,7 +182,7 @@ describe('walletConnectProvider', () => {
           listenerApi: mockListenerApi
         })
 
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'bitcoin_sendTransaction_success',
           {
             encrypted: expect.objectContaining({
@@ -206,7 +206,7 @@ describe('walletConnectProvider', () => {
           listenerApi: mockListenerApi
         })
 
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'solana_signAndSendTransaction_success',
           {
             encrypted: expect.objectContaining({
@@ -230,7 +230,7 @@ describe('walletConnectProvider', () => {
           listenerApi: mockListenerApi
         })
 
-        expect(AnalyticsService.captureWithEncryption).not.toHaveBeenCalled()
+        expect(AnalyticsService.capture).not.toHaveBeenCalled()
       })
 
       it('does not fire analytics when result is an empty string', async () => {
@@ -245,7 +245,7 @@ describe('walletConnectProvider', () => {
           listenerApi: mockListenerApi
         })
 
-        expect(AnalyticsService.captureWithEncryption).not.toHaveBeenCalled()
+        expect(AnalyticsService.capture).not.toHaveBeenCalled()
       })
     })
 
@@ -262,7 +262,7 @@ describe('walletConnectProvider', () => {
           listenerApi: mockListenerApi
         })
 
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'solana_signTransaction_approved',
           {
             encrypted: {
@@ -286,7 +286,7 @@ describe('walletConnectProvider', () => {
           listenerApi: mockListenerApi
         })
 
-        expect(AnalyticsService.captureWithEncryption).not.toHaveBeenCalled()
+        expect(AnalyticsService.capture).not.toHaveBeenCalled()
       })
 
       it('does not fire analytics for personal_sign', async () => {
@@ -298,7 +298,7 @@ describe('walletConnectProvider', () => {
           listenerApi: mockListenerApi
         })
 
-        expect(AnalyticsService.captureWithEncryption).not.toHaveBeenCalled()
+        expect(AnalyticsService.capture).not.toHaveBeenCalled()
       })
 
       it('does not fire analytics for eth_signTypedData_v4', async () => {
@@ -313,7 +313,7 @@ describe('walletConnectProvider', () => {
           listenerApi: mockListenerApi
         })
 
-        expect(AnalyticsService.captureWithEncryption).not.toHaveBeenCalled()
+        expect(AnalyticsService.capture).not.toHaveBeenCalled()
       })
     })
 

--- a/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.test.ts
+++ b/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.test.ts
@@ -92,10 +92,12 @@ describe('walletConnectProvider', () => {
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'eth_sendTransaction_success',
           {
-            dAppUrl: 'https://test.dapp.com',
-            address: mockActiveAccount.addressC,
-            chainId: 'eip155:1',
-            txHash: '0xdeadbeef'
+            encrypted: {
+              dAppUrl: 'https://test.dapp.com',
+              address: mockActiveAccount.addressC,
+              chainId: 'eip155:1',
+              txHash: '0xdeadbeef'
+            }
           }
         )
       })
@@ -114,11 +116,13 @@ describe('walletConnectProvider', () => {
 
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'avalanche_sendTransaction_success',
-          expect.objectContaining({
-            dAppUrl: 'https://test.dapp.com',
-            address: mockActiveAccount.addressC,
-            txHash: '0xcafebabe'
-          })
+          {
+            encrypted: expect.objectContaining({
+              dAppUrl: 'https://test.dapp.com',
+              address: mockActiveAccount.addressC,
+              txHash: '0xcafebabe'
+            })
+          }
         )
       })
 
@@ -136,9 +140,11 @@ describe('walletConnectProvider', () => {
 
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'avalanche_sendTransaction_success',
-          expect.objectContaining({
-            address: mockActiveAccount.addressPVM
-          })
+          {
+            encrypted: expect.objectContaining({
+              address: mockActiveAccount.addressPVM
+            })
+          }
         )
       })
 
@@ -156,9 +162,11 @@ describe('walletConnectProvider', () => {
 
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'avalanche_sendTransaction_success',
-          expect.objectContaining({
-            address: mockActiveAccount.addressAVM
-          })
+          {
+            encrypted: expect.objectContaining({
+              address: mockActiveAccount.addressAVM
+            })
+          }
         )
       })
 
@@ -176,11 +184,13 @@ describe('walletConnectProvider', () => {
 
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'bitcoin_sendTransaction_success',
-          expect.objectContaining({
-            dAppUrl: 'https://test.dapp.com',
-            address: mockActiveAccount.addressBTC,
-            txHash: 'btctxhash123'
-          })
+          {
+            encrypted: expect.objectContaining({
+              dAppUrl: 'https://test.dapp.com',
+              address: mockActiveAccount.addressBTC,
+              txHash: 'btctxhash123'
+            })
+          }
         )
       })
 
@@ -198,11 +208,13 @@ describe('walletConnectProvider', () => {
 
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'solana_signAndSendTransaction_success',
-          expect.objectContaining({
-            dAppUrl: 'https://test.dapp.com',
-            address: mockActiveAccount.addressSVM,
-            txHash: 'solanatxhash456'
-          })
+          {
+            encrypted: expect.objectContaining({
+              dAppUrl: 'https://test.dapp.com',
+              address: mockActiveAccount.addressSVM,
+              txHash: 'solanatxhash456'
+            })
+          }
         )
       })
 
@@ -253,9 +265,11 @@ describe('walletConnectProvider', () => {
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'solana_signTransaction_approved',
           {
-            dAppUrl: 'https://test.dapp.com',
-            address: mockActiveAccount.addressSVM,
-            chainId: SolanaCaip2ChainId.MAINNET
+            encrypted: {
+              dAppUrl: 'https://test.dapp.com',
+              address: mockActiveAccount.addressSVM,
+              chainId: SolanaCaip2ChainId.MAINNET
+            }
           }
         )
       })

--- a/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.ts
+++ b/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.ts
@@ -170,10 +170,12 @@ class WalletConnectProvider implements AgnosticRpcProvider {
           chainId
         )
         AnalyticsService.captureWithEncryption(`${request.method}_success`, {
-          dAppUrl: request.peerMeta.url,
-          address,
-          chainId,
-          txHash: result
+          encrypted: {
+            dAppUrl: request.peerMeta.url,
+            address,
+            chainId,
+            txHash: result
+          }
         })
       }
 
@@ -192,9 +194,11 @@ class WalletConnectProvider implements AgnosticRpcProvider {
         AnalyticsService.captureWithEncryption(
           'solana_signTransaction_approved',
           {
-            dAppUrl: request.peerMeta.url,
-            address,
-            chainId
+            encrypted: {
+              dAppUrl: request.peerMeta.url,
+              address,
+              chainId
+            }
           }
         )
       }

--- a/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.ts
+++ b/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.ts
@@ -169,7 +169,7 @@ class WalletConnectProvider implements AgnosticRpcProvider {
           selectActiveAccount(listenerApi.getState()),
           chainId
         )
-        AnalyticsService.captureWithEncryption(`${request.method}_success`, {
+        AnalyticsService.capture(`${request.method}_success`, {
           encrypted: {
             dAppUrl: request.peerMeta.url,
             address,
@@ -191,16 +191,13 @@ class WalletConnectProvider implements AgnosticRpcProvider {
           selectActiveAccount(listenerApi.getState()),
           chainId
         )
-        AnalyticsService.captureWithEncryption(
-          'solana_signTransaction_approved',
-          {
-            encrypted: {
-              dAppUrl: request.peerMeta.url,
-              address,
-              chainId
-            }
+        AnalyticsService.capture('solana_signTransaction_approved', {
+          encrypted: {
+            dAppUrl: request.peerMeta.url,
+            address,
+            chainId
           }
-        )
+        })
       }
 
       try {

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -114,8 +114,6 @@ export type AnalyticsEvents = {
   SwapConfirmed: {
     sourceAddress: string
     targetAddress: string
-    sourceChainId: string
-    targetChainId: string
     sourceTxHash?: string
     quoteSelectionMode: 'manual' | 'auto'
     autoRetryAttempt?: number
@@ -206,7 +204,7 @@ export type AnalyticsEvents = {
       addressSVM: string
     }[]
   }
-  SendTransactionSucceeded: { txHash: string; chainId: number }
+  SendTransactionSucceeded: { txHash: string }
 
   StakeTransactionStarted: { txHash: string; chainId: number }
   BridgeTransactionStarted: {
@@ -365,4 +363,9 @@ export type AnalyticsEvents = {
   PredictionsSearched: { query: string; resultCount: number }
   PredictionsClicked: undefined
   PerpsClicked: undefined
+}
+
+export type AnalyticsPlaintextEvents = {
+  SendTransactionSucceeded: { chainId: string }
+  SwapConfirmed: { sourceChainId: string; targetChainId: string }
 }

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -114,6 +114,8 @@ export type AnalyticsEvents = {
   SwapConfirmed: {
     sourceAddress: string
     targetAddress: string
+    sourceChainId: string
+    targetChainId: string
     sourceTxHash?: string
     quoteSelectionMode: 'manual' | 'auto'
     autoRetryAttempt?: number
@@ -204,7 +206,7 @@ export type AnalyticsEvents = {
       addressSVM: string
     }[]
   }
-  SendTransactionSucceeded: { txHash: string }
+  SendTransactionSucceeded: { txHash: string; chainId: number }
 
   StakeTransactionStarted: { txHash: string; chainId: number }
   BridgeTransactionStarted: {

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -366,6 +366,6 @@ export type AnalyticsEvents = {
 }
 
 export type AnalyticsPlaintextEvents = {
-  SendTransactionSucceeded: { chainId: string }
-  SwapConfirmed: { sourceChainId: string; targetChainId: string }
+  SendTransactionSucceeded: { caip2ChainId: string }
+  SwapConfirmed: { caip2SourceChainId: string; caip2TargetChainId: string }
 }

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -295,10 +295,31 @@ type WithEncrypted<
 > = T
 
 /**
- * Events sent through `captureWithEncryption`. The `encrypted` object is
- * JSON-stringified and encrypted before transport; any sibling fields are
- * sent alongside the encrypted payload as plaintext properties (e.g. for
- * PostHog dashboard filtering).
+ * Ensures `AnalyticsEvents` payloads never declare an `encrypted` field.
+ * The runtime path in `AnalyticsService.capture` dispatches to the encrypt
+ * flow whenever `'encrypted' in properties`; allowing plain events to own
+ * that key would misroute them into the encryption path. A plain event
+ * that grows sensitive data should move to `AnalyticsEncryptedEvents`.
+ *
+ * Exported so the compiler keeps checking this invariant; not intended
+ * for external consumption.
+ */
+type AssertNoEncryptedKey<T> = {
+  [K in keyof T]: T[K] extends undefined
+    ? undefined
+    : 'encrypted' extends keyof NonNullable<T[K]>
+    ? never
+    : T[K]
+}
+export type _AssertAnalyticsEventsHaveNoEncryptedKey =
+  AnalyticsEvents extends AssertNoEncryptedKey<AnalyticsEvents> ? true : never
+
+/**
+ * Events whose payloads contain an `encrypted` object. When a call to
+ * `AnalyticsService.capture` carries one of these events, the `encrypted`
+ * object is JSON-stringified and encrypted before transport; any sibling
+ * fields are sent alongside the encrypted payload as plaintext properties
+ * (e.g. for PostHog dashboard filtering).
  *
  * Rule: put any sensitive field inside `encrypted`. Only add siblings when
  * the field is explicitly meant to be plaintext.

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -15,6 +15,19 @@ type DappTxEventPayload = {
   txHash: string
 }
 
+/**
+ * All analytics event payloads.
+ *
+ * Events with an `encrypted` field are automatically encrypted by
+ * `AnalyticsService.capture` at transport time — the `encrypted` object is
+ * JSON-stringified and encrypted via HPKE before being sent to PostHog.
+ * Any sibling fields at the same level are forwarded as plaintext properties
+ * (e.g. CAIP-2 chain IDs used for PostHog dashboard filtering).
+ *
+ * Rule for encrypted events: put sensitive data (addresses, tx hashes, chain
+ * IDs) inside `encrypted`. Only add plaintext siblings when the field is
+ * explicitly intended to be readable on the dashboard.
+ */
 export type AnalyticsEvents = {
   AccountSelectorAddAccount: { accountNumber: number }
   ExplorerLinkClicked: undefined
@@ -46,6 +59,14 @@ export type AnalyticsEvents = {
     bridgeType: string
     activeChainId: number
     targetChainId: number
+  }
+  BridgeTransactionStarted: {
+    encrypted: {
+      sourceTxHash: string
+      chainId: number
+      fromAddress?: string
+      toAddress?: string
+    }
   }
 
   HallidayBuyClicked: undefined
@@ -85,6 +106,10 @@ export type AnalyticsEvents = {
   ReceivePageVisited: undefined
   RecoveryPhraseClicked: undefined
   SendTransactionFailed: { errorMessage: string; chainId: number }
+  SendTransactionSucceeded: {
+    encrypted: { txHash: string; chainId: number }
+    caip2ChainId: string
+  }
   SeedlessAddMfa: { type: string }
   SeedlessMfaAdded: undefined
   SeedlessExportCancelled: undefined
@@ -107,9 +132,58 @@ export type AnalyticsEvents = {
   StakeIssueDelegation: undefined
   StakeOpened: undefined
   StakeOpenDurationSelect: undefined
+  StakeTransactionStarted: {
+    encrypted: { txHash: string; chainId: number }
+  }
   SwapReviewOrder: {
     provider: string
     slippage: number
+  }
+  SwapConfirmed: {
+    encrypted: {
+      sourceAddress: string
+      targetAddress: string
+      sourceChainId: string
+      targetChainId: string
+      sourceTxHash?: string
+      quoteSelectionMode: 'manual' | 'auto'
+      autoRetryAttempt?: number
+    }
+    caip2SourceChainId: string
+    caip2TargetChainId: string
+  }
+  SwapSuccessful: {
+    encrypted: {
+      sourceAddress: string
+      targetAddress: string
+      sourceChainId: string
+      targetChainId: string
+      sourceTxHash: string
+      targetTxHash?: string
+    }
+  }
+  SwapFailed: {
+    encrypted: {
+      sourceAddress: string
+      targetAddress: string
+      sourceChainId: string
+      targetChainId: string
+      sourceTxHash?: string
+      targetTxHash?: string
+      errorCode?: string
+      errorReason?: string
+    }
+  }
+  SwapRefunded: {
+    encrypted: {
+      sourceAddress: string
+      targetAddress: string
+      sourceChainId: string
+      targetChainId: string
+      sourceTxHash: string
+      targetTxHash?: string
+      refundTxHash?: string
+    }
   }
   TotpValidationFailed: { error: string }
   TotpValidationSuccess: undefined
@@ -282,99 +356,6 @@ export type AnalyticsEvents = {
   PredictionsSearched: { query: string; resultCount: number }
   PredictionsClicked: undefined
   PerpsClicked: undefined
-}
-
-/**
- * Constrains an event map so every entry MUST have an `encrypted` object
- * whose value is a plain keyed object (not an array/function). If a new
- * entry in `AnalyticsEncryptedEvents` is missing `encrypted` or provides
- * a non-keyed value, the compiler fails right at the definition.
- */
-type WithEncrypted<
-  T extends Record<string, { encrypted: Record<string, unknown> }>
-> = T
-
-/**
- * Ensures `AnalyticsEvents` payloads never declare an `encrypted` field.
- * The runtime path in `AnalyticsService.capture` dispatches to the encrypt
- * flow whenever `'encrypted' in properties`; allowing plain events to own
- * that key would misroute them into the encryption path. A plain event
- * that grows sensitive data should move to `AnalyticsEncryptedEvents`.
- *
- * Exported so the compiler keeps checking this invariant; not intended
- * for external consumption.
- */
-type AssertNoEncryptedKey<T> = {
-  [K in keyof T]: T[K] extends undefined
-    ? undefined
-    : 'encrypted' extends keyof NonNullable<T[K]>
-    ? never
-    : T[K]
-}
-export type _AssertAnalyticsEventsHaveNoEncryptedKey =
-  AnalyticsEvents extends AssertNoEncryptedKey<AnalyticsEvents> ? true : never
-
-/**
- * Events whose payloads contain an `encrypted` object. When a call to
- * `AnalyticsService.capture` carries one of these events, the `encrypted`
- * object is JSON-stringified and encrypted before transport; any sibling
- * fields are sent alongside the encrypted payload as plaintext properties
- * (e.g. for PostHog dashboard filtering).
- *
- * Rule: put any sensitive field inside `encrypted`. Only add siblings when
- * the field is explicitly meant to be plaintext.
- */
-export type AnalyticsEncryptedEvents = WithEncrypted<{
-  SendTransactionSucceeded: {
-    encrypted: { txHash: string; chainId: number }
-    caip2ChainId: string
-  }
-  SwapConfirmed: {
-    encrypted: {
-      sourceAddress: string
-      targetAddress: string
-      sourceChainId: string
-      targetChainId: string
-      sourceTxHash?: string
-      quoteSelectionMode: 'manual' | 'auto'
-      autoRetryAttempt?: number
-    }
-    caip2SourceChainId: string
-    caip2TargetChainId: string
-  }
-  SwapSuccessful: {
-    encrypted: {
-      sourceAddress: string
-      targetAddress: string
-      sourceChainId: string
-      targetChainId: string
-      sourceTxHash: string
-      targetTxHash?: string
-    }
-  }
-  SwapFailed: {
-    encrypted: {
-      sourceAddress: string
-      targetAddress: string
-      sourceChainId: string
-      targetChainId: string
-      sourceTxHash?: string
-      targetTxHash?: string
-      errorCode?: string
-      errorReason?: string
-    }
-  }
-  SwapRefunded: {
-    encrypted: {
-      sourceAddress: string
-      targetAddress: string
-      sourceChainId: string
-      targetChainId: string
-      sourceTxHash: string
-      targetTxHash?: string
-      refundTxHash?: string
-    }
-  }
 
   // CP-7989 - Address and Tx Hash Analytics Collection
   AccountAddressesUpdated: {
@@ -387,18 +368,6 @@ export type AnalyticsEncryptedEvents = WithEncrypted<{
         addressCoreEth: string
         addressSVM: string
       }[]
-    }
-  }
-
-  StakeTransactionStarted: {
-    encrypted: { txHash: string; chainId: number }
-  }
-  BridgeTransactionStarted: {
-    encrypted: {
-      sourceTxHash: string
-      chainId: number
-      fromAddress?: string
-      toAddress?: string
     }
   }
 
@@ -433,4 +402,4 @@ export type AnalyticsEncryptedEvents = WithEncrypted<{
       timestamp: number
     }
   }
-}>
+}

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -285,11 +285,14 @@ export type AnalyticsEvents = {
 }
 
 /**
- * Constrains an event map so every entry MUST have an `encrypted` object.
- * If a new entry in `AnalyticsEncryptedEvents` is missing `encrypted`,
- * the compiler fails right at the definition.
+ * Constrains an event map so every entry MUST have an `encrypted` object
+ * whose value is a plain keyed object (not an array/function). If a new
+ * entry in `AnalyticsEncryptedEvents` is missing `encrypted` or provides
+ * a non-keyed value, the compiler fails right at the definition.
  */
-type WithEncrypted<T extends Record<string, { encrypted: object }>> = T
+type WithEncrypted<
+  T extends Record<string, { encrypted: Record<string, unknown> }>
+> = T
 
 /**
  * Events sent through `captureWithEncryption`. The `encrypted` object is

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -111,42 +111,6 @@ export type AnalyticsEvents = {
     provider: string
     slippage: number
   }
-  SwapConfirmed: {
-    sourceAddress: string
-    targetAddress: string
-    sourceChainId: string
-    targetChainId: string
-    sourceTxHash?: string
-    quoteSelectionMode: 'manual' | 'auto'
-    autoRetryAttempt?: number
-  }
-  SwapSuccessful: {
-    sourceAddress: string
-    targetAddress: string
-    sourceChainId: string
-    targetChainId: string
-    sourceTxHash: string
-    targetTxHash?: string
-  }
-  SwapFailed: {
-    sourceAddress: string
-    targetAddress: string
-    sourceChainId: string
-    targetChainId: string
-    sourceTxHash?: string
-    targetTxHash?: string
-    errorCode?: string
-    errorReason?: string
-  }
-  SwapRefunded: {
-    sourceAddress: string
-    targetAddress: string
-    sourceChainId: string
-    targetChainId: string
-    sourceTxHash: string
-    targetTxHash?: string
-    refundTxHash?: string
-  }
   TotpValidationFailed: { error: string }
   TotpValidationSuccess: undefined
   WalletConnectSessionApprovedV2: {
@@ -181,40 +145,6 @@ export type AnalyticsEvents = {
   BrowserHistoryTapped: { url: string }
   WalletConnectedToDapp: { dAppUrl: string }
   TxSubmittedToDapp: undefined
-  eth_sendTransaction_success: DappTxEventPayload
-  avalanche_sendTransaction_success: DappTxEventPayload
-  bitcoin_sendTransaction_success: DappTxEventPayload
-  solana_signAndSendTransaction_success: DappTxEventPayload
-  eth_sendTransaction_confirmed: DappTxEventPayload
-  avalanche_sendTransaction_confirmed: DappTxEventPayload
-  bitcoin_sendTransaction_confirmed: DappTxEventPayload
-  solana_signAndSendTransaction_confirmed: DappTxEventPayload
-  eth_sendTransaction_failed: DappTxEventPayload
-  avalanche_sendTransaction_failed: DappTxEventPayload
-  bitcoin_sendTransaction_failed: DappTxEventPayload
-  solana_signAndSendTransaction_failed: DappTxEventPayload
-  solana_signTransaction_approved: Omit<DappTxEventPayload, 'txHash'>
-
-  // CP-7989 - Address and Tx Hash Analytics Collection
-  AccountAddressesUpdated: {
-    addresses: {
-      address: string
-      addressBtc: string
-      addressAVM: string
-      addressPVM: string
-      addressCoreEth: string
-      addressSVM: string
-    }[]
-  }
-  SendTransactionSucceeded: { txHash: string; chainId: number }
-
-  StakeTransactionStarted: { txHash: string; chainId: number }
-  BridgeTransactionStarted: {
-    sourceTxHash: string
-    chainId: number
-    fromAddress?: string
-    toAddress?: string
-  }
 
   //Gasless
   GaslessFundSuccessful: { fundTxHash: string }
@@ -311,19 +241,6 @@ export type AnalyticsEvents = {
   }
   LedgerAccountDiscoveryFailed: undefined
 
-  // NEST EGG CAMPAIGN
-  NestEggCampaignModalViewed: { addressC: string }
-  NestEggSuccessModalViewed: { addressC: string }
-  NestEggQualified: {
-    addressC: string
-    txHash: string
-    chainId: number
-    fromTokenSymbol: string
-    toTokenSymbol: string
-    fromAmountUsd: number
-    timestamp: number
-  }
-
   // PREDICTIONS
   PredictionsBetStarted: {
     tickerId: string
@@ -367,7 +284,129 @@ export type AnalyticsEvents = {
   PerpsClicked: undefined
 }
 
-export type AnalyticsPlaintextEvents = {
-  SendTransactionSucceeded: { caip2ChainId: string }
-  SwapConfirmed: { caip2SourceChainId: string; caip2TargetChainId: string }
-}
+/**
+ * Constrains an event map so every entry MUST have an `encrypted` object.
+ * If a new entry in `AnalyticsEncryptedEvents` is missing `encrypted`,
+ * the compiler fails right at the definition.
+ */
+type WithEncrypted<T extends Record<string, { encrypted: object }>> = T
+
+/**
+ * Events sent through `captureWithEncryption`. The `encrypted` object is
+ * JSON-stringified and encrypted before transport; any sibling fields are
+ * sent alongside the encrypted payload as plaintext properties (e.g. for
+ * PostHog dashboard filtering).
+ *
+ * Rule: put any sensitive field inside `encrypted`. Only add siblings when
+ * the field is explicitly meant to be plaintext.
+ */
+export type AnalyticsEncryptedEvents = WithEncrypted<{
+  SendTransactionSucceeded: {
+    encrypted: { txHash: string; chainId: number }
+    caip2ChainId: string
+  }
+  SwapConfirmed: {
+    encrypted: {
+      sourceAddress: string
+      targetAddress: string
+      sourceChainId: string
+      targetChainId: string
+      sourceTxHash?: string
+      quoteSelectionMode: 'manual' | 'auto'
+      autoRetryAttempt?: number
+    }
+    caip2SourceChainId: string
+    caip2TargetChainId: string
+  }
+  SwapSuccessful: {
+    encrypted: {
+      sourceAddress: string
+      targetAddress: string
+      sourceChainId: string
+      targetChainId: string
+      sourceTxHash: string
+      targetTxHash?: string
+    }
+  }
+  SwapFailed: {
+    encrypted: {
+      sourceAddress: string
+      targetAddress: string
+      sourceChainId: string
+      targetChainId: string
+      sourceTxHash?: string
+      targetTxHash?: string
+      errorCode?: string
+      errorReason?: string
+    }
+  }
+  SwapRefunded: {
+    encrypted: {
+      sourceAddress: string
+      targetAddress: string
+      sourceChainId: string
+      targetChainId: string
+      sourceTxHash: string
+      targetTxHash?: string
+      refundTxHash?: string
+    }
+  }
+
+  // CP-7989 - Address and Tx Hash Analytics Collection
+  AccountAddressesUpdated: {
+    encrypted: {
+      addresses: {
+        address: string
+        addressBtc: string
+        addressAVM: string
+        addressPVM: string
+        addressCoreEth: string
+        addressSVM: string
+      }[]
+    }
+  }
+
+  StakeTransactionStarted: {
+    encrypted: { txHash: string; chainId: number }
+  }
+  BridgeTransactionStarted: {
+    encrypted: {
+      sourceTxHash: string
+      chainId: number
+      fromAddress?: string
+      toAddress?: string
+    }
+  }
+
+  // dApp transaction lifecycle
+  eth_sendTransaction_success: { encrypted: DappTxEventPayload }
+  avalanche_sendTransaction_success: { encrypted: DappTxEventPayload }
+  bitcoin_sendTransaction_success: { encrypted: DappTxEventPayload }
+  solana_signAndSendTransaction_success: { encrypted: DappTxEventPayload }
+  eth_sendTransaction_confirmed: { encrypted: DappTxEventPayload }
+  avalanche_sendTransaction_confirmed: { encrypted: DappTxEventPayload }
+  bitcoin_sendTransaction_confirmed: { encrypted: DappTxEventPayload }
+  solana_signAndSendTransaction_confirmed: { encrypted: DappTxEventPayload }
+  eth_sendTransaction_failed: { encrypted: DappTxEventPayload }
+  avalanche_sendTransaction_failed: { encrypted: DappTxEventPayload }
+  bitcoin_sendTransaction_failed: { encrypted: DappTxEventPayload }
+  solana_signAndSendTransaction_failed: { encrypted: DappTxEventPayload }
+  solana_signTransaction_approved: {
+    encrypted: Omit<DappTxEventPayload, 'txHash'>
+  }
+
+  // NEST EGG CAMPAIGN
+  NestEggCampaignModalViewed: { encrypted: { addressC: string } }
+  NestEggSuccessModalViewed: { encrypted: { addressC: string } }
+  NestEggQualified: {
+    encrypted: {
+      addressC: string
+      txHash: string
+      chainId: number
+      fromTokenSymbol: string
+      toTokenSymbol: string
+      fromAmountUsd: number
+      timestamp: number
+    }
+  }
+}>

--- a/packages/core-mobile/app/utils/caip2ChainIds.ts
+++ b/packages/core-mobile/app/utils/caip2ChainIds.ts
@@ -24,15 +24,19 @@ export const SOLANA_LEGACY_CHAIN_ID = 'solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ'
  * @param properties
  */
 export function applyTempChainIdConversion(properties?: JsonMap): void {
-  if (properties?.chainId) {
+  if (properties?.chainId && !isCaip2Format(properties.chainId)) {
     properties.chainId = updateChainIdIfNeeded(Number(properties.chainId))
   }
 
-  if (properties?.networkChainId) {
+  if (properties?.networkChainId && !isCaip2Format(properties.networkChainId)) {
     properties.networkChainId = updateChainIdIfNeeded(
       Number(properties.networkChainId)
     )
   }
+}
+
+function isCaip2Format(value: unknown): boolean {
+  return typeof value === 'string' && value.includes(':')
 }
 
 function updateChainIdIfNeeded(original: number): string {

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -293,7 +293,7 @@ describe('ApprovalController', () => {
 
       expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
         'eth_sendTransaction_confirmed',
-        expect.objectContaining({ txHash: TX_HASH })
+        { encrypted: expect.objectContaining({ txHash: TX_HASH }) }
       )
     })
 
@@ -382,10 +382,12 @@ describe('ApprovalController', () => {
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
           {
-            dAppUrl: DAPP_URL,
-            address: EVM_ADDRESS,
-            chainId: 'eip155:1',
-            txHash: TX_HASH
+            encrypted: {
+              dAppUrl: DAPP_URL,
+              address: EVM_ADDRESS,
+              chainId: 'eip155:1',
+              txHash: TX_HASH
+            }
           }
         )
       })
@@ -405,7 +407,7 @@ describe('ApprovalController', () => {
 
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'avalanche_sendTransaction_confirmed',
-          expect.objectContaining({ txHash: TX_HASH })
+          { encrypted: expect.objectContaining({ txHash: TX_HASH }) }
         )
       })
 
@@ -424,10 +426,12 @@ describe('ApprovalController', () => {
 
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'avalanche_sendTransaction_confirmed',
-          expect.objectContaining({
-            chainId: AvalancheCaip2ChainId.C,
-            txHash: TX_HASH
-          })
+          {
+            encrypted: expect.objectContaining({
+              chainId: AvalancheCaip2ChainId.C,
+              txHash: TX_HASH
+            })
+          }
         )
       })
 
@@ -462,7 +466,7 @@ describe('ApprovalController', () => {
         )
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
-          expect.objectContaining({ address: '0xBBBB' })
+          { encrypted: expect.objectContaining({ address: '0xBBBB' }) }
         )
       })
 
@@ -475,7 +479,7 @@ describe('ApprovalController', () => {
 
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
-          expect.objectContaining({ address: '' })
+          { encrypted: expect.objectContaining({ address: '' }) }
         )
       })
 
@@ -492,7 +496,7 @@ describe('ApprovalController', () => {
 
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
-          expect.objectContaining({ address: EVM_ADDRESS })
+          { encrypted: expect.objectContaining({ address: EVM_ADDRESS }) }
         )
 
         // Second call should get empty string (cache was cleaned up)
@@ -505,7 +509,7 @@ describe('ApprovalController', () => {
 
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
-          expect.objectContaining({ address: '' })
+          { encrypted: expect.objectContaining({ address: '' }) }
         )
       })
 
@@ -587,10 +591,12 @@ describe('ApprovalController', () => {
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'eth_sendTransaction_failed',
           {
-            dAppUrl: DAPP_URL,
-            address: EVM_ADDRESS,
-            chainId: 'eip155:1',
-            txHash: TX_HASH
+            encrypted: {
+              dAppUrl: DAPP_URL,
+              address: EVM_ADDRESS,
+              chainId: 'eip155:1',
+              txHash: TX_HASH
+            }
           }
         )
       })
@@ -610,10 +616,12 @@ describe('ApprovalController', () => {
 
         expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
           'bitcoin_sendTransaction_failed',
-          expect.objectContaining({
-            address: btcAddress,
-            txHash: 'btctxhash'
-          })
+          {
+            encrypted: expect.objectContaining({
+              address: btcAddress,
+              txHash: 'btctxhash'
+            })
+          }
         )
       })
 
@@ -642,7 +650,7 @@ describe('ApprovalController', () => {
 
         const call = (AnalyticsService.captureWithEncryption as jest.Mock).mock
           .calls[0]
-        expect(call[1]).toHaveProperty('txHash', '0xrevertedtx')
+        expect(call[1]).toHaveProperty('encrypted.txHash', '0xrevertedtx')
       })
     })
   })

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -291,7 +291,7 @@ describe('ApprovalController', () => {
         request
       })
 
-      expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+      expect(AnalyticsService.capture).toHaveBeenCalledWith(
         'eth_sendTransaction_confirmed',
         { encrypted: expect.objectContaining({ txHash: TX_HASH }) }
       )
@@ -369,7 +369,7 @@ describe('ApprovalController', () => {
     })
 
     describe('dapp analytics', () => {
-      it('fires captureWithEncryption with _confirmed event for dapp requests', async () => {
+      it('fires capture with _confirmed event for dapp requests', async () => {
         const request = makeDappRequest(RpcMethod.ETH_SEND_TRANSACTION)
         await populateSigningAddressCache(request)
 
@@ -379,7 +379,7 @@ describe('ApprovalController', () => {
           request
         })
 
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
           {
             encrypted: {
@@ -405,7 +405,7 @@ describe('ApprovalController', () => {
           request
         })
 
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'avalanche_sendTransaction_confirmed',
           { encrypted: expect.objectContaining({ txHash: TX_HASH }) }
         )
@@ -424,7 +424,7 @@ describe('ApprovalController', () => {
           request
         })
 
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'avalanche_sendTransaction_confirmed',
           {
             encrypted: expect.objectContaining({
@@ -444,7 +444,7 @@ describe('ApprovalController', () => {
           request: makeDappRequest(RpcMethod.ETH_SEND_TRANSACTION)
         })
 
-        expect(AnalyticsService.captureWithEncryption).not.toHaveBeenCalled()
+        expect(AnalyticsService.capture).not.toHaveBeenCalled()
       })
 
       it('uses getAddressForChainId to resolve the signing address', async () => {
@@ -464,7 +464,7 @@ describe('ApprovalController', () => {
           'eip155:137',
           mockAccount
         )
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
           { encrypted: expect.objectContaining({ address: '0xBBBB' }) }
         )
@@ -477,7 +477,7 @@ describe('ApprovalController', () => {
           request: makeDappRequest(RpcMethod.ETH_SEND_TRANSACTION)
         })
 
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
           { encrypted: expect.objectContaining({ address: '' }) }
         )
@@ -494,20 +494,20 @@ describe('ApprovalController', () => {
           request
         })
 
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
           { encrypted: expect.objectContaining({ address: EVM_ADDRESS }) }
         )
 
         // Second call should get empty string (cache was cleaned up)
-        ;(AnalyticsService.captureWithEncryption as jest.Mock).mockClear()
+        ;(AnalyticsService.capture as jest.Mock).mockClear()
         approvalController.onTransactionConfirmed({
           txHash: TX_HASH,
           explorerLink: '',
           request
         })
 
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
           { encrypted: expect.objectContaining({ address: '' }) }
         )
@@ -579,7 +579,7 @@ describe('ApprovalController', () => {
     })
 
     describe('dapp analytics', () => {
-      it('fires captureWithEncryption with _failed event including txHash for dapp requests', async () => {
+      it('fires capture with _failed event including txHash for dapp requests', async () => {
         const request = makeDappRequest(RpcMethod.ETH_SEND_TRANSACTION)
         await populateSigningAddressCache(request)
 
@@ -588,7 +588,7 @@ describe('ApprovalController', () => {
           request
         })
 
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_failed',
           {
             encrypted: {
@@ -614,7 +614,7 @@ describe('ApprovalController', () => {
           request
         })
 
-        expect(AnalyticsService.captureWithEncryption).toHaveBeenCalledWith(
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'bitcoin_sendTransaction_failed',
           {
             encrypted: expect.objectContaining({
@@ -633,7 +633,7 @@ describe('ApprovalController', () => {
           request: makeDappRequest(RpcMethod.ETH_SEND_TRANSACTION)
         })
 
-        expect(AnalyticsService.captureWithEncryption).not.toHaveBeenCalled()
+        expect(AnalyticsService.capture).not.toHaveBeenCalled()
       })
 
       it('always includes txHash in _failed payload (matches Extension behavior)', async () => {
@@ -648,8 +648,7 @@ describe('ApprovalController', () => {
           request
         })
 
-        const call = (AnalyticsService.captureWithEncryption as jest.Mock).mock
-          .calls[0]
+        const call = (AnalyticsService.capture as jest.Mock).mock.calls[0]
         expect(call[1]).toHaveProperty('encrypted.txHash', '0xrevertedtx')
       })
     })

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -100,10 +100,12 @@ class ApprovalController implements VmModuleApprovalController {
       this.signingAddressMap.delete(request.requestId)
       const eventName = `${request.method}_confirmed` as TxSendConfirmedEvent
       AnalyticsService.captureWithEncryption(eventName, {
-        dAppUrl: request.dappInfo.url,
-        address,
-        chainId: request.chainId,
-        txHash
+        encrypted: {
+          dAppUrl: request.dappInfo.url,
+          address,
+          chainId: request.chainId,
+          txHash
+        }
       })
     }
 
@@ -144,10 +146,12 @@ class ApprovalController implements VmModuleApprovalController {
       this.signingAddressMap.delete(request.requestId)
       const eventName = `${request.method}_failed` as TxSendFailedEvent
       AnalyticsService.captureWithEncryption(eventName, {
-        dAppUrl: request.dappInfo.url,
-        address,
-        chainId: request.chainId,
-        txHash
+        encrypted: {
+          dAppUrl: request.dappInfo.url,
+          address,
+          chainId: request.chainId,
+          txHash
+        }
       })
     }
   }

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -99,7 +99,7 @@ class ApprovalController implements VmModuleApprovalController {
       const address = this.signingAddressMap.get(request.requestId) ?? ''
       this.signingAddressMap.delete(request.requestId)
       const eventName = `${request.method}_confirmed` as TxSendConfirmedEvent
-      AnalyticsService.captureWithEncryption(eventName, {
+      AnalyticsService.capture(eventName, {
         encrypted: {
           dAppUrl: request.dappInfo.url,
           address,
@@ -145,7 +145,7 @@ class ApprovalController implements VmModuleApprovalController {
       const address = this.signingAddressMap.get(request.requestId) ?? ''
       this.signingAddressMap.delete(request.requestId)
       const eventName = `${request.method}_failed` as TxSendFailedEvent
-      AnalyticsService.captureWithEncryption(eventName, {
+      AnalyticsService.capture(eventName, {
         encrypted: {
           dAppUrl: request.dappInfo.url,
           address,


### PR DESCRIPTION
## Description

**Ticket: [CP-13944]**

- Introduce a dedicated `AnalyticsEncryptedEvents` type (enforced via `WithEncrypted<T>` helper) that forces every encrypted event to carry an `encrypted: { ... }` object alongside sibling plaintext properties (e.g. `caip2ChainId`, `caip2SourceChainId`, `caip2TargetChainId`).
- Narrow `AnalyticsService.captureWithEncryption` so the compiler only accepts events declared in `AnalyticsEncryptedEvents`; the method now destructures `{ encrypted, ...plaintext }`, encrypts only the `encrypted` object, and merges the plaintext siblings as top‑level PostHog properties. Spread order guarantees the encryption envelope (`data`/`enc`/`keyID`) cannot be overwritten by accidentally‑named plaintext keys.
- Migrate all 15 `captureWithEncryption` call sites (send, swap, bridge, earn/nest egg, account, WalletConnect, approval controller) to the new nested shape, and update associated Jest expectations (`ApprovalController.test.ts`, `walletConnect.test.ts`) to assert the nested `encrypted` payload and top‑level CAIP‑2 chain ID siblings.
- Motivation: previously `captureWithEncryption` was typed against `AnalyticsEvents`, which meant any event (including fully‑plaintext ones) could be passed through encryption, and there was no type‑level distinction between data that must be encrypted and data that may flow to the PostHog dashboard as plaintext for filtering. The new split prevents accidental leakage and makes the contract explicit at the type layer.
- Also pulls in `CP-14082`: `applyTempChainIdConversion` now guards with `isCaip2Format` so values that are already CAIP‑2 encoded are not re‑converted.
- No new dependencies. No runtime behavior changes to dashboards beyond the added plaintext CAIP‑2 chain IDs.

## Testing
iOS: 8284
Android: 8285

- [x] Verify `SendTransactionSucceeded` events include `chainId` as a top-level plaintext property (CAIP-2 format)
- [x] Verify `SwapConfirmed` events include `sourceChainId` and `targetChainId` as top-level plaintext properties
- [x] Verify encrypted `data` blob no longer contains chain ID fields for these events
- [ ] Verify existing analytics events without plaintext properties still work correctly
- [ ] TypeScript compiles cleanly (`yarn tsc`)

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [X] I have added testing steps
- [X] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-13944]: https://ava-labs.atlassian.net/browse/CP-13944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ