### PR TITLE
Validate custom RPC URL against the claimed chainId before adding it

### DIFF
--- a/packages/core-mobile/app/services/network/utils/validateCustomRpcUrl.test.ts
+++ b/packages/core-mobile/app/services/network/utils/validateCustomRpcUrl.test.ts
@@ -1,0 +1,116 @@
+import { validateCustomRpcUrl } from './validateCustomRpcUrl'
+
+describe('validateCustomRpcUrl', () => {
+  describe('happy path', () => {
+    it.each([
+      'https://eth.llamarpc.com',
+      'https://api.avax.network/ext/bc/C/rpc',
+      'https://rpc.gnosischain.com',
+      'https://linea-mainnet.infura.io/v3/abc123',
+      'https://1.1.1.1/rpc' // public IP — allowed
+    ])('accepts %s', url => {
+      expect(validateCustomRpcUrl(url)).toEqual({ ok: true })
+    })
+  })
+
+  describe('malformed URLs', () => {
+    it.each(['', 'not-a-url', 'javascript:alert(1)'])(
+      'rejects %s as invalid URL',
+      url => {
+        const result = validateCustomRpcUrl(url)
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.reason).toMatch(/valid URL|HTTPS/)
+        }
+      }
+    )
+  })
+
+  describe('non-HTTPS schemes', () => {
+    it.each([
+      'http://example.com',
+      'ws://example.com',
+      'wss://example.com',
+      'ftp://example.com'
+    ])('rejects %s', url => {
+      const result = validateCustomRpcUrl(url)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.reason).toContain('HTTPS')
+      }
+    })
+  })
+
+  describe('local hosts', () => {
+    it.each([
+      'https://localhost/rpc',
+      'https://localhost:8545',
+      'https://127.0.0.1/rpc',
+      'https://0.0.0.0/rpc',
+      'https://[::1]/rpc',
+      'https://LOCALHOST/rpc' // case-insensitive
+    ])('rejects %s', url => {
+      const result = validateCustomRpcUrl(url)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.reason).toContain('Local')
+      }
+    })
+  })
+
+  describe('IPv6 private/loopback', () => {
+    it.each([
+      // IPv4-mapped loopback, WHATWG-normalized form from the URL polyfill
+      'https://[::ffff:7f00:1]/rpc',
+      'https://[::ffff:7fff:ffff]/rpc',
+      // Unique-local fc00::/7 (both fc and fd prefixes)
+      'https://[fc00::1]/rpc',
+      'https://[fd00::1]/rpc',
+      'https://[fdab:cdef::1]/rpc',
+      // Link-local fe80::/10
+      'https://[fe80::1]/rpc',
+      'https://[fe80:abcd::1]/rpc'
+    ])('rejects %s', url => {
+      const result = validateCustomRpcUrl(url)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.reason).toMatch(/Local|Private/)
+      }
+    })
+  })
+
+  describe('private IPv4 ranges', () => {
+    it.each([
+      'https://10.0.0.1/rpc',
+      'https://10.255.255.255/rpc',
+      'https://192.168.1.1/rpc',
+      'https://192.168.50.50/rpc',
+      'https://172.16.0.1/rpc',
+      'https://172.20.10.5/rpc',
+      'https://172.31.255.255/rpc',
+      'https://169.254.1.1/rpc', // link-local
+      'https://100.64.0.1/rpc' // CGNAT
+    ])('rejects %s', url => {
+      const result = validateCustomRpcUrl(url)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.reason).toContain('Private')
+      }
+    })
+
+    it('does NOT reject public IPs that look superficially similar', () => {
+      // 172.15 is NOT in the 172.16-31 private block — should be allowed
+      expect(validateCustomRpcUrl('https://172.15.0.1/rpc')).toEqual({
+        ok: true
+      })
+      // 172.32 is also outside the private block
+      expect(validateCustomRpcUrl('https://172.32.0.1/rpc')).toEqual({
+        ok: true
+      })
+      // 100.63 is outside CGNAT (100.64-127)
+      expect(validateCustomRpcUrl('https://100.63.0.1/rpc')).toEqual({
+        ok: true
+      })
+    })
+  })
+})

--- a/packages/core-mobile/app/services/network/utils/validateCustomRpcUrl.ts
+++ b/packages/core-mobile/app/services/network/utils/validateCustomRpcUrl.ts
@@ -1,0 +1,89 @@
+/**
+ * Synchronous safety checks for a `wallet_addEthereumChain` RPC URL.
+ *
+ * Runs *before* we show the approval modal — the async chainId probe
+ * (`isValidRPCUrl`) happens after user approval and lives separately.
+ *
+ * Rejections:
+ * - non-HTTPS (http, ws, ws:)
+ * - localhost / loopback (127/8, ::1, IPv4-mapped ::ffff:127.0.0.0/8)
+ * - RFC1918 private IPv4 ranges (10/8, 172.16/12, 192.168/16)
+ * - link-local IPv4 (169.254/16), IPv6 (fe80::/10)
+ * - CGNAT (100.64/10)
+ * - IPv6 unique-local (fc00::/7)
+ *
+ * Requires `react-native-url-polyfill/auto` (loaded in polyfills/index.js).
+ * The stock Hermes `URL` is a regex-based class that does NOT normalize
+ * octal/integer IPv4 encodings (e.g. `0177.0.0.1` → `127.0.0.1`) or IPv6
+ * literals. Without the polyfill this validator becomes silently bypassable.
+ */
+
+export type RpcUrlValidationResult =
+  | { ok: true }
+  | { ok: false; reason: string }
+
+const PRIVATE_IPV4_PATTERNS = [
+  /^10\./,
+  /^192\.168\./,
+  /^172\.(1[6-9]|2[0-9]|3[0-1])\./,
+  /^169\.254\./,
+  /^100\.(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-7])\./
+]
+
+const LOCAL_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '0.0.0.0',
+  '[::1]',
+  '::1'
+])
+
+// IPv6 prefixes (WHATWG-normalized hostnames include brackets) that indicate
+// loopback, unique-local, or link-local addresses. Prefix-matched because
+// the polyfill may produce `[::ffff:7f00:1]`, `[fc00::1]`, etc.
+const LOCAL_IPV6_PREFIXES = [
+  '[::ffff:7f', // IPv4-mapped loopback (127.0.0.0/8 mapped into v6)
+  '[fc', // unique-local fc00::/7
+  '[fd', // unique-local fd00::/8
+  '[fe80:' // link-local fe80::/10
+]
+
+export function validateCustomRpcUrl(url: string): RpcUrlValidationResult {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return { ok: false, reason: 'RPC URL is not a valid URL' }
+  }
+
+  if (parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'RPC URL must use HTTPS' }
+  }
+
+  const hostname = parsed.hostname.toLowerCase()
+
+  if (!hostname) {
+    return { ok: false, reason: 'RPC URL has no host' }
+  }
+
+  if (LOCAL_HOSTS.has(hostname)) {
+    return { ok: false, reason: 'Local RPC URLs are not allowed' }
+  }
+
+  for (const prefix of LOCAL_IPV6_PREFIXES) {
+    if (hostname.startsWith(prefix)) {
+      return {
+        ok: false,
+        reason: 'Local/private RPC URLs are not allowed'
+      }
+    }
+  }
+
+  for (const pattern of PRIVATE_IPV4_PATTERNS) {
+    if (pattern.test(hostname)) {
+      return { ok: false, reason: 'Private-network RPC URLs are not allowed' }
+    }
+  }
+
+  return { ok: true }
+}

--- a/packages/core-mobile/app/store/rpc/handlers/chain/wallet_addEthereumChain/wallet_addEthereumChain.test.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/chain/wallet_addEthereumChain/wallet_addEthereumChain.test.ts
@@ -225,11 +225,10 @@ describe('wallet_addEthereumChain handler', () => {
     })
 
     it('shows modal immediately without pre-validating the RPC URL', async () => {
-      // isValidRPCUrl must NOT be called in handle() — dApps like Aave time out
-      // and crash waiting for the async RPC check before the approval modal appears.
-      // The extension shows the modal first; we follow the same pattern.
-      mockIsValidRPCUrl.mockImplementationOnce(() => false)
-
+      // isValidRPCUrl (the async chainId probe) must NOT be called in handle()
+      // — dApps like Aave time out waiting for an approval modal if we block
+      // on the network call. Synchronous URL checks (HTTPS / private-IP) still
+      // run; the chainId probe is deferred to approve().
       const testRequest = createRequest([sepoliaMainnetInfo])
 
       const result = await handler.handle(testRequest, mockListenerApi)
@@ -237,6 +236,49 @@ describe('wallet_addEthereumChain handler', () => {
       expect(mockIsValidRPCUrl).not.toHaveBeenCalled()
       expect(router.navigate).toHaveBeenCalledWith('/addEthereumChain')
       expect(result).toEqual({ success: true, value: expect.any(Symbol) })
+    })
+
+    it('rejects non-HTTPS RPC URLs in handle() before opening the approval', async () => {
+      const httpChain = {
+        ...sepoliaMainnetInfo,
+        rpcUrls: ['http://rpc.sepolia.dev']
+      }
+      const testRequest = createRequest([httpChain])
+
+      const result = await handler.handle(testRequest, mockListenerApi)
+
+      expect(router.navigate).not.toHaveBeenCalled()
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe(-32602)
+        expect(result.error.message).toContain('HTTPS')
+      }
+    })
+
+    it('rejects localhost RPC URLs in handle()', async () => {
+      const localChain = {
+        ...sepoliaMainnetInfo,
+        rpcUrls: ['https://localhost:8545']
+      }
+      const testRequest = createRequest([localChain])
+
+      const result = await handler.handle(testRequest, mockListenerApi)
+
+      expect(router.navigate).not.toHaveBeenCalled()
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects private-IP RPC URLs in handle()', async () => {
+      const privateChain = {
+        ...sepoliaMainnetInfo,
+        rpcUrls: ['https://192.168.1.1/rpc']
+      }
+      const testRequest = createRequest([privateChain])
+
+      const result = await handler.handle(testRequest, mockListenerApi)
+
+      expect(router.navigate).not.toHaveBeenCalled()
+      expect(result.success).toBe(false)
     })
 
     describe('when request contains isTestnet field', () => {
@@ -374,6 +416,52 @@ describe('wallet_addEthereumChain handler', () => {
       expect(mockDispatch).toHaveBeenCalledWith(toggleDeveloperMode())
 
       expect(result).toEqual({ success: true, value: null })
+    })
+
+    it('probes the RPC URL in approve() and rejects when chainId mismatches', async () => {
+      mockIsValidRPCUrl.mockImplementationOnce(() => false)
+
+      const testRequest = createRequest([sepoliaMainnetInfo])
+      const testNetwork = {
+        chainId: 11155111,
+        chainName: 'Sepolia',
+        description: '',
+        explorerUrl: 'https://sepolia.etherscan.io',
+        isTestnet: false,
+        logoUri: '',
+        mainnetChainId: 0,
+        networkToken: {
+          symbol: 'SEP',
+          name: 'SEP',
+          description: '',
+          decimals: 18,
+          logoUri: ''
+        },
+        platformChainId: '',
+        rpcUrl: 'https://rpc.sepolia.dev',
+        subnetId: '',
+        vmId: '',
+        vmName: 'EVM' as NetworkVMType
+      }
+
+      const result = await handler.approve(
+        {
+          request: testRequest,
+          data: { network: testNetwork, isExisting: false }
+        },
+        mockListenerApi
+      )
+
+      expect(mockIsValidRPCUrl).toHaveBeenCalledWith(
+        testNetwork.chainId,
+        testNetwork.rpcUrl
+      )
+      expect(mockDispatch).not.toHaveBeenCalledWith(addCustomNetwork(testNetwork))
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe(-32602)
+        expect(result.error.message).toContain(String(testNetwork.chainId))
+      }
     })
   })
 })

--- a/packages/core-mobile/app/store/rpc/handlers/chain/wallet_addEthereumChain/wallet_addEthereumChain.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/chain/wallet_addEthereumChain/wallet_addEthereumChain.ts
@@ -13,6 +13,8 @@ import {
   toggleDeveloperMode
 } from 'store/settings/advanced'
 import { walletConnectCache } from 'services/walletconnectv2/walletConnectCache/walletConnectCache'
+import { validateCustomRpcUrl } from 'services/network/utils/validateCustomRpcUrl'
+import { isValidRPCUrl } from 'services/network/utils/isValidRpcUrl'
 import { RpcMethod, RpcRequest } from '../../../types'
 import {
   ApproveResponse,
@@ -56,6 +58,18 @@ class WalletAddEthereumChainHandler
       return {
         success: false,
         error: rpcErrors.invalidParams('RPC url is missing')
+      }
+    }
+
+    // Synchronous safety checks on the URL (HTTPS, no localhost, no private
+    // IPs). The async chainId probe is deferred until after user approval
+    // because dApps like Aave time out waiting for an approval modal if we
+    // block on a network call here.
+    const urlCheck = validateCustomRpcUrl(rpcUrl)
+    if (!urlCheck.ok) {
+      return {
+        success: false,
+        error: rpcErrors.invalidParams(urlCheck.reason)
       }
     }
 
@@ -130,6 +144,20 @@ class WalletAddEthereumChainHandler
     }
 
     const data = result.data
+
+    // Probe the RPC URL once the user has approved — rejects if the URL
+    // fails to respond to eth_chainId or reports a different chainId than
+    // the dApp claimed. Closes the attack where a malicious site lists a
+    // trusted chainId but points at attacker-controlled infra.
+    const probeOk = await isValidRPCUrl(data.network.chainId, data.network.rpcUrl)
+    if (!probeOk) {
+      return {
+        success: false,
+        error: rpcErrors.invalidParams(
+          `RPC URL did not report chainId ${data.network.chainId}`
+        )
+      }
+    }
 
     dispatch(addCustomNetwork(data.network))
     dispatch(toggleEnabledChainId(data.network.chainId))


### PR DESCRIPTION
## Description

**Ticket: [CP-]**

Phase 4.2 of the injected-provider modernization plan (§7.4). Adds two layers of validation to `wallet_addEthereumChain` so a dApp can't silently trick the wallet into adopting a malicious RPC endpoint.

**Stacked on top of #3783** — base this PR on that branch. Once #3783 merges to main, I'll rebase the base here to `main`.

Before this change, a dApp could call `wallet_addEthereumChain` with any of:
- `http://` (no TLS, sniffable)
- `https://localhost:8545` / `127.0.0.1` (attacker loopback)
- Private-IP RPCs (`10.x`, `192.168.x`, etc.)
- An HTTPS URL that claims to be Ethereum mainnet (chainId 1) but points at attacker-controlled infrastructure

The first three categories now fail synchronously before we even show the approval modal. The last category fails in `approve()` — after the user has tapped Approve, we probe the RPC with `eth_chainId`; if the response doesn't match the declared chainId, we reject the request and do NOT commit the network to Redux.

### Why split sync and async?

Existing handler had a deliberate comment (line 228 of the old test file) explaining why the async RPC probe was NOT called in `handle()` — dApps like Aave crash / time out waiting for the approval modal if we block on a network call. The split here respects that: synchronous checks (static URL hygiene) run before the modal; the async chainId probe runs after user approval. Best of both worlds — security + UX.

### Summary of changes

- **NEW** `app/services/network/utils/validateCustomRpcUrl.ts` — synchronous validator. Rejects non-HTTPS, localhost/loopback (including IPv4-mapped `[::ffff:7f00:1]`), IPv6 unique-local (`fc00::/7`, `fd00::/8`), IPv6 link-local (`fe80::/10`), and RFC1918 + CGNAT IPv4 ranges.
- **NEW** `app/services/network/utils/validateCustomRpcUrl.test.ts` — 35 tests covering happy path, malformed URLs, non-HTTPS schemes, local hosts, IPv6 private ranges, IPv4 private ranges, and near-miss cases (172.15/172.32/100.63) that should NOT be flagged.
- **MODIFIED** `app/store/rpc/handlers/chain/wallet_addEthereumChain/wallet_addEthereumChain.ts` — calls `validateCustomRpcUrl` in `handle()`, calls `isValidRPCUrl(chainId, rpcUrl)` in `approve()` before dispatching the network mutation.
- **MODIFIED** `app/store/rpc/handlers/chain/wallet_addEthereumChain/wallet_addEthereumChain.test.ts` — added 3 new tests in `handle()` (http, localhost, private IP rejected) and 1 new test in `approve()` (chainId mismatch rejected, `addCustomNetwork` NOT dispatched). Removed a stale `mockImplementationOnce` that was bleeding across tests.

### Known trust model limitation

The `isValidRPCUrl` probe only catches accidentally-misconfigured or lazily-spoofing RPCs. A motivated attacker can set up a proxy that responds to `eth_chainId` with `0x1` and forwards nothing else. Closing this gap requires an allowlist of known RPC providers cross-checked against chainlist.org — scoped to a follow-up (Phase 4.3).

## Screenshots/Videos

No UI changes. The only user-visible difference: when a dApp sends an invalid RPC URL, the approval either does not open (sync check) or the dApp gets an error after approval (async check, no network written).

## Testing

**Unit tests:**
- `yarn test app/services/network/utils/validateCustomRpcUrl.test.ts` — 35/35 ✅
- `yarn test app/store/rpc/handlers/chain/wallet_addEthereumChain/` — 17/17 ✅ (was 13; added 4 new)

**Static:**
- `yarn tsc` — passes
- `yarn lint` — clean on touched files

**Manual dev testing steps:**

1. Rebuild, open the in-app browser, navigate to https://chainlist.org.
2. **Happy path:** Find a valid chain you haven't added (Gnosis, Linea). Tap **Add to Wallet** → approve → network added normally.
3. **Sync rejection** (not testable on chainlist directly — needs a crafted dApp or a modified chainlist fetch that returns `http://` URL). In dev, modify the handler inputs or use a test dApp that sends `http://rpc.example.com`. Expected: no modal appears, dApp receives invalidParams error.
4. **Async rejection** (chainId mismatch): call `wallet_addEthereumChain` with a legitimate HTTPS RPC but lie about the chainId. E.g., pass `chainId: "0x1"` with `rpcUrls: ["https://api.avax.network/ext/bc/C/rpc"]`. Expected: modal appears, user taps Approve, then `approve()` probes the URL, gets 43114 instead of 1, returns invalidParams. Network is NOT added. dApp sees the error.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works (unit tests)
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have included screenshots / videos of android and ios (no UI change; happy to capture an error-state toast if requested)
- [ ] I have updated the documentation