### PR TITLE
Require verified origin for every injected provider request

### DIFF
--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -174,7 +174,7 @@ describe('createInjectedProviderRouter', () => {
       )
     })
 
-    it('rejects signing methods when native origin is unavailable', () => {
+    it('rejects any method with unauthorized when native origin is unavailable', () => {
       const { deps, sendResponse } = makeDeps({ nativeOrigin: undefined })
       const router = createInjectedProviderRouter(deps)
 
@@ -183,8 +183,43 @@ describe('createInjectedProviderRouter', () => {
       expect(sendResponse).toHaveBeenCalledWith(
         1,
         expect.objectContaining({
-          code: -32603,
+          code: 4100,
           message: expect.stringContaining('Origin unavailable')
+        }),
+        undefined
+      )
+    })
+
+    it('rejects non-signing read-only methods when native origin is unavailable', () => {
+      const { deps, sendResponse } = makeDeps({ nativeOrigin: undefined })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'eth_blockNumber')
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: 4100 }),
+        undefined
+      )
+    })
+
+    it('rejects with invalidRequest when shim-reported origin differs from native origin', () => {
+      const { deps, sendResponse } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      router.handleProviderMessage(
+        JSON.stringify({
+          id: 1,
+          origin: 'https://evil.example',
+          request: { method: 'eth_blockNumber', params: [] }
+        })
+      )
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          code: -32600,
+          message: expect.stringContaining('Origin mismatch')
         }),
         undefined
       )
@@ -358,8 +393,12 @@ describe('createInjectedProviderRouter', () => {
       expect(sendResponse).toHaveBeenCalledWith(1, null, null)
     })
 
-    it('skips the slice write when origin is unknown, still emits accountsChanged', () => {
-      const { deps, emitEvent, revokePermission } = makeDeps({
+    it('rejects wallet_revokePermissions outright when origin is unknown', () => {
+      // Post-origin-hardening: no method proceeds without a verified native
+      // origin, including revoke. Returning 4100 makes the ambiguity explicit
+      // rather than silently emitting accountsChanged for an origin we can't
+      // identify.
+      const { deps, sendResponse, emitEvent, revokePermission } = makeDeps({
         nativeOrigin: undefined
       })
       const router = createInjectedProviderRouter(deps)
@@ -367,7 +406,15 @@ describe('createInjectedProviderRouter', () => {
       send(router, 1, 'wallet_revokePermissions')
 
       expect(revokePermission).not.toHaveBeenCalled()
-      expect(emitEvent).toHaveBeenCalledWith('accountsChanged', [])
+      expect(emitEvent).not.toHaveBeenCalledWith(
+        'accountsChanged',
+        expect.anything()
+      )
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: 4100 }),
+        undefined
+      )
     })
   })
 
@@ -515,13 +562,22 @@ describe('createInjectedProviderRouter', () => {
       expect(sendResponse).toHaveBeenCalledWith(1, null, [])
     })
 
-    it('returns an empty array when origin is missing', () => {
+    it('rejects wallet_getPermissions with unauthorized when origin is missing', () => {
+      // The prior behavior of returning [] for unknown origin would let a
+      // page with no verified origin (e.g. about:blank, pre-navigation race)
+      // make the request and get a clean empty response. Post-hardening every
+      // method requires a native origin; this call is rejected upstream of
+      // the handler.
       const { deps, sendResponse } = makeDeps({ nativeOrigin: undefined })
       const router = createInjectedProviderRouter(deps)
 
       send(router, 1, 'wallet_getPermissions')
 
-      expect(sendResponse).toHaveBeenCalledWith(1, null, [])
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: 4100 }),
+        undefined
+      )
     })
   })
 

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -505,10 +505,28 @@ export function createInjectedProviderRouter(
     const { method, params } = rpc
 
     const nativeOrigin = getNativeOrigin()
+
+    // Origin mismatch — the shim-reported origin disagrees with the origin
+    // tracked by the WebView's navigation state. Either a race during
+    // cross-origin navigation (rare) or a sign the page is trying to spoof
+    // its origin (hostile). Either way, refuse the request.
+    //
+    // Note: if the shim provides `pageOrigin` but `nativeOrigin` is missing
+    // (e.g., first RPC arrives before onNavigationStateChange has fired),
+    // we deliberately fall through to the `!nativeOrigin` gate below. We
+    // can't verify the shim's claim without a native anchor, so 4100
+    // "unauthorized" is the right response — not "invalidRequest," since
+    // the payload itself is well-formed.
     if (pageOrigin && nativeOrigin && pageOrigin !== nativeOrigin) {
       Logger.warn(
-        `[InjectedProvider] Origin mismatch: page=${pageOrigin} native=${nativeOrigin}`
+        `[InjectedProvider] Origin mismatch rejected: page=${pageOrigin} native=${nativeOrigin}`
       )
+      sendResponse(
+        id,
+        rpcErrors.invalidRequest('Origin mismatch'),
+        undefined
+      )
+      return
     }
 
     Logger.trace(`[InjectedProvider] ${method}`, params)
@@ -522,17 +540,20 @@ export function createInjectedProviderRouter(
       return
     }
 
-    if (nativeOrigin) {
-      trackPendingOrigin(id, nativeOrigin)
-    } else if (method in SIGNING_METHODS) {
-      // Signing methods require a verified page origin — reject without one.
+    // Every method requires a known native origin. Requests that arrive
+    // before the WebView has reported its first URL, or from an iframe or
+    // about:blank context, have no authoritative origin to gate on — reject
+    // rather than silently treat them as unscoped.
+    if (!nativeOrigin) {
       sendResponse(
         id,
-        rpcErrors.internal('Origin unavailable — cannot sign'),
+        providerErrors.unauthorized('Origin unavailable'),
         undefined
       )
       return
     }
+
+    trackPendingOrigin(id, nativeOrigin)
 
     // Ensure params is always an array for handlers that expect one.
     // wallet_watchAsset is the only method that legitimately accepts object-form

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -118,6 +118,20 @@ function setupMocks(
   )
 }
 
+// Wraps renderHook and seeds a native origin by default. Tests that explicitly
+// want the no-origin path pass an empty string: `renderProvider('')`.
+function renderProvider(url: string = 'https://example.com') {
+  const hookReturn = renderHook(() =>
+    useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+  )
+  if (url) {
+    act(() => {
+      hookReturn.result.current.setCurrentUrl(url)
+    })
+  }
+  return hookReturn
+}
+
 describe('useEvmInjectedProvider', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -128,9 +142,7 @@ describe('useEvmInjectedProvider', () => {
 
   describe('providerShimJs', () => {
     it('generates shim with active account and network', () => {
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
       expect(result.current.providerShimJs).toBe(
         'SHIM(0xa86a,0xTestAddress1234567890)'
       )
@@ -140,9 +152,7 @@ describe('useEvmInjectedProvider', () => {
       setupMocks({
         network: { ...mockActiveNetwork, vmName: NetworkVMType.BITCOIN }
       })
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
       expect(result.current.providerShimJs).toBe(
         'SHIM(0x1,0xTestAddress1234567890)'
       )
@@ -150,18 +160,14 @@ describe('useEvmInjectedProvider', () => {
 
     it('uses empty address when no active account', () => {
       setupMocks({ account: null })
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
       expect(result.current.providerShimJs).toBe('SHIM(0xa86a,)')
     })
   })
 
   describe('sendResponse', () => {
     it('injects __coreProviderRespond with result', () => {
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
 
       act(() => {
         result.current.emitEvent('chainChanged', '0x1')
@@ -175,9 +181,7 @@ describe('useEvmInjectedProvider', () => {
 
   describe('emitEvent', () => {
     it('injects __coreProviderEmit with event name and data', () => {
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
 
       act(() => {
         result.current.emitEvent('chainChanged', '0x1')
@@ -189,9 +193,7 @@ describe('useEvmInjectedProvider', () => {
     })
 
     it('injects accountsChanged with array data', () => {
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
 
       act(() => {
         result.current.emitEvent('accountsChanged', ['0xNewAddr'])
@@ -205,9 +207,7 @@ describe('useEvmInjectedProvider', () => {
 
   describe('handleProviderMessage', () => {
     it('ignores invalid JSON payload', () => {
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
 
       act(() => {
         result.current.handleProviderMessage('not-json')
@@ -218,9 +218,7 @@ describe('useEvmInjectedProvider', () => {
 
     describe('wallet_switchEthereumChain', () => {
       it('auto-approves, dispatches setTabChainId for the tab, and responds null', async () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -254,9 +252,7 @@ describe('useEvmInjectedProvider', () => {
         const mockSignFn = jest.fn().mockResolvedValue('0xSig')
         mockCreateInAppRequest.mockReturnValue(mockSignFn)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -308,9 +304,7 @@ describe('useEvmInjectedProvider', () => {
           }
         })
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         // Switch browser to chain 1 (auto-approved)
         await act(async () => {
@@ -342,9 +336,7 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('returns null immediately when requested chain is already active', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         // 43114 is the active chain
         const payload = JSON.stringify({
@@ -363,14 +355,12 @@ describe('useEvmInjectedProvider', () => {
           setTabChainId({ tabId: 'test-tab-id', chainId: 43114 })
         )
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
-          'window.__coreProviderRespond(2, null, null); true;'
+          expect.stringContaining('__coreProviderRespond(2, null, null)')
         )
       })
 
       it('returns error 4902 when chain is not in wallet (shim no-rollback prevents wagmi re-trigger loop)', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 3,
@@ -393,9 +383,7 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('returns error when chainId param is missing', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 4,
@@ -420,9 +408,7 @@ describe('useEvmInjectedProvider', () => {
         const mockRequest = jest.fn().mockResolvedValue(null)
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -474,9 +460,7 @@ describe('useEvmInjectedProvider', () => {
         })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         await act(async () => {
           result.current.handleProviderMessage(
@@ -501,9 +485,7 @@ describe('useEvmInjectedProvider', () => {
           .mockRejectedValue({ code: 4001, message: 'User rejected' })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         await act(async () => {
           result.current.handleProviderMessage(
@@ -531,9 +513,7 @@ describe('useEvmInjectedProvider', () => {
           .mockRejectedValue({ code: 4001, message: 'User rejected' })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -559,9 +539,7 @@ describe('useEvmInjectedProvider', () => {
 
     describe('wallet_revokePermissions', () => {
       it('emits accountsChanged (not disconnect) then responds null', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 7,
@@ -601,9 +579,7 @@ describe('useEvmInjectedProvider', () => {
         const mockRequest = jest.fn().mockResolvedValue(true)
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -636,9 +612,7 @@ describe('useEvmInjectedProvider', () => {
         const mockRequest = jest.fn().mockResolvedValue(true)
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -663,9 +637,7 @@ describe('useEvmInjectedProvider', () => {
           .mockRejectedValue({ code: 4001, message: 'User rejected' })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -724,9 +696,7 @@ describe('useEvmInjectedProvider', () => {
           const mockRequest = jest.fn().mockResolvedValue('0xSignature')
           mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-          const { result } = renderHook(() =>
-            useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-          )
+          const { result } = renderProvider()
 
           act(() => {
             result.current.setCurrentUrl('https://example.com')
@@ -760,9 +730,7 @@ describe('useEvmInjectedProvider', () => {
         const mockRequest = jest.fn().mockResolvedValue('0xSignatureResult')
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -791,9 +759,7 @@ describe('useEvmInjectedProvider', () => {
           .mockRejectedValue({ code: 4001, message: 'User rejected' })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -820,9 +786,7 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('rejects signing when origin is unavailable', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider('')
 
         const payload = JSON.stringify({
           id: 22,
@@ -834,7 +798,7 @@ describe('useEvmInjectedProvider', () => {
         })
 
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
-          expect.stringContaining('"code":-32603')
+          expect.stringContaining('"code":4100')
         )
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
           expect.stringContaining('Origin unavailable')
@@ -847,9 +811,7 @@ describe('useEvmInjectedProvider', () => {
           .mockRejectedValue({ code: 4902, message: 'Unrecognized chain ID' })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -878,9 +840,7 @@ describe('useEvmInjectedProvider', () => {
           .mockRejectedValue({ message: 'Something went wrong' })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -934,9 +894,7 @@ describe('useEvmInjectedProvider', () => {
         }
         global.fetch = jest.fn().mockResolvedValue(mockResponse)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 100,
@@ -964,9 +922,7 @@ describe('useEvmInjectedProvider', () => {
         }
         global.fetch = jest.fn().mockResolvedValue(mockResponse)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 101,
@@ -981,7 +937,9 @@ describe('useEvmInjectedProvider', () => {
         })
 
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
-          'window.__coreProviderRespond(101, null, "0xBalanceValue"); true;'
+          expect.stringContaining(
+            '__coreProviderRespond(101, null, "0xBalanceValue")'
+          )
         )
       })
 
@@ -993,9 +951,7 @@ describe('useEvmInjectedProvider', () => {
         }
         global.fetch = jest.fn().mockResolvedValue(mockResponse)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 102,
@@ -1014,9 +970,7 @@ describe('useEvmInjectedProvider', () => {
       it('handles fetch failure gracefully', async () => {
         global.fetch = jest.fn().mockRejectedValue(new Error('Network error'))
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 103,
@@ -1045,9 +999,7 @@ describe('useEvmInjectedProvider', () => {
           }
         })
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 104,
@@ -1067,9 +1019,7 @@ describe('useEvmInjectedProvider', () => {
 
     describe('unsupported methods', () => {
       it('returns error -32601 for unknown methods', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 200,
@@ -1094,9 +1044,7 @@ describe('useEvmInjectedProvider', () => {
         const mockRequest = jest.fn().mockResolvedValue('0xResult')
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -1119,9 +1067,7 @@ describe('useEvmInjectedProvider', () => {
 
     describe('validation and security', () => {
       it('rejects malformed payloads with -32600', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 400,
@@ -1138,9 +1084,7 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('rejects unknown methods with -32601', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 401,
@@ -1157,9 +1101,7 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('exposes setCurrentUrl', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         expect(typeof result.current.setCurrentUrl).toBe('function')
       })
@@ -1245,9 +1187,7 @@ describe('useEvmInjectedProvider', () => {
 
   describe('handleDomainMetadata', () => {
     it('stores valid domain metadata', () => {
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
 
       const metadata = {
         domain: 'opensea.io',
@@ -1264,9 +1204,7 @@ describe('useEvmInjectedProvider', () => {
     })
 
     it('handles invalid JSON gracefully', () => {
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
 
       act(() => {
         result.current.handleDomainMetadata('invalid-json')
@@ -1300,9 +1238,7 @@ describe('useEvmInjectedProvider', () => {
 
       it('injects accountsChanged([address]) when the origin has a grant for the active account', () => {
         mockUseStore.mockReturnValue(withPermission(mockActiveAccount.addressC))
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
         act(() => {
           result.current.setCurrentUrl('https://opensea.io/')
         })
@@ -1320,9 +1256,7 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('injects accountsChanged([]) when no grant exists for the origin', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
         act(() => {
           result.current.setCurrentUrl('https://opensea.io/')
         })
@@ -1340,9 +1274,7 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('does not inject accountsChanged when origin is missing', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider('')
         // currentUrlRef is never set, so origin stays ''
         mockInjectJavaScript.mockClear()
 
@@ -1357,9 +1289,7 @@ describe('useEvmInjectedProvider', () => {
 
       it('does not inject accountsChanged when there is no active account', () => {
         setupMocks({ account: null })
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
         act(() => {
           result.current.setCurrentUrl('https://opensea.io/')
         })


### PR DESCRIPTION
## Description

**Ticket: [CP-]**

Phase 3 Stage A of the injected-provider modernization plan (§6.4). Closes two origin-trust gaps in the router:

1. **Non-signing methods could proceed without a verified native origin.** Only signing methods were rejected when `nativeOrigin` was missing; read-only (`eth_blockNumber`, `eth_call`, …), `wallet_revokePermissions`, `wallet_addEthereumChain`, `wallet_watchAsset` all passed through. A page with no verifiable origin (pre-nav race, `about:blank`) could call any of them.
2. **Origin mismatch was logged but not rejected.** When the shim-reported `pageOrigin` differed from the WebView-tracked `nativeOrigin`, we emitted `Logger.warn` and continued serving the request. That's the hostile-page-spoofing-origin path as far as we can detect it in-band.

**Stacked on #3785** (RPC URL validation). Once that merges to main, I'll re-base this on main.

## Change

In `router.ts:handleProviderMessage`:
- Mismatch (`pageOrigin && nativeOrigin && pageOrigin !== nativeOrigin`) now rejects with `rpcErrors.invalidRequest('Origin mismatch')` instead of warn-and-pass.
- After the ALLOWED_METHODS check, any request with `!nativeOrigin` is rejected with `providerErrors.unauthorized('Origin unavailable')` (code 4100). All methods, not just signing.
- Existing `Logger.warn` on mismatch preserved for observability.

## Summary of changes

- **MODIFIED** `app/hooks/browser/injectedProvider/router.ts` — reshaped the origin gate in `handleProviderMessage`. Added explanatory comments covering the mismatch + no-origin + shim-claim-without-native-anchor cases.
- **MODIFIED** `app/hooks/browser/injectedProvider/router.test.ts` — updated 3 tests (signing error code now 4100 not -32603; revoke and getPermissions now rejected outright when origin missing), added 2 new tests (read-only rejection without origin; mismatch rejection). Total router tests: 35.
- **MODIFIED** `app/hooks/browser/useEvmInjectedProvider.test.ts` — added a `renderProvider(url = 'https://example.com')` helper that seeds `setCurrentUrl` by default. Tests that explicitly exercise the no-origin path pass `''` to skip the seed. Bulk-migrated ~40 `renderHook(...)` callsites. Two exact-string matchers replaced with `expect.stringContaining(...)` to accommodate the origin-gated `sendResponse` JS wrapping. Total hook tests: 170 (same count, updated shape).

## Trust model notes

- Error code 4100 ("unauthorized") is the least-wrong EIP-1193 code here. `-32603 internal` would be inaccurate (well-formed request), `-32600 invalidRequest` implies malformed envelope. 4100 matches the existing \"Origin unavailable — cannot connect\" branches in `handleRequestAccounts` / `handleRequestPermissions` for consistency.
- The mismatch path requires BOTH `pageOrigin` and `nativeOrigin` to be set. When the shim claims an origin but the native side hasn't tracked one yet, we fall through to the generic "no origin" gate — can't verify the claim, so no authorization.

## Screenshots/Videos

No UI changes. User-visible difference: if the first RPC call from a brand-new tab arrives before the WebView's first `onNavigationStateChange`, it now receives a 4100 rejection. Realistic dApps retry after `window.ethereum` emits `connect` or after `window.load`, so the race window is narrow.

## Testing

**Unit tests:**
- `yarn test app/hooks/browser/injectedProvider/router.test.ts` — 35/35 ✅
- `yarn test app/hooks/browser/` — 170/170 ✅

**Static:**
- `yarn tsc` — passes
- `yarn lint` — clean on touched files

**Manual dev testing (already covered by the earlier Phase 1(b) smoke tests):**

1. Fresh tab → Uniswap → Connect Wallet → approval modal appears → approve → dApp shows connected. (Validates the path where `onNavigationStateChange` has fired before the dApp calls `eth_requestAccounts`.)
2. Any dApp that triggers a signing request from a granted origin → approval screen appears with correct chain + peer info.
3. Revoke permission from Settings → Connected Sites → dApp shows disconnected on next refresh.
4. Hostile / tampered dApp case (requires crafted test page that posts a `provider_request` with a different `origin` field): the request is rejected with `invalidRequest('Origin mismatch')`. Tested in the new router unit test.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works (unit tests)
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have included screenshots / videos of android and ios (no UI change)
- [ ] I have updated the documentation