### PR TITLE
Cancel in-flight injected provider requests on cross-origin navigation

### DIFF
--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -642,12 +642,15 @@ describe('createInjectedProviderRouter', () => {
       send(router, 1, 'personal_sign', ['0xMsg', '0xAddr'])
       await new Promise(r => setImmediate(r))
 
-      expect(requestSigning).toHaveBeenCalledWith({
-        method: 'personal_sign',
-        params: ['0xMsg', '0xAddr'],
-        chainId: 'eip155:43114',
-        peerMeta: expect.objectContaining({ name: 'example' })
-      })
+      expect(requestSigning).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'personal_sign',
+          params: ['0xMsg', '0xAddr'],
+          chainId: 'eip155:43114',
+          peerMeta: expect.objectContaining({ name: 'example' }),
+          signal: expect.any(AbortSignal)
+        })
+      )
       expect(sendResponse).toHaveBeenCalledWith(1, null, '0xSig')
     })
 
@@ -729,6 +732,80 @@ describe('createInjectedProviderRouter', () => {
         expect.objectContaining({ code: -32603 }),
         undefined
       )
+    })
+  })
+
+  describe('cancelByOrigin', () => {
+    it('aborts in-flight signing requests whose origin does not match the new origin', async () => {
+      const { deps, requestSigning } = makeDeps()
+      // Never resolves — simulates a signing request sitting on an approval
+      // screen while the user navigates away.
+      let capturedSignal: AbortSignal | undefined
+      requestSigning.mockImplementationOnce(args => {
+        capturedSignal = args.signal
+        return new Promise(() => undefined)
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 42, 'personal_sign', ['0xMsg', '0xAddr'])
+      await new Promise(r => setImmediate(r))
+
+      expect(capturedSignal?.aborted).toBe(false)
+
+      router.cancelByOrigin('https://other.example')
+
+      expect(capturedSignal?.aborted).toBe(true)
+    })
+
+    it('does not abort requests whose origin matches the new origin', async () => {
+      const { deps, requestSigning } = makeDeps()
+      let capturedSignal: AbortSignal | undefined
+      requestSigning.mockImplementationOnce(args => {
+        capturedSignal = args.signal
+        return new Promise(() => undefined)
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 42, 'personal_sign', ['0xMsg', '0xAddr'])
+      await new Promise(r => setImmediate(r))
+
+      // Same origin as makeDeps default — should NOT abort
+      router.cancelByOrigin('https://example.com')
+
+      expect(capturedSignal?.aborted).toBe(false)
+    })
+
+    it('is a no-op when there are no in-flight requests', () => {
+      const { deps } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      // Does not throw, does not emit anything
+      expect(() => router.cancelByOrigin('https://anywhere.example')).not.toThrow()
+    })
+
+    it('cleans up in-flight tracking after abort', async () => {
+      const { deps, requestSigning } = makeDeps()
+      const signals: AbortSignal[] = []
+      requestSigning.mockImplementation(args => {
+        if (args.signal) signals.push(args.signal)
+        return new Promise(() => undefined)
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'personal_sign', ['a', 'b'])
+      await new Promise(r => setImmediate(r))
+
+      router.cancelByOrigin('https://other.example')
+      expect(signals[0]?.aborted).toBe(true)
+
+      // A second cancel round should not re-abort the same controller.
+      // (If it did, reading .aborted still returns true, but the important
+      // thing is the entry was removed from the map.) Fire another request
+      // and confirm it gets its own independent signal.
+      send(router, 2, 'personal_sign', ['c', 'd'])
+      await new Promise(r => setImmediate(r))
+      expect(signals[1]).toBeDefined()
+      expect(signals[1]?.aborted).toBe(false)
     })
   })
 })

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -124,6 +124,18 @@ function parseProviderPayload(
 
 export type InjectedProviderRouter = {
   handleProviderMessage: (payload: string) => void
+  /**
+   * Aborts every in-flight abortable request whose origin does not match
+   * `currentOrigin`. Call when the WebView navigates to a new origin so stale
+   * signing / add-chain / watch-asset flows tied to the prior page cannot
+   * complete or broadcast.
+   */
+  cancelByOrigin: (currentOrigin: string | undefined) => void
+}
+
+type InFlightRequest = {
+  origin: string
+  controller: AbortController
 }
 
 export function createInjectedProviderRouter(
@@ -147,6 +159,21 @@ export function createInjectedProviderRouter(
     revokePermission,
     requestConnectApproval
   } = deps
+
+  const inFlightRequests = new Map<number, InFlightRequest>()
+
+  const registerInFlight = (
+    id: number,
+    origin: string
+  ): AbortController => {
+    const controller = new AbortController()
+    inFlightRequests.set(id, { origin, controller })
+    return controller
+  }
+
+  const clearInFlight = (id: number): void => {
+    inFlightRequests.delete(id)
+  }
 
   const proxyToRpc = async (
     id: number,
@@ -206,17 +233,22 @@ export function createInjectedProviderRouter(
     }
 
     const caip2ChainId = getEvmCaip2ChainId(getBrowserNetwork().chainId)
+    const origin = getNativeOrigin() ?? ''
+    const controller = registerInFlight(id, origin)
 
     try {
       const result = await requestSigning({
         method: rpcMethod,
         params,
         chainId: caip2ChainId,
-        peerMeta: getPeerMeta()
+        peerMeta: getPeerMeta(),
+        signal: controller.signal
       })
       sendResponse(id, null, result)
     } catch (e) {
       sendResponse(id, e, undefined)
+    } finally {
+      clearInFlight(id)
     }
   }
 
@@ -280,12 +312,15 @@ export function createInjectedProviderRouter(
       | undefined
     const addHexChainId = addParam?.chainId
     const addRpcUrl = addParam?.rpcUrls?.[0]
+    const origin = getNativeOrigin() ?? ''
+    const controller = registerInFlight(id, origin)
     try {
       await requestSigning({
         method: 'wallet_addEthereumChain' as unknown as RpcMethod,
         params,
         chainId: getEvmCaip2ChainId(getBrowserNetwork().chainId),
-        peerMeta: getPeerMeta()
+        peerMeta: getPeerMeta(),
+        signal: controller.signal
       })
       // User approved — switch browser chain to the new network and notify dApp
       if (addHexChainId) {
@@ -303,6 +338,8 @@ export function createInjectedProviderRouter(
       sendResponse(id, null, null)
     } catch (e) {
       sendResponse(id, e, undefined)
+    } finally {
+      clearInFlight(id)
     }
   }
 
@@ -475,12 +512,15 @@ export function createInjectedProviderRouter(
   ): Promise<void> => {
     // Normalize: some dApps send object form { type, options } instead of array
     const normalizedParams = Array.isArray(params) ? params : [params]
+    const origin = getNativeOrigin() ?? ''
+    const controller = registerInFlight(id, origin)
     try {
       const result = await requestSigning({
         method: 'wallet_watchAsset' as unknown as RpcMethod,
         params: normalizedParams,
         chainId: getEvmCaip2ChainId(getBrowserNetwork().chainId),
-        peerMeta: getPeerMeta()
+        peerMeta: getPeerMeta(),
+        signal: controller.signal
       })
       sendResponse(id, null, result)
     } catch (e) {
@@ -491,6 +531,8 @@ export function createInjectedProviderRouter(
       } else {
         sendResponse(id, e, undefined)
       }
+    } finally {
+      clearInFlight(id)
     }
   }
 
@@ -581,5 +623,15 @@ export function createInjectedProviderRouter(
     }
   }
 
-  return { handleProviderMessage }
+  const cancelByOrigin = (currentOrigin: string | undefined): void => {
+    if (inFlightRequests.size === 0) return
+    for (const [id, entry] of inFlightRequests.entries()) {
+      if (entry.origin !== currentOrigin) {
+        entry.controller.abort()
+        inFlightRequests.delete(id)
+      }
+    }
+  }
+
+  return { handleProviderMessage, cancelByOrigin }
 }

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -51,6 +51,20 @@ jest.mock('./evmProviderShim', () => ({
   )
 }))
 
+jest.mock('expo-router', () => ({
+  router: {
+    canGoBack: jest.fn(() => false),
+    back: jest.fn(),
+    navigate: jest.fn()
+  }
+}))
+
+jest.mock('vmModule/ApprovalController/ApprovalController', () => ({
+  approvalController: {
+    handleGoBackIfNeeded: jest.fn()
+  }
+}))
+
 jest.mock('./getInjectedProviderUuid', () => ({
   getInjectedProviderUuid: () => 'test-uuid-1234'
 }))
@@ -715,14 +729,17 @@ describe('useEvmInjectedProvider', () => {
           })
 
           expect(mockCreateInAppRequest).toHaveBeenCalledWith(mockDispatch)
-          expect(mockRequest).toHaveBeenCalledWith({
-            method: rpcMethod,
-            params: ['param1', 'param2'],
-            chainId: 'eip155:43114',
-            peerMeta: expect.objectContaining({
-              url: 'https://example.com'
+          expect(mockRequest).toHaveBeenCalledWith(
+            expect.objectContaining({
+              method: rpcMethod,
+              params: ['param1', 'param2'],
+              chainId: 'eip155:43114',
+              peerMeta: expect.objectContaining({
+                url: 'https://example.com'
+              }),
+              signal: expect.any(AbortSignal)
             })
-          })
+          )
         }
       )
 
@@ -1182,6 +1199,68 @@ describe('useEvmInjectedProvider', () => {
         call[0].includes("__coreProviderEmit('chainChanged'")
       )
       expect(chainChangedCalls).toHaveLength(0)
+    })
+  })
+
+  describe('setCurrentUrl origin-change cleanup', () => {
+    it('aborts in-flight signing request when navigating cross-origin', async () => {
+      const { approvalController: mockApprovalController } =
+        jest.requireMock('vmModule/ApprovalController/ApprovalController')
+      ;(mockApprovalController.handleGoBackIfNeeded as jest.Mock).mockClear()
+
+      let capturedSignal: AbortSignal | undefined
+      const mockRequest = jest.fn(args => {
+        capturedSignal = args.signal
+        return new Promise(() => undefined)
+      })
+      mockCreateInAppRequest.mockReturnValue(mockRequest)
+
+      const { result } = renderProvider('https://uniswap.org')
+
+      await act(async () => {
+        result.current.handleProviderMessage(
+          JSON.stringify({
+            id: 99,
+            request: { method: 'personal_sign', params: ['0xMsg', '0xAddr'] }
+          })
+        )
+      })
+
+      expect(capturedSignal?.aborted).toBe(false)
+
+      act(() => {
+        result.current.setCurrentUrl('https://opensea.io')
+      })
+
+      expect(capturedSignal?.aborted).toBe(true)
+      expect(mockApprovalController.handleGoBackIfNeeded).toHaveBeenCalled()
+    })
+
+    it('does NOT abort in-flight request on same-origin navigation (SPA route change)', async () => {
+      let capturedSignal: AbortSignal | undefined
+      const mockRequest = jest.fn(args => {
+        capturedSignal = args.signal
+        return new Promise(() => undefined)
+      })
+      mockCreateInAppRequest.mockReturnValue(mockRequest)
+
+      const { result } = renderProvider('https://uniswap.org/swap')
+
+      await act(async () => {
+        result.current.handleProviderMessage(
+          JSON.stringify({
+            id: 99,
+            request: { method: 'personal_sign', params: ['0xMsg', '0xAddr'] }
+          })
+        )
+      })
+
+      act(() => {
+        // Same origin, different path — mimics a SPA nav_change message
+        result.current.setCurrentUrl('https://uniswap.org/pool')
+      })
+
+      expect(capturedSignal?.aborted).toBe(false)
     })
   })
 

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -12,6 +12,7 @@ import { PeerMeta } from 'store/rpc/types'
 import { serializeError } from '@metamask/rpc-errors'
 import { router as appRouter } from 'expo-router'
 import { walletConnectCache } from 'services/walletconnectv2/walletConnectCache/walletConnectCache'
+import { approvalController } from 'vmModule/ApprovalController/ApprovalController'
 import {
   grantPermission as grantPermissionAction,
   revokePermission as revokePermissionAction,
@@ -21,7 +22,10 @@ import type { RootState } from 'store/types'
 import type { Account } from 'store/account'
 import { buildEvmProviderShim } from './evmProviderShim'
 import { getInjectedProviderUuid } from './getInjectedProviderUuid'
-import { createInjectedProviderRouter } from './injectedProvider/router'
+import {
+  createInjectedProviderRouter,
+  InjectedProviderRouter
+} from './injectedProvider/router'
 import {
   BrowserNetwork,
   DomainMetadata,
@@ -94,8 +98,34 @@ export function useEvmInjectedProvider(
     )
   }, [activeNetwork, tabChainId, webViewRef])
 
+  // Router is assigned below (after useMemo). setCurrentUrl may fire before
+  // the router is constructed on first render, so we route through a ref.
+  const routerRef = useRef<InjectedProviderRouter | null>(null)
+
+  // Tracks the reject fn of an in-flight connect approval so a later request
+  // or an origin change can unstick it. Also used by requestConnectApproval
+  // in the memo below.
+  const prevInflightConnectReject = useRef<((err: unknown) => void) | null>(
+    null
+  )
+
   const setCurrentUrl = useCallback((url: string) => {
+    const prevOrigin = getOriginFromUrl(currentUrlRef.current)
     currentUrlRef.current = url
+    const newOrigin = getOriginFromUrl(url)
+
+    // Only cancel on actual origin change — within-origin SPA nav (nav_change
+    // messages firing on pushState/replaceState) keeps the tab connected to
+    // the same dApp, so stale approvals remain legitimate.
+    if (prevOrigin && prevOrigin !== newOrigin) {
+      routerRef.current?.cancelByOrigin(newOrigin)
+      prevInflightConnectReject.current?.({
+        code: 4001,
+        message: 'User rejected the request.'
+      })
+      prevInflightConnectReject.current = null
+      approvalController.handleGoBackIfNeeded()
+    }
   }, [])
 
   const chainIdHex = useMemo(() => {
@@ -186,13 +216,6 @@ export function useEvmInjectedProvider(
     activeAccountRef.current = activeAccount
   }, [activeAccount])
 
-  // Tracks the reject fn of an in-flight connect approval so a later request
-  // (or an unmount) can unstick it. Writes and clears happen only inside
-  // requestConnectApproval.
-  const prevInflightConnectReject = useRef<((err: unknown) => void) | null>(
-    null
-  )
-
   const router = useMemo(() => {
     // requestSigning closes over dispatch; keep its construction inside the
     // memo so it always uses the latest dispatch and re-builds when dispatch
@@ -280,6 +303,10 @@ export function useEvmInjectedProvider(
       requestConnectApproval
     })
   }, [dispatch, tabId, sendResponse, emitEvent, getPeerMeta, store])
+
+  // Publish the router to the ref so setCurrentUrl (defined above, fires
+  // on nav events) can call cancelByOrigin without restructuring the memo.
+  routerRef.current = router
 
   const handleProviderMessage = useCallback(
     (payload: string) => router.handleProviderMessage(payload),

--- a/packages/core-mobile/app/store/rpc/utils/createInAppRequest.test.ts
+++ b/packages/core-mobile/app/store/rpc/utils/createInAppRequest.test.ts
@@ -1,0 +1,201 @@
+import { RpcMethod as VmModuleRpcMethod } from '@avalabs/vm-module-types'
+import {
+  onInAppRequestFailed,
+  onInAppRequestSucceeded,
+  onRequest,
+  onRequestRejected
+} from '../slice'
+import { createInAppRequest } from './createInAppRequest'
+import * as generatePayload from './generateInAppRequestPayload'
+
+const FIXED_REQUEST_ID = 9999
+
+let mockListenerEffects: Array<(action: unknown) => void> = []
+
+jest.mock('store/middleware/listener', () => ({
+  addAppListener: (opts: { effect: (action: unknown) => void }) => {
+    return () => {
+      // Registering returns an action. When the reducer sees it, it'd hook
+      // the listener. Our mock directly tracks the effect so tests can
+      // drive it.
+      mockListenerEffects.push(opts.effect)
+      return () => {
+        mockListenerEffects = mockListenerEffects.filter(fn => fn !== opts.effect)
+      }
+    }
+  }
+}))
+
+// Some imports inside createInAppRequest use `store/rpc/types` to bring in
+// the full RpcMethod enum (required for the payload). We don't need a full
+// mock there — the real enum works fine in tests.
+
+describe('createInAppRequest', () => {
+  let dispatch: jest.Mock
+  let payloadSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    mockListenerEffects = []
+    dispatch = jest.fn(action => {
+      // Redux dispatch returns whatever the middleware chain returns. For
+      // the listener middleware, the dispatched action is a thunk-like thing
+      // that registers the listener and returns an unsubscribe. For plain
+      // actions, return the action.
+      if (typeof action === 'function') return action()
+      return action
+    })
+
+    // Deterministic request id so we can reference it in onRequestRejected
+    // assertions below.
+    payloadSpy = jest
+      .spyOn(generatePayload, 'generateInAppRequestPayload')
+      .mockImplementation(({ method, params, chainId, peerMeta }) => ({
+        provider: 'core-mobile' as unknown as never,
+        method,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        data: {
+          id: FIXED_REQUEST_ID,
+          topic: 'core-mobile-test',
+          params: { request: { method, params }, chainId: chainId ?? '' }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        peerMeta
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any))
+  })
+
+  afterEach(() => {
+    payloadSpy.mockRestore()
+  })
+
+  it('rejects synchronously without dispatching onRequest when signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    const request = createInAppRequest(dispatch)
+
+    await expect(
+      request({
+        method: VmModuleRpcMethod.PERSONAL_SIGN,
+        params: [],
+        signal: controller.signal
+      })
+    ).rejects.toEqual(
+      expect.objectContaining({ code: 4001 })
+    )
+
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: onRequest.type })
+    )
+  })
+
+  it('dispatches onRequestRejected when the signal aborts mid-flight', async () => {
+    const controller = new AbortController()
+    const request = createInAppRequest(dispatch)
+
+    const promise = request({
+      method: VmModuleRpcMethod.PERSONAL_SIGN,
+      params: ['0xMsg', '0xAddr'],
+      signal: controller.signal
+    })
+
+    // onRequest should have been dispatched once
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: onRequest.type })
+    )
+
+    controller.abort()
+
+    await expect(promise).rejects.toEqual(
+      expect.objectContaining({ code: 4001 })
+    )
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: onRequestRejected.type,
+        payload: expect.objectContaining({
+          request: expect.objectContaining({
+            data: expect.objectContaining({ id: FIXED_REQUEST_ID })
+          })
+        })
+      })
+    )
+  })
+
+  it('ignores a later success event after abort has settled the promise', async () => {
+    const controller = new AbortController()
+    const request = createInAppRequest(dispatch)
+
+    const promise = request({
+      method: VmModuleRpcMethod.PERSONAL_SIGN,
+      params: [],
+      signal: controller.signal
+    })
+
+    controller.abort()
+
+    // Fire a spurious success after abort — promise should already have
+    // settled to reject and must not flip to resolve.
+    mockListenerEffects.forEach(effect =>
+      effect(
+        onInAppRequestSucceeded({
+          requestId: FIXED_REQUEST_ID,
+          txHash: '0xDEADBEEF'
+        })
+      )
+    )
+
+    await expect(promise).rejects.toEqual(
+      expect.objectContaining({ code: 4001 })
+    )
+  })
+
+  it('does NOT dispatch onRequestRejected when the listener settles first (normal success)', async () => {
+    const controller = new AbortController()
+    const request = createInAppRequest(dispatch)
+
+    const promise = request({
+      method: VmModuleRpcMethod.PERSONAL_SIGN,
+      params: [],
+      signal: controller.signal
+    })
+
+    // Simulate the handler dispatching onInAppRequestSucceeded.
+    mockListenerEffects.forEach(effect =>
+      effect(
+        onInAppRequestSucceeded({
+          requestId: FIXED_REQUEST_ID,
+          txHash: '0xABC'
+        })
+      )
+    )
+
+    await expect(promise).resolves.toBe('0xABC')
+
+    // A subsequent abort should be a no-op: no onRequestRejected dispatched.
+    dispatch.mockClear()
+    controller.abort()
+
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: onRequestRejected.type })
+    )
+  })
+
+  it('rejects when the listener settles with onInAppRequestFailed (no abort involved)', async () => {
+    const request = createInAppRequest(dispatch)
+
+    const promise = request({
+      method: VmModuleRpcMethod.PERSONAL_SIGN,
+      params: []
+    })
+
+    const err = { code: 4001, message: 'user rejected' }
+    mockListenerEffects.forEach(effect =>
+      effect(
+        onInAppRequestFailed({ requestId: FIXED_REQUEST_ID, error: err })
+      )
+    )
+
+    await expect(promise).rejects.toEqual(err)
+  })
+})

--- a/packages/core-mobile/app/store/rpc/utils/createInAppRequest.ts
+++ b/packages/core-mobile/app/store/rpc/utils/createInAppRequest.ts
@@ -1,10 +1,12 @@
 import { Dispatch, isAnyOf } from '@reduxjs/toolkit'
+import { providerErrors } from '@metamask/rpc-errors'
 import { addAppListener } from 'store/middleware/listener'
 import { RpcMethod as VmModuleRpcMethod } from '@avalabs/vm-module-types'
 import {
   onInAppRequestFailed,
   onInAppRequestSucceeded,
-  onRequest
+  onRequest,
+  onRequestRejected
 } from '../slice'
 import { PeerMeta, RpcMethod } from '../types'
 import { generateInAppRequestPayload } from './generateInAppRequestPayload'
@@ -19,13 +21,22 @@ export type Request = ({
   params,
   chainId,
   context,
-  peerMeta
+  peerMeta,
+  signal
 }: {
   method: VmModuleRpcMethod
   params: unknown
   chainId?: string
   context?: Record<string, unknown>
   peerMeta?: PeerMeta
+  /**
+   * Optional AbortSignal. Aborting cancels the in-flight request by
+   * dispatching `onRequestRejected` (so any open handler — including
+   * `eth_sendTransaction` sitting on an approval screen — sees the rejection
+   * before it broadcasts) and rejects the returned Promise with
+   * `userRejectedRequest`.
+   */
+  signal?: AbortSignal
 }) => Promise<string>
 
 /**
@@ -51,9 +62,8 @@ export type Request = ({
  * })
  */
 export const createInAppRequest = (dispatch: Dispatch): Request => {
-  return ({ method, params, chainId, context, peerMeta }) => {
+  return ({ method, params, chainId, context, peerMeta, signal }) => {
     return new Promise((resolve, reject) => {
-      // create and dispatch the request
       const inAppRequest = generateInAppRequestPayload({
         method: method as unknown as RpcMethod,
         params,
@@ -61,8 +71,15 @@ export const createInAppRequest = (dispatch: Dispatch): Request => {
         context,
         peerMeta
       })
+
+      if (signal?.aborted) {
+        reject(providerErrors.userRejectedRequest())
+        return
+      }
+
       dispatch(onRequest(inAppRequest))
 
+      let settled = false
       // wait for the success/fail action and resolve/reject accordingly
       const unsubscribe = dispatch(
         addAppListener({
@@ -70,11 +87,13 @@ export const createInAppRequest = (dispatch: Dispatch): Request => {
           effect: action => {
             if (action.payload.requestId === inAppRequest.data.id) {
               if (onInAppRequestSucceeded.match(action)) {
-                // @ts-ignore unsubcribe is a valid function
+                settled = true
+                // @ts-ignore unsubscribe is a valid function
                 unsubscribe()
                 resolve(action.payload.txHash)
               } else if (onInAppRequestFailed.match(action)) {
-                // @ts-ignore unsubcribe is a valid function
+                settled = true
+                // @ts-ignore unsubscribe is a valid function
                 unsubscribe()
                 reject(action.payload.error)
               }
@@ -82,6 +101,43 @@ export const createInAppRequest = (dispatch: Dispatch): Request => {
           }
         })
       )
+
+      if (signal) {
+        signal.addEventListener(
+          'abort',
+          () => {
+            if (settled) return
+            settled = true
+            // @ts-ignore unsubscribe is a valid function
+            unsubscribe()
+            // Propagate a rejection so any handler currently sitting on the
+            // approval screen (e.g. eth_sendTransaction) short-circuits
+            // before broadcasting. The handler's machinery will dispatch
+            // onInAppRequestFailed, but the listener above is already
+            // `settled` so our reject() only fires once.
+            //
+            // Known race (Phase 3 Stage B): if the user has already tapped
+            // Approve and `handleRequestInternally` has matched the approval
+            // action, the handler's `approve(...)` path (which signs and
+            // broadcasts) is already running and this dispatch is dropped.
+            // Fully closing the window requires plumbing AbortSignal into
+            // WalletService.sign and the VM-module broadcast path — out of
+            // scope for this phase. The window we DO close: user opens an
+            // approval modal but has NOT yet tapped Approve when navigation
+            // happens.
+            dispatch(
+              onRequestRejected({
+                request: inAppRequest,
+                error: providerErrors.userRejectedRequest() as Parameters<
+                  typeof onRequestRejected
+                >[0]['error']
+              })
+            )
+            reject(providerErrors.userRejectedRequest())
+          },
+          { once: true }
+        )
+      }
     })
   }
 }

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -164,10 +164,14 @@ class ApprovalController implements VmModuleApprovalController {
 
   handleGoBackIfNeeded = (): void => {
     const currentRoute = currentRouteStore.getState().currentRoute
+    if (!router.canGoBack()) return
     if (
-      (currentRoute?.endsWith('ledgerReviewTransaction') ||
-        currentRoute?.endsWith('approval')) &&
-      router.canGoBack()
+      currentRoute?.endsWith('ledgerReviewTransaction') ||
+      currentRoute?.endsWith('approval') ||
+      currentRoute?.endsWith('addEthereumChain') ||
+      currentRoute?.endsWith('authorizeInjectedDapp') ||
+      currentRoute?.endsWith('authorizeDapp') ||
+      currentRoute?.endsWith('watchAsset')
     ) {
       router.back()
     }


### PR DESCRIPTION
## Description

**Ticket: [CP-]**

Phase 3 Stage B of the injected-provider modernization plan (§6.5). Closes the stale-approval attack: user triggers a signing request on dApp A, navigates away without approving, returns later and taps Approve — transaction broadcasts.

After this PR, on cross-origin navigation:
1. In-flight handlers (`eth_sendTransaction`, `personal_sign`, `eth_signTypedData_*`, `wallet_addEthereumChain`, `wallet_watchAsset`) are aborted via `AbortSignal` threaded through `createInAppRequest`. The abort dispatches `onRequestRejected` into the RPC slice, short-circuiting the handler before it broadcasts (assuming the user has NOT yet tapped Approve).
2. The in-flight connect approval (`wallet_requestAccounts` / `wallet_requestPermissions` parked promise) is rejected.
3. `ApprovalController.handleGoBackIfNeeded` dismisses the stale approval screen across the five relevant modal routes.

**Same-origin SPA nav (pushState/replaceState within `uniswap.org`) is preserved** — no cleanup fires. The gate is `prevOrigin && prevOrigin !== newOrigin`.

**Stacked on #3786** (Stage A origin hardening). Base will change to `main` after #3786 merges.

## Known race (documented inline)

If the user has already tapped Approve and `handleRequestInternally` has consumed the approval action, the VM module's sign + broadcast path is already running and this dispatch is dropped. Fully closing the window requires plumbing `AbortSignal` into `WalletService.sign` and the VM-module broadcast path — out of scope for this phase. The window we DO close: user opens an approval modal but has NOT yet tapped Approve when navigation happens. See the inline comment in `createInAppRequest.ts:135-145`.

## Summary of changes

- **MODIFIED `app/store/rpc/utils/createInAppRequest.ts`** — added optional `signal?: AbortSignal` to the `Request` type. On abort: unsubscribe listener, dispatch `onRequestRejected({request, error: userRejectedRequest})`, reject the Promise. A `settled` flag + `{ once: true }` listener prevent double-firing. Synchronous `signal.aborted` at entry → reject immediately, no dispatch.
- **NEW `app/store/rpc/utils/createInAppRequest.test.ts`** — 5 tests covering: pre-aborted signal, mid-flight abort, abort-then-success race (settled guard), normal success-then-abort, handler-dispatched failure.
- **MODIFIED `app/hooks/browser/injectedProvider/router.ts`** — router tracks `Map<id, {origin, controller}>` for every async handler that awaits `requestSigning`. `dispatchSigningRequest`, `handleAddEthereumChain`, `handleWatchAsset` pass `controller.signal` into the signing call and clean up in `finally`. New `cancelByOrigin(currentOrigin)` method aborts all entries whose origin doesn't match.
- **MODIFIED `app/hooks/browser/injectedProvider/router.test.ts`** — added `describe('cancelByOrigin')` with 4 tests (cross-origin aborts, same-origin preserves, empty-map no-op, cleanup correctness). Updated one existing signing test to accept `signal` in the call args.
- **MODIFIED `app/hooks/browser/useEvmInjectedProvider.ts`** — `setCurrentUrl` now detects origin change and calls `router.cancelByOrigin + prevInflightConnectReject + approvalController.handleGoBackIfNeeded`. Router is accessed via a `routerRef` because `setCurrentUrl` is defined before the router's `useMemo`.
- **MODIFIED `app/hooks/browser/useEvmInjectedProvider.test.ts`** — added mocks for `expo-router` and `approvalController`, new `describe('setCurrentUrl origin-change cleanup')` with 2 tests (cross-origin aborts, same-origin preserves). Updated one existing signing-dispatch test to use `objectContaining`.
- **MODIFIED `app/vmModule/ApprovalController/ApprovalController.ts`** — `handleGoBackIfNeeded` route list extended from `{ledgerReviewTransaction, approval}` to also include `addEthereumChain`, `authorizeInjectedDapp`, `authorizeDapp`, `watchAsset`. Existing callsites unaffected (they fire from inside `/approval` or `/ledgerReviewTransaction`).

## Screenshots/Videos

No UI changes. User-visible difference: opening an approval modal on dApp A, then navigating to dApp B via the URL bar, now dismisses the modal automatically. The dApp A tab receives a `4001` rejection for the in-flight request.

## Testing

**Unit tests (all green):**
- `createInAppRequest.test.ts` — 5/5 ✅
- `router.test.ts` — 39/39 ✅
- `useEvmInjectedProvider.test.ts` — 72/72 ✅ (was 70, added 2)
- Full `app/hooks/browser/` + `app/store/rpc/` — 351/351 ✅

**Static:**
- `yarn tsc` — passes
- `yarn lint` — clean on touched files

**Manual dev testing:**

1. Rebuild the app. Open the in-app browser, navigate to a dApp (e.g. opensea.io). Trigger a signing request → approval modal appears.
2. Without tapping Approve or Cancel, type a different URL in the address bar (e.g. app.uniswap.org) and navigate.
3. ✅ **Expected:** Approval modal dismisses automatically. The opensea.io tab's request receives `4001 user rejected`.
4. Alternative: swipe back to the prior tab, tap the dApp's Connect button → the grant check runs fresh, no stale modal reappears.
5. **Regression check — same-origin SPA nav:** open Uniswap → tap Swap, then tap Pool (same origin, different route) — any open approval modals should persist (SPA soft-nav doesn't count as origin change).
6. **Ledger flow:** trigger a signing request, open the Ledger review screen, then navigate away — the Ledger screen should dismiss (it's in the extended route list).

## Checklist

- [x] Self-review
- [x] Verified unit tests pass
- [x] Added testing steps
- [x] Added/updated necessary unit tests
- [ ] Included screenshots / videos of android and ios (no UI change beyond dismissal; happy to capture the dismissal behavior)
- [ ] Updated documentation