### PR TITLE
Return all granted addresses for a domain instead of just the active one

### DIFF
--- a/packages/core-mobile/app/hooks/browser/injectedProvider/resolveGrantedAccounts.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/resolveGrantedAccounts.test.ts
@@ -1,0 +1,35 @@
+import { resolveGrantedAccounts } from './resolveGrantedAccounts'
+
+describe('resolveGrantedAccounts', () => {
+  it('returns an empty list when nothing is granted', () => {
+    expect(resolveGrantedAccounts([], '0xActive')).toEqual([])
+    expect(resolveGrantedAccounts([], undefined)).toEqual([])
+  })
+
+  it('sorts the active address first when it is in the granted set', () => {
+    expect(
+      resolveGrantedAccounts(['0xOther', '0xActive', '0xAnother'], '0xActive')
+    ).toEqual(['0xActive', '0xOther', '0xAnother'])
+  })
+
+  it('returns the granted list unchanged when active is absent', () => {
+    expect(
+      resolveGrantedAccounts(['0xOther', '0xAnother'], '0xActive')
+    ).toEqual(['0xOther', '0xAnother'])
+  })
+
+  it('returns the granted list unchanged when active is undefined', () => {
+    expect(resolveGrantedAccounts(['0xA', '0xB'], undefined)).toEqual([
+      '0xA',
+      '0xB'
+    ])
+  })
+
+  it('is case-sensitive on the active-address comparison', () => {
+    // Documents current behavior — case normalization is intentionally
+    // deferred to the permissions slice (see reviewer issue Q9 in Phase 3c).
+    expect(
+      resolveGrantedAccounts(['0xABC', '0xDEF'], '0xabc')
+    ).toEqual(['0xABC', '0xDEF'])
+  })
+})

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/resolveGrantedAccounts.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/resolveGrantedAccounts.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared ordering rule for granted addresses returned to a dApp.
+ *
+ * Used by both the router's EIP-2255 handlers and the hook's
+ * `handleDomainMetadata` prime path so the two sites always produce the
+ * same accounts-list shape.
+ *
+ * Rules:
+ * - Empty granted list → `[]` (caller typically falls through to a prompt).
+ * - Active address present in the granted set → active sorted first, other
+ *   granted addresses follow in their original slice order.
+ * - Active address not in the granted set → granted list returned as-is.
+ */
+export function resolveGrantedAccounts(
+  granted: string[],
+  active: string | undefined
+): string[] {
+  if (granted.length === 0) return []
+  if (active && granted.includes(active)) {
+    return [active, ...granted.filter(addr => addr !== active)]
+  }
+  return granted
+}

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -36,7 +36,7 @@ type MockDeps = {
   trackPendingOrigin: jest.Mock
   setBrowserNetworkSpy: jest.Mock
   currentNetwork: { value: BrowserNetwork }
-  hasPermission: jest.Mock
+  getGrantedAddresses: jest.Mock
   grantPermission: jest.Mock
   revokePermission: jest.Mock
   requestConnectApproval: jest.Mock
@@ -53,6 +53,7 @@ function makeDeps(overrides?: {
   tabId?: string
   activeAccount?: Account | undefined
   hasPermission?: boolean
+  grantedAddresses?: string[]
 }): MockDeps {
   const currentNetwork = {
     value: overrides?.browserNetwork ?? {
@@ -79,7 +80,13 @@ function makeDeps(overrides?: {
   const setBrowserNetworkSpy = jest.fn((net: BrowserNetwork) => {
     currentNetwork.value = net
   })
-  const hasPermission = jest.fn(() => overrides?.hasPermission ?? false)
+  // `hasPermission: true` is kept as a shorthand for "grant exists for the
+  // active account" — it maps to `grantedAddresses = [MOCK_ADDR]` under the
+  // hood. Callers can pass `grantedAddresses` explicitly for finer control.
+  const defaultGranted =
+    overrides?.grantedAddresses ??
+    (overrides?.hasPermission ? [MOCK_ADDR] : [])
+  const getGrantedAddresses = jest.fn(() => defaultGranted)
   const grantPermission = jest.fn()
   const revokePermission = jest.fn()
   const requestConnectApproval = jest.fn()
@@ -111,7 +118,7 @@ function makeDeps(overrides?: {
       icons: []
     }),
     getActiveAccount: () => activeAccount.value,
-    hasPermission,
+    getGrantedAddresses,
     grantPermission,
     revokePermission,
     requestConnectApproval
@@ -124,7 +131,7 @@ function makeDeps(overrides?: {
     requestSigning,
     dispatch,
     trackPendingOrigin,
-    hasPermission,
+    getGrantedAddresses,
     grantPermission,
     revokePermission,
     requestConnectApproval,
@@ -463,6 +470,41 @@ describe('createInjectedProviderRouter', () => {
       await new Promise(r => setImmediate(r))
 
       expect(sendResponse).toHaveBeenCalledWith(1, rejection, undefined)
+    })
+
+    it('returns ALL granted addresses (active sorted first) even when the active account is a different one', async () => {
+      // Scenario: grant was made for address X; user later switched active
+      // account to Y. Prior behavior: re-prompt (since Y is not granted).
+      // Phase 3 Stage C: return [X] — no prompt, no re-auth.
+      const OTHER_GRANTED = '0xSomePreviouslyGrantedAddr'
+      const { deps, sendResponse, requestConnectApproval } = makeDeps({
+        activeAccount: { addressC: MOCK_ADDR } as Account,
+        grantedAddresses: [OTHER_GRANTED] // active addr NOT in granted list
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'eth_requestAccounts')
+      await new Promise(r => setImmediate(r))
+
+      expect(requestConnectApproval).not.toHaveBeenCalled()
+      expect(sendResponse).toHaveBeenCalledWith(1, null, [OTHER_GRANTED])
+    })
+
+    it('sorts the active address first when it is among the granted set', async () => {
+      const { deps, sendResponse } = makeDeps({
+        activeAccount: { addressC: MOCK_ADDR } as Account,
+        grantedAddresses: ['0xOtherGranted', MOCK_ADDR, '0xAnotherGranted']
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 1, 'eth_requestAccounts')
+      await new Promise(r => setImmediate(r))
+
+      expect(sendResponse).toHaveBeenCalledWith(1, null, [
+        MOCK_ADDR,
+        '0xOtherGranted',
+        '0xAnotherGranted'
+      ])
     })
 
     it('rejects with unauthorized (4100) when there is no active account', async () => {

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -9,6 +9,7 @@ import {
   ProviderRequest,
   RouterDeps
 } from './types'
+import { resolveGrantedAccounts } from './resolveGrantedAccounts'
 
 const READ_ONLY_METHODS = new Set([
   'eth_blockNumber',
@@ -154,7 +155,7 @@ export function createInjectedProviderRouter(
     trackPendingOrigin,
     getPeerMeta,
     getActiveAccount,
-    hasPermission,
+    getGrantedAddresses,
     grantPermission,
     revokePermission,
     requestConnectApproval
@@ -343,19 +344,18 @@ export function createInjectedProviderRouter(
     }
   }
 
-  // EIP-2255: resolve permissions for the current origin against the active
-  // EVM account. Today only `eth_accounts` is supported — there is no notion
-  // of a restricted method beyond account access.
-  const resolveActiveAccountAddresses = (origin: string): string[] => {
-    const active = getActiveAccount()
-    if (!active?.addressC) return []
-    const granted = hasPermission({
-      domain: origin,
-      address: active.addressC,
-      vmType: NetworkVMType.EVM
-    })
-    return granted ? [active.addressC] : []
-  }
+  // EIP-2255: resolve the EVM-granted addresses for the current origin. All
+  // granted addresses are returned — not just the active account — so that
+  // switching wallets doesn't force the dApp to re-prompt. If the active
+  // account is among the granted set, it's sorted first so the dApp's
+  // "primary" address view matches the wallet's active selection. The
+  // ordering rule lives in a shared helper so the hook's `handleDomainMetadata`
+  // prime path produces exactly the same list.
+  const resolveGrantedAddresses = (origin: string): string[] =>
+    resolveGrantedAccounts(
+      getGrantedAddresses({ domain: origin, vmType: NetworkVMType.EVM }),
+      getActiveAccount()?.addressC
+    )
 
   const handleRequestAccounts = async (id: number): Promise<void> => {
     const origin = getNativeOrigin()
@@ -377,15 +377,13 @@ export function createInjectedProviderRouter(
       return
     }
 
-    // Already connected: return without prompting.
-    if (
-      hasPermission({
-        domain: origin,
-        address: active.addressC,
-        vmType: NetworkVMType.EVM
-      })
-    ) {
-      sendResponse(id, null, [active.addressC])
+    // Already connected to any address at this origin: return without
+    // prompting. The granted-address list may include addresses other than
+    // the currently-active one — that's intentional, per the multi-account
+    // design in §6.2 (Phase 3 Stage C).
+    const alreadyGranted = resolveGrantedAddresses(origin)
+    if (alreadyGranted.length > 0) {
+      sendResponse(id, null, alreadyGranted)
       return
     }
 
@@ -439,14 +437,9 @@ export function createInjectedProviderRouter(
       return
     }
 
-    const alreadyGranted = hasPermission({
-      domain: origin,
-      address: active.addressC,
-      vmType: NetworkVMType.EVM
-    })
-
-    if (alreadyGranted) {
-      sendResponse(id, null, buildAccountsPermission([active.addressC]))
+    const alreadyGranted = resolveGrantedAddresses(origin)
+    if (alreadyGranted.length > 0) {
+      sendResponse(id, null, buildAccountsPermission(alreadyGranted))
       return
     }
 
@@ -484,7 +477,7 @@ export function createInjectedProviderRouter(
     sendResponse(
       id,
       null,
-      buildAccountsPermission(resolveActiveAccountAddresses(origin))
+      buildAccountsPermission(resolveGrantedAddresses(origin))
     )
   }
 

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/types.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/types.ts
@@ -48,12 +48,16 @@ export type RouterDeps = {
   getPeerMeta: () => PeerMeta | undefined
   getActiveAccount: () => Account | undefined
 
-  // Permissions
-  hasPermission: (args: {
+  /**
+   * Every address at `domain` granted for `vmType`. Used by
+   * `wallet_getPermissions` / `eth_requestAccounts` so that switching the
+   * active wallet account does not spuriously disconnect a dApp that was
+   * previously authorized for some other address.
+   */
+  getGrantedAddresses: (args: {
     domain: string
-    address: string
     vmType: NetworkVMType
-  }) => boolean
+  }) => string[]
   grantPermission: (args: {
     domain: string
     address: string

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -1315,6 +1315,23 @@ describe('useEvmInjectedProvider', () => {
           subscribe: jest.fn(() => () => undefined)
         } as unknown as ReturnType<typeof useStore>)
 
+      const withPermissions = (
+        addresses: string[]
+      ): ReturnType<typeof useStore> =>
+        ({
+          getState: () => ({
+            permissions: {
+              grants: {
+                'https://opensea.io': Object.fromEntries(
+                  addresses.map(a => [a, ['EVM']])
+                )
+              }
+            }
+          }),
+          dispatch: jest.fn(),
+          subscribe: jest.fn(() => () => undefined)
+        } as unknown as ReturnType<typeof useStore>)
+
       it('injects accountsChanged([address]) when the origin has a grant for the active account', () => {
         mockUseStore.mockReturnValue(withPermission(mockActiveAccount.addressC))
         const { result } = renderProvider()
@@ -1380,6 +1397,52 @@ describe('useEvmInjectedProvider', () => {
 
         expect(mockInjectJavaScript).not.toHaveBeenCalledWith(
           expect.stringContaining("__coreProviderEmit('accountsChanged'")
+        )
+      })
+
+      it('emits all granted addresses (active sorted first) — multi-account aware', () => {
+        // Grant exists for both active and another address; active is second
+        // in insertion order but should be first in the emitted list.
+        const OTHER = '0xOtherGranted111'
+        mockUseStore.mockReturnValue(
+          withPermissions([OTHER, mockActiveAccount.addressC])
+        )
+        const { result } = renderProvider()
+        act(() => {
+          result.current.setCurrentUrl('https://opensea.io/')
+        })
+        mockInjectJavaScript.mockClear()
+
+        act(() => {
+          result.current.handleDomainMetadata(metadata)
+        })
+
+        expect(mockInjectJavaScript).toHaveBeenCalledWith(
+          expect.stringContaining(
+            `__coreProviderEmit('accountsChanged', ["${mockActiveAccount.addressC}","${OTHER}"])`
+          )
+        )
+      })
+
+      it('emits granted addresses unchanged when active account is NOT in the granted set', () => {
+        // User switched wallet to account Y; only X was previously granted.
+        // Emit [X] so the dApp keeps the connection it already had.
+        const ONLY_OTHER = '0xOnlyOtherAddr'
+        mockUseStore.mockReturnValue(withPermissions([ONLY_OTHER]))
+        const { result } = renderProvider()
+        act(() => {
+          result.current.setCurrentUrl('https://opensea.io/')
+        })
+        mockInjectJavaScript.mockClear()
+
+        act(() => {
+          result.current.handleDomainMetadata(metadata)
+        })
+
+        expect(mockInjectJavaScript).toHaveBeenCalledWith(
+          expect.stringContaining(
+            `__coreProviderEmit('accountsChanged', ["${ONLY_OTHER}"])`
+          )
         )
       })
     })

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -16,7 +16,7 @@ import { approvalController } from 'vmModule/ApprovalController/ApprovalControll
 import {
   grantPermission as grantPermissionAction,
   revokePermission as revokePermissionAction,
-  selectHasPermission
+  selectGrantedAddressesForDomain
 } from 'store/permissions/slice'
 import type { RootState } from 'store/types'
 import type { Account } from 'store/account'
@@ -26,6 +26,7 @@ import {
   createInjectedProviderRouter,
   InjectedProviderRouter
 } from './injectedProvider/router'
+import { resolveGrantedAccounts } from './injectedProvider/resolveGrantedAccounts'
 import {
   BrowserNetwork,
   DomainMetadata,
@@ -292,8 +293,8 @@ export function useEvmInjectedProvider(
       },
       getPeerMeta,
       getActiveAccount: () => activeAccountRef.current,
-      hasPermission: ({ domain, address, vmType }) =>
-        selectHasPermission({ domain, address, vmType })(store.getState()),
+      getGrantedAddresses: ({ domain, vmType }) =>
+        selectGrantedAddressesForDomain({ domain, vmType })(store.getState()),
       grantPermission: ({ domain, address, vmType }) =>
         dispatch(grantPermissionAction({ domain, address, vmType })),
       revokePermission: ({ domain, address, vmType }) =>
@@ -322,21 +323,21 @@ export function useEvmInjectedProvider(
         Logger.error('[InjectedProvider] Invalid domain_metadata payload')
       }
 
-      // Prime the shim's _accounts cache on page load: if the current origin
-      // already has an EVM grant for the active account, emit accountsChanged
-      // so dApps with auto-reconnect (wagmi autoConnect, etc.) see the
-      // connection immediately without prompting. If no grant exists, emit
-      // an empty array to keep the shim in sync (e.g. after the user revoked
-      // the grant from Connected Sites while the tab was open).
+      // Prime the shim's _accounts cache on page load. Emit the full list
+      // of EVM-granted addresses for this origin (active sorted first if
+      // present) so dApps auto-reconnect against whatever was previously
+      // approved — even when the user has since switched the wallet's
+      // active account to a different one. If the grant set is empty, emit
+      // [] to keep the shim in sync (e.g. after the user revoked the grant
+      // via Connected Sites while the tab was open).
       const origin = getOriginFromUrl(currentUrlRef.current)
       const active = activeAccountRef.current
       if (!origin || !active?.addressC) return
-      const granted = selectHasPermission({
+      const granted = selectGrantedAddressesForDomain({
         domain: origin,
-        address: active.addressC,
         vmType: NetworkVMType.EVM
       })(store.getState())
-      const accounts = granted ? [active.addressC] : []
+      const accounts = resolveGrantedAccounts(granted, active.addressC)
       webViewRef.current?.injectJavaScript(
         `window.__coreProviderEmit && window.__coreProviderEmit('accountsChanged', ${JSON.stringify(
           accounts

--- a/packages/core-mobile/app/store/permissions/slice.test.ts
+++ b/packages/core-mobile/app/store/permissions/slice.test.ts
@@ -7,6 +7,7 @@ import {
   revokePermission,
   selectAddressesForDomain,
   selectConnectedDomains,
+  selectGrantedAddressesForDomain,
   selectGrantsForDomain,
   selectHasPermission
 } from './slice'
@@ -275,6 +276,54 @@ describe('permissions slice', () => {
     it('selectAddressesForDomain returns that domain\'s address keys', () => {
       expect(selectAddressesForDomain(DOMAIN_UNI)(state)).toEqual([ADDR_A])
       expect(selectAddressesForDomain('https://nope.test')(state)).toEqual([])
+    })
+
+    describe('selectGrantedAddressesForDomain', () => {
+      const multiVmState = buildRootState({
+        grants: {
+          [DOMAIN_UNI]: {
+            [ADDR_A]: [NetworkVMType.EVM, NetworkVMType.SVM],
+            [ADDR_B]: [NetworkVMType.SVM] // EVM-granted only for A
+          },
+          [DOMAIN_OS]: {
+            [ADDR_A]: [NetworkVMType.EVM],
+            [ADDR_B]: [NetworkVMType.EVM]
+          }
+        }
+      })
+
+      it('filters to only addresses granted for the requested vmType', () => {
+        expect(
+          selectGrantedAddressesForDomain({
+            domain: DOMAIN_UNI,
+            vmType: NetworkVMType.EVM
+          })(multiVmState)
+        ).toEqual([ADDR_A])
+      })
+
+      it('returns multiple addresses when several are granted for the vm', () => {
+        expect(
+          selectGrantedAddressesForDomain({
+            domain: DOMAIN_OS,
+            vmType: NetworkVMType.EVM
+          })(multiVmState)
+        ).toEqual(expect.arrayContaining([ADDR_A, ADDR_B]))
+      })
+
+      it('returns empty for unknown domain or un-granted vmType', () => {
+        expect(
+          selectGrantedAddressesForDomain({
+            domain: 'https://none.test',
+            vmType: NetworkVMType.EVM
+          })(multiVmState)
+        ).toEqual([])
+        expect(
+          selectGrantedAddressesForDomain({
+            domain: DOMAIN_OS,
+            vmType: NetworkVMType.SVM
+          })(multiVmState)
+        ).toEqual([])
+      })
     })
   })
 })

--- a/packages/core-mobile/app/store/permissions/slice.ts
+++ b/packages/core-mobile/app/store/permissions/slice.ts
@@ -116,6 +116,26 @@ export const selectAddressesForDomain =
     return Object.keys(domainGrants)
   }
 
+/**
+ * Returns every address under `domain` that has been granted access for the
+ * given `vmType`. Used by the injected provider to answer
+ * `wallet_getPermissions` / `eth_requestAccounts` with the full authorized
+ * set rather than only the currently-active account — so switching the
+ * wallet's active account does not force the user to re-grant the dApp.
+ */
+export const selectGrantedAddressesForDomain =
+  ({ domain, vmType }: { domain: Domain; vmType: NetworkVMType }) =>
+  (state: RootState): Address[] => {
+    const domainGrants = state.permissions.grants[domain]
+    if (!domainGrants) return []
+    const granted: Address[] = []
+    for (const address of Object.keys(domainGrants)) {
+      const vmTypes = domainGrants[address]
+      if (vmTypes?.includes(vmType)) granted.push(address)
+    }
+    return granted
+  }
+
 export const {
   grantPermission,
   revokePermission,

--- a/packages/core-mobile/app/store/rpc/utils/createInAppRequest.test.ts
+++ b/packages/core-mobile/app/store/rpc/utils/createInAppRequest.test.ts
@@ -192,7 +192,11 @@ describe('createInAppRequest', () => {
     const err = { code: 4001, message: 'user rejected' }
     mockListenerEffects.forEach(effect =>
       effect(
-        onInAppRequestFailed({ requestId: FIXED_REQUEST_ID, error: err })
+        onInAppRequestFailed({
+          requestId: FIXED_REQUEST_ID,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          error: err as any
+        })
       )
     )
 


### PR DESCRIPTION
## Description

**Ticket: [CP-]**

Phase 3 Stage C of the injected-provider modernization plan. Closes reviewer finding **I3** from the Phase 1(b) review: the injected provider previously only considered the **currently active wallet account** when answering connection queries. Result: if a user connected dApp A with wallet account W1, then switched to W2 in the wallet UI, the dApp would call `eth_accounts` / `eth_requestAccounts` and see \`[]\` — prompting again (spurious re-auth).

After this PR, `eth_requestAccounts`, `wallet_requestPermissions`, `wallet_getPermissions`, and the page-load prime path return the **full list of EVM-granted addresses for the origin** (active sorted first if present). Switching the wallet's active account no longer disconnects the dApp from the previously-granted address(es).

Stacked on #3787 (Phase 3 Stage B lifecycle cleanup). Base moves to main as the stack lands.

## Summary of changes

- **`app/store/permissions/slice.ts`** — added `selectGrantedAddressesForDomain({domain, vmType}) → string[]`. Filters the domain's address map to those whose vmType list includes the requested vmType.
- **`app/store/permissions/slice.test.ts`** — 3 tests on the new selector (single grant, multi-address, unknown domain / un-granted vmType).
- **NEW `app/hooks/browser/injectedProvider/resolveGrantedAccounts.ts`** — shared helper implementing the active-first ordering rule. Used by both the router and the hook's prime path so they never drift.
- **NEW `app/hooks/browser/injectedProvider/resolveGrantedAccounts.test.ts`** — 5 tests covering empty, active-in-set, active-not-in-set, missing active, and case sensitivity (documents current behavior).
- **`app/hooks/browser/injectedProvider/types.ts`** — added `getGrantedAddresses(args)` to `RouterDeps`. Removed the now-unused `hasPermission` dep.
- **`app/hooks/browser/injectedProvider/router.ts`** — replaced `resolveActiveAccountAddresses` with `resolveGrantedAddresses` (uses the shared helper). `handleRequestAccounts`, `handleRequestPermissions`, `handleGetPermissions` now short-circuit when the granted-addresses list is non-empty, not just when the active account is granted.
- **`app/hooks/browser/injectedProvider/router.test.ts`** — added 2 tests that lock in the new behavior: returns granted addresses even when the active account differs; sorts active-first when it's in the set. Mock deps updated to drop `hasPermission` and add `getGrantedAddresses`.
- **`app/hooks/browser/useEvmInjectedProvider.ts`** — wired `selectGrantedAddressesForDomain` as the `getGrantedAddresses` dep. Updated `handleDomainMetadata` prime path to emit the full granted list via `resolveGrantedAccounts`. Removed the now-unused `selectHasPermission` import.
- **`app/hooks/browser/useEvmInjectedProvider.test.ts`** — added 2 prime-path tests for multi-grant + active-in-set and grant-only-for-non-active cases.
- **`app/store/rpc/utils/createInAppRequest.test.ts`** — minor type cast fix for a pre-existing `RpcError` assertion the reviewer caught.

## Behavioral change (user-visible)

- Connect dApp with W1, switch wallet to W2, re-visit dApp: dApp still shows connected to W1. No re-prompt.
- dApp `eth_accounts` returns `[W1]`. User's wallet active account is W2 but the dApp's view stays on W1.
- If the user wants to grant W2 too, a fresh `wallet_requestPermissions` or `eth_requestAccounts` call (triggered by an explicit dApp Connect button click) still prompts — because only W1 is in the granted set; the hook returns the existing grant, and new grants are written only after the user taps Connect in the approval modal.

## Testing

- `yarn tsc` — ✅
- `yarn test app/hooks/browser/ app/store/permissions/ app/store/rpc/` — 378/378 ✅
- New / updated test counts: permissions slice 18/18, router 41/41, createInAppRequest 5/5, resolveGrantedAccounts 5/5 (new), useEvmInjectedProvider 180/180.

**Manual dev testing:**

1. Rebuild the app. Open in-app browser, connect to Uniswap with wallet account A. Verify dApp shows A.
2. In the wallet UI (Portfolio tab → account switcher), switch active account to B.
3. Return to the Uniswap tab and refresh the page.
4. ✅ **Expected:** Uniswap still shows connected to A. No approval modal. No "connect wallet" button.
5. Open a new tab, navigate to Uniswap, tap Connect Wallet → our modal opens. Pick account B, tap Connect.
6. ✅ **Expected:** Original tab now has BOTH A and B granted. Refreshing either tab shows the active account sorted first.

## Checklist

- [x] Self-review
- [x] Verified unit tests pass
- [x] Added testing steps
- [x] Added/updated necessary unit tests
- [ ] Included screenshots / videos of android and ios
- [ ] Updated documentation