### PR TITLE
CP-14122: auto-advance to next quote on provider-specific fee errors

### DIFF
--- a/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
+++ b/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
@@ -16,7 +16,7 @@ import { selectActiveAccount } from 'store/account'
 import { getAddressByNetwork } from 'store/account/utils'
 import { useNetworks } from 'hooks/networks/useNetworks'
 import AnalyticsService from 'services/analytics/AnalyticsService'
-import { transactionSnackbar } from 'common/utils/toast'
+import { showSnackbar, transactionSnackbar } from 'common/utils/toast'
 import Logger from 'utils/Logger'
 import {
   selectMarkrSwapMaxRetries,
@@ -41,6 +41,7 @@ import {
   getSwapErrorMessage
 } from '../utils/fusionErrors'
 import { trackFusionTransfer } from '../store/actions'
+import { findNextQuote } from '../utils/findNextQuote'
 import { logSdkError } from '../utils/fusionLogger'
 
 const DEFAULT_SLIPPAGE = 0.2
@@ -381,16 +382,20 @@ export const SwapContextProvider = ({
           allQuotes.length > 1 &&
           shouldRetryWithNextQuote(error)
         ) {
-          const currentIndex = allQuotes.findIndex(q => q.id === quoteToUse.id)
-          const nextQuote = allQuotes[currentIndex + 1]
+          const nextQuote = findNextQuote(allQuotes, quoteToUse.id)
 
           if (nextQuote) {
-            Logger.info('[SwapContext] retrying with next quote:', {
+            Logger.error('[SwapContext] retrying with next quote', {
               failed: quoteToUse.aggregator.name,
+              failedId: quoteToUse.id,
               retrying: nextQuote.aggregator.name,
+              retryingId: nextQuote.id,
               attempt: retries + 1,
-              maxRetries
+              maxRetries,
+              errorMessage:
+                error instanceof Error ? error.message : String(error)
             })
+            showSnackbar('Swap failed, trying next available quote')
             // Recursive retry
             return swap(nextQuote, retries + 1)
           }

--- a/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
+++ b/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
@@ -4,6 +4,7 @@ import React, {
   ReactNode,
   useCallback,
   useContext,
+  useEffect,
   useRef,
   useState,
   useMemo
@@ -29,7 +30,8 @@ import {
   useSwapSelectedFromToken,
   useSwapSelectedToToken,
   useBestQuote,
-  useUserSelectedQuote,
+  useUserSelectedQuoteIds,
+  useAutoAdvancedQuoteIds,
   useAllQuotes,
   useFusionTransfers
 } from '../hooks/useZustandStore'
@@ -43,6 +45,7 @@ import {
 import { trackFusionTransfer } from '../store/actions'
 import { findNextQuote } from '../utils/findNextQuote'
 import { logSdkError } from '../utils/fusionLogger'
+import { matchQuoteByIdentifiers } from '../utils/matchQuoteByIdentifiers'
 
 const DEFAULT_SLIPPAGE = 0.2
 
@@ -60,11 +63,20 @@ interface SwapContextState {
   setToToken: Dispatch<LocalTokenWithBalance | undefined>
   bestQuote: Quote | null
   userQuote: Quote | null
+  /**
+   * Quote promoted by pre-swap auto-advance when the best quote fails fee
+   * validation with a provider-specific error. Distinct from userQuote so
+   * swap-time retry (`!userQuote` gate) and analytics (`quoteSelectionMode`)
+   * aren't affected by an automatic promotion.
+   */
+  autoAdvancedQuote: Quote | null
   allQuotes: Quote[]
   isQuoteLoading: boolean
   quoteError: Error | null
   selectQuoteById: (quoteId: string | null) => void
-  swap(): Promise<void>
+  /** Promote a quote to the active position without marking it as a user pick. */
+  advanceBestQuote: (quoteId: string) => void
+  swap(quote: Quote): Promise<void>
   slippage: number
   setSlippage: Dispatch<number>
   autoSlippage: boolean
@@ -101,33 +113,33 @@ export const SwapContextProvider = ({
 
   // Get quotes
   const [bestQuote] = useBestQuote()
-  const [selectedQuote, setSelectedQuote] = useUserSelectedQuote()
+  const [userSelectedQuoteIds, setUserSelectedQuoteIds] =
+    useUserSelectedQuoteIds()
+  const [autoAdvancedQuoteIds, setAutoAdvancedQuoteIds] =
+    useAutoAdvancedQuoteIds()
   const [allQuotes] = useAllQuotes()
 
   // Transfer storage
   const { setTransfers } = useFusionTransfers()
 
-  // Derive the actual selected quote from allQuotes with fallback matching
-  // Strategy:
-  // 1. Try to match by exact quoteId (preferred - same quote after refresh)
-  // 2. Fallback to serviceType + aggregatorId (same provider after refresh)
-  // This ensures quote selection persists across quote updates (slippage/expiry)
-  const userQuote = useMemo(() => {
-    if (!selectedQuote) return null
+  // Resolve identifiers → Quote with fallback matching, so both manual and
+  // auto-advanced selections stay sticky across quote refreshes.
+  const userQuote = useMemo(
+    () => matchQuoteByIdentifiers(userSelectedQuoteIds, allQuotes),
+    [userSelectedQuoteIds, allQuotes]
+  )
 
-    // Try exact match first
-    const exactMatch = allQuotes.find(q => q.id === selectedQuote.quoteId)
-    if (exactMatch) return exactMatch
+  // When the token pair changes, drop any stale auto-advanced identifier —
+  // the previous pair's provider selection shouldn't influence the new pair's
+  // default even if a provider's serviceType+aggregatorId happens to match.
+  useEffect(() => {
+    setAutoAdvancedQuoteIds(null)
+  }, [fromToken?.internalId, toToken?.internalId, setAutoAdvancedQuoteIds])
 
-    // Fallback: match by serviceType + aggregatorId
-    const fallbackMatch = allQuotes.find(
-      q =>
-        q.serviceType === selectedQuote.serviceType &&
-        q.aggregator.id === selectedQuote.aggregatorId
-    )
-
-    return fallbackMatch ?? null
-  }, [selectedQuote, allQuotes])
+  const autoAdvancedQuote = useMemo(
+    () => matchQuoteByIdentifiers(autoAdvancedQuoteIds, allQuotes),
+    [autoAdvancedQuoteIds, allQuotes]
+  )
 
   // Get account and networks
   const activeAccount = useSelector(selectActiveAccount)
@@ -177,30 +189,51 @@ export const SwapContextProvider = ({
     onNoQuotesError
   })
 
-  // Method to select a specific quote or auto mode
+  // Method to select a specific quote or auto mode. Also clears any
+  // auto-advanced selection so the user's explicit choice (or their return
+  // to Auto mode) takes full control.
   const selectQuoteById = useCallback(
     (quoteId: string | null) => {
+      setAutoAdvancedQuoteIds(null)
+
       if (quoteId === null) {
         // Clear selection (Auto mode)
-        setSelectedQuote(null)
+        setUserSelectedQuoteIds(null)
         return
       }
 
       // Find the quote to extract serviceType and aggregatorId
       const quote = allQuotes.find(q => q.id === quoteId)
       if (!quote) {
-        setSelectedQuote(null)
+        setUserSelectedQuoteIds(null)
         return
       }
 
       // Store all identifiers for fallback matching
-      setSelectedQuote({
+      setUserSelectedQuoteIds({
         quoteId: quote.id,
         serviceType: quote.serviceType,
         aggregatorId: quote.aggregator.id
       })
     },
-    [allQuotes, setSelectedQuote]
+    [allQuotes, setUserSelectedQuoteIds, setAutoAdvancedQuoteIds]
+  )
+
+  // Promote a quote to the active position without marking it as a user pick.
+  // Used by the pre-swap auto-advance so swap-time retry (!userQuote gate) and
+  // analytics (quoteSelectionMode) remain correctly classified as 'auto'.
+  const advanceBestQuote = useCallback(
+    (quoteId: string) => {
+      const quote = allQuotes.find(q => q.id === quoteId)
+      if (!quote) return
+
+      setAutoAdvancedQuoteIds({
+        quoteId: quote.id,
+        serviceType: quote.serviceType,
+        aggregatorId: quote.aggregator.id
+      })
+    },
+    [allQuotes, setAutoAdvancedQuoteIds]
   )
 
   // Handle swap success: logging, storage, and analytics
@@ -316,16 +349,12 @@ export const SwapContextProvider = ({
   // Swap execution with retry logic
   const swap = useCallback(
     // eslint-disable-next-line sonarjs/cognitive-complexity
-    async (retryQuote?: Quote, retries = 0) => {
+    async (quote: Quote, retryQuote?: Quote, retries = 0) => {
       // Guard against concurrent swap executions on initial call (ref is synchronous, unlike state)
       if (retries === 0 && isSwappingRef.current) return
 
       // Determine which quote to use (retry or normal flow)
-      const quoteToUse = retryQuote ?? userQuote ?? bestQuote
-
-      if (!quoteToUse) {
-        throw new Error('No quote available')
-      }
+      const quoteToUse = retryQuote ?? quote
 
       if (!fromToken || !toToken) {
         throw new Error('Tokens not selected')
@@ -396,8 +425,8 @@ export const SwapContextProvider = ({
                 error instanceof Error ? error.message : String(error)
             })
             showSnackbar('Swap failed, trying next available quote')
-            // Recursive retry
-            return swap(nextQuote, retries + 1)
+            // Recursive retry — pass the original `quote` through unchanged
+            return swap(quote, nextQuote, retries + 1)
           }
         }
 
@@ -412,7 +441,6 @@ export const SwapContextProvider = ({
       fromAddress,
       toAddress,
       userQuote,
-      bestQuote,
       allQuotes,
       maxRetries,
       transferGasMarginBps,
@@ -428,10 +456,12 @@ export const SwapContextProvider = ({
     setToToken,
     bestQuote,
     userQuote,
+    autoAdvancedQuote,
     allQuotes,
     isQuoteLoading,
     quoteError,
     selectQuoteById,
+    advanceBestQuote,
     swap,
     slippage,
     setSlippage,

--- a/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
+++ b/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
@@ -430,7 +430,7 @@ export const SwapContextProvider = ({
               errorMessage:
                 error instanceof Error ? error.message : String(error)
             })
-            showSnackbar('Swap failed, trying next available quote')
+            showSnackbar('Swap failed, trying next available')
             // Recursive retry — pass the original `quote` through unchanged
             return swap(quote, nextQuote, retries + 1)
           }

--- a/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
+++ b/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
@@ -64,12 +64,13 @@ interface SwapContextState {
   bestQuote: Quote | null
   userQuote: Quote | null
   /**
-   * Quote promoted by pre-swap auto-advance when the best quote fails fee
-   * validation with a provider-specific error. Distinct from userQuote so
-   * swap-time retry (`!userQuote` gate) and analytics (`quoteSelectionMode`)
-   * aren't affected by an automatic promotion.
+   * Effective quote after precedence: userQuote > autoAdvancedQuote >
+   * bestQuote. Single source of truth — consumers should prefer this over
+   * recomputing the chain. autoAdvancedQuote is deliberately kept internal
+   * so the pre-swap auto-advance can't mis-tag analytics or disable
+   * swap-time retry.
    */
-  autoAdvancedQuote: Quote | null
+  activeQuote: Quote | null
   allQuotes: Quote[]
   isQuoteLoading: boolean
   quoteError: Error | null
@@ -134,12 +135,17 @@ export const SwapContextProvider = ({
   // default even if a provider's serviceType+aggregatorId happens to match.
   useEffect(() => {
     setAutoAdvancedQuoteIds(null)
-  }, [fromToken?.internalId, toToken?.internalId, setAutoAdvancedQuoteIds])
+  }, [fromToken?.localId, toToken?.localId, setAutoAdvancedQuoteIds])
 
   const autoAdvancedQuote = useMemo(
     () => matchQuoteByIdentifiers(autoAdvancedQuoteIds, allQuotes),
     [autoAdvancedQuoteIds, allQuotes]
   )
+
+  // Precedence: user manual pick > auto-advanced promotion > stream best.
+  // Centralised so all consumer screens (SwapScreen, pricing/slippage
+  // modals) agree on which quote is currently in use.
+  const activeQuote = userQuote ?? autoAdvancedQuote ?? bestQuote
 
   // Get account and networks
   const activeAccount = useSelector(selectActiveAccount)
@@ -456,7 +462,7 @@ export const SwapContextProvider = ({
     setToToken,
     bestQuote,
     userQuote,
-    autoAdvancedQuote,
+    activeQuote,
     allQuotes,
     isQuoteLoading,
     quoteError,

--- a/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.test.ts
@@ -1,0 +1,329 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { showSnackbar } from 'common/utils/toast'
+import Logger from 'utils/Logger'
+import type { Quote } from '../types'
+import { FusionQuoteError, fusionErrors } from '../utils/fusionErrors'
+import { useAutoAdvanceOnFeeValidationError } from './useAutoAdvanceOnFeeValidationError'
+
+jest.mock('common/utils/toast', () => ({
+  showSnackbar: jest.fn()
+}))
+
+jest.mock('utils/Logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}))
+
+const mockShowSnackbar = jest.mocked(showSnackbar)
+const mockLoggerError = jest.mocked(Logger.error)
+
+const makeQuote = (id: string, aggregatorName = id): Quote =>
+  ({ id, aggregator: { name: aggregatorName } } as unknown as Quote)
+
+const providerSpecificError = (): FusionQuoteError =>
+  fusionErrors.insufficientFundsForFee(undefined)
+const balanceError = (): FusionQuoteError =>
+  fusionErrors.networkFeeExceedsBalance('0.001 AVAX')
+const warningError = (): FusionQuoteError => fusionErrors.gasEstimationFailed()
+
+const DEFAULT_MAX = 3
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('useAutoAdvanceOnFeeValidationError', () => {
+  it('advances to the next quote when the error is provider-specific', () => {
+    const quotes = [makeQuote('a'), makeQuote('b'), makeQuote('c')]
+    const selectQuoteById = jest.fn()
+
+    renderHook(() =>
+      useAutoAdvanceOnFeeValidationError({
+        feeValidationError: providerSpecificError(),
+        activeQuote: quotes[0] as Quote,
+        allQuotes: quotes,
+        selectQuoteById,
+        maxAdvances: DEFAULT_MAX
+      })
+    )
+
+    expect(selectQuoteById).toHaveBeenCalledWith('b')
+    expect(mockShowSnackbar).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs the advance via Logger.error for Sentry reporting', () => {
+    const quotes = [
+      makeQuote('a', 'Markr'),
+      makeQuote('b', 'DeBridge'),
+      makeQuote('c')
+    ]
+    const selectQuoteById = jest.fn()
+
+    renderHook(() =>
+      useAutoAdvanceOnFeeValidationError({
+        feeValidationError: providerSpecificError(),
+        activeQuote: quotes[0] as Quote,
+        allQuotes: quotes,
+        selectQuoteById,
+        maxAdvances: DEFAULT_MAX
+      })
+    )
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1)
+    const [message, context] = mockLoggerError.mock.calls[0] ?? []
+    expect(message).toContain('auto-advanc')
+    expect(context).toMatchObject({
+      failed: 'Markr',
+      retrying: 'DeBridge',
+      attempt: 1,
+      maxAdvances: DEFAULT_MAX
+    })
+  })
+
+  it('does nothing when the error is undefined', () => {
+    const quotes = [makeQuote('a'), makeQuote('b')]
+    const selectQuoteById = jest.fn()
+
+    renderHook(() =>
+      useAutoAdvanceOnFeeValidationError({
+        feeValidationError: undefined,
+        activeQuote: quotes[0] as Quote,
+        allQuotes: quotes,
+        selectQuoteById,
+        maxAdvances: DEFAULT_MAX
+      })
+    )
+
+    expect(selectQuoteById).not.toHaveBeenCalled()
+    expect(mockShowSnackbar).not.toHaveBeenCalled()
+    expect(mockLoggerError).not.toHaveBeenCalled()
+  })
+
+  it('does nothing for balance-threshold errors', () => {
+    const quotes = [makeQuote('a'), makeQuote('b')]
+    const selectQuoteById = jest.fn()
+
+    renderHook(() =>
+      useAutoAdvanceOnFeeValidationError({
+        feeValidationError: balanceError(),
+        activeQuote: quotes[0] as Quote,
+        allQuotes: quotes,
+        selectQuoteById,
+        maxAdvances: DEFAULT_MAX
+      })
+    )
+
+    expect(selectQuoteById).not.toHaveBeenCalled()
+    expect(mockShowSnackbar).not.toHaveBeenCalled()
+  })
+
+  it('does nothing for warning errors (Next already enabled)', () => {
+    const quotes = [makeQuote('a'), makeQuote('b')]
+    const selectQuoteById = jest.fn()
+
+    renderHook(() =>
+      useAutoAdvanceOnFeeValidationError({
+        feeValidationError: warningError(),
+        activeQuote: quotes[0] as Quote,
+        allQuotes: quotes,
+        selectQuoteById,
+        maxAdvances: DEFAULT_MAX
+      })
+    )
+
+    expect(selectQuoteById).not.toHaveBeenCalled()
+    expect(mockShowSnackbar).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the active quote is already the last one', () => {
+    const quotes = [makeQuote('a'), makeQuote('b')]
+    const selectQuoteById = jest.fn()
+
+    renderHook(() =>
+      useAutoAdvanceOnFeeValidationError({
+        feeValidationError: providerSpecificError(),
+        activeQuote: quotes[1] as Quote,
+        allQuotes: quotes,
+        selectQuoteById,
+        maxAdvances: DEFAULT_MAX
+      })
+    )
+
+    expect(selectQuoteById).not.toHaveBeenCalled()
+    expect(mockShowSnackbar).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the active quote is not present in allQuotes', () => {
+    const quotes = [makeQuote('a'), makeQuote('b')]
+    const selectQuoteById = jest.fn()
+
+    renderHook(() =>
+      useAutoAdvanceOnFeeValidationError({
+        feeValidationError: providerSpecificError(),
+        activeQuote: makeQuote('stale'),
+        allQuotes: quotes,
+        selectQuoteById,
+        maxAdvances: DEFAULT_MAX
+      })
+    )
+
+    expect(selectQuoteById).not.toHaveBeenCalled()
+    expect(mockShowSnackbar).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when activeQuote is null', () => {
+    const quotes = [makeQuote('a'), makeQuote('b')]
+    const selectQuoteById = jest.fn()
+
+    renderHook(() =>
+      useAutoAdvanceOnFeeValidationError({
+        feeValidationError: providerSpecificError(),
+        activeQuote: null,
+        allQuotes: quotes,
+        selectQuoteById,
+        maxAdvances: DEFAULT_MAX
+      })
+    )
+
+    expect(selectQuoteById).not.toHaveBeenCalled()
+    expect(mockShowSnackbar).not.toHaveBeenCalled()
+  })
+
+  it('advances only once per error occurrence', () => {
+    const quotes = [makeQuote('a'), makeQuote('b'), makeQuote('c')]
+    const selectQuoteById = jest.fn()
+    const error = providerSpecificError()
+
+    const { rerender } = renderHook(
+      props => useAutoAdvanceOnFeeValidationError(props),
+      {
+        initialProps: {
+          feeValidationError: error,
+          activeQuote: quotes[0] as Quote,
+          allQuotes: quotes,
+          selectQuoteById,
+          maxAdvances: DEFAULT_MAX
+        }
+      }
+    )
+
+    // Re-render with same inputs should not trigger another advance
+    rerender({
+      feeValidationError: error,
+      activeQuote: quotes[0] as Quote,
+      allQuotes: quotes,
+      selectQuoteById,
+      maxAdvances: DEFAULT_MAX
+    })
+
+    expect(selectQuoteById).toHaveBeenCalledTimes(1)
+    expect(mockShowSnackbar).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops advancing once maxAdvances is reached', () => {
+    const quotes = [
+      makeQuote('a'),
+      makeQuote('b'),
+      makeQuote('c'),
+      makeQuote('d'),
+      makeQuote('e')
+    ]
+    const selectQuoteById = jest.fn()
+    const error = providerSpecificError()
+
+    // Simulate: advance from a → b → c → d (3 advances = maxAdvances)
+    const { rerender } = renderHook(
+      props => useAutoAdvanceOnFeeValidationError(props),
+      {
+        initialProps: {
+          feeValidationError: error,
+          activeQuote: quotes[0] as Quote,
+          allQuotes: quotes,
+          selectQuoteById,
+          maxAdvances: 3
+        }
+      }
+    )
+    rerender({
+      feeValidationError: error,
+      activeQuote: quotes[1] as Quote,
+      allQuotes: quotes,
+      selectQuoteById,
+      maxAdvances: 3
+    })
+    rerender({
+      feeValidationError: error,
+      activeQuote: quotes[2] as Quote,
+      allQuotes: quotes,
+      selectQuoteById,
+      maxAdvances: 3
+    })
+
+    expect(selectQuoteById).toHaveBeenCalledTimes(3)
+
+    // Fourth attempt — should stop
+    rerender({
+      feeValidationError: error,
+      activeQuote: quotes[3] as Quote,
+      allQuotes: quotes,
+      selectQuoteById,
+      maxAdvances: 3
+    })
+
+    expect(selectQuoteById).toHaveBeenCalledTimes(3)
+  })
+
+  it('resets the advance counter when the error clears', () => {
+    const quotes = [makeQuote('a'), makeQuote('b'), makeQuote('c')]
+    const selectQuoteById = jest.fn()
+    const error = providerSpecificError()
+
+    const { rerender } = renderHook(
+      props => useAutoAdvanceOnFeeValidationError(props),
+      {
+        initialProps: {
+          feeValidationError: error as FusionQuoteError | undefined,
+          activeQuote: quotes[0] as Quote,
+          allQuotes: quotes,
+          selectQuoteById,
+          maxAdvances: 1
+        }
+      }
+    )
+
+    // 1 advance, then hit the cap
+    expect(selectQuoteById).toHaveBeenCalledTimes(1)
+    rerender({
+      feeValidationError: error,
+      activeQuote: quotes[1] as Quote,
+      allQuotes: quotes,
+      selectQuoteById,
+      maxAdvances: 1
+    })
+    expect(selectQuoteById).toHaveBeenCalledTimes(1)
+
+    // Error clears (e.g. user fixed input) — counter resets
+    rerender({
+      feeValidationError: undefined,
+      activeQuote: quotes[1] as Quote,
+      allQuotes: quotes,
+      selectQuoteById,
+      maxAdvances: 1
+    })
+
+    // New provider-specific error — should advance again (counter was reset)
+    rerender({
+      feeValidationError: error,
+      activeQuote: quotes[1] as Quote,
+      allQuotes: quotes,
+      selectQuoteById,
+      maxAdvances: 1
+    })
+    expect(selectQuoteById).toHaveBeenCalledTimes(2)
+    expect(selectQuoteById).toHaveBeenLastCalledWith('c')
+  })
+})

--- a/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.test.ts
@@ -39,19 +39,20 @@ beforeEach(() => {
 describe('useAutoAdvanceOnFeeValidationError', () => {
   it('advances to the next quote when the error is provider-specific', () => {
     const quotes = [makeQuote('a'), makeQuote('b'), makeQuote('c')]
-    const selectQuoteById = jest.fn()
+    const advanceBestQuote = jest.fn()
 
     renderHook(() =>
       useAutoAdvanceOnFeeValidationError({
         feeValidationError: providerSpecificError(),
         activeQuote: quotes[0] as Quote,
         allQuotes: quotes,
-        selectQuoteById,
+        userQuote: null,
+        advanceBestQuote,
         maxAdvances: DEFAULT_MAX
       })
     )
 
-    expect(selectQuoteById).toHaveBeenCalledWith('b')
+    expect(advanceBestQuote).toHaveBeenCalledWith('b')
     expect(mockShowSnackbar).toHaveBeenCalledTimes(1)
   })
 
@@ -61,14 +62,15 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
       makeQuote('b', 'DeBridge'),
       makeQuote('c')
     ]
-    const selectQuoteById = jest.fn()
+    const advanceBestQuote = jest.fn()
 
     renderHook(() =>
       useAutoAdvanceOnFeeValidationError({
         feeValidationError: providerSpecificError(),
         activeQuote: quotes[0] as Quote,
         allQuotes: quotes,
-        selectQuoteById,
+        userQuote: null,
+        advanceBestQuote,
         maxAdvances: DEFAULT_MAX
       })
     )
@@ -84,118 +86,143 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
     })
   })
 
+  it('does nothing when the user has manually picked a quote', () => {
+    const quotes = [makeQuote('a'), makeQuote('b')]
+    const advanceBestQuote = jest.fn()
+
+    renderHook(() =>
+      useAutoAdvanceOnFeeValidationError({
+        feeValidationError: providerSpecificError(),
+        activeQuote: quotes[0] as Quote,
+        allQuotes: quotes,
+        userQuote: quotes[0] as Quote,
+        advanceBestQuote,
+        maxAdvances: DEFAULT_MAX
+      })
+    )
+
+    expect(advanceBestQuote).not.toHaveBeenCalled()
+    expect(mockShowSnackbar).not.toHaveBeenCalled()
+  })
+
   it('does nothing when the error is undefined', () => {
     const quotes = [makeQuote('a'), makeQuote('b')]
-    const selectQuoteById = jest.fn()
+    const advanceBestQuote = jest.fn()
 
     renderHook(() =>
       useAutoAdvanceOnFeeValidationError({
         feeValidationError: undefined,
         activeQuote: quotes[0] as Quote,
         allQuotes: quotes,
-        selectQuoteById,
+        userQuote: null,
+        advanceBestQuote,
         maxAdvances: DEFAULT_MAX
       })
     )
 
-    expect(selectQuoteById).not.toHaveBeenCalled()
+    expect(advanceBestQuote).not.toHaveBeenCalled()
     expect(mockShowSnackbar).not.toHaveBeenCalled()
     expect(mockLoggerError).not.toHaveBeenCalled()
   })
 
   it('does nothing for balance-threshold errors', () => {
     const quotes = [makeQuote('a'), makeQuote('b')]
-    const selectQuoteById = jest.fn()
+    const advanceBestQuote = jest.fn()
 
     renderHook(() =>
       useAutoAdvanceOnFeeValidationError({
         feeValidationError: balanceError(),
         activeQuote: quotes[0] as Quote,
         allQuotes: quotes,
-        selectQuoteById,
+        userQuote: null,
+        advanceBestQuote,
         maxAdvances: DEFAULT_MAX
       })
     )
 
-    expect(selectQuoteById).not.toHaveBeenCalled()
+    expect(advanceBestQuote).not.toHaveBeenCalled()
     expect(mockShowSnackbar).not.toHaveBeenCalled()
   })
 
   it('does nothing for warning errors (Next already enabled)', () => {
     const quotes = [makeQuote('a'), makeQuote('b')]
-    const selectQuoteById = jest.fn()
+    const advanceBestQuote = jest.fn()
 
     renderHook(() =>
       useAutoAdvanceOnFeeValidationError({
         feeValidationError: warningError(),
         activeQuote: quotes[0] as Quote,
         allQuotes: quotes,
-        selectQuoteById,
+        userQuote: null,
+        advanceBestQuote,
         maxAdvances: DEFAULT_MAX
       })
     )
 
-    expect(selectQuoteById).not.toHaveBeenCalled()
+    expect(advanceBestQuote).not.toHaveBeenCalled()
     expect(mockShowSnackbar).not.toHaveBeenCalled()
   })
 
   it('does nothing when the active quote is already the last one', () => {
     const quotes = [makeQuote('a'), makeQuote('b')]
-    const selectQuoteById = jest.fn()
+    const advanceBestQuote = jest.fn()
 
     renderHook(() =>
       useAutoAdvanceOnFeeValidationError({
         feeValidationError: providerSpecificError(),
         activeQuote: quotes[1] as Quote,
         allQuotes: quotes,
-        selectQuoteById,
+        userQuote: null,
+        advanceBestQuote,
         maxAdvances: DEFAULT_MAX
       })
     )
 
-    expect(selectQuoteById).not.toHaveBeenCalled()
+    expect(advanceBestQuote).not.toHaveBeenCalled()
     expect(mockShowSnackbar).not.toHaveBeenCalled()
   })
 
   it('does nothing when the active quote is not present in allQuotes', () => {
     const quotes = [makeQuote('a'), makeQuote('b')]
-    const selectQuoteById = jest.fn()
+    const advanceBestQuote = jest.fn()
 
     renderHook(() =>
       useAutoAdvanceOnFeeValidationError({
         feeValidationError: providerSpecificError(),
         activeQuote: makeQuote('stale'),
         allQuotes: quotes,
-        selectQuoteById,
+        userQuote: null,
+        advanceBestQuote,
         maxAdvances: DEFAULT_MAX
       })
     )
 
-    expect(selectQuoteById).not.toHaveBeenCalled()
+    expect(advanceBestQuote).not.toHaveBeenCalled()
     expect(mockShowSnackbar).not.toHaveBeenCalled()
   })
 
   it('does nothing when activeQuote is null', () => {
     const quotes = [makeQuote('a'), makeQuote('b')]
-    const selectQuoteById = jest.fn()
+    const advanceBestQuote = jest.fn()
 
     renderHook(() =>
       useAutoAdvanceOnFeeValidationError({
         feeValidationError: providerSpecificError(),
         activeQuote: null,
         allQuotes: quotes,
-        selectQuoteById,
+        userQuote: null,
+        advanceBestQuote,
         maxAdvances: DEFAULT_MAX
       })
     )
 
-    expect(selectQuoteById).not.toHaveBeenCalled()
+    expect(advanceBestQuote).not.toHaveBeenCalled()
     expect(mockShowSnackbar).not.toHaveBeenCalled()
   })
 
   it('advances only once per error occurrence', () => {
     const quotes = [makeQuote('a'), makeQuote('b'), makeQuote('c')]
-    const selectQuoteById = jest.fn()
+    const advanceBestQuote = jest.fn()
     const error = providerSpecificError()
 
     const { rerender } = renderHook(
@@ -205,7 +232,8 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
           feeValidationError: error,
           activeQuote: quotes[0] as Quote,
           allQuotes: quotes,
-          selectQuoteById,
+          userQuote: null as Quote | null,
+          advanceBestQuote,
           maxAdvances: DEFAULT_MAX
         }
       }
@@ -216,11 +244,12 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
       feeValidationError: error,
       activeQuote: quotes[0] as Quote,
       allQuotes: quotes,
-      selectQuoteById,
+      userQuote: null,
+      advanceBestQuote,
       maxAdvances: DEFAULT_MAX
     })
 
-    expect(selectQuoteById).toHaveBeenCalledTimes(1)
+    expect(advanceBestQuote).toHaveBeenCalledTimes(1)
     expect(mockShowSnackbar).toHaveBeenCalledTimes(1)
   })
 
@@ -232,7 +261,7 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
       makeQuote('d'),
       makeQuote('e')
     ]
-    const selectQuoteById = jest.fn()
+    const advanceBestQuote = jest.fn()
     const error = providerSpecificError()
 
     // Simulate: advance from a → b → c → d (3 advances = maxAdvances)
@@ -243,7 +272,8 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
           feeValidationError: error,
           activeQuote: quotes[0] as Quote,
           allQuotes: quotes,
-          selectQuoteById,
+          userQuote: null as Quote | null,
+          advanceBestQuote,
           maxAdvances: 3
         }
       }
@@ -252,34 +282,37 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
       feeValidationError: error,
       activeQuote: quotes[1] as Quote,
       allQuotes: quotes,
-      selectQuoteById,
+      userQuote: null,
+      advanceBestQuote,
       maxAdvances: 3
     })
     rerender({
       feeValidationError: error,
       activeQuote: quotes[2] as Quote,
       allQuotes: quotes,
-      selectQuoteById,
+      userQuote: null,
+      advanceBestQuote,
       maxAdvances: 3
     })
 
-    expect(selectQuoteById).toHaveBeenCalledTimes(3)
+    expect(advanceBestQuote).toHaveBeenCalledTimes(3)
 
     // Fourth attempt — should stop
     rerender({
       feeValidationError: error,
       activeQuote: quotes[3] as Quote,
       allQuotes: quotes,
-      selectQuoteById,
+      userQuote: null,
+      advanceBestQuote,
       maxAdvances: 3
     })
 
-    expect(selectQuoteById).toHaveBeenCalledTimes(3)
+    expect(advanceBestQuote).toHaveBeenCalledTimes(3)
   })
 
   it('resets the advance counter when the error clears', () => {
     const quotes = [makeQuote('a'), makeQuote('b'), makeQuote('c')]
-    const selectQuoteById = jest.fn()
+    const advanceBestQuote = jest.fn()
     const error = providerSpecificError()
 
     const { rerender } = renderHook(
@@ -289,29 +322,32 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
           feeValidationError: error as FusionQuoteError | undefined,
           activeQuote: quotes[0] as Quote,
           allQuotes: quotes,
-          selectQuoteById,
+          userQuote: null as Quote | null,
+          advanceBestQuote,
           maxAdvances: 1
         }
       }
     )
 
     // 1 advance, then hit the cap
-    expect(selectQuoteById).toHaveBeenCalledTimes(1)
+    expect(advanceBestQuote).toHaveBeenCalledTimes(1)
     rerender({
       feeValidationError: error,
       activeQuote: quotes[1] as Quote,
       allQuotes: quotes,
-      selectQuoteById,
+      userQuote: null,
+      advanceBestQuote,
       maxAdvances: 1
     })
-    expect(selectQuoteById).toHaveBeenCalledTimes(1)
+    expect(advanceBestQuote).toHaveBeenCalledTimes(1)
 
     // Error clears (e.g. user fixed input) — counter resets
     rerender({
       feeValidationError: undefined,
       activeQuote: quotes[1] as Quote,
       allQuotes: quotes,
-      selectQuoteById,
+      userQuote: null,
+      advanceBestQuote,
       maxAdvances: 1
     })
 
@@ -320,10 +356,127 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
       feeValidationError: error,
       activeQuote: quotes[1] as Quote,
       allQuotes: quotes,
-      selectQuoteById,
+      userQuote: null,
+      advanceBestQuote,
       maxAdvances: 1
     })
-    expect(selectQuoteById).toHaveBeenCalledTimes(2)
-    expect(selectQuoteById).toHaveBeenLastCalledWith('c')
+    expect(advanceBestQuote).toHaveBeenCalledTimes(2)
+    expect(advanceBestQuote).toHaveBeenLastCalledWith('c')
+  })
+
+  it('does not advance twice from the same quote when allQuotes identity changes but contents do not', () => {
+    // Reviewer scenario: stream pushes a fresh allQuotes array with the same
+    // contents. activeQuote.id is unchanged. We must not advance again.
+    const quotesV1 = [makeQuote('a'), makeQuote('b'), makeQuote('c')]
+    const quotesV2 = [makeQuote('a'), makeQuote('b'), makeQuote('c')]
+    const advanceBestQuote = jest.fn()
+    const error = providerSpecificError()
+
+    const { rerender } = renderHook(
+      props => useAutoAdvanceOnFeeValidationError(props),
+      {
+        initialProps: {
+          feeValidationError: error,
+          activeQuote: quotesV1[0] as Quote,
+          allQuotes: quotesV1,
+          userQuote: null as Quote | null,
+          advanceBestQuote,
+          maxAdvances: DEFAULT_MAX
+        }
+      }
+    )
+    expect(advanceBestQuote).toHaveBeenCalledTimes(1)
+
+    // Stream refresh: new array identity, identical contents, same active
+    // quote by id (imagine autoAdvance hasn't propagated yet in this tick).
+    rerender({
+      feeValidationError: error,
+      activeQuote: quotesV1[0] as Quote,
+      allQuotes: quotesV2,
+      userQuote: null,
+      advanceBestQuote,
+      maxAdvances: DEFAULT_MAX
+    })
+
+    expect(advanceBestQuote).toHaveBeenCalledTimes(1)
+    expect(mockShowSnackbar).toHaveBeenCalledTimes(1)
+  })
+
+  it('advances again once activeQuote has moved on', () => {
+    // After the hook advances from a → b and activeQuote transitions to b,
+    // a later render with the new activeQuote should be free to advance.
+    const quotes = [makeQuote('a'), makeQuote('b'), makeQuote('c')]
+    const advanceBestQuote = jest.fn()
+    const error = providerSpecificError()
+
+    const { rerender } = renderHook(
+      props => useAutoAdvanceOnFeeValidationError(props),
+      {
+        initialProps: {
+          feeValidationError: error,
+          activeQuote: quotes[0] as Quote,
+          allQuotes: quotes,
+          userQuote: null as Quote | null,
+          advanceBestQuote,
+          maxAdvances: DEFAULT_MAX
+        }
+      }
+    )
+    expect(advanceBestQuote).toHaveBeenCalledWith('b')
+
+    rerender({
+      feeValidationError: error,
+      activeQuote: quotes[1] as Quote,
+      allQuotes: quotes,
+      userQuote: null,
+      advanceBestQuote,
+      maxAdvances: DEFAULT_MAX
+    })
+
+    expect(advanceBestQuote).toHaveBeenCalledTimes(2)
+    expect(advanceBestQuote).toHaveBeenLastCalledWith('c')
+  })
+
+  it('resets the advance counter when the user takes manual control', () => {
+    const quotes = [makeQuote('a'), makeQuote('b'), makeQuote('c')]
+    const advanceBestQuote = jest.fn()
+    const error = providerSpecificError()
+
+    const { rerender } = renderHook(
+      props => useAutoAdvanceOnFeeValidationError(props),
+      {
+        initialProps: {
+          feeValidationError: error,
+          activeQuote: quotes[0] as Quote,
+          allQuotes: quotes,
+          userQuote: null as Quote | null,
+          advanceBestQuote,
+          maxAdvances: 1
+        }
+      }
+    )
+    expect(advanceBestQuote).toHaveBeenCalledTimes(1)
+
+    // User manually picks — advance is disabled and counter resets
+    rerender({
+      feeValidationError: error,
+      activeQuote: quotes[2] as Quote,
+      allQuotes: quotes,
+      userQuote: quotes[2] as Quote,
+      advanceBestQuote,
+      maxAdvances: 1
+    })
+    expect(advanceBestQuote).toHaveBeenCalledTimes(1)
+
+    // User clears manual selection back to Auto — counter should be fresh
+    rerender({
+      feeValidationError: error,
+      activeQuote: quotes[0] as Quote,
+      allQuotes: quotes,
+      userQuote: null,
+      advanceBestQuote,
+      maxAdvances: 1
+    })
+    expect(advanceBestQuote).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.ts
@@ -7,43 +7,64 @@ import type { Quote } from '../types'
 
 /**
  * When the active quote fails fee validation with a provider-specific error,
- * advance to the next quote in the list. Mirrors core-web's FusionSwapForm
- * behavior so users aren't blocked by a single provider's revert/simulation
- * failure when other quotes are available.
+ * advance to the next quote in the list via advanceBestQuote — which promotes
+ * the next quote without flipping the flow into manual-selection mode, so
+ * swap-time retry and analytics stay correctly classified as 'auto'.
  *
  * Bounded by maxAdvances to avoid churning through every provider on a bad
- * token pair or amount. The counter resets whenever the error clears.
+ * token pair or amount. The counter resets whenever the error clears or the
+ * user takes manual control via the Pricing sheet.
+ *
+ * No-op when userQuote is set — respect the user's explicit pick.
  */
 export const useAutoAdvanceOnFeeValidationError = ({
   feeValidationError,
   activeQuote,
   allQuotes,
-  selectQuoteById,
+  userQuote,
+  advanceBestQuote,
   maxAdvances
 }: {
   feeValidationError: FusionQuoteError | undefined
   activeQuote: Quote | null
   allQuotes: Quote[]
-  selectQuoteById: (quoteId: string | null) => void
+  userQuote: Quote | null
+  advanceBestQuote: (quoteId: string) => void
   maxAdvances: number
 }): void => {
   const advanceCountRef = useRef(0)
+  // Tracks the id of the quote we most recently advanced away from. Guards
+  // against re-firing when `allQuotes` gets a new array identity from a
+  // stream refresh while `activeQuote.id` hasn't changed yet.
+  const lastAdvancedFromRef = useRef<string | null>(null)
 
   useEffect(() => {
+    // User has manually picked a quote — don't override their choice.
+    if (userQuote) {
+      advanceCountRef.current = 0
+      lastAdvancedFromRef.current = null
+      return
+    }
+
     if (feeValidationError?.kind !== 'provider-specific') {
       // Non-blocking or non-provider-specific error → reset so a fresh run of
       // failures can advance up to maxAdvances again.
       advanceCountRef.current = 0
+      lastAdvancedFromRef.current = null
       return
     }
 
     if (advanceCountRef.current >= maxAdvances) return
     if (!activeQuote) return
 
+    // Already advanced away from this quote — don't re-fire on stream refresh.
+    if (lastAdvancedFromRef.current === activeQuote.id) return
+
     const nextQuote = findNextQuote(allQuotes, activeQuote.id)
     if (!nextQuote) return
 
     advanceCountRef.current += 1
+    lastAdvancedFromRef.current = activeQuote.id
 
     Logger.error(
       '[useAutoAdvanceOnFeeValidationError] auto-advancing to next quote',
@@ -59,7 +80,14 @@ export const useAutoAdvanceOnFeeValidationError = ({
       }
     )
 
-    selectQuoteById(nextQuote.id)
+    advanceBestQuote(nextQuote.id)
     showSnackbar('Quote failed gas estimation, trying next available quote')
-  }, [feeValidationError, activeQuote, allQuotes, selectQuoteById, maxAdvances])
+  }, [
+    feeValidationError,
+    activeQuote,
+    allQuotes,
+    userQuote,
+    advanceBestQuote,
+    maxAdvances
+  ])
 }

--- a/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.ts
@@ -81,7 +81,7 @@ export const useAutoAdvanceOnFeeValidationError = ({
     )
 
     advanceBestQuote(nextQuote.id)
-    showSnackbar('Quote failed gas estimation, trying next available quote')
+    showSnackbar('Quote failed fee validation, trying next available quote')
   }, [
     feeValidationError,
     activeQuote,

--- a/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.ts
@@ -81,7 +81,7 @@ export const useAutoAdvanceOnFeeValidationError = ({
     )
 
     advanceBestQuote(nextQuote.id)
-    showSnackbar('Quote failed fee validation, trying next available quote')
+    showSnackbar('Quote failed, trying next available')
   }, [
     feeValidationError,
     activeQuote,

--- a/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react'
+import { showSnackbar } from 'common/utils/toast'
+import Logger from 'utils/Logger'
+import { findNextQuote } from '../utils/findNextQuote'
+import type { FusionQuoteError } from '../utils/fusionErrors'
+import type { Quote } from '../types'
+
+/**
+ * When the active quote fails fee validation with a provider-specific error,
+ * advance to the next quote in the list. Mirrors core-web's FusionSwapForm
+ * behavior so users aren't blocked by a single provider's revert/simulation
+ * failure when other quotes are available.
+ *
+ * Bounded by maxAdvances to avoid churning through every provider on a bad
+ * token pair or amount. The counter resets whenever the error clears.
+ */
+export const useAutoAdvanceOnFeeValidationError = ({
+  feeValidationError,
+  activeQuote,
+  allQuotes,
+  selectQuoteById,
+  maxAdvances
+}: {
+  feeValidationError: FusionQuoteError | undefined
+  activeQuote: Quote | null
+  allQuotes: Quote[]
+  selectQuoteById: (quoteId: string | null) => void
+  maxAdvances: number
+}): void => {
+  const advanceCountRef = useRef(0)
+
+  useEffect(() => {
+    if (feeValidationError?.kind !== 'provider-specific') {
+      // Non-blocking or non-provider-specific error → reset so a fresh run of
+      // failures can advance up to maxAdvances again.
+      advanceCountRef.current = 0
+      return
+    }
+
+    if (advanceCountRef.current >= maxAdvances) return
+    if (!activeQuote) return
+
+    const nextQuote = findNextQuote(allQuotes, activeQuote.id)
+    if (!nextQuote) return
+
+    advanceCountRef.current += 1
+
+    Logger.error(
+      '[useAutoAdvanceOnFeeValidationError] auto-advancing to next quote',
+      {
+        failed: activeQuote.aggregator.name,
+        failedId: activeQuote.id,
+        retrying: nextQuote.aggregator.name,
+        retryingId: nextQuote.id,
+        attempt: advanceCountRef.current,
+        maxAdvances,
+        errorKind: feeValidationError.kind,
+        errorMessage: feeValidationError.message
+      }
+    )
+
+    selectQuoteById(nextQuote.id)
+    showSnackbar('Quote failed gas estimation, trying next available quote')
+  }, [feeValidationError, activeQuote, allQuotes, selectQuoteById, maxAdvances])
+}

--- a/packages/core-mobile/app/new/features/swap/hooks/useFeeValidation/utils.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFeeValidation/utils.test.ts
@@ -309,25 +309,26 @@ describe('getFeeEstimationError', () => {
       const error = makeEstimateError(undefined)
       const result = getFeeEstimationError(error)
       expect(result?.message).toBe('Insufficient funds to estimate the fee')
-      expect(result?.kind).toBe('other')
+      expect(result?.kind).toBe('provider-specific')
     })
 
     it('returns generic insufficientFundsForFee when cause is a non-InsufficientFundsError', () => {
       const error = makeEstimateError(new Error('rpc timeout'))
       const result = getFeeEstimationError(error)
       expect(result?.message).toBe('Insufficient funds to estimate the fee')
-      expect(result?.kind).toBe('other')
+      expect(result?.kind).toBe('provider-specific')
     })
   })
 
   describe('SdkError with arithmetic underflow message', () => {
-    it('returns swapAmountTooSmall', () => {
+    it('returns swapAmountTooSmall tagged as provider-specific', () => {
       const error = new SdkError(
         'arithmetic underflow or overflow',
         ErrorCode.UNKNOWN
       )
       const result = getFeeEstimationError(error)
       expect(result?.message).toContain('too small')
+      expect(result?.kind).toBe('provider-specific')
     })
   })
 

--- a/packages/core-mobile/app/new/features/swap/hooks/useZustandStore.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useZustandStore.ts
@@ -35,7 +35,14 @@ export type SelectedQuoteIdentifiers = {
   aggregatorId: string
 } | null
 
-export const useUserSelectedQuote =
+export const useUserSelectedQuoteIds =
+  createZustandStore<SelectedQuoteIdentifiers>(null)
+// Ids for the quote promoted by pre-swap auto-advance when the best quote
+// fails fee validation with a provider-specific error. Kept distinct from
+// useUserSelectedQuoteIds so it doesn't flip the flow into manual-selection
+// mode (which would disable swap-time retry and mis-tag analytics as
+// 'manual').
+export const useAutoAdvancedQuoteIds =
   createZustandStore<SelectedQuoteIdentifiers>(null)
 export const useAllQuotes = createZustandStore<Quote[]>([])
 

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -46,7 +46,10 @@ import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { useTokensWithBalanceForAccount } from 'features/portfolio/hooks/useTokensWithBalanceForAccount'
 import { caip2ChainIds } from 'consts/caip2ChainIds'
 import { selectActiveAccountHasSolanaAddress } from 'store/account'
-import { selectIsSolanaSwapBlocked } from 'store/posthog'
+import {
+  selectIsSolanaSwapBlocked,
+  selectMarkrSwapMaxRetries
+} from 'store/posthog'
 import { AdditiveFeesNotice } from '../components/AdditiveFeesNotice'
 import { FeeDebugTable } from '../components/FeeDebugTable'
 import { useFusionTokenLookup } from '../hooks/useFusionTokenLookup'
@@ -72,6 +75,7 @@ import {
 import { useMaxSwapAmount } from '../hooks/useMaxSwapAmount'
 import { useMinimumTransferAmount } from '../hooks/useMinimumTransferAmount'
 import { useFeeValidation } from '../hooks/useFeeValidation'
+import { useAutoAdvanceOnFeeValidationError } from '../hooks/useAutoAdvanceOnFeeValidationError'
 import { getTokenKey } from '../utils/tokenKey'
 
 export const SwapScreen = (): JSX.Element => {
@@ -147,7 +151,8 @@ export const SwapScreen = (): JSX.Element => {
     setAmount,
     quoteError,
     swapStatus,
-    successTransferId
+    successTransferId,
+    selectQuoteById
   } = useSwapContext()
   const [fromTokenValue, setFromTokenValue] = useState<bigint>()
   const [toTokenValue, setToTokenValue] = useState<bigint>()
@@ -235,6 +240,16 @@ export const SwapScreen = (): JSX.Element => {
     nativeTokenBalance: nativeFromToken?.balance,
     amount: debouncedFromTokenValue,
     quote: activeQuote
+  })
+
+  const maxQuoteAdvances = useSelector(selectMarkrSwapMaxRetries)
+
+  useAutoAdvanceOnFeeValidationError({
+    feeValidationError,
+    activeQuote,
+    allQuotes,
+    selectQuoteById,
+    maxAdvances: maxQuoteAdvances
   })
 
   const activeError = validationError ?? quoteError

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -143,6 +143,7 @@ export const SwapScreen = (): JSX.Element => {
     setToToken,
     bestQuote,
     userQuote,
+    autoAdvancedQuote,
     allQuotes,
     isQuoteLoading,
     setDestination,
@@ -152,7 +153,7 @@ export const SwapScreen = (): JSX.Element => {
     quoteError,
     swapStatus,
     successTransferId,
-    selectQuoteById
+    advanceBestQuote
   } = useSwapContext()
   const [fromTokenValue, setFromTokenValue] = useState<bigint>()
   const [toTokenValue, setToTokenValue] = useState<bigint>()
@@ -192,8 +193,10 @@ export const SwapScreen = (): JSX.Element => {
 
   const { getNetwork } = useNetworks()
 
-  // userQuote takes precedence over bestQuote
-  const activeQuote = userQuote ?? bestQuote
+  // Precedence: explicit user pick > auto-advanced (pre-swap fallback) >
+  // best quote from the stream. autoAdvancedQuote is kept distinct so it
+  // doesn't flip the flow into manual-selection mode.
+  const activeQuote = userQuote ?? autoAdvancedQuote ?? bestQuote
   Logger.info('activeQuote', activeQuote)
 
   const {
@@ -248,7 +251,8 @@ export const SwapScreen = (): JSX.Element => {
     feeValidationError,
     activeQuote,
     allQuotes,
-    selectQuoteById,
+    userQuote,
+    advanceBestQuote,
     maxAdvances: maxQuoteAdvances
   })
 
@@ -376,14 +380,15 @@ export const SwapScreen = (): JSX.Element => {
     activeQuote?.serviceType === ServiceType.LOMBARD_BTCB_TO_BTC
 
   const handleSwap = useCallback(() => {
+    if (!activeQuote) return
     AnalyticsService.capture('SwapReviewOrder', {
-      provider: activeQuote?.aggregator.name ?? 'Unknown',
+      provider: activeQuote.aggregator.name,
       slippage
     })
 
     dismissKeyboardIfNeeded()
 
-    swap()
+    swap(activeQuote)
   }, [swap, activeQuote, slippage])
 
   const handleFromAmountChange = useCallback(

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -141,9 +141,8 @@ export const SwapScreen = (): JSX.Element => {
     setFromToken,
     toToken,
     setToToken,
-    bestQuote,
     userQuote,
-    autoAdvancedQuote,
+    activeQuote,
     allQuotes,
     isQuoteLoading,
     setDestination,
@@ -193,10 +192,6 @@ export const SwapScreen = (): JSX.Element => {
 
   const { getNetwork } = useNetworks()
 
-  // Precedence: explicit user pick > auto-advanced (pre-swap fallback) >
-  // best quote from the stream. autoAdvancedQuote is kept distinct so it
-  // doesn't flip the flow into manual-selection mode.
-  const activeQuote = userQuote ?? autoAdvancedQuote ?? bestQuote
   Logger.info('activeQuote', activeQuote)
 
   const {

--- a/packages/core-mobile/app/new/features/swap/utils/findNextQuote.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/findNextQuote.test.ts
@@ -1,0 +1,26 @@
+import type { Quote } from '../types'
+import { findNextQuote } from './findNextQuote'
+
+const makeQuote = (id: string): Quote => ({ id } as unknown as Quote)
+
+describe('findNextQuote', () => {
+  it('returns the quote after the current one', () => {
+    const quotes = [makeQuote('a'), makeQuote('b'), makeQuote('c')]
+    expect(findNextQuote(quotes, 'a')?.id).toBe('b')
+    expect(findNextQuote(quotes, 'b')?.id).toBe('c')
+  })
+
+  it('returns undefined when the current quote is the last one', () => {
+    const quotes = [makeQuote('a'), makeQuote('b')]
+    expect(findNextQuote(quotes, 'b')).toBeUndefined()
+  })
+
+  it('returns undefined when the current id is not in the list', () => {
+    const quotes = [makeQuote('a'), makeQuote('b')]
+    expect(findNextQuote(quotes, 'missing')).toBeUndefined()
+  })
+
+  it('returns undefined for an empty list', () => {
+    expect(findNextQuote([], 'any')).toBeUndefined()
+  })
+})

--- a/packages/core-mobile/app/new/features/swap/utils/findNextQuote.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/findNextQuote.ts
@@ -1,0 +1,18 @@
+import type { Quote } from '../types'
+
+/**
+ * Returns the quote immediately following the one with the given id, or
+ * undefined if the current id isn't found or it's already the last quote.
+ *
+ * Used by both the pre-swap auto-advance on fee-validation errors and the
+ * swap-time retry in SwapContext, so both paths walk the quote list the same
+ * way.
+ */
+export const findNextQuote = (
+  allQuotes: Quote[],
+  currentId: string
+): Quote | undefined => {
+  const currentIndex = allQuotes.findIndex(q => q.id === currentId)
+  if (currentIndex < 0) return undefined
+  return allQuotes[currentIndex + 1]
+}

--- a/packages/core-mobile/app/new/features/swap/utils/fusionErrors.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/fusionErrors.test.ts
@@ -99,6 +99,28 @@ describe('fusionErrors', () => {
         'Swap amount is too small for this token pair.\nTry a larger amount.'
       )
     })
+
+    it('should be tagged as provider-specific', () => {
+      const error = fusionErrors.swapAmountTooSmall()
+      expect(error.kind).toBe('provider-specific')
+    })
+  })
+
+  describe('insufficientFundsForFee', () => {
+    it('tags the undefined cause branch as provider-specific', () => {
+      const error = fusionErrors.insufficientFundsForFee(undefined)
+      expect(error.kind).toBe('provider-specific')
+    })
+
+    it('keeps the confirmed-native branch as network-fee-only', () => {
+      const error = fusionErrors.insufficientFundsForFee(true)
+      expect(error.kind).toBe('network-fee-only')
+    })
+
+    it('keeps the confirmed-token branch as other', () => {
+      const error = fusionErrors.insufficientFundsForFee(false)
+      expect(error.kind).toBe('other')
+    })
   })
 })
 
@@ -131,14 +153,49 @@ describe('isUserRejectionError', () => {
 })
 
 describe('isGasEstimationError', () => {
-  it('should return true for "gas estimation" message', () => {
+  it('should return true for legacy "gas estimation" message (pre-0.15.0 SDK)', () => {
     expect(isGasEstimationError(new Error('gas estimation failed'))).toBe(true)
     expect(isGasEstimationError(new Error('gas estimation error'))).toBe(true)
+  })
+
+  it('should return true for post-0.15.0 "estimate gas" messages', () => {
+    expect(
+      isGasEstimationError(
+        new Error('Failed to estimate gas for Markr swap transaction.')
+      )
+    ).toBe(true)
+    expect(
+      isGasEstimationError(
+        new Error(
+          'Failed to estimate gas for Markr swap transaction. Revert: TargetCallFailed().'
+        )
+      )
+    ).toBe(true)
+    expect(
+      isGasEstimationError(
+        new Error('Failed to estimate gas for ERC20 approval transaction.')
+      )
+    ).toBe(true)
+  })
+
+  it('should return true for EstimateNativeFeeError instances via the SDK type guard', () => {
+    class FakeEstimateNativeFeeError extends Error {
+      override name = 'EstimateNativeFeeError'
+    }
+    // The SDK's isEstimateNativeFeeError uses instanceof on its own class, so
+    // this test covers the substring fallback path for duck-typed errors.
+    const err = new FakeEstimateNativeFeeError('opaque message with no hint')
+    // Fallback path: no "estimate gas" substring, so without a real SDK
+    // instance the matcher returns false — this documents that behavior.
+    expect(isGasEstimationError(err)).toBe(false)
   })
 
   it('should be case-insensitive', () => {
     expect(isGasEstimationError(new Error('Gas Estimation Failed'))).toBe(true)
     expect(isGasEstimationError(new Error('GAS ESTIMATION'))).toBe(true)
+    expect(
+      isGasEstimationError(new Error('FAILED TO ESTIMATE GAS FOR SWAP'))
+    ).toBe(true)
   })
 
   it('should return false for unrelated errors', () => {
@@ -198,6 +255,13 @@ describe('shouldRetryWithNextQuote', () => {
     expect(shouldRetryWithNextQuote(new Error('gas estimation failed'))).toBe(
       true
     )
+    expect(
+      shouldRetryWithNextQuote(
+        new Error(
+          'Failed to estimate gas for Markr swap transaction. Revert: TargetCallFailed().'
+        )
+      )
+    ).toBe(true)
   })
 
   it('should return true for invalid response errors', () => {

--- a/packages/core-mobile/app/new/features/swap/utils/fusionErrors.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/fusionErrors.test.ts
@@ -1,3 +1,4 @@
+import { EstimateNativeFeeError, ErrorCode } from '@avalabs/fusion-sdk'
 import {
   fusionErrors,
   isGasOnlyNetworkFeeError,
@@ -178,15 +179,26 @@ describe('isGasEstimationError', () => {
     ).toBe(true)
   })
 
-  it('should return true for EstimateNativeFeeError instances via the SDK type guard', () => {
+  it('should return true for real SDK EstimateNativeFeeError instances via the type guard', () => {
+    // Real SDK instance — the type guard uses instanceof and matches this.
+    const err = new EstimateNativeFeeError({
+      errorCode: ErrorCode.VIEM_ERROR,
+      tx: '0xtx'
+    })
+    expect(isGasEstimationError(err)).toBe(true)
+  })
+
+  it('should return false for duck-typed EstimateNativeFeeError without a matching substring', () => {
+    // The SDK's isEstimateNativeFeeError uses instanceof on its own class,
+    // so an error that merely has the same `name` property is not matched
+    // by the type guard. Without a "gas estimation" / "estimate gas"
+    // substring in the message, the substring fallback also misses —
+    // documenting that cross-realm / fake instances require SDK-wrapped
+    // errors or a recognisable message to be classified.
     class FakeEstimateNativeFeeError extends Error {
       override name = 'EstimateNativeFeeError'
     }
-    // The SDK's isEstimateNativeFeeError uses instanceof on its own class, so
-    // this test covers the substring fallback path for duck-typed errors.
     const err = new FakeEstimateNativeFeeError('opaque message with no hint')
-    // Fallback path: no "estimate gas" substring, so without a real SDK
-    // instance the matcher returns false — this documents that behavior.
     expect(isGasEstimationError(err)).toBe(false)
   })
 

--- a/packages/core-mobile/app/new/features/swap/utils/fusionErrors.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/fusionErrors.ts
@@ -1,8 +1,9 @@
-import { isSdkError } from '@avalabs/fusion-sdk'
+import { isEstimateNativeFeeError, isSdkError } from '@avalabs/fusion-sdk'
 import type { QuoterDoneReason } from '@avalabs/fusion-sdk'
 
 export type FusionQuoteErrorKind =
   | 'network-fee-only' // gas alone exceeds balance; no bridge fee involved
+  | 'provider-specific' // error is specific to this quote's provider and may not repeat on another quote
   | 'other'
 
 export class FusionQuoteError extends Error {
@@ -163,14 +164,17 @@ export const fusionErrors = {
         'Insufficient token funds to estimate the fee'
       )
     }
-    return new FusionQuoteError('Insufficient funds to estimate the fee')
+    return new FusionQuoteError('Insufficient funds to estimate the fee', {
+      kind: 'provider-specific'
+    })
   },
   gasEstimationFailed(): FusionQuoteError {
     return new FusionQuoteError('Unable to estimate gas', { isWarning: true })
   },
   swapAmountTooSmall(): FusionQuoteError {
     return new FusionQuoteError(
-      'Swap amount is too small for this token pair.\nTry a larger amount.'
+      'Swap amount is too small for this token pair.\nTry a larger amount.',
+      { kind: 'provider-specific' }
     )
   }
 }
@@ -194,13 +198,19 @@ export function isUserRejectionError(error: unknown): boolean {
   return error.message.toLowerCase().includes('user rejected')
 }
 
+// The SDK has updated its error phrasing across versions, so the checkers
+// below match both legacy and current substrings to keep the retry/advance
+// logic firing.
+
 /**
  * Check if error is gas estimation failure
  * These are retryable with next quote (auto mode only)
  */
 export function isGasEstimationError(error: unknown): boolean {
+  if (isEstimateNativeFeeError(error)) return true
   if (!(error instanceof Error)) return false
-  return error.message.toLowerCase().includes('gas estimation')
+  const message = error.message.toLowerCase()
+  return message.includes('gas estimation') || message.includes('estimate gas')
 }
 
 /**

--- a/packages/core-mobile/app/new/features/swap/utils/matchQuoteByIdentifiers.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/matchQuoteByIdentifiers.test.ts
@@ -1,0 +1,95 @@
+import type { Quote } from '../types'
+import { matchQuoteByIdentifiers } from './matchQuoteByIdentifiers'
+
+const makeQuote = (
+  id: string,
+  serviceType: string,
+  aggregatorId: string
+): Quote =>
+  ({
+    id,
+    serviceType,
+    aggregator: { id: aggregatorId }
+  } as unknown as Quote)
+
+describe('matchQuoteByIdentifiers', () => {
+  const markr123 = makeQuote('markr-123', 'MARKR', 'markr')
+  const debridge456 = makeQuote('debridge-456', 'MARKR', 'debridge')
+  const avaxEvm = makeQuote('avax-789', 'AVALANCHE_EVM', 'avalanche-evm')
+
+  it('returns the exact match by quoteId', () => {
+    const match = matchQuoteByIdentifiers(
+      {
+        quoteId: 'markr-123',
+        serviceType: 'MARKR',
+        aggregatorId: 'markr'
+      },
+      [markr123, debridge456, avaxEvm]
+    )
+
+    expect(match).toBe(markr123)
+  })
+
+  it('falls back to serviceType + aggregatorId when quoteId has rotated', () => {
+    // Stream refresh rotated Markr's quote id from 123 → 999 but the
+    // provider is still the same; we should resolve to the new quote.
+    const markr999 = makeQuote('markr-999', 'MARKR', 'markr')
+    const match = matchQuoteByIdentifiers(
+      {
+        quoteId: 'markr-123',
+        serviceType: 'MARKR',
+        aggregatorId: 'markr'
+      },
+      [markr999, debridge456]
+    )
+
+    expect(match).toBe(markr999)
+  })
+
+  it('prefers the exact match over the fallback when both exist', () => {
+    // Edge case: somehow both the exact id and a same-provider quote exist.
+    // Exact should win.
+    const markr123Duplicate = makeQuote('markr-123', 'MARKR', 'markr')
+    const anotherMarkr = makeQuote('markr-456', 'MARKR', 'markr')
+    const match = matchQuoteByIdentifiers(
+      {
+        quoteId: 'markr-123',
+        serviceType: 'MARKR',
+        aggregatorId: 'markr'
+      },
+      [anotherMarkr, markr123Duplicate]
+    )
+
+    expect(match).toBe(markr123Duplicate)
+  })
+
+  it('returns null when identifiers is null', () => {
+    expect(matchQuoteByIdentifiers(null, [markr123, debridge456])).toBeNull()
+  })
+
+  it('returns null when no exact and no fallback match', () => {
+    const match = matchQuoteByIdentifiers(
+      {
+        quoteId: 'ghost-id',
+        serviceType: 'LOMBARD_BTC_TO_BTCB',
+        aggregatorId: 'lombard'
+      },
+      [markr123, debridge456]
+    )
+
+    expect(match).toBeNull()
+  })
+
+  it('returns null for an empty allQuotes list', () => {
+    const match = matchQuoteByIdentifiers(
+      {
+        quoteId: 'markr-123',
+        serviceType: 'MARKR',
+        aggregatorId: 'markr'
+      },
+      []
+    )
+
+    expect(match).toBeNull()
+  })
+})

--- a/packages/core-mobile/app/new/features/swap/utils/matchQuoteByIdentifiers.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/matchQuoteByIdentifiers.ts
@@ -1,0 +1,33 @@
+import type { SelectedQuoteIdentifiers } from '../hooks/useZustandStore'
+import type { Quote } from '../types'
+
+/**
+ * Resolves a stored quote identifier to the matching Quote in allQuotes.
+ *
+ * Strategy:
+ *  1. Exact match by quoteId (stable across non-refreshing updates)
+ *  2. Fallback to serviceType + aggregatorId (same provider after the id
+ *     rotates from slippage/expiry refreshes)
+ *
+ * Returns null when identifiers is null or no match exists.
+ *
+ * Used by SwapContext for both userQuote and autoAdvancedQuote so manual and
+ * auto-advanced selections stay sticky across quote refreshes.
+ */
+export const matchQuoteByIdentifiers = (
+  identifiers: SelectedQuoteIdentifiers,
+  allQuotes: Quote[]
+): Quote | null => {
+  if (!identifiers) return null
+
+  const exactMatch = allQuotes.find(q => q.id === identifiers.quoteId)
+  if (exactMatch) return exactMatch
+
+  const fallbackMatch = allQuotes.find(
+    q =>
+      q.serviceType === identifiers.serviceType &&
+      q.aggregator.id === identifiers.aggregatorId
+  )
+
+  return fallbackMatch ?? null
+}

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/swap/pricingDetails.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/swap/pricingDetails.tsx
@@ -8,12 +8,10 @@ export default (): JSX.Element => {
     selectQuoteById,
     allQuotes,
     userQuote,
+    activeQuote,
     fromToken,
     toToken
   } = useSwapContext()
-
-  // userQuote takes precedence over bestQuote
-  const selectedQuote = userQuote ?? bestQuote
 
   return (
     <SwapPricingDetailsScreen
@@ -21,7 +19,7 @@ export default (): JSX.Element => {
       toToken={toToken}
       bestQuote={bestQuote}
       userQuote={userQuote}
-      selectedQuote={selectedQuote}
+      selectedQuote={activeQuote}
       allQuotes={allQuotes}
       selectQuoteById={selectQuoteById}
     />

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/swap/slippageDetails.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/swap/slippageDetails.tsx
@@ -3,17 +3,8 @@ import { SwapSlippageDetailsScreen } from 'features/swap/screens/SwapSlippageDet
 import { useSwapContext } from 'features/swap/contexts/SwapContext'
 
 export default (): JSX.Element => {
-  const {
-    slippage,
-    setSlippage,
-    autoSlippage,
-    setAutoSlippage,
-    bestQuote,
-    userQuote
-  } = useSwapContext()
-
-  // userQuote takes precedence over bestQuote
-  const selectedQuote = userQuote ?? bestQuote
+  const { slippage, setSlippage, autoSlippage, setAutoSlippage, activeQuote } =
+    useSwapContext()
 
   return (
     <SwapSlippageDetailsScreen
@@ -21,8 +12,8 @@ export default (): JSX.Element => {
       setSlippage={setSlippage}
       autoSlippage={autoSlippage}
       setAutoSlippage={setAutoSlippage}
-      serviceType={selectedQuote?.serviceType}
-      quoteSlippageBps={selectedQuote?.slippageBps}
+      serviceType={activeQuote?.serviceType}
+      quoteSlippageBps={activeQuote?.slippageBps}
     />
   )
 }


### PR DESCRIPTION
## Description

**Ticket: [CP-14122](https://ava-labs.atlassian.net/browse/CP-14122)**

When the active swap quote fails fee validation with a provider-specific error (opaque `EstimateNativeFeeError`, arithmetic underflow during a route's fee math), the Next button was disabled and the user could only unblock the flow by manually opening the Pricing sheet and picking a different provider. This PR auto-advances to the next available quote in that case, mirroring core-web's `FusionSwapForm` behavior.

**Errors eligible for auto-advance** (tagged `kind: 'provider-specific'`):
- ✅ `insufficientFundsForFee(undefined)` — opaque `EstimateNativeFeeError` (Solana Kit simulation failure, unrecognised cause)
- ✅ `swapAmountTooSmall()` — arithmetic underflow inside a specific route's fee math

**Errors that continue to block** (balance is the same regardless of provider):
- ❌ SDK-confirmed `insufficientFundsForFee(true|false)` — SDK proved the shortfall
- ❌ Balance-threshold errors (`networkFeeExceedsBalance`, `feesExceedBalance`, `bridgeFeeExceedsBalance`, etc.)

**Key changes:**
- New `useAutoAdvanceOnFeeValidationError` hook wired into `SwapScreen`. Bounded by the existing `MARKR_SWAP_MAX_RETRIES` PostHog flag (default 3); the counter resets whenever the error clears, so changing tokens/amount gets a fresh budget.
- Extracted `findNextQuote` utility shared by the hook and `SwapContext`'s swap-time retry, so both paths walk the quote list the same way.
- Swap-time retry now also shows a snackbar (was silent) and logs via `Logger.error` (was `Logger.info`), bringing parity with the pre-swap auto-advance and giving Sentry visibility into which providers fail most.
- Added an SDK-drift note above the message-substring matchers in `fusionErrors.ts`.

**Dependencies:** none.

## Screenshots/Videos
https://github.com/user-attachments/assets/e3f5f7cf-23e3-4e17-94be-24fb273ea65a


## Testing
**iOS: 0.0.0.8310
Android: 0.0.0.8311**
1. Open the Swap screen.
2. Select AVAX → USDC.
3. Enter an amount that reliably triggers a provider-specific error on the top quote (0.5 or 1 AVAX is a good starting point).
4. Observe the snackbar: _"Quote failed gas estimation, trying next available quote"_ and that the selected quote in the Pricing sheet has advanced to the next provider.
5. Confirm Next becomes enabled once a working quote is found.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14122]: https://ava-labs.atlassian.net/browse/CP-14122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ