### PR TITLE
CP-14114: fix Show hidden filter to display only hidden NFTs

### DIFF
--- a/packages/core-mobile/app/new/features/portfolio/collectibles/hooks/useCollectiblesFilterAndSort.ts
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/hooks/useCollectiblesFilterAndSort.ts
@@ -264,10 +264,9 @@ export const useCollectiblesFilterAndSort = (
 
   const isEveryCollectibleHidden = useMemo(
     () =>
-      filteredAndSorted.every(collectible =>
-        isCollectibleVisible(collectiblesVisibility, collectible)
-      ) && collectibles?.length > 0,
-    [collectibles?.length, collectiblesVisibility, filteredAndSorted]
+      collectibles.length > 0 &&
+      collectibles.every(c => !isCollectibleVisible(collectiblesVisibility, c)),
+    [collectibles, collectiblesVisibility]
   )
 
   const isHiddenVisible = filter.selected[1] !== CollectibleStatus.Hidden

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/hooks/useCollectiblesFilterAndSort.ts
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/hooks/useCollectiblesFilterAndSort.ts
@@ -1,6 +1,6 @@
 import { DropdownSelection } from 'common/types'
 import { useCallback, useMemo, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { isAvalancheChainId } from 'services/network/utils/isAvalancheNetwork'
 import { isEthereumChainId } from 'services/network/utils/isEthereumNetwork'
 import { NftContentType, NftItem, NftLocalStatus } from 'services/nft/types'
@@ -18,8 +18,7 @@ import {
 import { isCollectibleVisible } from 'store/nft/utils'
 import {
   selectCollectibleUnprocessableVisibility,
-  selectCollectibleVisibility,
-  toggleCollectibleUnprocessableVisibility
+  selectCollectibleVisibility
 } from 'store/portfolio'
 import { sortNftsByDateUpdated } from 'services/nft/utils'
 import { useCollectiblesView } from 'features/portfolio/store'
@@ -156,6 +155,7 @@ export const useCollectiblesFilterAndSort = (
       if (nfts?.length === 0) return []
 
       const [network, contentType] = filter.selected
+      const isShowingHidden = contentType === CollectibleStatus.Hidden
 
       const availableNetworks = [
         AssetNetworkFilter.AvalancheCChain,
@@ -170,15 +170,19 @@ export const useCollectiblesFilterAndSort = (
 
       let tempNfts = [...(nfts ?? [])]
 
-      if (isUnprocessableHidden)
+      // In "Show hidden" mode we intentionally bypass the unprocessable filter
+      // so that explicitly-hidden unprocessable items also appear in the list.
+      if (isUnprocessableHidden && !isShowingHidden)
         tempNfts = tempNfts.filter((nft: NftItem) => {
           return nft.status === NftLocalStatus.Processed
         })
 
-      if (contentType !== CollectibleStatus.Hidden)
-        tempNfts = tempNfts.filter((nft: NftItem) => {
-          return isCollectibleVisible(collectiblesVisibility, nft)
-        })
+      // "Show hidden" mode: show only items the user has hidden.
+      // Normal mode: show only visible items.
+      tempNfts = tempNfts.filter((nft: NftItem) => {
+        const visible = isCollectibleVisible(collectiblesVisibility, nft)
+        return isShowingHidden ? !visible : visible
+      })
 
       if (availableNetworks.includes(network as AssetNetworkFilter))
         tempNfts = tempNfts.filter((nft: NftItem) => {
@@ -244,8 +248,6 @@ export const useCollectiblesFilterAndSort = (
     [sort.selected]
   )
 
-  const dispatch = useDispatch()
-
   const onResetFilter = (): void => {
     setSelectedNetworkFilter(AssetNetworkFilter.AllNetworks)
     setSelectedContentTypeFilter(CollectibleTypeFilter.AllContents)
@@ -253,9 +255,6 @@ export const useCollectiblesFilterAndSort = (
 
   const onShowHidden = (): void => {
     setSelectedContentTypeFilter(CollectibleStatus.Hidden)
-    if (isUnprocessableHidden && isEveryCollectibleHidden) {
-      dispatch(toggleCollectibleUnprocessableVisibility())
-    }
   }
 
   const filteredAndSorted = useMemo(() => {


### PR DESCRIPTION
## Description

**Ticket: [CP-14114]**

- Fixed `getFiltered` in `useCollectiblesFilterAndSort` so that the "Show hidden" filter displays **only** items the user has explicitly hidden, instead of showing all items regardless of visibility
- Removed erroneous `toggleCollectibleUnprocessableVisibility` dispatch from `onShowHidden` — this was unintentionally mutating unrelated Redux state on every "Show hidden" press
- In "Show hidden" mode, the unprocessable filter is now bypassed so that explicitly-hidden unprocessable items also appear in the hidden list
- Simplified `isEveryCollectibleHidden` to check the raw `collectibles` list directly instead of the derived `filteredAndSorted`, removing an indirect dependency and avoiding vacuous truth on empty arrays

## Screenshots/Videos

https://github.com/user-attachments/assets/bab59d5c-67f4-4688-ac25-87e5bd7358a8


## Testing
iOS: 8290
Android: 8291

1. Open the Collectibles tab with multiple NFTs
2. Hide several NFTs individually via Manage List (toggle OFF)
3. Return to the main Collectibles screen — hidden NFTs should not appear
4. Tap "Show hidden Nfts" in filter menu — only the hidden NFTs should appear; visible NFTs should not be listed
5. Open Manage List while in "Show hidden" mode and toggle a hidden NFT back ON
6. Return to Collectibles — that NFT should no longer appear in the "Show hidden" list
7. Un-hide all NFTs → "Show hidden" list should be empty (shows "No collectibles found" with "Reset filter" button)

## Checklist
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14114]: https://ava-labs.atlassian.net/browse/CP-14114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ