### PR TITLE
Propagate wallet active-account switch to connected dApps

### DIFF
--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -134,7 +134,7 @@ function setupMocks(
 
 // Wraps renderHook and seeds a native origin by default. Tests that explicitly
 // want the no-origin path pass an empty string: `renderProvider('')`.
-function renderProvider(url: string = 'https://example.com') {
+function renderProvider(url = 'https://example.com') {
   const hookReturn = renderHook(() =>
     useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
   )
@@ -145,6 +145,26 @@ function renderProvider(url: string = 'https://example.com') {
   }
   return hookReturn
 }
+
+// Shared helper used by prime / propagation tests — returns a mock useStore
+// whose state has an EVM permissions grant for each of `addresses` at
+// opensea.io.
+const makeOpenSeaStore = (
+  addresses: string[]
+): ReturnType<typeof useStore> =>
+  ({
+    getState: () => ({
+      permissions: {
+        grants: {
+          'https://opensea.io': Object.fromEntries(
+            addresses.map(a => [a, ['EVM']])
+          )
+        }
+      }
+    }),
+    dispatch: jest.fn(),
+    subscribe: jest.fn(() => () => undefined)
+  } as unknown as ReturnType<typeof useStore>)
 
 describe('useEvmInjectedProvider', () => {
   beforeEach(() => {
@@ -1202,10 +1222,97 @@ describe('useEvmInjectedProvider', () => {
     })
   })
 
+  describe('active account switch propagation', () => {
+    const NEW_ACTIVE = '0xSecondAccountAddress'
+
+    it('emits accountsChanged with the new active first when it is in the granted set', () => {
+      mockUseStore.mockReturnValue(
+        makeOpenSeaStore([mockActiveAccount.addressC, NEW_ACTIVE])
+      )
+      setupMocks({ account: mockActiveAccount })
+      const { result, rerender } = renderHook(() =>
+        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+      )
+      act(() => {
+        result.current.setCurrentUrl('https://opensea.io/')
+      })
+      mockInjectJavaScript.mockClear()
+
+      setupMocks({ account: { addressC: NEW_ACTIVE } })
+      rerender()
+
+      const accountsChangedCalls = mockInjectJavaScript.mock.calls.filter(
+        call => call[0].includes("__coreProviderEmit('accountsChanged'")
+      )
+      expect(accountsChangedCalls.length).toBeGreaterThan(0)
+      expect(accountsChangedCalls[0][0]).toContain(
+        `["${NEW_ACTIVE}","${mockActiveAccount.addressC}"]`
+      )
+    })
+
+    it('does NOT emit accountsChanged when the new active is not in the granted set', () => {
+      mockUseStore.mockReturnValue(
+        makeOpenSeaStore([mockActiveAccount.addressC]) // only the original
+      )
+      setupMocks({ account: mockActiveAccount })
+      const { result, rerender } = renderHook(() =>
+        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+      )
+      act(() => {
+        result.current.setCurrentUrl('https://opensea.io/')
+      })
+      mockInjectJavaScript.mockClear()
+
+      setupMocks({ account: { addressC: NEW_ACTIVE } })
+      rerender()
+
+      const accountsChangedCalls = mockInjectJavaScript.mock.calls.filter(
+        call => call[0].includes("__coreProviderEmit('accountsChanged'")
+      )
+      expect(accountsChangedCalls).toHaveLength(0)
+    })
+
+    it('does NOT emit on first render before setCurrentUrl has been called', () => {
+      mockUseStore.mockReturnValue(
+        makeOpenSeaStore([mockActiveAccount.addressC])
+      )
+      setupMocks({ account: mockActiveAccount })
+      mockInjectJavaScript.mockClear()
+
+      renderProvider('')
+
+      const accountsChangedCalls = mockInjectJavaScript.mock.calls.filter(
+        call => call[0].includes("__coreProviderEmit('accountsChanged'")
+      )
+      expect(accountsChangedCalls).toHaveLength(0)
+    })
+
+    it('does NOT emit when there is no grant for the current domain', () => {
+      mockUseStore.mockReturnValue(makeOpenSeaStore([])) // empty grants
+      setupMocks({ account: mockActiveAccount })
+      const { result, rerender } = renderHook(() =>
+        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+      )
+      act(() => {
+        result.current.setCurrentUrl('https://opensea.io/')
+      })
+      mockInjectJavaScript.mockClear()
+
+      setupMocks({ account: { addressC: NEW_ACTIVE } })
+      rerender()
+
+      const accountsChangedCalls = mockInjectJavaScript.mock.calls.filter(
+        call => call[0].includes("__coreProviderEmit('accountsChanged'")
+      )
+      expect(accountsChangedCalls).toHaveLength(0)
+    })
+  })
+
   describe('setCurrentUrl origin-change cleanup', () => {
     it('aborts in-flight signing request when navigating cross-origin', async () => {
-      const { approvalController: mockApprovalController } =
-        jest.requireMock('vmModule/ApprovalController/ApprovalController')
+      const { approvalController: mockApprovalController } = jest.requireMock(
+        'vmModule/ApprovalController/ApprovalController'
+      )
       ;(mockApprovalController.handleGoBackIfNeeded as jest.Mock).mockClear()
 
       let capturedSignal: AbortSignal | undefined
@@ -1315,23 +1422,6 @@ describe('useEvmInjectedProvider', () => {
           subscribe: jest.fn(() => () => undefined)
         } as unknown as ReturnType<typeof useStore>)
 
-      const withPermissions = (
-        addresses: string[]
-      ): ReturnType<typeof useStore> =>
-        ({
-          getState: () => ({
-            permissions: {
-              grants: {
-                'https://opensea.io': Object.fromEntries(
-                  addresses.map(a => [a, ['EVM']])
-                )
-              }
-            }
-          }),
-          dispatch: jest.fn(),
-          subscribe: jest.fn(() => () => undefined)
-        } as unknown as ReturnType<typeof useStore>)
-
       it('injects accountsChanged([address]) when the origin has a grant for the active account', () => {
         mockUseStore.mockReturnValue(withPermission(mockActiveAccount.addressC))
         const { result } = renderProvider()
@@ -1363,9 +1453,7 @@ describe('useEvmInjectedProvider', () => {
         })
 
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
-          expect.stringContaining(
-            "__coreProviderEmit('accountsChanged', [])"
-          )
+          expect.stringContaining("__coreProviderEmit('accountsChanged', [])")
         )
       })
 
@@ -1405,7 +1493,7 @@ describe('useEvmInjectedProvider', () => {
         // in insertion order but should be first in the emitted list.
         const OTHER = '0xOtherGranted111'
         mockUseStore.mockReturnValue(
-          withPermissions([OTHER, mockActiveAccount.addressC])
+          makeOpenSeaStore([OTHER, mockActiveAccount.addressC])
         )
         const { result } = renderProvider()
         act(() => {
@@ -1428,7 +1516,7 @@ describe('useEvmInjectedProvider', () => {
         // User switched wallet to account Y; only X was previously granted.
         // Emit [X] so the dApp keeps the connection it already had.
         const ONLY_OTHER = '0xOnlyOtherAddr'
-        mockUseStore.mockReturnValue(withPermissions([ONLY_OTHER]))
+        mockUseStore.mockReturnValue(makeOpenSeaStore([ONLY_OTHER]))
         const { result } = renderProvider()
         act(() => {
           result.current.setCurrentUrl('https://opensea.io/')

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -217,6 +217,36 @@ export function useEvmInjectedProvider(
     activeAccountRef.current = activeAccount
   }, [activeAccount])
 
+  // Propagate wallet active-account switches to the dApp. MetaMask users
+  // expect the wallet's account selector to flip the dApp's connected
+  // account — dApps typically have no account-picker UI of their own. We
+  // only re-order / emit when the new active account is already in the
+  // granted list for this tab's origin; switching to an ungranted account
+  // leaves the dApp's last-known state alone (user has to go through a
+  // fresh connect to add that account).
+  const lastEmittedActiveRef = useRef<string | undefined>(undefined)
+  useEffect(() => {
+    const newActive = activeAccount?.addressC
+    if (!newActive) return
+    const origin = getOriginFromUrl(currentUrlRef.current)
+    if (!origin) return
+    const granted = selectGrantedAddressesForDomain({
+      domain: origin,
+      vmType: NetworkVMType.EVM
+    })(store.getState())
+    if (granted.length === 0) return
+    if (!granted.includes(newActive)) return
+    if (lastEmittedActiveRef.current === newActive) return
+
+    const accounts = resolveGrantedAccounts(granted, newActive)
+    lastEmittedActiveRef.current = newActive
+    webViewRef.current?.injectJavaScript(
+      `window.__coreProviderEmit && window.__coreProviderEmit('accountsChanged', ${JSON.stringify(
+        accounts
+      )}); true;`
+    )
+  }, [activeAccount, store, webViewRef])
+
   const router = useMemo(() => {
     // requestSigning closes over dispatch; keep its construction inside the
     // memo so it always uses the latest dispatch and re-builds when dispatch
@@ -298,9 +328,7 @@ export function useEvmInjectedProvider(
       grantPermission: ({ domain, address, vmType }) =>
         dispatch(grantPermissionAction({ domain, address, vmType })),
       revokePermission: ({ domain, address, vmType }) =>
-        dispatch(
-          revokePermissionAction({ domain, address, vmType })
-        ),
+        dispatch(revokePermissionAction({ domain, address, vmType })),
       requestConnectApproval
     })
   }, [dispatch, tabId, sendResponse, emitEvent, getPeerMeta, store])


### PR DESCRIPTION
## Description

**Ticket: [CP-]**

Phase 3 Stage D of the injected-provider modernization plan. Closes the UX gap flagged during manual testing: after a user connects multiple accounts to a dApp, there's usually no dApp-side UI to switch between them. MetaMask solves this by letting the **wallet's active-account switcher** drive the dApp's current account — when the user picks a new active account, MetaMask emits `accountsChanged` and the dApp follows.

This PR replicates that behavior while keeping our per-address permission model from Phase 3(c).

## Behavior

When the user changes the wallet's active account:

- **New active is in the granted list for the current tab's origin:** emit `accountsChanged([newActive, ...others])`. The dApp's wagmi/viem listener updates and the dApp flips to newActive.
- **New active is NOT in the granted list:** no emit. The dApp's last-known state (granted addresses from the original connect) stays put. No accidental disconnect.

## Why not always emit?

If the user switches to an ungranted account, emitting `[newActive]` would be a security violation (exposing an address we never got consent for). Emitting `[]` would look like an unexpected disconnect to the dApp. No-op is the right behavior — the user has to go through a fresh connect (via the dApp's Connect button) to grant the new account.

## Summary of changes

- **`app/hooks/browser/useEvmInjectedProvider.ts`** — added a `useEffect` watching `activeAccount`. On change: look up granted list for current origin; if new active is in the set, emit `accountsChanged([newActive, ...others])`. A `lastEmittedActiveRef` dedups so an unrelated re-render with the same active account doesn't re-emit.
- **`app/hooks/browser/useEvmInjectedProvider.test.ts`** — 4 new tests covering:
  - active switches into granted set → emit reordered list with new active first
  - active switches to non-granted → no emit
  - first render with no origin tracked → no emit
  - no grant exists for the origin → no emit
- Plus: shared `makeOpenSeaStore` helper hoisted to module scope (replaces duplicate inline helpers that lint flagged as identical).

**Stacked on #3788** (Stage C multi-account). Base shifts to main as the stack lands.

## Screenshots/Videos

No new UI. Behavioral change is visible in the dApp: switching wallet active while on the dApp's tab now flips the dApp's connected-account view (assuming the new active is granted).

## Testing

**Unit tests:**
- `yarn test app/hooks/browser/` — 189/189 ✅

**Static:**
- `yarn tsc` — passes
- `yarn lint` — clean on touched files

**Manual dev testing (once stack merges):**

1. Rebuild. Open in-app browser, connect to a dApp (e.g. Uniswap). Tap both account A and account B in the approval modal → Connect.
2. dApp shows A as the current account.
3. Switch wallet's active account to B (Portfolio → account switcher).
4. ✅ **Expected:** dApp flips to B without any reload or dApp-side action.
5. Switch back to A → dApp flips to A.
6. Switch to C (not granted) → dApp stays on B (last-emitted state). No disconnect.

## Known follow-ups (out of scope)

- Manage connected accounts UI inside Connected Sites (to add/remove accounts on existing grants).
- Decide whether `wallet_requestPermissions` should always re-prompt (currently short-circuits on existing grants, matching `eth_requestAccounts`).

## Checklist

- [x] Self-review
- [x] Verified unit tests pass
- [x] Added testing steps
- [x] Added/updated necessary unit tests
- [ ] Included screenshots / videos of android and ios
- [ ] Updated documentation