### PR TITLE
CP-14129: stop showing notifications for deleted wallets

### DIFF
--- a/packages/core-mobile/app/new/features/notifications/components/BalanceChangeItem.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/BalanceChangeItem.tsx
@@ -1,13 +1,9 @@
 import React, { FC } from 'react'
-import { useSelector } from 'react-redux'
-import { selectAccounts } from 'store/account'
-import { selectWallets } from 'store/wallet/slice'
 import {
   AppNotification,
   isBalanceChangeNotification,
   BalanceChangeEventSchema
 } from '../types'
-import { getAccountLabel } from '../utils'
 import NotificationListItem from './NotificationListItem'
 import NotificationIcon from './NotificationIcon'
 
@@ -15,6 +11,12 @@ type BalanceChangeItemProps = {
   notification: AppNotification
   showSeparator: boolean
   accessoryType: 'chevron' | 'none'
+  /**
+   * Optional "{wallet} · {account}" label resolved by the parent screen.
+   * Prepended to the subtitle so multi-wallet users can tell which wallet a
+   * balance-change notification belongs to.
+   */
+  accountLabel?: string | null
   testID?: string
 }
 
@@ -74,11 +76,9 @@ const BalanceChangeItem: FC<BalanceChangeItemProps> = ({
   notification,
   showSeparator,
   accessoryType,
+  accountLabel,
   testID
 }) => {
-  const accounts = useSelector(selectAccounts)
-  const wallets = useSelector(selectWallets)
-  const accountLabel = getAccountLabel(notification, accounts, wallets)
   const baseSubtitle = getSubtitle(notification)
   const subtitle = accountLabel
     ? `${accountLabel} · ${baseSubtitle}`

--- a/packages/core-mobile/app/new/features/notifications/components/BalanceChangeItem.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/BalanceChangeItem.tsx
@@ -1,9 +1,13 @@
 import React, { FC } from 'react'
+import { useSelector } from 'react-redux'
+import { selectAccounts } from 'store/account'
+import { selectWallets } from 'store/wallet/slice'
 import {
   AppNotification,
   isBalanceChangeNotification,
   BalanceChangeEventSchema
 } from '../types'
+import { getAccountLabel } from '../utils'
 import NotificationListItem from './NotificationListItem'
 import NotificationIcon from './NotificationIcon'
 
@@ -72,10 +76,18 @@ const BalanceChangeItem: FC<BalanceChangeItemProps> = ({
   accessoryType,
   testID
 }) => {
+  const accounts = useSelector(selectAccounts)
+  const wallets = useSelector(selectWallets)
+  const accountLabel = getAccountLabel(notification, accounts, wallets)
+  const baseSubtitle = getSubtitle(notification)
+  const subtitle = accountLabel
+    ? `${accountLabel} · ${baseSubtitle}`
+    : baseSubtitle
+
   return (
     <NotificationListItem
       title={getTitle(notification)}
-      subtitle={getSubtitle(notification)}
+      subtitle={subtitle}
       icon={<NotificationIcon notification={notification} />}
       timestamp={notification.timestamp}
       showSeparator={showSeparator}

--- a/packages/core-mobile/app/new/features/notifications/hooks/useNotifications.ts
+++ b/packages/core-mobile/app/new/features/notifications/hooks/useNotifications.ts
@@ -6,14 +6,12 @@ import {
   UseQueryResult,
   UseMutationResult
 } from '@tanstack/react-query'
-import { useSelector } from 'react-redux'
-import { selectAccounts } from 'store/account'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import Logger from 'utils/Logger'
 import { useDeviceArn } from 'common/hooks/useDeviceArn'
 import NotificationCenterService from '../services/NotificationCenterService'
 import { AppNotification, BackendNotification, NotificationTab } from '../types'
-import { filterByOwnedAddresses, filterByTab } from '../utils'
+import { filterByTab } from '../utils'
 
 /**
  * Hook to fetch notifications from backend
@@ -36,23 +34,6 @@ export function useBackendNotifications(): UseQueryResult<
 }
 
 /**
- * Set of lowercased EVM addresses currently owned by the user's wallets. Used
- * to drop balance-change notifications for wallets that were imported and then
- * deleted (CP-14129) before the backend has caught up.
- */
-function useOwnedAddresses(): Set<string> {
-  const accounts = useSelector(selectAccounts)
-
-  return useMemo(
-    () =>
-      new Set(
-        Object.values(accounts).map(account => account.addressC.toLowerCase())
-      ),
-    [accounts]
-  )
-}
-
-/**
  * Hook to get notifications with tab filtering.
  * All notifications returned by the API are unread.
  */
@@ -61,19 +42,14 @@ export function useNotifications(tab: NotificationTab = NotificationTab.ALL): {
   isLoading: boolean
 } {
   const { data: backendNotifications, isLoading } = useBackendNotifications()
-  const ownedAddresses = useOwnedAddresses()
 
   const notifications = useMemo(() => {
-    const owned = filterByOwnedAddresses(
-      backendNotifications ?? [],
-      ownedAddresses
-    )
-    const sorted: AppNotification[] = [...owned].sort(
+    const sorted: AppNotification[] = [...(backendNotifications ?? [])].sort(
       (a, b) => b.timestamp - a.timestamp
     )
 
     return filterByTab(sorted, tab)
-  }, [backendNotifications, ownedAddresses, tab])
+  }, [backendNotifications, tab])
 
   return {
     notifications,
@@ -87,13 +63,8 @@ export function useNotifications(tab: NotificationTab = NotificationTab.ALL): {
  */
 export function useUnreadCount(): number {
   const { data: backendNotifications } = useBackendNotifications()
-  const ownedAddresses = useOwnedAddresses()
 
-  return useMemo(
-    () =>
-      filterByOwnedAddresses(backendNotifications ?? [], ownedAddresses).length,
-    [backendNotifications, ownedAddresses]
-  )
+  return backendNotifications?.length ?? 0
 }
 
 /**

--- a/packages/core-mobile/app/new/features/notifications/hooks/useNotifications.ts
+++ b/packages/core-mobile/app/new/features/notifications/hooks/useNotifications.ts
@@ -6,12 +6,14 @@ import {
   UseQueryResult,
   UseMutationResult
 } from '@tanstack/react-query'
+import { useSelector } from 'react-redux'
+import { selectAccounts } from 'store/account'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import Logger from 'utils/Logger'
 import { useDeviceArn } from 'common/hooks/useDeviceArn'
 import NotificationCenterService from '../services/NotificationCenterService'
 import { AppNotification, BackendNotification, NotificationTab } from '../types'
-import { filterByTab } from '../utils'
+import { filterByOwnedAddresses, filterByTab } from '../utils'
 
 /**
  * Hook to fetch notifications from backend
@@ -34,6 +36,23 @@ export function useBackendNotifications(): UseQueryResult<
 }
 
 /**
+ * Set of lowercased EVM addresses currently owned by the user's wallets. Used
+ * to drop balance-change notifications for wallets that were imported and then
+ * deleted (CP-14129) before the backend has caught up.
+ */
+function useOwnedAddresses(): Set<string> {
+  const accounts = useSelector(selectAccounts)
+
+  return useMemo(
+    () =>
+      new Set(
+        Object.values(accounts).map(account => account.addressC.toLowerCase())
+      ),
+    [accounts]
+  )
+}
+
+/**
  * Hook to get notifications with tab filtering.
  * All notifications returned by the API are unread.
  */
@@ -42,14 +61,19 @@ export function useNotifications(tab: NotificationTab = NotificationTab.ALL): {
   isLoading: boolean
 } {
   const { data: backendNotifications, isLoading } = useBackendNotifications()
+  const ownedAddresses = useOwnedAddresses()
 
   const notifications = useMemo(() => {
-    const sorted: AppNotification[] = [...(backendNotifications ?? [])].sort(
+    const owned = filterByOwnedAddresses(
+      backendNotifications ?? [],
+      ownedAddresses
+    )
+    const sorted: AppNotification[] = [...owned].sort(
       (a, b) => b.timestamp - a.timestamp
     )
 
     return filterByTab(sorted, tab)
-  }, [backendNotifications, tab])
+  }, [backendNotifications, ownedAddresses, tab])
 
   return {
     notifications,
@@ -63,8 +87,13 @@ export function useNotifications(tab: NotificationTab = NotificationTab.ALL): {
  */
 export function useUnreadCount(): number {
   const { data: backendNotifications } = useBackendNotifications()
+  const ownedAddresses = useOwnedAddresses()
 
-  return backendNotifications?.length ?? 0
+  return useMemo(
+    () =>
+      filterByOwnedAddresses(backendNotifications ?? [], ownedAddresses).length,
+    [backendNotifications, ownedAddresses]
+  )
 }
 
 /**

--- a/packages/core-mobile/app/new/features/notifications/screens/NotificationsScreen.tsx
+++ b/packages/core-mobile/app/new/features/notifications/screens/NotificationsScreen.tsx
@@ -14,6 +14,8 @@ import {
   selectIsInAppDefiBorrowBlocked,
   selectIsFusionEnabled
 } from 'store/posthog'
+import { selectAccounts } from 'store/account'
+import { selectWallets } from 'store/wallet/slice'
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import { LoadingState } from 'common/components/LoadingState'
 import { useFusionTransfers } from 'features/swap/hooks/useZustandStore'
@@ -35,7 +37,7 @@ import {
   isPriceAlertNotification,
   isBalanceChangeNotification
 } from '../types'
-import { isSwapTerminal } from '../utils'
+import { buildAccountLabelMap, isSwapTerminal } from '../utils'
 import { FusionTransferItem } from '../components/FusionTransferItem'
 
 const TITLE = 'Notifications'
@@ -100,14 +102,25 @@ const renderNotificationItem = (
     accessoryType: 'chevron' | 'none'
     index: number
     testID: string
-  }
+  },
+  accountLabelMap: Map<string, string>
 ): React.JSX.Element => {
   if (isPriceAlertWithData(item)) {
     return <PriceAlertItem notification={item} {...props} />
   }
 
   if (isBalanceChangeWithData(item)) {
-    return <BalanceChangeItem notification={item} {...props} />
+    const addr = isBalanceChangeNotification(item)
+      ? item.data?.accountAddress?.toLowerCase()
+      : undefined
+    const accountLabel = addr ? accountLabelMap.get(addr) ?? null : null
+    return (
+      <BalanceChangeItem
+        notification={item}
+        accountLabel={accountLabel}
+        {...props}
+      />
+    )
   }
 
   return <GenericNotificationItem notification={item} {...props} />
@@ -122,6 +135,12 @@ export const NotificationsScreen = (): JSX.Element => {
   const isEarnBlocked = useSelector(selectIsEarnBlocked)
   const isInAppDefiBorrowBlocked = useSelector(selectIsInAppDefiBorrowBlocked)
   const isFusionEnabled = useSelector(selectIsFusionEnabled)
+  const accounts = useSelector(selectAccounts)
+  const wallets = useSelector(selectWallets)
+  const accountLabelMap = useMemo(
+    () => buildAccountLabelMap(accounts, wallets),
+    [accounts, wallets]
+  )
   const selectedTabIndex = useSharedValue(0)
   const [selectedTabState, setSelectedTabState] = useState(0)
   const selectedTab = TAB_ITEMS[selectedTabState]?.value ?? NotificationTab.ALL
@@ -331,12 +350,18 @@ export const NotificationsScreen = (): JSX.Element => {
               : () => handleNotificationPress(notification)
           }
           enabled={!isClearingAll}>
-          {renderNotificationItem(notification, {
-            showSeparator: !isLast,
-            accessoryType: hasActionableUrl(notification) ? 'chevron' : 'none',
-            index,
-            testID: `notification-item-${notification.id}`
-          })}
+          {renderNotificationItem(
+            notification,
+            {
+              showSeparator: !isLast,
+              accessoryType: hasActionableUrl(notification)
+                ? 'chevron'
+                : 'none',
+              index,
+              testID: `notification-item-${notification.id}`
+            },
+            accountLabelMap
+          )}
         </SwipeableRow>
       )
     },
@@ -346,7 +371,8 @@ export const NotificationsScreen = (): JSX.Element => {
       removeTransfer,
       handleSwapActivityPress,
       dismissNotification,
-      handleNotificationPress
+      handleNotificationPress,
+      accountLabelMap
     ]
   )
 

--- a/packages/core-mobile/app/new/features/notifications/screens/NotificationsScreen.tsx
+++ b/packages/core-mobile/app/new/features/notifications/screens/NotificationsScreen.tsx
@@ -14,7 +14,7 @@ import {
   selectIsInAppDefiBorrowBlocked,
   selectIsFusionEnabled
 } from 'store/posthog'
-import { selectAccounts } from 'store/account'
+import { selectAccounts, selectActiveAccount } from 'store/account'
 import { selectWallets } from 'store/wallet/slice'
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import { LoadingState } from 'common/components/LoadingState'
@@ -137,9 +137,10 @@ export const NotificationsScreen = (): JSX.Element => {
   const isFusionEnabled = useSelector(selectIsFusionEnabled)
   const accounts = useSelector(selectAccounts)
   const wallets = useSelector(selectWallets)
+  const activeAccount = useSelector(selectActiveAccount)
   const accountLabelMap = useMemo(
-    () => buildAccountLabelMap(accounts, wallets),
-    [accounts, wallets]
+    () => buildAccountLabelMap(accounts, wallets, activeAccount?.id),
+    [accounts, wallets, activeAccount?.id]
   )
   const selectedTabIndex = useSharedValue(0)
   const [selectedTabState, setSelectedTabState] = useState(0)

--- a/packages/core-mobile/app/new/features/notifications/utils.test.ts
+++ b/packages/core-mobile/app/new/features/notifications/utils.test.ts
@@ -6,7 +6,9 @@ import {
   NotificationTab
 } from './types'
 import {
+  filterByOwnedAddresses,
   filterByTab,
+  getAccountLabel,
   isSwapTerminal,
   mapTransferToSourceChainStatus,
   mapTransferToSwapStatus,
@@ -125,6 +127,159 @@ describe('filterByTab', () => {
 
   it('returns empty array when input is empty', () => {
     expect(filterByTab([], NotificationTab.ALL)).toEqual([])
+  })
+})
+
+// ─── filterByOwnedAddresses ───────────────────────────────────────────────────
+
+describe('filterByOwnedAddresses', () => {
+  const ownedAddr = '0x1111111111111111111111111111111111111111'
+  const orphanAddr = '0x2222222222222222222222222222222222222222'
+
+  const ownedBalanceChange = makeNotification({
+    id: 'owned-bc',
+    type: 'BALANCE_CHANGES',
+    category: NotificationCategory.TRANSACTION,
+    data: { accountAddress: ownedAddr }
+  } as Partial<AppNotification> & Pick<AppNotification, 'type' | 'category'>)
+
+  const orphanBalanceChange = makeNotification({
+    id: 'orphan-bc',
+    type: 'BALANCE_CHANGES',
+    category: NotificationCategory.TRANSACTION,
+    data: { accountAddress: orphanAddr }
+  } as Partial<AppNotification> & Pick<AppNotification, 'type' | 'category'>)
+
+  it('drops balance-change notifications whose address is not owned', () => {
+    const owned = new Set([ownedAddr.toLowerCase()])
+    const result = filterByOwnedAddresses(
+      [ownedBalanceChange, orphanBalanceChange],
+      owned
+    )
+    expect(result).toEqual([ownedBalanceChange])
+  })
+
+  it('matches addresses case-insensitively', () => {
+    const owned = new Set([ownedAddr.toLowerCase()])
+    const mixedCase = makeNotification({
+      id: 'mixed',
+      type: 'BALANCE_CHANGES',
+      category: NotificationCategory.TRANSACTION,
+      data: { accountAddress: ownedAddr.toUpperCase() }
+    } as Partial<AppNotification> & Pick<AppNotification, 'type' | 'category'>)
+    expect(filterByOwnedAddresses([mixedCase], owned)).toEqual([mixedCase])
+  })
+
+  it('keeps non-balance-change notifications regardless of ownership', () => {
+    const owned = new Set<string>()
+    expect(filterByOwnedAddresses([priceAlert, news], owned)).toEqual([
+      priceAlert,
+      news
+    ])
+  })
+
+  it('keeps balance-change notifications without an accountAddress', () => {
+    const owned = new Set<string>()
+    expect(filterByOwnedAddresses([balanceChange], owned)).toEqual([
+      balanceChange
+    ])
+  })
+})
+
+// ─── getAccountLabel ──────────────────────────────────────────────────────────
+
+describe('getAccountLabel', () => {
+  const accountAddr = '0x1111111111111111111111111111111111111111'
+
+  const makeAccounts = (
+    entries: { id: string; addressC: string; name: string; walletId: string }[]
+  ): Parameters<typeof getAccountLabel>[1] =>
+    Object.fromEntries(
+      entries.map(e => [
+        e.id,
+        {
+          id: e.id,
+          addressC: e.addressC,
+          name: e.name,
+          walletId: e.walletId,
+          addressBTC: '',
+          index: 0
+        }
+      ])
+    ) as Parameters<typeof getAccountLabel>[1]
+
+  const makeWallets = (
+    entries: { id: string; name: string }[]
+  ): Parameters<typeof getAccountLabel>[2] =>
+    Object.fromEntries(
+      entries.map(e => [e.id, { id: e.id, name: e.name, type: 'MNEMONIC' }])
+    ) as Parameters<typeof getAccountLabel>[2]
+
+  const ownedBalanceChange = makeNotification({
+    id: 'owned-bc',
+    type: 'BALANCE_CHANGES',
+    category: NotificationCategory.TRANSACTION,
+    data: { accountAddress: accountAddr }
+  } as Partial<AppNotification> & Pick<AppNotification, 'type' | 'category'>)
+
+  it('returns just the account name when the user has one wallet', () => {
+    const accounts = makeAccounts([
+      { id: 'a1', addressC: accountAddr, name: 'Account 2', walletId: 'w1' }
+    ])
+    const wallets = makeWallets([{ id: 'w1', name: 'Wallet A' }])
+
+    expect(getAccountLabel(ownedBalanceChange, accounts, wallets)).toBe(
+      'Account 2'
+    )
+  })
+
+  it('prefixes the wallet name when the user has multiple wallets', () => {
+    const accounts = makeAccounts([
+      { id: 'a1', addressC: accountAddr, name: 'Account 2', walletId: 'w2' }
+    ])
+    const wallets = makeWallets([
+      { id: 'w1', name: 'Wallet A' },
+      { id: 'w2', name: 'Wallet B' }
+    ])
+
+    expect(getAccountLabel(ownedBalanceChange, accounts, wallets)).toBe(
+      'Wallet B · Account 2'
+    )
+  })
+
+  it('matches addresses case-insensitively', () => {
+    const accounts = makeAccounts([
+      {
+        id: 'a1',
+        addressC: accountAddr.toUpperCase(),
+        name: 'Account 2',
+        walletId: 'w1'
+      }
+    ])
+    const wallets = makeWallets([{ id: 'w1', name: 'Wallet A' }])
+
+    expect(getAccountLabel(ownedBalanceChange, accounts, wallets)).toBe(
+      'Account 2'
+    )
+  })
+
+  it('returns null for non-balance-change notifications', () => {
+    expect(getAccountLabel(priceAlert, {}, {})).toBeNull()
+    expect(getAccountLabel(news, {}, {})).toBeNull()
+  })
+
+  it('returns null when the address is not owned', () => {
+    const accounts = makeAccounts([
+      {
+        id: 'a1',
+        addressC: '0x9999999999999999999999999999999999999999',
+        name: 'Account 1',
+        walletId: 'w1'
+      }
+    ])
+    const wallets = makeWallets([{ id: 'w1', name: 'Wallet A' }])
+
+    expect(getAccountLabel(ownedBalanceChange, accounts, wallets)).toBeNull()
   })
 })
 

--- a/packages/core-mobile/app/new/features/notifications/utils.test.ts
+++ b/packages/core-mobile/app/new/features/notifications/utils.test.ts
@@ -212,6 +212,37 @@ describe('buildAccountLabelMap', () => {
   it('returns an empty map when there are no accounts', () => {
     expect(buildAccountLabelMap({}, {}).size).toBe(0)
   })
+
+  it('lets the active account win when an address collides across wallets', () => {
+    // e.g. a private-key wallet imports a key already derived in a mnemonic
+    // wallet — both accounts legitimately own the same EVM address.
+    const accounts = makeAccounts([
+      {
+        id: 'mnemonic-acct',
+        addressC: addr,
+        name: 'Account 5',
+        walletId: 'w1'
+      },
+      {
+        id: 'private-key-acct',
+        addressC: addr,
+        name: 'Imported',
+        walletId: 'w2'
+      }
+    ])
+    const wallets = makeWallets([
+      { id: 'w1', name: 'Mnemonic Wallet' },
+      { id: 'w2', name: 'Private Key Wallet' }
+    ])
+
+    expect(
+      buildAccountLabelMap(accounts, wallets, 'private-key-acct').get(addr)
+    ).toBe('Private Key Wallet · Imported')
+
+    expect(
+      buildAccountLabelMap(accounts, wallets, 'mnemonic-acct').get(addr)
+    ).toBe('Mnemonic Wallet · Account 5')
+  })
 })
 
 // ─── mapTransferToSwapStatus ──────────────────────────────────────────────────

--- a/packages/core-mobile/app/new/features/notifications/utils.test.ts
+++ b/packages/core-mobile/app/new/features/notifications/utils.test.ts
@@ -6,7 +6,6 @@ import {
   NotificationTab
 } from './types'
 import {
-  filterByOwnedAddresses,
   filterByTab,
   getAccountLabel,
   isSwapTerminal,
@@ -127,62 +126,6 @@ describe('filterByTab', () => {
 
   it('returns empty array when input is empty', () => {
     expect(filterByTab([], NotificationTab.ALL)).toEqual([])
-  })
-})
-
-// ─── filterByOwnedAddresses ───────────────────────────────────────────────────
-
-describe('filterByOwnedAddresses', () => {
-  const ownedAddr = '0x1111111111111111111111111111111111111111'
-  const orphanAddr = '0x2222222222222222222222222222222222222222'
-
-  const ownedBalanceChange = makeNotification({
-    id: 'owned-bc',
-    type: 'BALANCE_CHANGES',
-    category: NotificationCategory.TRANSACTION,
-    data: { accountAddress: ownedAddr }
-  } as Partial<AppNotification> & Pick<AppNotification, 'type' | 'category'>)
-
-  const orphanBalanceChange = makeNotification({
-    id: 'orphan-bc',
-    type: 'BALANCE_CHANGES',
-    category: NotificationCategory.TRANSACTION,
-    data: { accountAddress: orphanAddr }
-  } as Partial<AppNotification> & Pick<AppNotification, 'type' | 'category'>)
-
-  it('drops balance-change notifications whose address is not owned', () => {
-    const owned = new Set([ownedAddr.toLowerCase()])
-    const result = filterByOwnedAddresses(
-      [ownedBalanceChange, orphanBalanceChange],
-      owned
-    )
-    expect(result).toEqual([ownedBalanceChange])
-  })
-
-  it('matches addresses case-insensitively', () => {
-    const owned = new Set([ownedAddr.toLowerCase()])
-    const mixedCase = makeNotification({
-      id: 'mixed',
-      type: 'BALANCE_CHANGES',
-      category: NotificationCategory.TRANSACTION,
-      data: { accountAddress: ownedAddr.toUpperCase() }
-    } as Partial<AppNotification> & Pick<AppNotification, 'type' | 'category'>)
-    expect(filterByOwnedAddresses([mixedCase], owned)).toEqual([mixedCase])
-  })
-
-  it('keeps non-balance-change notifications regardless of ownership', () => {
-    const owned = new Set<string>()
-    expect(filterByOwnedAddresses([priceAlert, news], owned)).toEqual([
-      priceAlert,
-      news
-    ])
-  })
-
-  it('keeps balance-change notifications without an accountAddress', () => {
-    const owned = new Set<string>()
-    expect(filterByOwnedAddresses([balanceChange], owned)).toEqual([
-      balanceChange
-    ])
   })
 })
 

--- a/packages/core-mobile/app/new/features/notifications/utils.test.ts
+++ b/packages/core-mobile/app/new/features/notifications/utils.test.ts
@@ -6,8 +6,8 @@ import {
   NotificationTab
 } from './types'
 import {
+  buildAccountLabelMap,
   filterByTab,
-  getAccountLabel,
   isSwapTerminal,
   mapTransferToSourceChainStatus,
   mapTransferToSwapStatus,
@@ -129,14 +129,15 @@ describe('filterByTab', () => {
   })
 })
 
-// ─── getAccountLabel ──────────────────────────────────────────────────────────
+// ─── buildAccountLabelMap ─────────────────────────────────────────────────────
 
-describe('getAccountLabel', () => {
-  const accountAddr = '0x1111111111111111111111111111111111111111'
+describe('buildAccountLabelMap', () => {
+  const addr = '0x1111111111111111111111111111111111111111'
+  const otherAddr = '0x2222222222222222222222222222222222222222'
 
   const makeAccounts = (
     entries: { id: string; addressC: string; name: string; walletId: string }[]
-  ): Parameters<typeof getAccountLabel>[1] =>
+  ): Parameters<typeof buildAccountLabelMap>[0] =>
     Object.fromEntries(
       entries.map(e => [
         e.id,
@@ -149,80 +150,67 @@ describe('getAccountLabel', () => {
           index: 0
         }
       ])
-    ) as Parameters<typeof getAccountLabel>[1]
+    ) as Parameters<typeof buildAccountLabelMap>[0]
 
   const makeWallets = (
     entries: { id: string; name: string }[]
-  ): Parameters<typeof getAccountLabel>[2] =>
+  ): Parameters<typeof buildAccountLabelMap>[1] =>
     Object.fromEntries(
       entries.map(e => [e.id, { id: e.id, name: e.name, type: 'MNEMONIC' }])
-    ) as Parameters<typeof getAccountLabel>[2]
+    ) as Parameters<typeof buildAccountLabelMap>[1]
 
-  const ownedBalanceChange = makeNotification({
-    id: 'owned-bc',
-    type: 'BALANCE_CHANGES',
-    category: NotificationCategory.TRANSACTION,
-    data: { accountAddress: accountAddr }
-  } as Partial<AppNotification> & Pick<AppNotification, 'type' | 'category'>)
-
-  it('returns just the account name when the user has one wallet', () => {
+  it('uses just the account name when the user has one wallet', () => {
     const accounts = makeAccounts([
-      { id: 'a1', addressC: accountAddr, name: 'Account 2', walletId: 'w1' }
+      { id: 'a1', addressC: addr, name: 'Account 2', walletId: 'w1' }
     ])
     const wallets = makeWallets([{ id: 'w1', name: 'Wallet A' }])
 
-    expect(getAccountLabel(ownedBalanceChange, accounts, wallets)).toBe(
-      'Account 2'
-    )
+    expect(buildAccountLabelMap(accounts, wallets).get(addr)).toBe('Account 2')
   })
 
   it('prefixes the wallet name when the user has multiple wallets', () => {
     const accounts = makeAccounts([
-      { id: 'a1', addressC: accountAddr, name: 'Account 2', walletId: 'w2' }
+      { id: 'a1', addressC: addr, name: 'Account 2', walletId: 'w2' }
     ])
     const wallets = makeWallets([
       { id: 'w1', name: 'Wallet A' },
       { id: 'w2', name: 'Wallet B' }
     ])
 
-    expect(getAccountLabel(ownedBalanceChange, accounts, wallets)).toBe(
+    expect(buildAccountLabelMap(accounts, wallets).get(addr)).toBe(
       'Wallet B · Account 2'
     )
   })
 
-  it('matches addresses case-insensitively', () => {
+  it('keys the map by lowercased address regardless of input casing', () => {
     const accounts = makeAccounts([
       {
         id: 'a1',
-        addressC: accountAddr.toUpperCase(),
+        addressC: addr.toUpperCase(),
         name: 'Account 2',
         walletId: 'w1'
       }
     ])
     const wallets = makeWallets([{ id: 'w1', name: 'Wallet A' }])
 
-    expect(getAccountLabel(ownedBalanceChange, accounts, wallets)).toBe(
-      'Account 2'
-    )
+    const map = buildAccountLabelMap(accounts, wallets)
+    expect(map.get(addr)).toBe('Account 2')
+    expect(map.get(addr.toUpperCase())).toBeUndefined()
   })
 
-  it('returns null for non-balance-change notifications', () => {
-    expect(getAccountLabel(priceAlert, {}, {})).toBeNull()
-    expect(getAccountLabel(news, {}, {})).toBeNull()
-  })
-
-  it('returns null when the address is not owned', () => {
+  it('omits addresses for accounts the user does not own', () => {
     const accounts = makeAccounts([
-      {
-        id: 'a1',
-        addressC: '0x9999999999999999999999999999999999999999',
-        name: 'Account 1',
-        walletId: 'w1'
-      }
+      { id: 'a1', addressC: addr, name: 'Account 1', walletId: 'w1' }
     ])
     const wallets = makeWallets([{ id: 'w1', name: 'Wallet A' }])
 
-    expect(getAccountLabel(ownedBalanceChange, accounts, wallets)).toBeNull()
+    expect(
+      buildAccountLabelMap(accounts, wallets).get(otherAddr)
+    ).toBeUndefined()
+  })
+
+  it('returns an empty map when there are no accounts', () => {
+    expect(buildAccountLabelMap({}, {}).size).toBe(0)
   })
 })
 

--- a/packages/core-mobile/app/new/features/notifications/utils.ts
+++ b/packages/core-mobile/app/new/features/notifications/utils.ts
@@ -3,7 +3,6 @@ import { AccountCollection } from 'store/account/types'
 import { Wallet } from 'store/wallet/types'
 import {
   AppNotification,
-  isBalanceChangeNotification,
   NotificationCategory,
   NotificationTab,
   NotificationType,
@@ -103,34 +102,28 @@ export function mapTypeToCategory(
 }
 
 /**
- * Returns a short label identifying which wallet/account a balance-change
- * notification is for, so users with multiple imported wallets can tell them
- * apart. Returns null for non-balance-change notifications or when the
- * address is not owned by the user (e.g. backend lag after deletion).
+ * Builds a lookup map from lowercase EVM address to a short
+ * "wallet/account" label for every owned account, so balance-change
+ * notifications in the Notification Center can be attributed to the
+ * correct wallet without each list row re-subscribing to Redux.
  *
  * Single-wallet users see just the account name; multi-wallet users see
  * "{walletName} · {accountName}".
  */
-export function getAccountLabel(
-  notification: AppNotification,
+export function buildAccountLabelMap(
   accounts: AccountCollection,
   wallets: { [id: string]: Wallet }
-): string | null {
-  if (!isBalanceChangeNotification(notification)) return null
-  const addr = notification.data?.accountAddress?.toLowerCase()
-  if (!addr) return null
+): Map<string, string> {
+  const multiWallet = Object.keys(wallets).length > 1
+  const map = new Map<string, string>()
 
-  const account = Object.values(accounts).find(
-    a => a.addressC.toLowerCase() === addr
-  )
-  if (!account) return null
-
-  const walletCount = Object.keys(wallets).length
-  if (walletCount > 1) {
-    const wallet = wallets[account.walletId]
-    if (wallet) return `${wallet.name} · ${account.name}`
+  for (const account of Object.values(accounts)) {
+    const wallet = multiWallet ? wallets[account.walletId] : undefined
+    const label = wallet ? `${wallet.name} · ${account.name}` : account.name
+    map.set(account.addressC.toLowerCase(), label)
   }
-  return account.name
+
+  return map
 }
 
 /**

--- a/packages/core-mobile/app/new/features/notifications/utils.ts
+++ b/packages/core-mobile/app/new/features/notifications/utils.ts
@@ -103,25 +103,6 @@ export function mapTypeToCategory(
 }
 
 /**
- * Drop balance-change notifications whose target address is no longer owned by
- * the user (wallet/account was removed). Non-balance-change notifications pass
- * through unchanged. The backend still returns these until its own cleanup
- * runs, so we filter client-side to avoid surfacing stranger-wallet activity in
- * the Notification Center — see CP-14129.
- */
-export function filterByOwnedAddresses(
-  notifications: AppNotification[],
-  ownedAddresses: Set<string>
-): AppNotification[] {
-  return notifications.filter(n => {
-    if (n.type !== 'BALANCE_CHANGES') return true
-    const addr = n.data?.accountAddress?.toLowerCase()
-    if (!addr) return true
-    return ownedAddresses.has(addr)
-  })
-}
-
-/**
  * Returns a short label identifying which wallet/account a balance-change
  * notification is for, so users with multiple imported wallets can tell them
  * apart. Returns null for non-balance-change notifications or when the

--- a/packages/core-mobile/app/new/features/notifications/utils.ts
+++ b/packages/core-mobile/app/new/features/notifications/utils.ts
@@ -1,6 +1,9 @@
 import { Transfer } from 'features/swap/types'
+import { AccountCollection } from 'store/account/types'
+import { Wallet } from 'store/wallet/types'
 import {
   AppNotification,
+  isBalanceChangeNotification,
   NotificationCategory,
   NotificationTab,
   NotificationType,
@@ -97,6 +100,56 @@ export function mapTypeToCategory(
     default:
       return NotificationCategory.NEWS
   }
+}
+
+/**
+ * Drop balance-change notifications whose target address is no longer owned by
+ * the user (wallet/account was removed). Non-balance-change notifications pass
+ * through unchanged. The backend still returns these until its own cleanup
+ * runs, so we filter client-side to avoid surfacing stranger-wallet activity in
+ * the Notification Center — see CP-14129.
+ */
+export function filterByOwnedAddresses(
+  notifications: AppNotification[],
+  ownedAddresses: Set<string>
+): AppNotification[] {
+  return notifications.filter(n => {
+    if (n.type !== 'BALANCE_CHANGES') return true
+    const addr = n.data?.accountAddress?.toLowerCase()
+    if (!addr) return true
+    return ownedAddresses.has(addr)
+  })
+}
+
+/**
+ * Returns a short label identifying which wallet/account a balance-change
+ * notification is for, so users with multiple imported wallets can tell them
+ * apart. Returns null for non-balance-change notifications or when the
+ * address is not owned by the user (e.g. backend lag after deletion).
+ *
+ * Single-wallet users see just the account name; multi-wallet users see
+ * "{walletName} · {accountName}".
+ */
+export function getAccountLabel(
+  notification: AppNotification,
+  accounts: AccountCollection,
+  wallets: { [id: string]: Wallet }
+): string | null {
+  if (!isBalanceChangeNotification(notification)) return null
+  const addr = notification.data?.accountAddress?.toLowerCase()
+  if (!addr) return null
+
+  const account = Object.values(accounts).find(
+    a => a.addressC.toLowerCase() === addr
+  )
+  if (!account) return null
+
+  const walletCount = Object.keys(wallets).length
+  if (walletCount > 1) {
+    const wallet = wallets[account.walletId]
+    if (wallet) return `${wallet.name} · ${account.name}`
+  }
+  return account.name
 }
 
 /**

--- a/packages/core-mobile/app/new/features/notifications/utils.ts
+++ b/packages/core-mobile/app/new/features/notifications/utils.ts
@@ -108,19 +108,36 @@ export function mapTypeToCategory(
  * correct wallet without each list row re-subscribing to Redux.
  *
  * Single-wallet users see just the account name; multi-wallet users see
- * "{walletName} · {accountName}".
+ * "{walletName} · {accountName}". When the same EVM address is owned by
+ * accounts in multiple wallets (e.g. a private-key wallet importing a key
+ * already derived inside a mnemonic wallet), the active account wins so
+ * the user sees the wallet they currently consider canonical for that
+ * address.
  */
 export function buildAccountLabelMap(
   accounts: AccountCollection,
-  wallets: { [id: string]: Wallet }
+  wallets: { [id: string]: Wallet },
+  activeAccountId?: string | null
 ): Map<string, string> {
   const multiWallet = Object.keys(wallets).length > 1
   const map = new Map<string, string>()
 
-  for (const account of Object.values(accounts)) {
+  // Process the active account first so its label wins on collisions; the
+  // remaining accounts only fill in addresses that are not already covered.
+  const activeAccount = activeAccountId ? accounts[activeAccountId] : undefined
+  const ordered = activeAccount
+    ? [
+        activeAccount,
+        ...Object.values(accounts).filter(a => a.id !== activeAccount.id)
+      ]
+    : Object.values(accounts)
+
+  for (const account of ordered) {
+    const key = account.addressC.toLowerCase()
+    if (map.has(key)) continue
     const wallet = multiWallet ? wallets[account.walletId] : undefined
     const label = wallet ? `${wallet.name} · ${account.name}` : account.name
-    map.set(account.addressC.toLowerCase(), label)
+    map.set(key, label)
   }
 
   return map

--- a/packages/core-mobile/app/services/notifications/balanceChange/subscribeForBalanceChange.test.ts
+++ b/packages/core-mobile/app/services/notifications/balanceChange/subscribeForBalanceChange.test.ts
@@ -41,7 +41,8 @@ describe('subscribe', () => {
         deviceArn,
         chainIds,
         addresses
-      })
+      }),
+      { signal: undefined }
     )
 
     // Check if the response was handled correctly
@@ -70,5 +71,27 @@ describe('subscribe', () => {
     await expect(
       subscribeForBalanceChange({ deviceArn, chainIds, addresses })
     ).rejects.toThrow('404:not found')
+  })
+
+  it('forwards an abort signal so superseded subscribes can be cancelled', async () => {
+    mockAppCheckPostJson.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({ message: 'ok' })
+    })
+    const controller = new AbortController()
+
+    await subscribeForBalanceChange({
+      deviceArn,
+      chainIds,
+      addresses,
+      signal: controller.signal
+    })
+
+    expect(mockAppCheckPostJson).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      { signal: controller.signal }
+    )
   })
 })

--- a/packages/core-mobile/app/services/notifications/balanceChange/subscribeForBalanceChange.ts
+++ b/packages/core-mobile/app/services/notifications/balanceChange/subscribeForBalanceChange.ts
@@ -5,11 +5,13 @@ import { appCheckPostJson } from 'utils/api/common/appCheckFetch'
 export async function subscribeForBalanceChange({
   deviceArn,
   chainIds,
-  addresses
+  addresses,
+  signal
 }: {
   deviceArn: string
   chainIds: string[]
   addresses: string[]
+  signal?: AbortSignal
 }): Promise<{ message: 'ok' }> {
   const response = await appCheckPostJson(
     Config.NOTIFICATION_SENDER_API_URL + '/v1/push/balance-changes/subscribe',
@@ -17,7 +19,8 @@ export async function subscribeForBalanceChange({
       deviceArn,
       chainIds,
       addresses
-    })
+    }),
+    { signal }
   ).catch(error => {
     Logger.error(`[subscribeForBalanceChange.ts][subscribe]${error}`)
     throw new Error(error)

--- a/packages/core-mobile/app/store/notifications/listeners/listeners.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/listeners.ts
@@ -93,7 +93,6 @@ export const addNotificationsListeners = (
 
   startListening({
     matcher: isAnyOf(
-      onRehydrationComplete,
       onAppUnlocked,
       setAccounts,
       setNonActiveAccounts,
@@ -104,6 +103,11 @@ export const addNotificationsListeners = (
       onNotificationsTurnedOnForBalanceChange
     ),
     effect: async (_, listenerApi) => {
+      // removeWallet dispatches removeAccount once per account synchronously,
+      // so coalesce bursts to avoid an out-of-order subscribe re-adding an
+      // address we just removed (the backend reconciles to the posted set).
+      listenerApi.cancelActiveListeners()
+      await listenerApi.delay(100)
       await subscribeBalanceChangeNotifications(listenerApi).catch(reason => {
         Logger.error(
           `[listeners.ts][subscribeBalanceChangeNotifications]${reason}`

--- a/packages/core-mobile/app/store/notifications/listeners/listeners.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/listeners.ts
@@ -106,8 +106,14 @@ export const addNotificationsListeners = (
       // removeWallet dispatches removeAccount once per account synchronously,
       // so coalesce bursts to avoid an out-of-order subscribe re-adding an
       // address we just removed (the backend reconciles to the posted set).
+      // The signal is also threaded into the fetch so a superseded request is
+      // aborted on the wire, not just at the listener boundary.
       listenerApi.cancelActiveListeners()
-      await listenerApi.delay(100)
+      try {
+        await listenerApi.delay(100)
+      } catch {
+        return
+      }
       await subscribeBalanceChangeNotifications(listenerApi).catch(reason => {
         Logger.error(
           `[listeners.ts][subscribeBalanceChangeNotifications]${reason}`

--- a/packages/core-mobile/app/store/notifications/listeners/listeners.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/listeners.ts
@@ -1,6 +1,11 @@
 import { AppStartListening } from 'store/types'
 import { onAppUnlocked, onLogOut, onRehydrationComplete } from 'store/app'
-import { setAccount, setAccounts, setNonActiveAccounts } from 'store/account'
+import {
+  removeAccount,
+  setAccount,
+  setAccounts,
+  setNonActiveAccounts
+} from 'store/account'
 import { subscribeBalanceChangeNotifications } from 'store/notifications/listeners/subscribeBalanceChangeNotifications'
 import Logger from 'utils/Logger'
 import { AnyAction, isAnyOf, PayloadAction } from '@reduxjs/toolkit'
@@ -92,6 +97,7 @@ export const addNotificationsListeners = (
       setAccounts,
       setNonActiveAccounts,
       setAccount,
+      removeAccount,
       onFcmTokenChange,
       turnOnAllNotifications,
       onNotificationsTurnedOnForBalanceChange

--- a/packages/core-mobile/app/store/notifications/listeners/listeners.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/listeners.ts
@@ -94,6 +94,7 @@ export const addNotificationsListeners = (
   startListening({
     matcher: isAnyOf(
       onRehydrationComplete,
+      onAppUnlocked,
       setAccounts,
       setNonActiveAccounts,
       setAccount,

--- a/packages/core-mobile/app/store/notifications/listeners/listeners.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/listeners.ts
@@ -103,11 +103,15 @@ export const addNotificationsListeners = (
       onNotificationsTurnedOnForBalanceChange
     ),
     effect: async (_, listenerApi) => {
-      // removeWallet dispatches removeAccount once per account synchronously,
-      // so coalesce bursts to avoid an out-of-order subscribe re-adding an
-      // address we just removed (the backend reconciles to the posted set).
-      // The signal is also threaded into the fetch so a superseded request is
-      // aborted on the wire, not just at the listener boundary.
+      // Coalesce bursts so only the latest invocation posts to the backend
+      // (the subscribe endpoint reconciles to the *current* address set, so
+      // an out-of-order older POST could re-add an address we just removed).
+      // Bursts happen for any matched action — most notably `removeWallet`,
+      // which dispatches `removeAccount` once per account in the same tick —
+      // but also rapid imports, sign-in flows, etc.
+      // `cancelActiveListeners()` aborts the listener task and the threaded
+      // `listenerApi.signal` aborts any in-flight subscribe fetch, so the
+      // last invocation wins both at the listener boundary and on the wire.
       listenerApi.cancelActiveListeners()
       try {
         await listenerApi.delay(100)

--- a/packages/core-mobile/app/store/notifications/listeners/subscribeBalanceChangeNotifications.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/subscribeBalanceChangeNotifications.ts
@@ -51,7 +51,8 @@ export async function subscribeBalanceChangeNotifications(
   const response = await subscribeForBalanceChange({
     addresses,
     chainIds,
-    deviceArn
+    deviceArn,
+    signal: listenerApi.signal
   })
   if (response.message !== 'ok') {
     Logger.error(

--- a/packages/core-mobile/app/utils/api/common/appCheckFetch.ts
+++ b/packages/core-mobile/app/utils/api/common/appCheckFetch.ts
@@ -104,11 +104,13 @@ export const appCheckStreamingFetch = async (
 
 export const appCheckPostJson = async (
   url: string,
-  bodyJson: string
+  bodyJson: string,
+  options?: { signal?: AbortSignal }
 ): Promise<Response> => {
   return appCheckFetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: bodyJson
+    body: bodyJson,
+    signal: options?.signal
   })
 }


### PR DESCRIPTION
## Summary
- Re-subscribes balance-change notifications on `removeAccount` so the backend webhook drops addresses for deleted wallets. The `/v1/push/balance-changes/subscribe` endpoint is a full override (confirmed by Ferenc and the service docs), so re-posting the current address list is the correct "unsubscribe" — the dedicated unsubscribe endpoint is device-wide and wrong for this case.
- Re-runs the same subscribe on `onAppUnlocked` so users who already deleted a wallet *before* installing this version get auto-reconciled the next time they open the app, rather than having to re-add and remove the wallet.
- Shows the wallet/account a balance-change item belongs to in the Notification Center, so users with multiple imported wallets can tell them apart (Gergely's ask).

https://github.com/user-attachments/assets/3622abd0-aa44-41e2-ac68-9aea92862465




## Why
Akash reported this morning that the Notification Center was showing transactions he never made ("USDC approved", etc.). Amanda screen-shared with him and repro'd the bug: import a wallet, delete it, have someone else transact on that address → the tx still appears in Akash's NC.

Root cause on the mobile side: `removeAccount` / `removeWallet` Redux dispatches never re-triggered `subscribeBalanceChangeNotifications`, so the backend kept the deleted address subscribed. Parallel fix landing on extension (Bohdan, linked thread below) uses the same approach since the extension already resubscribes on `ACCOUNTS_UPDATED`.

Expected behavior, confirmed by Gergely + Ferenc ([thread](https://avalancheavax.slack.com/archives/C0440E1H8DS/p1777040332726119)):

iOS: 8351
Android: 8352

1. Add wallet 1 & 2
2. Transact on wallet 2 → TX1 delivered
3. NC shows TX1
4. Remove wallet 2
5. Someone transacts on wallet 2 → TX2
6. **TX1 should remain in the NC until dismissed** (already delivered history)
7. **TX2 should not arrive**

Step 7 is handled by the listener change (this PR). Step 6 means we intentionally do **not** filter already-delivered notifications client-side — Ferenc confirmed the backend keeps history and Gergely confirmed that's the desired UX.

Jira:
- https://ava-labs.atlassian.net/browse/CP-14129 — Amanda's mobile NC ticket
- https://ava-labs.atlassian.net/browse/CP-14130 — cross-platform client-side bug (Bohdan, extension fix in parallel)

## Test plan
- [ ] Import a second wallet into a prod build
- [ ] Have someone transact on that wallet → confirm notification appears in NC attributed to the correct wallet/account
- [ ] Delete the imported wallet
- [ ] Have them transact again → confirm **no new notification** appears for the deleted address
- [ ] Confirm the **previously-delivered** notification for the deleted wallet is **still visible** in the NC until dismissed
- [ ] **Legacy-user case:** on a build *before* this PR, import a wallet, delete it, then upgrade to this build. Open the app and unlock with PIN. Have someone transact on the deleted address → confirm no new notification arrives (the unlock-time re-sync should drop it from the backend webhook).
- [ ] Single-wallet setup: items show just the account name (e.g. "Account 2 · to 0x...")
- [ ] Two-wallet setup: items show wallet + account (e.g. "Wallet B · Account 2 · to 0x...")
- [ ] Confirm price-alert and news notifications still render unchanged