### PR TITLE
CP-8877: fix NFT purchases shown as swaps in activity history

### DIFF
--- a/packages/core-mobile/app/new/features/activity/utils.test.ts
+++ b/packages/core-mobile/app/new/features/activity/utils.test.ts
@@ -209,6 +209,34 @@ describe('isCollectibleTransaction', () => {
 
     expect(isCollectibleTransaction(tx)).toBe(false)
   })
+
+  it('respects explicit SWAP txType even when an NFT leg is present', () => {
+    // Defensive guard: if the backend confidently classified the tx as a
+    // swap, we should not reclassify it as a collectible just because a
+    // routing leg happens to include an NFT token entry.
+    const tx = makeTx({
+      isContractCall: true,
+      txType: TransactionType.SWAP,
+      tokens: [
+        {
+          type: TokenType.NATIVE,
+          name: 'Avalanche',
+          symbol: 'AVAX',
+          amount: '1'
+        },
+        {
+          type: TokenType.ERC721,
+          address: NFT_CONTRACT,
+          name: 'Cool NFT',
+          symbol: 'COOL',
+          amount: '1',
+          collectableTokenId: TOKEN_ID
+        }
+      ]
+    })
+
+    expect(isCollectibleTransaction(tx)).toBe(false)
+  })
 })
 
 describe('isNftTransaction', () => {

--- a/packages/core-mobile/app/new/features/activity/utils.test.ts
+++ b/packages/core-mobile/app/new/features/activity/utils.test.ts
@@ -1,0 +1,272 @@
+import { ChainId } from '@avalabs/core-chains-sdk'
+import { TokenType, TransactionType } from '@avalabs/vm-module-types'
+import { Transaction } from 'store/transaction'
+import {
+  findNftToken,
+  isCollectibleTransaction,
+  isNftTransaction,
+  isPotentiallySwap
+} from './utils'
+
+const USER_ADDRESS = '0xUser'
+const MARKETPLACE = '0xMarketplace'
+const NFT_CONTRACT = '0xCollection'
+const TOKEN_ID = '42'
+
+function makeTx(
+  overrides: Partial<Transaction> & { tokens: Transaction['tokens'] }
+): Transaction {
+  return {
+    isContractCall: false,
+    isIncoming: false,
+    isOutgoing: false,
+    isSender: false,
+    timestamp: Date.now(),
+    hash: '0xabc',
+    from: USER_ADDRESS,
+    to: '0xto',
+    gasUsed: '21000',
+    chainId: String(ChainId.AVALANCHE_MAINNET_ID),
+    explorerLink: '',
+    txType: TransactionType.UNKNOWN,
+    ...overrides
+  }
+}
+
+describe('findNftToken', () => {
+  it('returns the NFT token when it sits at index 1 (purchase pattern)', () => {
+    const tx = makeTx({
+      tokens: [
+        {
+          type: TokenType.NATIVE,
+          name: 'Avalanche',
+          symbol: 'AVAX',
+          amount: '0.075'
+        },
+        {
+          type: TokenType.ERC721,
+          address: NFT_CONTRACT,
+          name: 'Cool NFT',
+          symbol: 'COOL',
+          amount: '1',
+          collectableTokenId: TOKEN_ID
+        }
+      ]
+    })
+
+    const nft = findNftToken(tx)
+    expect(nft?.type).toBe(TokenType.ERC721)
+    expect(nft?.collectableTokenId).toBe(TOKEN_ID)
+  })
+
+  it('prefers the NFT entry that carries collectableTokenId when paired entries exist', () => {
+    const tx = makeTx({
+      tokens: [
+        {
+          type: TokenType.ERC721,
+          address: NFT_CONTRACT,
+          name: 'Cool NFT',
+          symbol: 'COOL',
+          amount: '1'
+        },
+        {
+          type: TokenType.ERC721,
+          address: NFT_CONTRACT,
+          name: 'Cool NFT',
+          symbol: 'COOL',
+          amount: '1',
+          collectableTokenId: TOKEN_ID
+        }
+      ]
+    })
+
+    expect(findNftToken(tx)?.collectableTokenId).toBe(TOKEN_ID)
+  })
+
+  it('returns undefined when no NFT token is present', () => {
+    const tx = makeTx({
+      tokens: [
+        {
+          type: TokenType.NATIVE,
+          name: 'Avalanche',
+          symbol: 'AVAX',
+          amount: '1'
+        },
+        {
+          type: TokenType.ERC20,
+          address: '0x123',
+          name: 'USDC',
+          symbol: 'USDC',
+          amount: '5'
+        }
+      ]
+    })
+
+    expect(findNftToken(tx)).toBeUndefined()
+  })
+})
+
+describe('isCollectibleTransaction', () => {
+  it('detects a marketplace NFT purchase (NATIVE + ERC721, txType=UNKNOWN)', () => {
+    const tx = makeTx({
+      isContractCall: true,
+      txType: TransactionType.UNKNOWN,
+      tokens: [
+        {
+          type: TokenType.NATIVE,
+          name: 'Avalanche',
+          symbol: 'AVAX',
+          amount: '0.075',
+          from: { address: USER_ADDRESS }
+        },
+        {
+          type: TokenType.ERC721,
+          address: NFT_CONTRACT,
+          name: 'Cool NFT',
+          symbol: 'COOL',
+          amount: '1',
+          collectableTokenId: TOKEN_ID,
+          from: { address: MARKETPLACE },
+          to: { address: USER_ADDRESS }
+        }
+      ]
+    })
+
+    expect(isCollectibleTransaction(tx)).toBe(true)
+  })
+
+  it('still detects the legacy paired-NFT pattern', () => {
+    const tx = makeTx({
+      tokens: [
+        {
+          type: TokenType.ERC721,
+          address: NFT_CONTRACT,
+          name: 'Cool NFT',
+          symbol: 'COOL',
+          amount: '1'
+        },
+        {
+          type: TokenType.ERC721,
+          address: NFT_CONTRACT,
+          name: 'Cool NFT',
+          symbol: 'COOL',
+          amount: '1',
+          collectableTokenId: TOKEN_ID
+        }
+      ]
+    })
+
+    expect(isCollectibleTransaction(tx)).toBe(true)
+  })
+
+  it('detects via txType for NFT_BUY / NFT_SEND / NFT_RECEIVE', () => {
+    const baseTokens: Transaction['tokens'] = [
+      {
+        type: TokenType.NATIVE,
+        name: 'Avalanche',
+        symbol: 'AVAX',
+        amount: '1'
+      }
+    ]
+
+    expect(
+      isCollectibleTransaction(
+        makeTx({ txType: TransactionType.NFT_BUY, tokens: baseTokens })
+      )
+    ).toBe(true)
+    expect(
+      isCollectibleTransaction(
+        makeTx({ txType: TransactionType.NFT_SEND, tokens: baseTokens })
+      )
+    ).toBe(true)
+    expect(
+      isCollectibleTransaction(
+        makeTx({ txType: TransactionType.NFT_RECEIVE, tokens: baseTokens })
+      )
+    ).toBe(true)
+  })
+
+  it('returns false for plain swap-like transactions (no NFT, non-NFT txType)', () => {
+    const tx = makeTx({
+      isContractCall: true,
+      txType: TransactionType.SWAP,
+      tokens: [
+        {
+          type: TokenType.NATIVE,
+          name: 'Avalanche',
+          symbol: 'AVAX',
+          amount: '1'
+        },
+        {
+          type: TokenType.ERC20,
+          address: '0x123',
+          name: 'USDC',
+          symbol: 'USDC',
+          amount: '20'
+        }
+      ]
+    })
+
+    expect(isCollectibleTransaction(tx)).toBe(false)
+  })
+})
+
+describe('isNftTransaction', () => {
+  it('returns true only for NFT_* txTypes', () => {
+    expect(
+      isNftTransaction(makeTx({ txType: TransactionType.NFT_BUY, tokens: [] }))
+    ).toBe(true)
+    expect(
+      isNftTransaction(makeTx({ txType: TransactionType.NFT_SEND, tokens: [] }))
+    ).toBe(true)
+    expect(
+      isNftTransaction(
+        makeTx({ txType: TransactionType.NFT_RECEIVE, tokens: [] })
+      )
+    ).toBe(true)
+    expect(
+      isNftTransaction(makeTx({ txType: TransactionType.SWAP, tokens: [] }))
+    ).toBe(false)
+  })
+})
+
+describe('isPotentiallySwap', () => {
+  it('returns true when tx and token from/to addresses match', () => {
+    const tx = makeTx({
+      from: USER_ADDRESS,
+      to: MARKETPLACE,
+      tokens: [
+        {
+          type: TokenType.NATIVE,
+          name: 'Avalanche',
+          symbol: 'AVAX',
+          amount: '1',
+          from: { address: USER_ADDRESS },
+          to: { address: MARKETPLACE }
+        }
+      ]
+    })
+
+    expect(isPotentiallySwap(tx)).toBe(true)
+  })
+
+  it('returns false when token transfer does not align with tx endpoints', () => {
+    const tx = makeTx({
+      from: USER_ADDRESS,
+      to: MARKETPLACE,
+      tokens: [
+        {
+          type: TokenType.ERC20,
+          address: '0x123',
+          name: 'Tok',
+          symbol: 'TKN',
+          amount: '1',
+          from: { address: '0xother' },
+          to: { address: USER_ADDRESS }
+        }
+      ]
+    })
+
+    expect(isPotentiallySwap(tx)).toBe(false)
+  })
+})

--- a/packages/core-mobile/app/new/features/activity/utils.test.ts
+++ b/packages/core-mobile/app/new/features/activity/utils.test.ts
@@ -1,11 +1,17 @@
 import { ChainId } from '@avalabs/core-chains-sdk'
-import { TokenType, TransactionType } from '@avalabs/vm-module-types'
+import { TokenType, TransactionType, TxToken } from '@avalabs/vm-module-types'
+import { Account } from 'store/account'
 import { Transaction } from 'store/transaction'
 import {
   findNftToken,
+  findPaymentToken,
+  getNftLabel,
   isCollectibleTransaction,
   isNftTransaction,
-  isPotentiallySwap
+  isPaymentTokenType,
+  isPotentiallySwap,
+  resolvePaymentSymbol,
+  resolveUserIsRecipient
 } from './utils'
 
 const USER_ADDRESS = '0xUser'
@@ -296,5 +302,249 @@ describe('isPotentiallySwap', () => {
     })
 
     expect(isPotentiallySwap(tx)).toBe(false)
+  })
+})
+
+describe('isPaymentTokenType', () => {
+  it('accepts NATIVE and ERC20 as payment legs', () => {
+    expect(isPaymentTokenType({ type: TokenType.NATIVE } as TxToken)).toBe(true)
+    expect(isPaymentTokenType({ type: TokenType.ERC20 } as TxToken)).toBe(true)
+  })
+
+  it('rejects ERC721/ERC1155 and undefined', () => {
+    expect(isPaymentTokenType({ type: TokenType.ERC721 } as TxToken)).toBe(
+      false
+    )
+    expect(isPaymentTokenType({ type: TokenType.ERC1155 } as TxToken)).toBe(
+      false
+    )
+    expect(isPaymentTokenType(undefined)).toBe(false)
+  })
+})
+
+describe('resolvePaymentSymbol', () => {
+  it('returns the token symbol when present', () => {
+    const token = {
+      type: TokenType.ERC20,
+      symbol: 'USDC',
+      name: 'USDC',
+      amount: '5'
+    } as TxToken
+    expect(resolvePaymentSymbol(token, 'AVAX')).toBe('USDC')
+  })
+
+  it('falls back to the network token symbol for NATIVE legs without a symbol', () => {
+    const token = {
+      type: TokenType.NATIVE,
+      symbol: '',
+      name: '',
+      amount: '1'
+    } as TxToken
+    expect(resolvePaymentSymbol(token, 'AVAX')).toBe('AVAX')
+  })
+
+  it('falls back to the token type as a last resort', () => {
+    const token = {
+      type: TokenType.ERC20,
+      symbol: '',
+      name: '',
+      amount: '1'
+    } as TxToken
+    expect(resolvePaymentSymbol(token, undefined)).toBe(TokenType.ERC20)
+  })
+})
+
+const buildAccount = (overrides: Partial<Account> = {}): Account =>
+  ({
+    addressC: USER_ADDRESS,
+    addressBTC: '',
+    addressAVM: '',
+    addressPVM: '',
+    addressSVM: '',
+    ...overrides
+  } as unknown as Account)
+
+describe('resolveUserIsRecipient', () => {
+  it('returns true when the NFT lands at the user address', () => {
+    const nftToken = {
+      type: TokenType.ERC721,
+      from: { address: MARKETPLACE },
+      to: { address: USER_ADDRESS }
+    } as TxToken
+    const tx = makeTx({ tokens: [nftToken] })
+
+    expect(
+      resolveUserIsRecipient({
+        nftToken,
+        userAddressLower: USER_ADDRESS.toLowerCase(),
+        transaction: tx,
+        account: buildAccount()
+      })
+    ).toBe(true)
+  })
+
+  it('returns false when the NFT leaves the user address', () => {
+    const nftToken = {
+      type: TokenType.ERC721,
+      from: { address: USER_ADDRESS },
+      to: { address: MARKETPLACE }
+    } as TxToken
+    const tx = makeTx({ tokens: [nftToken] })
+
+    expect(
+      resolveUserIsRecipient({
+        nftToken,
+        userAddressLower: USER_ADDRESS.toLowerCase(),
+        transaction: tx,
+        account: buildAccount()
+      })
+    ).toBe(false)
+  })
+
+  it('falls back to tx-level isSender flag when the NFT leg has no addresses', () => {
+    const nftToken = { type: TokenType.ERC721 } as TxToken
+    const tx = makeTx({ tokens: [nftToken], isSender: true })
+
+    expect(
+      resolveUserIsRecipient({
+        nftToken,
+        userAddressLower: USER_ADDRESS.toLowerCase(),
+        transaction: tx,
+        account: buildAccount()
+      })
+    ).toBe(false)
+  })
+
+  it('falls back to account-derived sender check when nftToken is undefined', () => {
+    const tx = makeTx({ tokens: [], from: USER_ADDRESS })
+
+    expect(
+      resolveUserIsRecipient({
+        nftToken: undefined,
+        userAddressLower: USER_ADDRESS.toLowerCase(),
+        transaction: tx,
+        account: buildAccount({ addressC: USER_ADDRESS })
+      })
+    ).toBe(false)
+  })
+})
+
+describe('findPaymentToken', () => {
+  const userLower = USER_ADDRESS.toLowerCase()
+
+  it('returns the directional payment token when the user is the buyer', () => {
+    const payment = {
+      type: TokenType.NATIVE,
+      symbol: 'AVAX',
+      amount: '0.075',
+      from: { address: USER_ADDRESS },
+      to: { address: MARKETPLACE }
+    } as TxToken
+    const nft = {
+      type: TokenType.ERC721,
+      from: { address: MARKETPLACE },
+      to: { address: USER_ADDRESS }
+    } as TxToken
+
+    expect(findPaymentToken([payment, nft], true, userLower)).toBe(payment)
+  })
+
+  it('returns the directional payment token when the user is the seller', () => {
+    const payment = {
+      type: TokenType.ERC20,
+      symbol: 'USDC',
+      amount: '20',
+      from: { address: MARKETPLACE },
+      to: { address: USER_ADDRESS }
+    } as TxToken
+    const nft = {
+      type: TokenType.ERC721,
+      from: { address: USER_ADDRESS },
+      to: { address: MARKETPLACE }
+    } as TxToken
+
+    expect(findPaymentToken([payment, nft], false, userLower)).toBe(payment)
+  })
+
+  it('falls back to a single payment token when direction info is missing', () => {
+    const payment = {
+      type: TokenType.NATIVE,
+      symbol: 'AVAX',
+      amount: '1'
+    } as TxToken
+    const nft = { type: TokenType.ERC721 } as TxToken
+
+    expect(findPaymentToken([payment, nft], true, userLower)).toBe(payment)
+  })
+
+  it('does NOT fall back when multiple payment legs are ambiguous', () => {
+    const payment1 = {
+      type: TokenType.NATIVE,
+      symbol: 'AVAX',
+      amount: '1'
+    } as TxToken
+    const payment2 = {
+      type: TokenType.ERC20,
+      symbol: 'USDC',
+      amount: '10'
+    } as TxToken
+
+    expect(
+      findPaymentToken([payment1, payment2], true, userLower)
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when no NATIVE/ERC20 leg exists', () => {
+    const nft = { type: TokenType.ERC721 } as TxToken
+    expect(findPaymentToken([nft], true, userLower)).toBeUndefined()
+  })
+})
+
+describe('getNftLabel', () => {
+  it('combines name and symbol when distinct', () => {
+    expect(
+      getNftLabel({
+        type: TokenType.ERC721,
+        name: 'Cool NFT',
+        symbol: 'COOL'
+      } as TxToken)
+    ).toBe('Cool NFT (COOL)')
+  })
+
+  it('avoids redundant "Name (SYMBOL)" when they match (case-insensitive)', () => {
+    expect(
+      getNftLabel({
+        type: TokenType.ERC1155,
+        name: 'AvaxApes',
+        symbol: 'avaxapes'
+      } as TxToken)
+    ).toBe('AvaxApes')
+  })
+
+  it('returns the symbol alone when name is missing', () => {
+    expect(
+      getNftLabel({
+        type: TokenType.ERC721,
+        name: '',
+        symbol: 'COOL'
+      } as TxToken)
+    ).toBe('COOL')
+  })
+
+  it('returns the name alone when symbol is missing', () => {
+    expect(
+      getNftLabel({
+        type: TokenType.ERC721,
+        name: 'Cool NFT',
+        symbol: ''
+      } as TxToken)
+    ).toBe('Cool NFT')
+  })
+
+  it('falls back to "NFT" when both name and symbol are missing', () => {
+    expect(
+      getNftLabel({ type: TokenType.ERC721, name: '', symbol: '' } as TxToken)
+    ).toBe('NFT')
+    expect(getNftLabel(undefined)).toBe('NFT')
   })
 })

--- a/packages/core-mobile/app/new/features/activity/utils.ts
+++ b/packages/core-mobile/app/new/features/activity/utils.ts
@@ -1,11 +1,13 @@
 import { BridgeTransfer } from '@avalabs/bridge-unified'
 import { BridgeTransaction } from '@avalabs/core-bridge-sdk'
-import { TransactionType, TxToken } from '@avalabs/vm-module-types'
+import { TokenType, TransactionType, TxToken } from '@avalabs/vm-module-types'
 import { format, isToday } from 'date-fns'
 import { TokenActivityTransaction } from 'features/portfolio/assets/components/TokenActivityListItem'
+import { isTxSentFromAccount } from 'features/portfolio/utils'
 import { isAvalancheCChainId } from 'services/network/utils/isAvalancheNetwork'
 import { isEthereumChainId } from 'services/network/utils/isEthereumNetwork'
 import { isNftTokenType } from 'services/nft/utils'
+import { Account } from 'store/account'
 import { Transaction } from 'store/transaction'
 
 export type ActivityListItem =
@@ -127,16 +129,6 @@ export function findNftToken(
   return firstNft
 }
 
-// Picks the token to represent an NFT activity row. Prefers a real
-// ERC721/ERC1155 entry via `findNftToken`, falling back to `tokens[0]` when
-// no NFT entry is available so callers keep a non-empty token to render
-// (title, subtitle, and collectible thumbnail all share this choice).
-export function getDisplayNftToken(
-  tx: TokenActivityTransaction
-): TxToken | undefined {
-  return findNftToken(tx) ?? tx.tokens[0]
-}
-
 export function isCollectibleTransaction(
   tx: TokenActivityTransaction
 ): boolean {
@@ -173,4 +165,94 @@ export function isPotentiallySwap(tx: TokenActivityTransaction): boolean {
     tx.from === tx.tokens[0]?.from?.address &&
     tx.to === tx.tokens[0]?.to?.address
   )
+}
+
+// `findPaymentToken` and `resolvePaymentSymbol` only consider tokens that
+// could plausibly be the payment leg of an NFT trade — NATIVE or ERC20.
+export const isPaymentTokenType = (token: TxToken | undefined): boolean =>
+  token?.type === TokenType.NATIVE || token?.type === TokenType.ERC20
+
+// Resolve the symbol shown for a payment leg. Mirrors the swap-title fallback
+// chain: prefer `token.symbol`, then the network token symbol when the leg is
+// NATIVE (Glacier often returns empty symbol for native assets), finally
+// `token.type` so we never render `"undefined"`.
+export const resolvePaymentSymbol = (
+  token: TxToken,
+  networkTokenSymbol: string | undefined
+): string => {
+  if (token.symbol) return token.symbol
+  if (token.type === TokenType.NATIVE && networkTokenSymbol) {
+    return networkTokenSymbol
+  }
+  return token.type ?? ''
+}
+
+// Determines whether the active user ended up holding the NFT after the tx.
+// Prefers NFT-leg from/to addresses; falls back to top-level tx flags when
+// the NFT entry omits them (some Glacier responses do).
+export const resolveUserIsRecipient = ({
+  nftToken,
+  userAddressLower,
+  transaction,
+  account
+}: {
+  nftToken: TxToken | undefined
+  userAddressLower: string | undefined
+  transaction: TokenActivityTransaction
+  account: Account | undefined
+}): boolean => {
+  const nftFromLower = nftToken?.from?.address?.toLowerCase()
+  const nftToLower = nftToken?.to?.address?.toLowerCase()
+
+  if (nftToLower && nftToLower === userAddressLower) return true
+  if (nftFromLower && nftFromLower === userAddressLower) return false
+
+  return !(
+    transaction.isSender || isTxSentFromAccount(transaction.from, account)
+  )
+}
+
+// Picks a NATIVE/ERC20 leg matching the user's direction (payment leaves the
+// user on a buy, lands at the user on a sell). When direction-based matching
+// fails (some Glacier responses omit `from`/`to`), only fall back if there is
+// a single unambiguous payment token — multiple payment legs without
+// direction info could mislead (e.g. royalty/fee legs vs. seller payout).
+export const findPaymentToken = (
+  tokens: TxToken[],
+  userIsRecipient: boolean,
+  userAddressLower: string | undefined
+): TxToken | undefined => {
+  const matchesUserDirection = (token: TxToken): boolean => {
+    const addr = (
+      userIsRecipient ? token.from?.address : token.to?.address
+    )?.toLowerCase()
+    return Boolean(addr) && addr === userAddressLower
+  }
+
+  const directional = tokens.find(
+    t => isPaymentTokenType(t) && matchesUserDirection(t)
+  )
+  if (directional) return directional
+
+  const payments = tokens.filter(isPaymentTokenType)
+  return payments.length === 1 ? payments[0] : undefined
+}
+
+// Composes a human-readable label for the NFT in the title. Uses whichever of
+// `name`/`symbol` are populated and falls back to "NFT" when both are missing.
+// Applies to both ERC721 and ERC1155 — ERC1155 collections like game assets
+// often carry meaningful names worth surfacing.
+export const getNftLabel = (nftToken: TxToken | undefined): string => {
+  const name = nftToken?.name?.trim()
+  const symbol = nftToken?.symbol?.trim()
+
+  // Avoid redundant "Name (SYMBOL)" when name and symbol are effectively
+  // identical (case-insensitive) — common for ERC1155 game assets where both
+  // fields carry the same string.
+  if (name && symbol && name.toLowerCase() !== symbol.toLowerCase()) {
+    return `${name} (${symbol})`
+  }
+  if (name) return name
+  if (symbol) return symbol
+  return 'NFT'
 }

--- a/packages/core-mobile/app/new/features/activity/utils.ts
+++ b/packages/core-mobile/app/new/features/activity/utils.ts
@@ -1,10 +1,11 @@
 import { BridgeTransfer } from '@avalabs/bridge-unified'
 import { BridgeTransaction } from '@avalabs/core-bridge-sdk'
-import { TokenType, TransactionType, TxToken } from '@avalabs/vm-module-types'
+import { TransactionType, TxToken } from '@avalabs/vm-module-types'
 import { format, isToday } from 'date-fns'
 import { TokenActivityTransaction } from 'features/portfolio/assets/components/TokenActivityListItem'
 import { isAvalancheCChainId } from 'services/network/utils/isAvalancheNetwork'
 import { isEthereumChainId } from 'services/network/utils/isEthereumNetwork'
+import { isNftTokenType } from 'services/nft/utils'
 import { Transaction } from 'store/transaction'
 
 export type ActivityListItem =
@@ -107,9 +108,6 @@ export function buildGroupedData(
   return flatData
 }
 
-const isNftTokenType = (token: TxToken | undefined): boolean =>
-  token?.type === TokenType.ERC721 || token?.type === TokenType.ERC1155
-
 // Returns an ERC721/ERC1155 token from the transaction, regardless of its
 // position in `tokens[]`. NFT purchases through marketplaces typically place
 // the paid token (NATIVE/ERC20) at index 0 and the NFT at index 1, so we
@@ -122,7 +120,7 @@ export function findNftToken(
 ): TxToken | undefined {
   let firstNft: TxToken | undefined
   for (const token of tx.tokens) {
-    if (!isNftTokenType(token)) continue
+    if (!isNftTokenType(token.type)) continue
     if (token.collectableTokenId) return token
     firstNft = firstNft ?? token
   }

--- a/packages/core-mobile/app/new/features/activity/utils.ts
+++ b/packages/core-mobile/app/new/features/activity/utils.ts
@@ -1,6 +1,6 @@
 import { BridgeTransfer } from '@avalabs/bridge-unified'
 import { BridgeTransaction } from '@avalabs/core-bridge-sdk'
-import { TokenType, TransactionType } from '@avalabs/vm-module-types'
+import { TokenType, TransactionType, TxToken } from '@avalabs/vm-module-types'
 import { format, isToday } from 'date-fns'
 import { TokenActivityTransaction } from 'features/portfolio/assets/components/TokenActivityListItem'
 import { isAvalancheCChainId } from 'services/network/utils/isAvalancheNetwork'
@@ -107,6 +107,26 @@ export function buildGroupedData(
   return flatData
 }
 
+// Returns an ERC721/ERC1155 token from the transaction, regardless of its
+// position in `tokens[]`. NFT purchases through marketplaces typically place
+// the paid token (NATIVE/ERC20) at index 0 and the NFT at index 1, so we
+// cannot rely on `tokens[0]` alone. When multiple NFT entries are present
+// (some Glacier responses include both a transfer log and a token entry),
+// prefer the one that carries `collectableTokenId` so callers can fetch
+// metadata correctly.
+export function findNftToken(
+  tx: TokenActivityTransaction
+): TxToken | undefined {
+  const isNftType = (token: TxToken | undefined): boolean =>
+    token?.type === TokenType.ERC721 || token?.type === TokenType.ERC1155
+
+  return (
+    tx.tokens.find(
+      token => isNftType(token) && Boolean(token?.collectableTokenId)
+    ) ?? tx.tokens.find(isNftType)
+  )
+}
+
 export function isCollectibleTransaction(
   tx: TokenActivityTransaction
 ): boolean {
@@ -114,7 +134,8 @@ export function isCollectibleTransaction(
     ((tx.tokens[0]?.type === TokenType.ERC1155 ||
       tx.tokens[0]?.type === TokenType.ERC721) &&
       Boolean(tx.tokens[1]?.collectableTokenId)) ||
-    isNftTransaction(tx)
+    isNftTransaction(tx) ||
+    Boolean(findNftToken(tx))
   )
 }
 

--- a/packages/core-mobile/app/new/features/activity/utils.ts
+++ b/packages/core-mobile/app/new/features/activity/utils.ts
@@ -139,15 +139,9 @@ export function isCollectibleTransaction(
   // get reclassified as collectibles.
   if (tx.txType === TransactionType.SWAP) return false
 
-  // Legacy paired-NFT pattern (NFT at index 0, paired NFT entry with
-  // `collectableTokenId` at index 1).
-  if (
-    isNftTokenType(tx.tokens[0]) &&
-    Boolean(tx.tokens[1]?.collectableTokenId)
-  ) {
-    return true
-  }
-
+  // Covers both single-NFT transfers and the legacy paired-NFT pattern
+  // (an NFT entry with `collectableTokenId` will be picked regardless of
+  // its index in `tokens[]`).
   return Boolean(findNftToken(tx))
 }
 

--- a/packages/core-mobile/app/new/features/activity/utils.ts
+++ b/packages/core-mobile/app/new/features/activity/utils.ts
@@ -107,6 +107,9 @@ export function buildGroupedData(
   return flatData
 }
 
+const isNftTokenType = (token: TxToken | undefined): boolean =>
+  token?.type === TokenType.ERC721 || token?.type === TokenType.ERC1155
+
 // Returns an ERC721/ERC1155 token from the transaction, regardless of its
 // position in `tokens[]`. NFT purchases through marketplaces typically place
 // the paid token (NATIVE/ERC20) at index 0 and the NFT at index 1, so we
@@ -117,26 +120,35 @@ export function buildGroupedData(
 export function findNftToken(
   tx: TokenActivityTransaction
 ): TxToken | undefined {
-  const isNftType = (token: TxToken | undefined): boolean =>
-    token?.type === TokenType.ERC721 || token?.type === TokenType.ERC1155
-
-  return (
-    tx.tokens.find(
-      token => isNftType(token) && Boolean(token?.collectableTokenId)
-    ) ?? tx.tokens.find(isNftType)
-  )
+  let firstNft: TxToken | undefined
+  for (const token of tx.tokens) {
+    if (!isNftTokenType(token)) continue
+    if (token.collectableTokenId) return token
+    firstNft = firstNft ?? token
+  }
+  return firstNft
 }
 
 export function isCollectibleTransaction(
   tx: TokenActivityTransaction
 ): boolean {
-  return (
-    ((tx.tokens[0]?.type === TokenType.ERC1155 ||
-      tx.tokens[0]?.type === TokenType.ERC721) &&
-      Boolean(tx.tokens[1]?.collectableTokenId)) ||
-    isNftTransaction(tx) ||
-    Boolean(findNftToken(tx))
-  )
+  if (isNftTransaction(tx)) return true
+
+  // Respect explicit non-NFT classifications from the backend so that swaps
+  // routed through pools that incidentally include an NFT leg (rare) do not
+  // get reclassified as collectibles.
+  if (tx.txType === TransactionType.SWAP) return false
+
+  // Legacy paired-NFT pattern (NFT at index 0, paired NFT entry with
+  // `collectableTokenId` at index 1).
+  if (
+    isNftTokenType(tx.tokens[0]) &&
+    Boolean(tx.tokens[1]?.collectableTokenId)
+  ) {
+    return true
+  }
+
+  return Boolean(findNftToken(tx))
 }
 
 export function isNftTransaction(tx: TokenActivityTransaction): boolean {

--- a/packages/core-mobile/app/new/features/activity/utils.ts
+++ b/packages/core-mobile/app/new/features/activity/utils.ts
@@ -127,6 +127,16 @@ export function findNftToken(
   return firstNft
 }
 
+// Picks the token to represent an NFT activity row. Prefers a real
+// ERC721/ERC1155 entry via `findNftToken`, falling back to `tokens[0]` when
+// no NFT entry is available so callers keep a non-empty token to render
+// (title, subtitle, and collectible thumbnail all share this choice).
+export function getDisplayNftToken(
+  tx: TokenActivityTransaction
+): TxToken | undefined {
+  return findNftToken(tx) ?? tx.tokens[0]
+}
+
 export function isCollectibleTransaction(
   tx: TokenActivityTransaction
 ): boolean {

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
@@ -73,11 +73,8 @@ export const TokenActivityListItem: FC<Props> = ({
   const subtitle = useMemo(() => {
     if (isCollectibleTransaction(tx)) {
       const nftToken = findNftToken(tx) ?? tx.tokens[0]
-      return `#${
-        nftToken?.collectableTokenId ||
-        tx.tokens[0]?.collectableTokenId ||
-        tx.tokens[1]?.collectableTokenId
-      } - ${nftToken?.type}`
+      const tokenId = nftToken?.collectableTokenId ?? '?'
+      return `#${tokenId} - ${nftToken?.type ?? 'NFT'}`
     }
 
     if (tx.txType === TransactionType.TRANSFER) {

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
@@ -2,7 +2,7 @@ import { PriceChangeStatus, useTheme, View } from '@avalabs/k2-alpine'
 import { TransactionType } from '@avalabs/vm-module-types'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import {
-  getDisplayNftToken,
+  findNftToken,
   isCollectibleTransaction,
   isPotentiallySwap
 } from 'features/activity/utils'
@@ -72,7 +72,10 @@ export const TokenActivityListItem: FC<Props> = ({
 
   const subtitle = useMemo(() => {
     if (isCollectibleTransaction(tx)) {
-      const nftToken = getDisplayNftToken(tx)
+      // No fallback to tokens[0] — when the tx is NFT-classified but lacks an
+      // NFT leg, surfacing a NATIVE/ERC20 token's type (e.g. "NATIVE") as the
+      // subtitle would be misleading. Drop the subtitle instead.
+      const nftToken = findNftToken(tx)
       const tokenId = nftToken?.collectableTokenId
       const type = nftToken?.type
 

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
@@ -2,7 +2,7 @@ import { PriceChangeStatus, useTheme, View } from '@avalabs/k2-alpine'
 import { TransactionType } from '@avalabs/vm-module-types'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import {
-  findNftToken,
+  getDisplayNftToken,
   isCollectibleTransaction,
   isPotentiallySwap
 } from 'features/activity/utils'
@@ -72,7 +72,7 @@ export const TokenActivityListItem: FC<Props> = ({
 
   const subtitle = useMemo(() => {
     if (isCollectibleTransaction(tx)) {
-      const nftToken = findNftToken(tx) ?? tx.tokens[0]
+      const nftToken = getDisplayNftToken(tx)
       const tokenId = nftToken?.collectableTokenId
       const type = nftToken?.type
 

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
@@ -73,8 +73,15 @@ export const TokenActivityListItem: FC<Props> = ({
   const subtitle = useMemo(() => {
     if (isCollectibleTransaction(tx)) {
       const nftToken = findNftToken(tx) ?? tx.tokens[0]
-      const tokenId = nftToken?.collectableTokenId ?? '?'
-      return `#${tokenId} - ${nftToken?.type ?? 'NFT'}`
+      const tokenId = nftToken?.collectableTokenId
+      const type = nftToken?.type
+
+      // Avoid showing "#?"-style placeholders when fields are missing — drop
+      // the subtitle entirely instead of surfacing meaningless data.
+      if (tokenId && type) return `#${tokenId} - ${type}`
+      if (tokenId) return `#${tokenId}`
+      if (type) return type
+      return null
     }
 
     if (tx.txType === TransactionType.TRANSFER) {

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItem.tsx
@@ -2,6 +2,7 @@ import { PriceChangeStatus, useTheme, View } from '@avalabs/k2-alpine'
 import { TransactionType } from '@avalabs/vm-module-types'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import {
+  findNftToken,
   isCollectibleTransaction,
   isPotentiallySwap
 } from 'features/activity/utils'
@@ -71,9 +72,12 @@ export const TokenActivityListItem: FC<Props> = ({
 
   const subtitle = useMemo(() => {
     if (isCollectibleTransaction(tx)) {
+      const nftToken = findNftToken(tx) ?? tx.tokens[0]
       return `#${
-        tx.tokens[0]?.collectableTokenId || tx.tokens[1]?.collectableTokenId
-      } - ${tx?.tokens[0]?.type}`
+        nftToken?.collectableTokenId ||
+        tx.tokens[0]?.collectableTokenId ||
+        tx.tokens[1]?.collectableTokenId
+      } - ${nftToken?.type}`
     }
 
     if (tx.txType === TransactionType.TRANSFER) {

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
@@ -5,7 +5,7 @@ import { SubTextNumber } from 'common/components/SubTextNumber'
 import { useBlockchainNames } from 'common/utils/useBlockchainNames'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
 import {
-  findNftToken,
+  getDisplayNftToken,
   isCollectibleTransaction,
   isPotentiallySwap
 } from 'features/activity/utils'
@@ -251,7 +251,7 @@ export const TokenActivityListItemTitle = ({
   // includes the payment amount when present.
   const getCollectibleTitle = useCallback(
     (transaction: TokenActivityTransaction): ReactNode[] => {
-      const nftToken = findNftToken(transaction) ?? transaction.tokens[0]
+      const nftToken = getDisplayNftToken(transaction)
       const network = getNetwork(Number(transaction.chainId))
       const userAddress =
         network && activeAccount

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
@@ -1,96 +1,27 @@
 import { Text, useTheme, View } from '@avalabs/k2-alpine'
-import { TokenType, TransactionType, TxToken } from '@avalabs/vm-module-types'
+import { TransactionType } from '@avalabs/vm-module-types'
 import { HiddenBalanceText } from 'common/components/HiddenBalanceText'
 import { SubTextNumber } from 'common/components/SubTextNumber'
 import { useBlockchainNames } from 'common/utils/useBlockchainNames'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
 import {
-  getDisplayNftToken,
+  findNftToken,
+  findPaymentToken,
+  getNftLabel,
   isCollectibleTransaction,
-  isPotentiallySwap
+  isPotentiallySwap,
+  resolvePaymentSymbol,
+  resolveUserIsRecipient
 } from 'features/activity/utils'
 import { useNetworks } from 'hooks/networks/useNetworks'
 import React, { ReactNode, useCallback, useMemo } from 'react'
 import { useSelector } from 'react-redux'
-import { Account, selectActiveAccount } from 'store/account'
+import { selectActiveAccount } from 'store/account'
 import { getAddressByNetwork } from 'store/account/utils'
 import { selectIsPrivacyModeEnabled } from 'store/settings/securityPrivacy'
 import Logger from 'utils/Logger'
 import { isTxSentFromAccount } from 'features/portfolio/utils'
 import { TokenActivityTransaction } from './TokenActivityListItem'
-
-const isPaymentTokenType = (token: TxToken | undefined): boolean =>
-  token?.type === TokenType.NATIVE || token?.type === TokenType.ERC20
-
-// Determines whether the active user ended up holding the NFT after the tx.
-// Prefers NFT-leg from/to addresses; falls back to top-level tx flags when
-// the NFT entry omits them (some Glacier responses do).
-const resolveUserIsRecipient = ({
-  nftToken,
-  userAddressLower,
-  transaction,
-  account
-}: {
-  nftToken: TxToken | undefined
-  userAddressLower: string | undefined
-  transaction: TokenActivityTransaction
-  account: Account | undefined
-}): boolean => {
-  const nftFromLower = nftToken?.from?.address?.toLowerCase()
-  const nftToLower = nftToken?.to?.address?.toLowerCase()
-
-  if (nftToLower && nftToLower === userAddressLower) return true
-  if (nftFromLower && nftFromLower === userAddressLower) return false
-
-  return !(
-    transaction.isSender || isTxSentFromAccount(transaction.from, account)
-  )
-}
-
-// Picks a NATIVE/ERC20 leg matching the user's direction (payment leaves the
-// user on a buy, lands at the user on a sell). When direction-based matching
-// fails (some Glacier responses omit `from`/`to`), only fall back if there is
-// a single unambiguous payment token — multiple payment legs without
-// direction info could mislead (e.g. royalty/fee legs vs. seller payout).
-const findPaymentToken = (
-  tokens: TxToken[],
-  userIsRecipient: boolean,
-  userAddressLower: string | undefined
-): TxToken | undefined => {
-  const matchesUserDirection = (token: TxToken): boolean => {
-    const addr = (
-      userIsRecipient ? token.from?.address : token.to?.address
-    )?.toLowerCase()
-    return Boolean(addr) && addr === userAddressLower
-  }
-
-  const directional = tokens.find(
-    t => isPaymentTokenType(t) && matchesUserDirection(t)
-  )
-  if (directional) return directional
-
-  const payments = tokens.filter(isPaymentTokenType)
-  return payments.length === 1 ? payments[0] : undefined
-}
-
-// Composes a human-readable label for the NFT in the title. Uses whichever
-// of `name`/`symbol` are populated and falls back to "NFT" when both are
-// missing. Applies to both ERC721 and ERC1155 — ERC1155 collections like
-// game assets often carry meaningful names worth surfacing.
-const getNftLabel = (nftToken: TxToken | undefined): string => {
-  const name = nftToken?.name?.trim()
-  const symbol = nftToken?.symbol?.trim()
-
-  // Avoid redundant "Name (SYMBOL)" when name and symbol are effectively
-  // identical (case-insensitive) — common for ERC1155 game assets where
-  // both fields carry the same string.
-  if (name && symbol && name.toLowerCase() !== symbol.toLowerCase()) {
-    return `${name} (${symbol})`
-  }
-  if (name) return name
-  if (symbol) return symbol
-  return 'NFT'
-}
 
 export const TokenActivityListItemTitle = ({
   tx
@@ -251,7 +182,10 @@ export const TokenActivityListItemTitle = ({
   // includes the payment amount when present.
   const getCollectibleTitle = useCallback(
     (transaction: TokenActivityTransaction): ReactNode[] => {
-      const nftToken = getDisplayNftToken(transaction)
+      // `nftToken` may be undefined when an NFT_* tx lacks an ERC721/ERC1155
+      // leg; downstream helpers (`getNftLabel`, `resolveUserIsRecipient`)
+      // tolerate undefined and we render the generic "NFT" label.
+      const nftToken = findNftToken(transaction)
       const network = getNetwork(Number(transaction.chainId))
       const userAddress =
         network && activeAccount
@@ -274,11 +208,15 @@ export const TokenActivityListItemTitle = ({
 
       if (paymentToken) {
         const action = userIsRecipient ? 'bought' : 'sold'
+        const paymentSymbol = resolvePaymentSymbol(
+          paymentToken,
+          network?.networkToken.symbol
+        )
         return [
           `${nftLabel} ${action} for `,
           renderAmount(paymentToken.amount),
           ' ',
-          paymentToken.symbol
+          paymentSymbol
         ]
       }
 

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
@@ -1,10 +1,11 @@
 import { Text, useTheme, View } from '@avalabs/k2-alpine'
-import { TokenType, TransactionType } from '@avalabs/vm-module-types'
+import { TokenType, TransactionType, TxToken } from '@avalabs/vm-module-types'
 import { HiddenBalanceText } from 'common/components/HiddenBalanceText'
 import { SubTextNumber } from 'common/components/SubTextNumber'
 import { useBlockchainNames } from 'common/utils/useBlockchainNames'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
 import {
+  findNftToken,
   isCollectibleTransaction,
   isPotentiallySwap
 } from 'features/activity/utils'
@@ -172,6 +173,76 @@ export const TokenActivityListItemTitle = ({
     ]
   )
 
+  // Title for NFT-related transactions. Distinguishes marketplace
+  // purchases/sales (NFT + NATIVE/ERC20 leg) from plain transfers, and
+  // includes the payment amount when present.
+  const getCollectibleTitle = useCallback(
+    // eslint-disable-next-line sonarjs/cognitive-complexity
+    (transaction: TokenActivityTransaction): ReactNode[] => {
+      const nftToken = findNftToken(transaction) ?? transaction.tokens[0]
+
+      const network = getNetwork(Number(transaction.chainId))
+      const userAddress =
+        network && activeAccount
+          ? getAddressByNetwork(activeAccount, network)
+          : transaction.from
+      const userAddressLower = userAddress?.toLowerCase()
+      const nftFromLower = nftToken?.from?.address?.toLowerCase()
+      const nftToLower = nftToken?.to?.address?.toLowerCase()
+
+      let userIsRecipient: boolean
+      if (nftToLower && nftToLower === userAddressLower) {
+        userIsRecipient = true
+      } else if (nftFromLower && nftFromLower === userAddressLower) {
+        userIsRecipient = false
+      } else {
+        userIsRecipient = !(
+          transaction.isSender ||
+          isTxSentFromAccount(transaction.from, activeAccount)
+        )
+      }
+
+      // Pick a payment leg matching the user's direction. For a purchase the
+      // payment originates from the user; for a sale it lands at the user.
+      // Falls back to any NATIVE/ERC20 token if address-based matching fails
+      // (some Glacier responses omit `from`/`to` on token entries).
+      const isPaymentToken = (t: TxToken | undefined): boolean =>
+        t?.type === TokenType.NATIVE || t?.type === TokenType.ERC20
+
+      const matchesUserDirection = (t: TxToken): boolean => {
+        const tFromLower = t.from?.address?.toLowerCase()
+        const tToLower = t.to?.address?.toLowerCase()
+        return userIsRecipient
+          ? tFromLower === userAddressLower
+          : tToLower === userAddressLower
+      }
+
+      const paymentToken =
+        transaction.tokens.find(
+          t => isPaymentToken(t) && matchesUserDirection(t)
+        ) ?? transaction.tokens.find(isPaymentToken)
+
+      const isErc1155 = nftToken?.type === TokenType.ERC1155
+      const nftLabel = isErc1155
+        ? 'NFT'
+        : `${nftToken?.name} (${nftToken?.symbol})`
+
+      if (paymentToken) {
+        const action = userIsRecipient ? 'bought' : 'sold'
+        return [
+          `${nftLabel} ${action} for `,
+          renderAmount(paymentToken.amount),
+          ' ',
+          paymentToken.symbol
+        ]
+      }
+
+      const action = userIsRecipient ? 'received' : 'sent'
+      return [`${nftLabel} ${action}`]
+    },
+    [activeAccount, getNetwork, renderAmount]
+  )
+
   // Build an array of nodes: strings and React elements
   // eslint-disable-next-line sonarjs/cognitive-complexity
   const nodes = useMemo<ReactNode[]>(() => {
@@ -204,15 +275,7 @@ export const TokenActivityListItemTitle = ({
 
       default: {
         if (isCollectibleTransaction(tx)) {
-          if (tx.tokens[0]?.type === TokenType.ERC1155) {
-            return [`NFT ${tx.isSender || isFromAccount ? 'sent' : 'received'}`]
-          }
-
-          return [
-            `${tx.tokens[0]?.name} (${tx?.tokens[0]?.symbol}) ${
-              tx.isSender || isFromAccount ? 'sent' : 'received'
-            }`
-          ]
+          return getCollectibleTitle(tx)
         }
         if (tx.isContractCall) {
           // if the tx has 3 tokens, it means we funded the gas
@@ -268,6 +331,7 @@ export const TokenActivityListItemTitle = ({
     getIOTokenAmountAndSymbol,
     tx,
     getSwapTitle,
+    getCollectibleTitle,
     renderAmount,
     sourceBlockchain,
     targetBlockchain,

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
@@ -12,12 +12,73 @@ import {
 import { useNetworks } from 'hooks/networks/useNetworks'
 import React, { ReactNode, useCallback, useMemo } from 'react'
 import { useSelector } from 'react-redux'
-import { selectActiveAccount } from 'store/account'
+import { Account, selectActiveAccount } from 'store/account'
 import { getAddressByNetwork } from 'store/account/utils'
 import { selectIsPrivacyModeEnabled } from 'store/settings/securityPrivacy'
 import Logger from 'utils/Logger'
 import { isTxSentFromAccount } from 'features/portfolio/utils'
 import { TokenActivityTransaction } from './TokenActivityListItem'
+
+const isPaymentTokenType = (token: TxToken | undefined): boolean =>
+  token?.type === TokenType.NATIVE || token?.type === TokenType.ERC20
+
+// Determines whether the active user ended up holding the NFT after the tx.
+// Prefers NFT-leg from/to addresses; falls back to top-level tx flags when
+// the NFT entry omits them (some Glacier responses do).
+const resolveUserIsRecipient = ({
+  nftToken,
+  userAddressLower,
+  transaction,
+  account
+}: {
+  nftToken: TxToken | undefined
+  userAddressLower: string | undefined
+  transaction: TokenActivityTransaction
+  account: Account | undefined
+}): boolean => {
+  const nftFromLower = nftToken?.from?.address?.toLowerCase()
+  const nftToLower = nftToken?.to?.address?.toLowerCase()
+
+  if (nftToLower && nftToLower === userAddressLower) return true
+  if (nftFromLower && nftFromLower === userAddressLower) return false
+
+  return !(
+    transaction.isSender || isTxSentFromAccount(transaction.from, account)
+  )
+}
+
+// Picks a NATIVE/ERC20 leg matching the user's direction (payment leaves the
+// user on a buy, lands at the user on a sell). Falls back to any payment
+// token if address-based matching fails.
+const findPaymentToken = (
+  tokens: TxToken[],
+  userIsRecipient: boolean,
+  userAddressLower: string | undefined
+): TxToken | undefined => {
+  const matchesUserDirection = (token: TxToken): boolean => {
+    const addr = (
+      userIsRecipient ? token.from?.address : token.to?.address
+    )?.toLowerCase()
+    return Boolean(addr) && addr === userAddressLower
+  }
+
+  return (
+    tokens.find(t => isPaymentTokenType(t) && matchesUserDirection(t)) ??
+    tokens.find(isPaymentTokenType)
+  )
+}
+
+// Composes a human-readable label for the NFT in the title. ERC1155 entries
+// rarely carry meaningful name/symbol, so always show "NFT". For ERC721 we
+// fall back to "NFT" when the name is missing, and omit the symbol if empty.
+const getNftLabel = (nftToken: TxToken | undefined): string => {
+  if (!nftToken || nftToken.type === TokenType.ERC1155 || !nftToken.name) {
+    return 'NFT'
+  }
+  return nftToken.symbol
+    ? `${nftToken.name} (${nftToken.symbol})`
+    : nftToken.name
+}
 
 export const TokenActivityListItemTitle = ({
   tx
@@ -177,55 +238,27 @@ export const TokenActivityListItemTitle = ({
   // purchases/sales (NFT + NATIVE/ERC20 leg) from plain transfers, and
   // includes the payment amount when present.
   const getCollectibleTitle = useCallback(
-    // eslint-disable-next-line sonarjs/cognitive-complexity
     (transaction: TokenActivityTransaction): ReactNode[] => {
       const nftToken = findNftToken(transaction) ?? transaction.tokens[0]
-
       const network = getNetwork(Number(transaction.chainId))
       const userAddress =
         network && activeAccount
           ? getAddressByNetwork(activeAccount, network)
           : transaction.from
       const userAddressLower = userAddress?.toLowerCase()
-      const nftFromLower = nftToken?.from?.address?.toLowerCase()
-      const nftToLower = nftToken?.to?.address?.toLowerCase()
 
-      let userIsRecipient: boolean
-      if (nftToLower && nftToLower === userAddressLower) {
-        userIsRecipient = true
-      } else if (nftFromLower && nftFromLower === userAddressLower) {
-        userIsRecipient = false
-      } else {
-        userIsRecipient = !(
-          transaction.isSender ||
-          isTxSentFromAccount(transaction.from, activeAccount)
-        )
-      }
-
-      // Pick a payment leg matching the user's direction. For a purchase the
-      // payment originates from the user; for a sale it lands at the user.
-      // Falls back to any NATIVE/ERC20 token if address-based matching fails
-      // (some Glacier responses omit `from`/`to` on token entries).
-      const isPaymentToken = (t: TxToken | undefined): boolean =>
-        t?.type === TokenType.NATIVE || t?.type === TokenType.ERC20
-
-      const matchesUserDirection = (t: TxToken): boolean => {
-        const tFromLower = t.from?.address?.toLowerCase()
-        const tToLower = t.to?.address?.toLowerCase()
-        return userIsRecipient
-          ? tFromLower === userAddressLower
-          : tToLower === userAddressLower
-      }
-
-      const paymentToken =
-        transaction.tokens.find(
-          t => isPaymentToken(t) && matchesUserDirection(t)
-        ) ?? transaction.tokens.find(isPaymentToken)
-
-      const isErc1155 = nftToken?.type === TokenType.ERC1155
-      const nftLabel = isErc1155
-        ? 'NFT'
-        : `${nftToken?.name} (${nftToken?.symbol})`
+      const userIsRecipient = resolveUserIsRecipient({
+        nftToken,
+        userAddressLower,
+        transaction,
+        account: activeAccount
+      })
+      const paymentToken = findPaymentToken(
+        transaction.tokens,
+        userIsRecipient,
+        userAddressLower
+      )
+      const nftLabel = getNftLabel(nftToken)
 
       if (paymentToken) {
         const action = userIsRecipient ? 'bought' : 'sold'

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
@@ -48,8 +48,10 @@ const resolveUserIsRecipient = ({
 }
 
 // Picks a NATIVE/ERC20 leg matching the user's direction (payment leaves the
-// user on a buy, lands at the user on a sell). Falls back to any payment
-// token if address-based matching fails.
+// user on a buy, lands at the user on a sell). When direction-based matching
+// fails (some Glacier responses omit `from`/`to`), only fall back if there is
+// a single unambiguous payment token — multiple payment legs without
+// direction info could mislead (e.g. royalty/fee legs vs. seller payout).
 const findPaymentToken = (
   tokens: TxToken[],
   userIsRecipient: boolean,
@@ -62,22 +64,27 @@ const findPaymentToken = (
     return Boolean(addr) && addr === userAddressLower
   }
 
-  return (
-    tokens.find(t => isPaymentTokenType(t) && matchesUserDirection(t)) ??
-    tokens.find(isPaymentTokenType)
+  const directional = tokens.find(
+    t => isPaymentTokenType(t) && matchesUserDirection(t)
   )
+  if (directional) return directional
+
+  const payments = tokens.filter(isPaymentTokenType)
+  return payments.length === 1 ? payments[0] : undefined
 }
 
-// Composes a human-readable label for the NFT in the title. ERC1155 entries
-// rarely carry meaningful name/symbol, so always show "NFT". For ERC721 we
-// fall back to "NFT" when the name is missing, and omit the symbol if empty.
+// Composes a human-readable label for the NFT in the title. Uses whichever
+// of `name`/`symbol` are populated and falls back to "NFT" when both are
+// missing. Applies to both ERC721 and ERC1155 — ERC1155 collections like
+// game assets often carry meaningful names worth surfacing.
 const getNftLabel = (nftToken: TxToken | undefined): string => {
-  if (!nftToken || nftToken.type === TokenType.ERC1155 || !nftToken.name) {
-    return 'NFT'
-  }
-  return nftToken.symbol
-    ? `${nftToken.name} (${nftToken.symbol})`
-    : nftToken.name
+  const name = nftToken?.name?.trim()
+  const symbol = nftToken?.symbol?.trim()
+
+  if (name && symbol) return `${name} (${symbol})`
+  if (name) return name
+  if (symbol) return symbol
+  return 'NFT'
 }
 
 export const TokenActivityListItemTitle = ({

--- a/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/components/TokenActivityListItemTitle.tsx
@@ -81,7 +81,12 @@ const getNftLabel = (nftToken: TxToken | undefined): string => {
   const name = nftToken?.name?.trim()
   const symbol = nftToken?.symbol?.trim()
 
-  if (name && symbol) return `${name} (${symbol})`
+  // Avoid redundant "Name (SYMBOL)" when name and symbol are effectively
+  // identical (case-insensitive) — common for ERC1155 game assets where
+  // both fields carry the same string.
+  if (name && symbol && name.toLowerCase() !== symbol.toLowerCase()) {
+    return `${name} (${symbol})`
+  }
   if (name) return name
   if (symbol) return symbol
   return 'NFT'

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleFetchAndRender.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleFetchAndRender.tsx
@@ -1,5 +1,5 @@
 import { TokenType } from '@avalabs/vm-module-types'
-import { getDisplayNftToken } from 'features/activity/utils'
+import { findNftToken } from 'features/activity/utils'
 import { TokenActivityTransaction } from 'features/portfolio/assets/components/TokenActivityListItem'
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { NftItem, NftLocalStatus } from 'services/nft/types'
@@ -17,7 +17,11 @@ export const CollectibleFetchAndRender = memo(
     size: number
     iconSize: number
   }): JSX.Element => {
-    const token = getDisplayNftToken(tx)
+    // When the tx has no ERC721/ERC1155 leg (rare backend inconsistency for
+    // NFT_* txTypes), `token` is undefined; the metadata fetch below short-
+    // circuits on missing contractAddress/tokenId so we fall back to an
+    // unprocessed placeholder card instead of fetching the wrong asset.
+    const token = findNftToken(tx)
     const [isLoading, setIsLoading] = useState(true)
 
     const contractAddress = token && 'address' in token ? token.address : ''

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleFetchAndRender.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleFetchAndRender.tsx
@@ -1,10 +1,16 @@
-import { TokenType } from '@avalabs/vm-module-types'
+import { TokenType, TxToken } from '@avalabs/vm-module-types'
+import { findNftToken } from 'features/activity/utils'
 import { TokenActivityTransaction } from 'features/portfolio/assets/components/TokenActivityListItem'
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { NftItem, NftLocalStatus } from 'services/nft/types'
 import { fetchNftData, getNftLocalId, isNftTokenType } from 'services/nft/utils'
 import { CardContainer } from './CardContainer'
 import { CollectibleRenderer } from './CollectibleRenderer'
+
+// NFT can be at any index (e.g. marketplace purchase puts NATIVE at 0).
+const getDisplayToken = (tx: TokenActivityTransaction): TxToken | undefined => {
+  return findNftToken(tx) ?? tx.tokens[0]
+}
 
 export const CollectibleFetchAndRender = memo(
   ({
@@ -16,7 +22,7 @@ export const CollectibleFetchAndRender = memo(
     size: number
     iconSize: number
   }): JSX.Element => {
-    const token = tx.tokens[0]
+    const token = getDisplayToken(tx)
     const [isLoading, setIsLoading] = useState(true)
 
     const contractAddress = token && 'address' in token ? token.address : ''

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleFetchAndRender.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/components/CollectibleFetchAndRender.tsx
@@ -1,16 +1,11 @@
-import { TokenType, TxToken } from '@avalabs/vm-module-types'
-import { findNftToken } from 'features/activity/utils'
+import { TokenType } from '@avalabs/vm-module-types'
+import { getDisplayNftToken } from 'features/activity/utils'
 import { TokenActivityTransaction } from 'features/portfolio/assets/components/TokenActivityListItem'
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { NftItem, NftLocalStatus } from 'services/nft/types'
 import { fetchNftData, getNftLocalId, isNftTokenType } from 'services/nft/utils'
 import { CardContainer } from './CardContainer'
 import { CollectibleRenderer } from './CollectibleRenderer'
-
-// NFT can be at any index (e.g. marketplace purchase puts NATIVE at 0).
-const getDisplayToken = (tx: TokenActivityTransaction): TxToken | undefined => {
-  return findNftToken(tx) ?? tx.tokens[0]
-}
 
 export const CollectibleFetchAndRender = memo(
   ({
@@ -22,7 +17,7 @@ export const CollectibleFetchAndRender = memo(
     size: number
     iconSize: number
   }): JSX.Element => {
-    const token = getDisplayToken(tx)
+    const token = getDisplayNftToken(tx)
     const [isLoading, setIsLoading] = useState(true)
 
     const contractAddress = token && 'address' in token ? token.address : ''

--- a/packages/core-mobile/app/services/wallet/WalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/WalletService.test.ts
@@ -1,6 +1,5 @@
 import { NetworkVMType } from '@avalabs/vm-module-types'
 import { WalletType } from 'services/wallet/types'
-import * as profileApiClientModule from 'utils/api/generated/profileApi.client'
 import type { GetAddressesResponse } from 'utils/api/generated/profileApi.client/types.gen'
 import WalletFactory from './WalletFactory'
 import WalletService from './WalletService'
@@ -17,28 +16,16 @@ const pvmEmptyResponse: GetAddressesResponse = {
   internalAddresses: []
 }
 
-const createDeferred = <T>() => {
-  let resolve!: (value: T | PromiseLike<T>) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res
-    reject = rej
-  })
-
-  return { promise, resolve, reject }
-}
-
+// Module-level mocks below exist purely to satisfy WalletService's import
+// graph during test loading. The actual XP-activity behavior is exercised
+// via a direct spy on `getAddressesForExtendedPublicKey` (see below) so
+// that the postV1GetAddresses + unwrap + validation path is never run by
+// these tests. That path was the source of a long-standing CI flake
+// ("Failed to get addresses from postV1GetAddresses") whenever mock-
+// implementation timing or fall-through left the body undefined.
 jest.mock('utils/api/generated/profileApi.client', () => ({
   __esModule: true,
-  postV1GetAddresses: jest.fn(() =>
-    Promise.resolve({
-      data: {
-        networkType: 'PVM',
-        externalAddresses: [],
-        internalAddresses: []
-      }
-    })
-  )
+  postV1GetAddresses: jest.fn()
 }))
 
 jest.mock('utils/api/clients/profileApiClient', () => ({
@@ -58,25 +45,30 @@ jest.mock('utils/Logger', () => ({
   }
 }))
 
-const mockPostV1GetAddresses =
-  profileApiClientModule.postV1GetAddresses as jest.Mock
-
-/** Valid fallback so `mockReset()` never leaves `postV1GetAddresses` returning `undefined` (parallel AVM/PVM calls). */
-const defaultPostV1GetAddressesImpl = () =>
-  Promise.resolve({ data: pvmEmptyResponse })
+// `getAddressesForExtendedPublicKey` is a private method, but TS `private`
+// is compile-time only — Jest can spy on it at runtime. We strip the
+// original (private-bearing) type via `unknown as` so the public-shape
+// overlay below doesn't conflict with the private declaration, and so
+// `jest.spyOn` can correctly infer the implementation signature.
+const walletServiceInternal = WalletService as unknown as {
+  getAddressesForExtendedPublicKey: (opts: {
+    extendedPublicKey: string
+    networkType: NetworkVMType.AVM | NetworkVMType.PVM
+    isTestnet: boolean
+    onlyWithActivity: boolean
+  }) => Promise<GetAddressesResponse>
+}
 
 describe('WalletService.hasActivityFromXpubXP', () => {
   beforeEach(() => {
     WalletFactory.cache.clearWallet('wallet-1')
-    // Re-apply the default implementation each test. Do NOT use mockReset() —
-    // it clears the factory-level default and leaves the mock returning
-    // undefined if mockImplementation is re-set asynchronously. CI has been
-    // observed to hit that window and fail isGetAddressesResponseBody(body).
-    mockPostV1GetAddresses.mockImplementation(defaultPostV1GetAddressesImpl)
   })
 
   afterEach(() => {
-    jest.spyOn(WalletService, 'getRawXpubXP').mockRestore()
+    // Restores both spies (`getRawXpubXP`, `getAddressesForExtendedPublicKey`)
+    // back to their originals. Module-level `jest.fn()` mocks are not affected
+    // — see Jest docs on `restoreAllMocks` (only spies are restored).
+    jest.restoreAllMocks()
   })
 
   it('reuses one XP xpub for AVM and PVM activity lookups', async () => {
@@ -84,19 +76,14 @@ describe('WalletService.hasActivityFromXpubXP', () => {
       .spyOn(WalletService, 'getRawXpubXP')
       .mockResolvedValue('xpub-123')
 
-    // AVM and PVM requests run in parallel; mockResolvedValueOnce order is not stable across environments.
-    mockPostV1GetAddresses.mockImplementation(
-      (options: { body: { networkType: NetworkVMType } }) => {
-        const nt = options?.body?.networkType
-        if (nt === NetworkVMType.AVM) {
-          return Promise.resolve({ data: avmWithActivityResponse })
+    const getAddressesSpy = jest
+      .spyOn(walletServiceInternal, 'getAddressesForExtendedPublicKey')
+      .mockImplementation(async ({ networkType }) => {
+        if (networkType === NetworkVMType.AVM) {
+          return avmWithActivityResponse
         }
-        if (nt === NetworkVMType.PVM) {
-          return Promise.resolve({ data: pvmEmptyResponse })
-        }
-        return defaultPostV1GetAddressesImpl()
-      }
-    )
+        return pvmEmptyResponse
+      })
 
     const hasActivity = await WalletService.hasActivityFromXpubXP({
       walletId: 'wallet-1',
@@ -107,29 +94,29 @@ describe('WalletService.hasActivityFromXpubXP', () => {
 
     expect(hasActivity).toBe(true)
     expect(getRawXpubXPSpy).toHaveBeenCalledTimes(1)
-    expect(mockPostV1GetAddresses).toHaveBeenCalledTimes(2)
-    expect(mockPostV1GetAddresses).toHaveBeenCalledWith(
+    expect(getAddressesSpy).toHaveBeenCalledTimes(2)
+    expect(getAddressesSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        body: expect.objectContaining({
-          extendedPublicKey: 'xpub-123',
-          networkType: 'AVM',
-          onlyWithActivity: true
-        })
+        extendedPublicKey: 'xpub-123',
+        networkType: NetworkVMType.AVM,
+        onlyWithActivity: true
       })
     )
-    expect(mockPostV1GetAddresses).toHaveBeenCalledWith(
+    expect(getAddressesSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        body: expect.objectContaining({
-          extendedPublicKey: 'xpub-123',
-          networkType: 'PVM',
-          onlyWithActivity: true
-        })
+        extendedPublicKey: 'xpub-123',
+        networkType: NetworkVMType.PVM,
+        onlyWithActivity: true
       })
     )
   })
 
   it('skips non-primary Keystone accounts until per-account XP xpubs are supported', async () => {
     const getRawXpubXPSpy = jest.spyOn(WalletService, 'getRawXpubXP')
+    const getAddressesSpy = jest.spyOn(
+      walletServiceInternal,
+      'getAddressesForExtendedPublicKey'
+    )
 
     const hasActivity = await WalletService.hasActivityFromXpubXP({
       walletId: 'wallet-1',
@@ -140,43 +127,34 @@ describe('WalletService.hasActivityFromXpubXP', () => {
 
     expect(hasActivity).toBe(false)
     expect(getRawXpubXPSpy).not.toHaveBeenCalled()
-    expect(mockPostV1GetAddresses).not.toHaveBeenCalled()
+    expect(getAddressesSpy).not.toHaveBeenCalled()
   })
 
   it('returns as soon as one XP network reports activity', async () => {
     jest.spyOn(WalletService, 'getRawXpubXP').mockResolvedValue('xpub-123')
 
-    const pendingPvmResponse = createDeferred<{ data: GetAddressesResponse }>()
-
-    mockPostV1GetAddresses.mockImplementation(
-      (options: { body: { networkType: NetworkVMType } }) => {
-        const nt = options?.body?.networkType
-        if (nt === NetworkVMType.AVM) {
-          return Promise.resolve({ data: avmWithActivityResponse })
+    // PVM is intentionally a never-resolving promise: if `hasActivityFromXpubXP`
+    // were to await PVM, this test would hang forever (no real timer / deferred
+    // resolution dance needed). Resolving via AVM only proves the early-exit
+    // behavior of `raceAnyTrueOrThrow` deterministically.
+    jest
+      .spyOn(walletServiceInternal, 'getAddressesForExtendedPublicKey')
+      .mockImplementation(({ networkType }) => {
+        if (networkType === NetworkVMType.AVM) {
+          return Promise.resolve(avmWithActivityResponse)
         }
-        if (nt === NetworkVMType.PVM) {
-          return pendingPvmResponse.promise
-        }
-        return defaultPostV1GetAddressesImpl()
-      }
-    )
+        return new Promise<GetAddressesResponse>(() => {
+          /* never resolves */
+        })
+      })
 
-    const hasActivityPromise = WalletService.hasActivityFromXpubXP({
-      walletId: 'wallet-1',
-      walletType: WalletType.MNEMONIC,
-      accountIndex: 2,
-      isTestnet: false
-    })
-
-    const resultOrTimeout = await Promise.race([
-      hasActivityPromise,
-      new Promise<'timeout'>(resolve =>
-        setTimeout(() => resolve('timeout'), 5000)
-      )
-    ])
-
-    pendingPvmResponse.resolve({ data: pvmEmptyResponse })
-
-    expect(resultOrTimeout).toBe(true)
+    await expect(
+      WalletService.hasActivityFromXpubXP({
+        walletId: 'wallet-1',
+        walletType: WalletType.MNEMONIC,
+        accountIndex: 2,
+        isTestnet: false
+      })
+    ).resolves.toBe(true)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -37013,7 +37013,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: d6ceb75e1d0f5755370d6d91f67902bd2b8a23a3ca43cb853d2964b43798f30477e8ab0223ea8b620534fbdf5f56d39550f40d24bec2d2398c323ccfe8a5a556
+  checksum: 44ee8c8ebc4dc4d3423e9045e1aebac31829eb518824e24f41b2bd10ab1e8343e824e9d912f259bfec7bfa798e96513cc05dbdcdf36087b2a43806f74a3b0fa2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: [CP-8877]**

- Fixes Activity History rendering NFT marketplace purchases as token swaps (e.g. `0.075 AVAX swapped for 1`).
- Adds a new `findNftToken` helper that locates the ERC721/ERC1155 token regardless of its position in `tokens[]` and prefers the entry carrying `collectableTokenId`. Marketplace purchases typically place the paid token (NATIVE/ERC20) at index 0 and the NFT at index 1, so `tokens[0]`-only logic was misclassifying them.
- Centralizes the NFT-token-to-display lookup in a single `getDisplayNftToken` helper used by the row title, subtitle, and collectible thumbnail so they always render consistent data.
- Broadens `isCollectibleTransaction` to use `findNftToken`, with a defensive `SWAP` guard so backend-classified swaps that incidentally include an NFT leg are not reclassified as collectibles.
- Replaces the generic NFT activity title with a marketplace-aware one — `bought / sold for {amount} {symbol}` when a NATIVE/ERC20 payment leg is present, and `received / sent` for plain transfers. The label uses NFT `name`/`symbol` (deduped when they are effectively identical) and falls back to `"NFT"`.
- Subtitle (`#{tokenId} - {type}`) now degrades gracefully when fields are missing instead of surfacing `#?`-style placeholders.
- `CollectibleFetchAndRender` now resolves the right NFT token before fetching metadata so collectible thumbnails are correct on marketplace-purchase rows.
- Refactors `TokenActivityListItemTitle` helpers (`isPaymentTokenType`, `resolveUserIsRecipient`, `findPaymentToken`, `getNftLabel`) to module level for testability and reduced cognitive complexity.
- Adds 24 unit tests covering NFT discovery, marketplace purchase patterns, the SWAP guard, NFT_* `txType` paths, and `isPotentiallySwap` boundaries.

## Screenshots/Videos
| before | after |
| --- | --- |
| <img width="320" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-04-27 at 13 20 00" src="https://github.com/user-attachments/assets/15895ece-e701-44d2-a0c5-37f95730bb7e" /> | <img width="320" alt="IMG_1241" src="https://github.com/user-attachments/assets/00e55e56-bc6c-4cb5-baa0-6c36ef7be2ba" /> |

## Testing
iOS: 8324
Android: 8325

Open Activity History and verify each row label:
1. **NFT purchase** → `{NFT name} (SYMBOL) bought for {amount} {symbol}` (was `{amount} swapped for 1`).
2. **Plain NFT transfer** → `{NFT name} received` or `{NFT name} sent` (no payment leg).
3. **Real ERC20 swap** → still renders `{amount} {in} swapped for {amount} {out}` (regression guard).

## Checklist
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-8877]: https://ava-labs.atlassian.net/browse/CP-8877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ