### PR TITLE
CP-14152: use contractType from token aggregator API in swap flow

### DIFF
--- a/packages/core-mobile/aggregator-api.config.js
+++ b/packages/core-mobile/aggregator-api.config.js
@@ -5,8 +5,40 @@ const TOKEN_AGGREGATOR_SCHEMA_URL = isCI
   ? 'https://core-token-aggregator.avax.network/schema.json'
   : 'https://core-token-aggregator.avax-test.network/schema.json'
 
+// TODO: remove once the backend updates the OpenAPI schema to 3.1.1.
+// openapi-ts drops `nullable: true` when it's combined with `enum`, so
+// fields like `contractType` end up typed as a non-null union. Walking
+// each affected schema and pushing `null` onto the enum array forces
+// the generator to include `| null`. OpenAPI 3.1.x encodes nullability
+// differently and this workaround won't be needed.
+const addNullToNullableEnums = node => {
+  if (!node || typeof node !== 'object') return
+  if (Array.isArray(node)) {
+    node.forEach(addNullToNullableEnums)
+    return
+  }
+  if (
+    node.nullable === true &&
+    Array.isArray(node.enum) &&
+    !node.enum.includes(null)
+  ) {
+    node.enum.push(null)
+  }
+  for (const value of Object.values(node)) {
+    addNullToNullableEnums(value)
+  }
+}
+
 export default {
   input: TOKEN_AGGREGATOR_SCHEMA_URL,
   output: './app/utils/api/generated/tokenAggregator/aggregatorApi.client',
+  parser: {
+    patch: {
+      schemas: {
+        TokenListResponse: addNullToNullableEnums,
+        NetworkTokensByCaip2Response: addNullToNullableEnums
+      }
+    }
+  },
   plugins: ['@hey-api/client-fetch']
 }

--- a/packages/core-mobile/app/new/features/swap/utils/buildLocalToken.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/buildLocalToken.test.ts
@@ -359,6 +359,81 @@ describe('buildLocalToken', () => {
     })
   })
 
+  describe('contractType resolution', () => {
+    // The lookup API doesn't return contractType, so buildLocalToken passes
+    // null to mapApiTokenToLocal, which derives the token type from the
+    // caip2Id namespace.
+    it('resolves to SPL for a non-native token on a Solana caip2Id', () => {
+      const tokenInfo = makeTokenInfo({
+        platforms: {
+          [SOL_CAIP2]: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+        },
+        meta: { logoUri: null, decimals: { [SOL_CAIP2]: 6 } }
+      })
+
+      const result = buildLocalToken({
+        accountTokens: [],
+        tokenInfo,
+        caip2Id: SOL_CAIP2,
+        chainId: ChainId.SOLANA_MAINNET_ID
+      })
+
+      expect(result.type).toBe(TokenType.SPL)
+    })
+
+    it('resolves to ERC20 for a non-native token on an Avalanche caip2Id', () => {
+      const tokenInfo = makeTokenInfo({
+        platforms: {
+          [AVAX_CAIP2]: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E'
+        },
+        meta: { logoUri: null, decimals: { [AVAX_CAIP2]: 6 } }
+      })
+
+      const result = buildLocalToken({
+        accountTokens: [],
+        tokenInfo,
+        caip2Id: AVAX_CAIP2,
+        chainId: ChainId.AVALANCHE_MAINNET_ID
+      })
+
+      expect(result.type).toBe(TokenType.ERC20)
+    })
+
+    it('resolves to ERC20 for a non-native token on an Ethereum caip2Id', () => {
+      const tokenInfo = makeTokenInfo({
+        platforms: {
+          [ETH_CAIP2]: '0x6B175474E89094C44Da98b954EedeAC495271d0F'
+        },
+        meta: { logoUri: null, decimals: { [ETH_CAIP2]: 18 } }
+      })
+
+      const result = buildLocalToken({
+        accountTokens: [],
+        tokenInfo,
+        caip2Id: ETH_CAIP2,
+        chainId: ChainId.ETHEREUM_HOMESTEAD
+      })
+
+      expect(result.type).toBe(TokenType.ERC20)
+    })
+
+    it('resolves to NATIVE for a native token regardless of caip2Id', () => {
+      const tokenInfo = makeTokenInfo({
+        internalId: tokenIds.SOL,
+        isNative: true
+      })
+
+      const result = buildLocalToken({
+        accountTokens: [],
+        tokenInfo,
+        caip2Id: SOL_CAIP2,
+        chainId: ChainId.SOLANA_MAINNET_ID
+      })
+
+      expect(result.type).toBe(TokenType.NATIVE)
+    })
+  })
+
   describe('balance data integration', () => {
     it('merges balance from matching accountToken', () => {
       const tokenInfo = makeTokenInfo({

--- a/packages/core-mobile/app/new/features/swap/utils/buildLocalToken.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/buildLocalToken.ts
@@ -73,7 +73,8 @@ export const buildLocalToken = ({
       internalId: balanceData?.internalId ?? tokenInfo.internalId,
       logoUri: balanceData?.logoUri ?? tokenInfo.meta?.logoUri ?? null,
       networkCaip2Id: caip2Id,
-      top250Rank: null
+      top250Rank: null,
+      contractType: null
     },
     chainId,
     balanceData

--- a/packages/core-mobile/app/new/features/swap/utils/getLocalTokenIdFromApi.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/getLocalTokenIdFromApi.test.ts
@@ -13,7 +13,8 @@ describe('getLocalTokenIdFromApi', () => {
         internalId: 'avax-native',
         logoUri: 'https://example.com/avax.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe('NATIVE-AVAX')
@@ -29,7 +30,8 @@ describe('getLocalTokenIdFromApi', () => {
         internalId: 'sol-native',
         logoUri: 'https://example.com/sol.png',
         networkCaip2Id: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe('NATIVE-SOL')
@@ -45,7 +47,8 @@ describe('getLocalTokenIdFromApi', () => {
         internalId: 'btc-native',
         logoUri: 'https://example.com/btc.png',
         networkCaip2Id: 'bip122:000000000019d6689c085ae165831e93',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe('NATIVE-BTC')
@@ -61,7 +64,8 @@ describe('getLocalTokenIdFromApi', () => {
         internalId: 'eth-native',
         logoUri: 'https://example.com/eth.png',
         networkCaip2Id: 'eip155:1',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe('NATIVE-ETH')
@@ -79,7 +83,8 @@ describe('getLocalTokenIdFromApi', () => {
         internalId: 'usdc-avax-c',
         logoUri: 'https://example.com/usdc.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe(
@@ -97,7 +102,8 @@ describe('getLocalTokenIdFromApi', () => {
         internalId: 'usdc-solana',
         logoUri: 'https://example.com/usdc.png',
         networkCaip2Id: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe(
@@ -115,7 +121,8 @@ describe('getLocalTokenIdFromApi', () => {
         internalId: 'dai-ethereum',
         logoUri: 'https://example.com/dai.png',
         networkCaip2Id: 'eip155:1',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe(
@@ -133,7 +140,8 @@ describe('getLocalTokenIdFromApi', () => {
         internalId: 'weth-ethereum',
         logoUri: 'https://example.com/weth.png',
         networkCaip2Id: 'eip155:1',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe(
@@ -151,7 +159,8 @@ describe('getLocalTokenIdFromApi', () => {
         internalId: 'usdt-ethereum',
         logoUri: 'https://example.com/usdt.png',
         networkCaip2Id: 'eip155:1',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe(
@@ -171,7 +180,8 @@ describe('getLocalTokenIdFromApi', () => {
         internalId: 'token-1',
         logoUri: 'https://example.com/token.png',
         networkCaip2Id: 'eip155:1',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       const token2: ApiToken = {
@@ -183,7 +193,8 @@ describe('getLocalTokenIdFromApi', () => {
         internalId: 'token-2',
         logoUri: 'https://example.com/token.png',
         networkCaip2Id: 'eip155:1',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       // Both should return the same localId (lowercase)
@@ -206,7 +217,8 @@ describe('getLocalTokenIdFromApi', () => {
         internalId: 'avax',
         logoUri: 'https://example.com/avax.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe('NATIVE-AVAX')
@@ -222,7 +234,8 @@ describe('getLocalTokenIdFromApi', () => {
         internalId: 'avax-bridged',
         logoUri: 'https://example.com/avax.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe('NATIVE-AVAX.e')
@@ -238,7 +251,8 @@ describe('getLocalTokenIdFromApi', () => {
         internalId: 'btc2',
         logoUri: 'https://example.com/btc.png',
         networkCaip2Id: 'bip122:000000000019d6689c085ae165831e93',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe('NATIVE-BTC2.0')
@@ -255,7 +269,8 @@ describe('getLocalTokenIdFromApi', () => {
         internalId: 'long-token',
         logoUri: 'https://example.com/long.png',
         networkCaip2Id: 'eip155:1',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       expect(getLocalTokenIdFromApi(apiToken)).toBe(longAddress.toLowerCase())

--- a/packages/core-mobile/app/new/features/swap/utils/mapApiTokenToLocal.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/mapApiTokenToLocal.test.ts
@@ -17,7 +17,8 @@ describe('mapApiTokenToLocal', () => {
         internalId: 'avax-native',
         logoUri: 'https://example.com/avax.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -44,7 +45,8 @@ describe('mapApiTokenToLocal', () => {
         internalId: 'sol-native',
         logoUri: 'https://example.com/sol.png',
         networkCaip2Id: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.SOLANA_MAINNET_ID)
@@ -69,7 +71,8 @@ describe('mapApiTokenToLocal', () => {
         internalId: 'usdc-avax-c',
         logoUri: 'https://example.com/usdc.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: 'ERC-20'
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -97,7 +100,8 @@ describe('mapApiTokenToLocal', () => {
         internalId: 'dai-ethereum',
         logoUri: 'https://example.com/dai.png',
         networkCaip2Id: 'eip155:1',
-        top250Rank: null
+        top250Rank: null,
+        contractType: 'ERC-20'
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.ETHEREUM_HOMESTEAD)
@@ -120,7 +124,8 @@ describe('mapApiTokenToLocal', () => {
         internalId: 'usdc-solana',
         logoUri: 'https://example.com/usdc.png',
         networkCaip2Id: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-        top250Rank: null
+        top250Rank: null,
+        contractType: 'SPL'
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.SOLANA_MAINNET_ID)
@@ -136,6 +141,67 @@ describe('mapApiTokenToLocal', () => {
     })
   })
 
+  describe('contractType fallback via networkCaip2Id', () => {
+    it('falls back to SPL when contractType is null on a Solana caip2Id', () => {
+      const apiToken: ApiToken = {
+        symbol: 'USDC',
+        name: 'USD Coin',
+        address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        decimals: 6,
+        isNative: false,
+        internalId: 'usdc-solana',
+        logoUri: 'https://example.com/usdc.png',
+        networkCaip2Id: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        top250Rank: null,
+        contractType: null
+      }
+
+      const result = mapApiTokenToLocal(apiToken, ChainId.SOLANA_MAINNET_ID)
+
+      expect(result.type).toBe(TokenType.SPL)
+    })
+
+    it('falls back to ERC20 when contractType is null on an EVM caip2Id', () => {
+      const apiToken: ApiToken = {
+        symbol: 'USDC',
+        name: 'USD Coin',
+        address: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
+        decimals: 6,
+        isNative: false,
+        internalId: 'usdc-avax-c',
+        logoUri: 'https://example.com/usdc.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null,
+        contractType: null
+      }
+
+      const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
+
+      expect(result.type).toBe(TokenType.ERC20)
+    })
+
+    it('explicit contractType wins over caip2Id namespace', () => {
+      // ERC-20 contractType on a solana caip2Id is nonsensical but exercises
+      // that the explicit value is honored before the fallback runs.
+      const apiToken: ApiToken = {
+        symbol: 'WEIRD',
+        name: 'Weird',
+        address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        decimals: 6,
+        isNative: false,
+        internalId: 'weird',
+        logoUri: null,
+        networkCaip2Id: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        top250Rank: null,
+        contractType: 'ERC-20'
+      }
+
+      const result = mapApiTokenToLocal(apiToken, ChainId.SOLANA_MAINNET_ID)
+
+      expect(result.type).toBe(TokenType.ERC20)
+    })
+  })
+
   describe('Balance integration', () => {
     it('should merge balance data when provided', () => {
       const apiToken: ApiToken = {
@@ -147,7 +213,8 @@ describe('mapApiTokenToLocal', () => {
         internalId: 'avax-native',
         logoUri: 'https://example.com/avax.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       const balanceData: Partial<LocalTokenWithBalance> = {
@@ -181,7 +248,8 @@ describe('mapApiTokenToLocal', () => {
         internalId: 'usdc-avax-c',
         logoUri: 'https://example.com/usdc.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: 'ERC-20'
       }
 
       const balanceData: Partial<LocalTokenWithBalance> = {
@@ -214,7 +282,8 @@ describe('mapApiTokenToLocal', () => {
         internalId: 'avax-native',
         logoUri: 'https://example.com/avax.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -237,7 +306,8 @@ describe('mapApiTokenToLocal', () => {
         address: '0x123',
         isNative: false,
         internalId: 'test-token',
-        logoUri: 'https://example.com/test.png'
+        logoUri: 'https://example.com/test.png',
+        networkCaip2Id: 'eip155:43114'
       } as ApiToken
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -255,7 +325,8 @@ describe('mapApiTokenToLocal', () => {
         address: '',
         decimals: 18,
         isNative: true,
-        internalId: 'test-token'
+        internalId: 'test-token',
+        networkCaip2Id: 'eip155:43114'
       } as ApiToken
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -276,7 +347,8 @@ describe('mapApiTokenToLocal', () => {
         internalId: 'avax-native',
         logoUri: 'https://example.com/avax.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -299,7 +371,8 @@ describe('mapApiTokenToLocal', () => {
         internalId: 'avax-native',
         logoUri: 'https://example.com/avax.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -320,7 +393,8 @@ describe('mapApiTokenToLocal', () => {
         internalId: 'avax-native',
         logoUri: 'https://example.com/avax.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -341,7 +415,8 @@ describe('mapApiTokenToLocal', () => {
         internalId: 'usdc-avax-c-chain',
         logoUri: 'https://example.com/usdc.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: 'ERC-20'
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -362,7 +437,8 @@ describe('mapApiTokenToLocal', () => {
         internalId: 'avax-native',
         logoUri: 'https://example.com/avax.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       const result = mapApiTokenToLocal(apiToken, ChainId.AVALANCHE_MAINNET_ID)
@@ -385,7 +461,8 @@ describe('mapApiTokenToLocal', () => {
         internalId: 'test-token',
         logoUri: 'https://example.com/test.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       const balanceData: Partial<LocalTokenWithBalance> = {
@@ -415,7 +492,8 @@ describe('mapApiTokenToLocal', () => {
         internalId: 'avax-native',
         logoUri: 'https://example.com/avax.png',
         networkCaip2Id: 'eip155:43114',
-        top250Rank: null
+        top250Rank: null,
+        contractType: null
       }
 
       const balanceData: Partial<LocalTokenWithBalance> = {

--- a/packages/core-mobile/app/new/features/swap/utils/mapApiTokenToLocal.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/mapApiTokenToLocal.ts
@@ -1,6 +1,5 @@
 import { TokenType } from '@avalabs/vm-module-types'
 import { LocalTokenWithBalance } from 'store/balance'
-import { ChainId } from '@avalabs/core-chains-sdk'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { DEFAULT_TOKEN_DECIMALS } from '../consts'
 import { ApiToken } from '../types'
@@ -18,8 +17,17 @@ export const mapApiTokenToLocal = (
     if (apiToken.isNative) {
       return TokenType.NATIVE
     }
-    // EVM chains use ERC20, Solana uses SPL
-    return networkChainId === ChainId.SOLANA_MAINNET_ID
+
+    if (apiToken.contractType === 'ERC-20') {
+      return TokenType.ERC20
+    }
+
+    if (apiToken.contractType === 'SPL') {
+      return TokenType.SPL
+    }
+
+    // contractType can be null on the wire; fall back to the caip2Id namespace.
+    return apiToken.networkCaip2Id.startsWith('solana:')
       ? TokenType.SPL
       : TokenType.ERC20
   }


### PR DESCRIPTION
## Description

**Ticket: [CP-14152](https://ava-labs.atlassian.net/browse/CP-14152)**

The token aggregator API now returns a `contractType` ('ERC-20' | 'SPL') field on each token. Use it as the source of truth for picking `TokenType` in the swap flow instead of inferring from the network chain id.

`contractType` is declared `nullable: true` in the schema, but `@hey-api/openapi-ts` drops the `| null` whenever the field is also an `enum`. Patched the codegen via `parser.patch` to push `null` onto every nullable enum array so the generated type is honest. The mapper handles the null case by falling back to the `caip2Id` namespace (`solana:` → SPL, otherwise ERC20). The codegen patch can be removed once the backend upgrades the spec to OpenAPI 3.1.x.

- Updated `mapApiTokenToLocal` to read `apiToken.contractType` and fall back via `networkCaip2Id`.
- `buildLocalToken` (lookup-API path) now passes `contractType: null` and lets the mapper resolve it, since the lookup API doesn't return contractType.
- Added `parser.patch.schemas` walker in `aggregator-api.config.js` for `TokenListResponse` and `NetworkTokensByCaip2Response`.
- Updated unit tests for both utils.

## Testing

- Open the Swap screen and confirm the token list loads and renders correctly on Avalanche, Ethereum, and Solana.
- Pick an EVM token and a Solana SPL token from the list and verify they appear with the correct symbol, logo, and balance.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14152]: https://ava-labs.atlassian.net/browse/CP-14152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ