### PR TITLE
CP-14159: prevent in-app browser origin spoofing via postMessage

### DIFF
--- a/packages/core-mobile/app/hooks/browser/evmProviderShim.test.ts
+++ b/packages/core-mobile/app/hooks/browser/evmProviderShim.test.ts
@@ -380,4 +380,26 @@ describe('buildEvmProviderShim', () => {
       expect(shim).not.toContain("event === 'accountsChanged'")
     })
   })
+
+  describe('SPA navigation listener (security)', () => {
+    it('does not emit nav_change messages from page JS', () => {
+      const shim = buildEvmProviderShim({
+        chainId: '0xa86a',
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        uuid: 'test-uuid-1234'
+      })
+      // The page must not be able to drive the native origin via postMessage.
+      expect(shim).not.toContain('nav_change')
+    })
+
+    it('does not patch history.pushState or history.replaceState', () => {
+      const shim = buildEvmProviderShim({
+        chainId: '0xa86a',
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        uuid: 'test-uuid-1234'
+      })
+      expect(shim).not.toContain('history.pushState')
+      expect(shim).not.toContain('history.replaceState')
+    })
+  })
 })

--- a/packages/core-mobile/app/hooks/browser/evmProviderShim.ts
+++ b/packages/core-mobile/app/hooks/browser/evmProviderShim.ts
@@ -466,31 +466,6 @@ export function buildEvmProviderShim({
     document.addEventListener('DOMContentLoaded', sendDomainMetadata);
   }
 
-  // ──────────────────────────────────────────────
-  // 10. SPA navigation listener
-  // ──────────────────────────────────────────────
-  (function() {
-    var lastUrl = window.location.href;
-    function onUrlChange() {
-      var newUrl = window.location.href;
-      if (newUrl !== lastUrl) {
-        lastUrl = newUrl;
-        safeSend({ method: 'nav_change', payload: newUrl });
-      }
-    }
-    var origPushState = history.pushState;
-    history.pushState = function() {
-      origPushState.apply(history, arguments);
-      onUrlChange();
-    };
-    var origReplaceState = history.replaceState;
-    history.replaceState = function() {
-      origReplaceState.apply(history, arguments);
-      onUrlChange();
-    };
-    window.addEventListener('popstate', onUrlChange);
-  })();
-
   safeSend({ method: 'log', payload: 'Core EVM provider injected (chainId=' + _chainId + ')' });
 })();`
 }

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -759,6 +759,54 @@ describe('useEvmInjectedProvider', () => {
         }
       )
 
+      it('derives peerMeta.name from the native URL hostname, not from page-supplied domain_metadata', async () => {
+        const mockRequest = jest.fn().mockResolvedValue('0xSig')
+        mockCreateInAppRequest.mockReturnValue(mockRequest)
+
+        const { result } = renderHook(() =>
+          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+        )
+
+        // The page is actually loaded from a malicious origin...
+        act(() => {
+          result.current.setCurrentUrl('https://malicious.example/path')
+        })
+
+        // ...but it tries to spoof its display name via domain_metadata.
+        act(() => {
+          result.current.handleDomainMetadata(
+            JSON.stringify({
+              domain: 'core.app',
+              name: 'core.app',
+              icon: 'https://core.app/favicon.ico',
+              url: 'https://core.app/'
+            })
+          )
+        })
+
+        await act(async () => {
+          result.current.handleProviderMessage(
+            JSON.stringify({
+              id: 99,
+              request: {
+                method: 'personal_sign',
+                params: ['0xMessage', '0xAddress']
+              }
+            })
+          )
+        })
+
+        expect(mockRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            peerMeta: expect.objectContaining({
+              name: 'malicious.example',
+              url: 'https://malicious.example/path',
+              icons: ['https://core.app/favicon.ico']
+            })
+          })
+        )
+      })
+
       it('responds with signature on approval', async () => {
         const mockRequest = jest.fn().mockResolvedValue('0xSignatureResult')
         mockCreateInAppRequest.mockReturnValue(mockRequest)

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -892,6 +892,60 @@ describe('useEvmInjectedProvider', () => {
         )
       })
 
+      it('rejects wallet_addEthereumChain when origin is unavailable (no Core attribution)', async () => {
+        const mockRequest = jest.fn()
+        mockCreateInAppRequest.mockReturnValue(mockRequest)
+
+        const { result } = renderHook(() =>
+          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+        )
+
+        const payload = JSON.stringify({
+          id: 30,
+          request: {
+            method: 'wallet_addEthereumChain',
+            params: [{ chainId: '0x1' }]
+          }
+        })
+
+        await act(async () => {
+          result.current.handleProviderMessage(payload)
+        })
+
+        // Must NOT reach the approval pipeline (would otherwise be attributed
+        // to CORE_MOBILE_META by generateInAppRequestPayload).
+        expect(mockRequest).not.toHaveBeenCalled()
+        expect(mockInjectJavaScript).toHaveBeenCalledWith(
+          expect.stringContaining('Origin unavailable')
+        )
+      })
+
+      it('rejects wallet_watchAsset when origin is unavailable (no Core attribution)', async () => {
+        const mockRequest = jest.fn()
+        mockCreateInAppRequest.mockReturnValue(mockRequest)
+
+        const { result } = renderHook(() =>
+          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+        )
+
+        const payload = JSON.stringify({
+          id: 31,
+          request: {
+            method: 'wallet_watchAsset',
+            params: [{ type: 'ERC20', options: { address: '0x0' } }]
+          }
+        })
+
+        await act(async () => {
+          result.current.handleProviderMessage(payload)
+        })
+
+        expect(mockRequest).not.toHaveBeenCalled()
+        expect(mockInjectJavaScript).toHaveBeenCalledWith(
+          expect.stringContaining('Origin unavailable')
+        )
+      })
+
       it('preserves well-formed RPC errors without re-serializing', async () => {
         const mockRequest = jest
           .fn()

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -75,6 +75,16 @@ const ALLOWED_METHODS = new Set([
   'wallet_watchAsset'
 ])
 
+// Methods that trigger a user-facing approval modal and therefore require a
+// verified native origin. Without one, the downstream generateInAppRequestPayload
+// would fall back to CORE_MOBILE_META and misattribute the request to Core —
+// the same spoofing class CP-14159 exists to prevent.
+const APPROVAL_METHODS = new Set([
+  ...Object.keys(SIGNING_METHODS),
+  'wallet_addEthereumChain',
+  'wallet_watchAsset'
+])
+
 function validateProviderRequest(data: unknown): data is ProviderRequest {
   if (typeof data !== 'object' || data === null) return false
   const obj = data as Record<string, unknown>
@@ -293,26 +303,29 @@ export function useEvmInjectedProvider(
     [sendResponse]
   )
 
-  const buildDappPeerMeta = useCallback((): PeerMeta | undefined => {
+  const buildDappPeerMeta = useCallback((): PeerMeta => {
     const nativeUrl = currentUrlRef.current
-    if (!nativeUrl) return undefined
-
-    let hostname: string
-    try {
-      hostname = new URL(nativeUrl).hostname
-    } catch {
-      return undefined
+    let hostname = ''
+    if (nativeUrl) {
+      try {
+        hostname = new URL(nativeUrl).hostname
+      } catch {
+        // fall through to placeholder
+      }
     }
 
     // The dApp name and URL are derived ONLY from the WebView's actual
     // top-level URL. The page-supplied domain_metadata cannot influence
     // either (it would be a spoofing vector). The favicon is taken from
-    // domain_metadata since it is purely cosmetic.
+    // domain_metadata since it is purely cosmetic. When the native URL is
+    // unavailable we return a non-Core placeholder so the downstream
+    // generateInAppRequestPayload does NOT fall back to CORE_MOBILE_META
+    // (which would misattribute the request to https://core.app).
     const icon = dappMetadata.current?.icon
     return {
-      name: hostname,
+      name: hostname || 'Unknown site',
       description: '',
-      url: nativeUrl,
+      url: hostname ? nativeUrl : '',
       icons: icon ? [icon] : []
     }
   }, [])
@@ -505,13 +518,11 @@ export function useEvmInjectedProvider(
 
       if (nativeOrigin) {
         pendingOrigins.current.set(id, nativeOrigin)
-      } else if (method in SIGNING_METHODS) {
-        // Signing methods require a verified page origin — reject without one.
-        sendResponse(
-          id,
-          rpcErrors.internal('Origin unavailable — cannot sign'),
-          undefined
-        )
+      } else if (APPROVAL_METHODS.has(method)) {
+        // Methods that surface an approval modal require a verified native
+        // origin. Without one, peerMeta would be undefined downstream and
+        // CORE_MOBILE_META would attribute the request to Core/core.app.
+        sendResponse(id, rpcErrors.internal('Origin unavailable'), undefined)
         return
       }
 

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -294,15 +294,26 @@ export function useEvmInjectedProvider(
   )
 
   const buildDappPeerMeta = useCallback((): PeerMeta | undefined => {
-    const meta = dappMetadata.current
     const nativeUrl = currentUrlRef.current
-    if (!meta && !nativeUrl) return undefined
+    if (!nativeUrl) return undefined
 
+    let hostname: string
+    try {
+      hostname = new URL(nativeUrl).hostname
+    } catch {
+      return undefined
+    }
+
+    // The dApp name and URL are derived ONLY from the WebView's actual
+    // top-level URL. The page-supplied domain_metadata cannot influence
+    // either (it would be a spoofing vector). The favicon is taken from
+    // domain_metadata since it is purely cosmetic.
+    const icon = dappMetadata.current?.icon
     return {
-      name: meta?.name ?? new URL(nativeUrl).hostname,
+      name: hostname,
       description: '',
-      url: nativeUrl || meta?.url || '',
-      icons: meta?.icon ? [meta.icon] : []
+      url: nativeUrl,
+      icons: icon ? [icon] : []
     }
   }, [])
 

--- a/packages/core-mobile/app/hooks/browser/useInjectedJavascript.ts
+++ b/packages/core-mobile/app/hooks/browser/useInjectedJavascript.ts
@@ -24,7 +24,6 @@ export type InjectedJsMessageWrapper = {
     | 'walletConnect_deeplink_blocked'
     | 'provider_request'
     | 'domain_metadata'
-    | 'nav_change'
   payload: string
 }
 

--- a/packages/core-mobile/app/new/features/browser/components/BrowserTab.tsx
+++ b/packages/core-mobile/app/new/features/browser/components/BrowserTab.tsx
@@ -341,10 +341,6 @@ export const BrowserTab = forwardRef<BrowserTabRef, { tabId: string }>(
               handleDomainMetadata(wrapper.payload)
               break
             }
-            case 'nav_change': {
-              setCurrentUrl(wrapper.payload)
-              break
-            }
             case 'window_ethereum_used': {
               if (injectedProviderEnabled) break
               const sessions = WalletConnectService.getSessions()
@@ -382,7 +378,6 @@ export const BrowserTab = forwardRef<BrowserTabRef, { tabId: string }>(
         showWalletConnectDialog,
         handleProviderMessage,
         handleDomainMetadata,
-        setCurrentUrl,
         urlToLoad
       ]
     )


### PR DESCRIPTION
## Description

**Ticket: [CP-14159](https://ava-labs.atlassian.net/browse/CP-14159)**

A bug bounty was filed against the in-app browser: a malicious page can call `window.ReactNativeWebView.postMessage` from its own JS context to send a `nav_change` payload that spoofs the displayed origin (e.g. to `https://core.app`), then immediately send a `provider_request` so the transaction approval modal appears to come from `core.app`.

The native side trusted the page-supplied origin — `currentUrlRef` (the value used by the signing approval flow) had two writers: the trusted `BrowserTab.onNavigationStateChange` event and the untrusted page-driven `nav_change` message handler.

**Fix — three layers, defense in depth:**

1. **Trust boundary.** Removed the page-injected SPA navigation listener in `evmProviderShim.ts` (the only producer of `nav_change`). Removed the `case 'nav_change'` branch from `BrowserTab.onMessageHandler`. Removed `'nav_change'` from the `InjectedJsMessageWrapper.method` union so the type system enforces the contract going forward. After this, `currentUrlRef` has exactly one writer: the trusted native `onNavigationStateChange` event.
2. **Hardening.** `buildDappPeerMeta` now derives `peerMeta.name` and `peerMeta.url` strictly from the WebView's actual top-level URL. Page-supplied `domain_metadata.name`/`url` are no longer read at all (`icon` is still consumed — purely cosmetic).
3. **Existing guard kept.** The signing path already rejects with `'Origin unavailable — cannot sign'` when `currentUrlRef` is empty.

**UX trade-off:** Approval modals now show the page's hostname (`app.uniswap.org`) instead of the page-supplied friendly name (`Uniswap Interface`). This matches MetaMask Mobile / Trust Wallet behavior and is required to make the displayed origin verifiable.

No new dependencies. Not a breaking change for users; only the displayed dApp name on in-app browser approvals shifts from page-supplied to hostname-derived.

**References**
- Bug bounty (Immunefi): https://bugs.immunefi.com/magnus/936/projects/345/reports/74679
- Slack: [#core-mobile-bb-postmessage-origin-spoofing](https://avalancheavax.slack.com/archives/C0B06LWF6CF/p1777480749887789)

## Screenshots/Videos

Verified on a physical Pixel 8 Pro running the internal debug build, hosting the bounty hunter's PoC (`cps.html`) over a local HTTP server tunneled via `adb reverse`.

**1. PoC page — sent both attack messages successfully from page JS**

<img width="879" height="1930" alt="Screenshot 2026-05-07 at 1 40 50 PM" src="https://github.com/user-attachments/assets/d3f8a70f-df21-46f4-91b4-cf741f1206b8" />

**2. `personal_sign` approval modal — origin correctly attributed to `localhost` (not `core.app`)**

<img width="871" height="1921" alt="Screenshot 2026-05-07 at 1 38 49 PM" src="https://github.com/user-attachments/assets/7b10001a-ece8-4ccc-b929-ae9adf829966" />

**3. `eth_sendTransaction` approval modal — no `core.app` anywhere; spoof has no surface to land on**
<img width="893" height="1940" alt="Screenshot 2026-05-07 at 1 40 41 PM" src="https://github.com/user-attachments/assets/f06ade3e-f22b-4fb0-b7be-cda70a1543e6" />


iOS verification pending (no iOS-only code paths changed; the fix is in shared JS / hooks, so behavior is identical on iOS).

## Testing

**Dev Testing**

Bitrise: _<!-- replace with build numbers once builds finish -->_

Reviewer steps to reproduce the verification:

1. Pull this branch and run `yarn android` (Pixel 8 Pro / any modern Android device or emulator).
2. Save the bounty hunter's `cps.html` (in Slack `#core-mobile-bb-postmessage-origin-spoofing`) to any local directory.

[cps.html](https://github.com/user-attachments/files/27492131/cps.html)

3. Serve it: `cd <dir> && python3 -m http.server 8765`
4. Tunnel: `adb reverse tcp:8765 tcp:8765`
5. In the in-app browser address bar, navigate to `http://localhost:8765/cps.html`. (Note: the URL bar's `normalizeUrlWithHttps` upgrades inputs to https. For testing, target the LAN IP over a service that already speaks https, or use a local HTTPS proxy. The fix itself does not depend on http vs https.)
6. Tap **"1) personal_sign"** → approval modal must show `localhost` (NOT `core.app` and NOT "Core").
7. Tap **"2) eth_sendTransaction"** → approval modal must show no `core.app` reference anywhere.

**Edge cases**

- Tap the unlabeled prime button (sends `nav_change` only): address bar must not change to `core.app` and no native state must shift.
- Open a real SPA dApp (e.g. `app.uniswap.org`) in the in-app browser, navigate between routes via SPA pushState, then sign — confirm hostname/favicon still display correctly.
- Reject path: cancel both approval modals; subsequent legit dApp interactions still work.

**Unit tests added**

- `useEvmInjectedProvider.test.ts`: `peerMeta.name` cannot be spoofed via `domain_metadata`; `icon` still flows through.
- `evmProviderShim.test.ts`: shim no longer emits `nav_change` and no longer patches `history.pushState` / `history.replaceState`.

`yarn test` passes 2676/2676. `yarn lint` clean. `yarn tsc` shows 3 pre-existing errors on `main` in unrelated files (trade predictions screen, k2-alpine haptics) — none caused by this change.

**QA Testing**

- Browse a few well-behaved dApps (Uniswap, Aave, OpenSea) in the in-app browser. Connect, sign, send. Confirm approval modals show the correct hostname for each and the flows complete normally.
- Acceptance: no `core.app` text or Core branding ever appears on approvals originating from a non-core.app site. Page-supplied display name is no longer used; hostname is shown instead.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works (Pixel 8 Pro, internal debug build, against the bounty hunter's PoC)
- [x] I have included screenshots / videos of android (iOS pending — JS-only change, behavior identical)
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation (N/A)

[CP-14159]: https://ava-labs.atlassian.net/browse/CP-14159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ