### PR TITLE
CP-14162: stop swap auto-advance from churning on every quote refresh

### DIFF
--- a/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.test.ts
@@ -32,6 +32,20 @@ const warningError = (): FusionQuoteError => fusionErrors.gasEstimationFailed()
 
 const DEFAULT_MAX = 3
 
+type HookProps = Parameters<typeof useAutoAdvanceOnFeeValidationError>[0]
+
+const props = (overrides: Partial<HookProps> = {}): HookProps => ({
+  feeValidationError: undefined,
+  isValidating: false,
+  isSwapping: false,
+  activeQuote: null,
+  allQuotes: [],
+  userQuote: null,
+  advanceBestQuote: jest.fn(),
+  maxAdvances: DEFAULT_MAX,
+  ...overrides
+})
+
 beforeEach(() => {
   jest.clearAllMocks()
 })
@@ -42,14 +56,14 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
     const advanceBestQuote = jest.fn()
 
     renderHook(() =>
-      useAutoAdvanceOnFeeValidationError({
-        feeValidationError: providerSpecificError(),
-        activeQuote: quotes[0] as Quote,
-        allQuotes: quotes,
-        userQuote: null,
-        advanceBestQuote,
-        maxAdvances: DEFAULT_MAX
-      })
+      useAutoAdvanceOnFeeValidationError(
+        props({
+          feeValidationError: providerSpecificError(),
+          activeQuote: quotes[0] as Quote,
+          allQuotes: quotes,
+          advanceBestQuote
+        })
+      )
     )
 
     expect(advanceBestQuote).toHaveBeenCalledWith('b')
@@ -65,14 +79,14 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
     const advanceBestQuote = jest.fn()
 
     renderHook(() =>
-      useAutoAdvanceOnFeeValidationError({
-        feeValidationError: providerSpecificError(),
-        activeQuote: quotes[0] as Quote,
-        allQuotes: quotes,
-        userQuote: null,
-        advanceBestQuote,
-        maxAdvances: DEFAULT_MAX
-      })
+      useAutoAdvanceOnFeeValidationError(
+        props({
+          feeValidationError: providerSpecificError(),
+          activeQuote: quotes[0] as Quote,
+          allQuotes: quotes,
+          advanceBestQuote
+        })
+      )
     )
 
     expect(mockLoggerError).toHaveBeenCalledTimes(1)
@@ -91,14 +105,15 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
     const advanceBestQuote = jest.fn()
 
     renderHook(() =>
-      useAutoAdvanceOnFeeValidationError({
-        feeValidationError: providerSpecificError(),
-        activeQuote: quotes[0] as Quote,
-        allQuotes: quotes,
-        userQuote: quotes[0] as Quote,
-        advanceBestQuote,
-        maxAdvances: DEFAULT_MAX
-      })
+      useAutoAdvanceOnFeeValidationError(
+        props({
+          feeValidationError: providerSpecificError(),
+          activeQuote: quotes[0] as Quote,
+          allQuotes: quotes,
+          userQuote: quotes[0] as Quote,
+          advanceBestQuote
+        })
+      )
     )
 
     expect(advanceBestQuote).not.toHaveBeenCalled()
@@ -110,14 +125,13 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
     const advanceBestQuote = jest.fn()
 
     renderHook(() =>
-      useAutoAdvanceOnFeeValidationError({
-        feeValidationError: undefined,
-        activeQuote: quotes[0] as Quote,
-        allQuotes: quotes,
-        userQuote: null,
-        advanceBestQuote,
-        maxAdvances: DEFAULT_MAX
-      })
+      useAutoAdvanceOnFeeValidationError(
+        props({
+          activeQuote: quotes[0] as Quote,
+          allQuotes: quotes,
+          advanceBestQuote
+        })
+      )
     )
 
     expect(advanceBestQuote).not.toHaveBeenCalled()
@@ -130,14 +144,14 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
     const advanceBestQuote = jest.fn()
 
     renderHook(() =>
-      useAutoAdvanceOnFeeValidationError({
-        feeValidationError: balanceError(),
-        activeQuote: quotes[0] as Quote,
-        allQuotes: quotes,
-        userQuote: null,
-        advanceBestQuote,
-        maxAdvances: DEFAULT_MAX
-      })
+      useAutoAdvanceOnFeeValidationError(
+        props({
+          feeValidationError: balanceError(),
+          activeQuote: quotes[0] as Quote,
+          allQuotes: quotes,
+          advanceBestQuote
+        })
+      )
     )
 
     expect(advanceBestQuote).not.toHaveBeenCalled()
@@ -149,14 +163,14 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
     const advanceBestQuote = jest.fn()
 
     renderHook(() =>
-      useAutoAdvanceOnFeeValidationError({
-        feeValidationError: warningError(),
-        activeQuote: quotes[0] as Quote,
-        allQuotes: quotes,
-        userQuote: null,
-        advanceBestQuote,
-        maxAdvances: DEFAULT_MAX
-      })
+      useAutoAdvanceOnFeeValidationError(
+        props({
+          feeValidationError: warningError(),
+          activeQuote: quotes[0] as Quote,
+          allQuotes: quotes,
+          advanceBestQuote
+        })
+      )
     )
 
     expect(advanceBestQuote).not.toHaveBeenCalled()
@@ -168,14 +182,14 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
     const advanceBestQuote = jest.fn()
 
     renderHook(() =>
-      useAutoAdvanceOnFeeValidationError({
-        feeValidationError: providerSpecificError(),
-        activeQuote: quotes[1] as Quote,
-        allQuotes: quotes,
-        userQuote: null,
-        advanceBestQuote,
-        maxAdvances: DEFAULT_MAX
-      })
+      useAutoAdvanceOnFeeValidationError(
+        props({
+          feeValidationError: providerSpecificError(),
+          activeQuote: quotes[1] as Quote,
+          allQuotes: quotes,
+          advanceBestQuote
+        })
+      )
     )
 
     expect(advanceBestQuote).not.toHaveBeenCalled()
@@ -187,14 +201,14 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
     const advanceBestQuote = jest.fn()
 
     renderHook(() =>
-      useAutoAdvanceOnFeeValidationError({
-        feeValidationError: providerSpecificError(),
-        activeQuote: makeQuote('stale'),
-        allQuotes: quotes,
-        userQuote: null,
-        advanceBestQuote,
-        maxAdvances: DEFAULT_MAX
-      })
+      useAutoAdvanceOnFeeValidationError(
+        props({
+          feeValidationError: providerSpecificError(),
+          activeQuote: makeQuote('stale'),
+          allQuotes: quotes,
+          advanceBestQuote
+        })
+      )
     )
 
     expect(advanceBestQuote).not.toHaveBeenCalled()
@@ -206,14 +220,14 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
     const advanceBestQuote = jest.fn()
 
     renderHook(() =>
-      useAutoAdvanceOnFeeValidationError({
-        feeValidationError: providerSpecificError(),
-        activeQuote: null,
-        allQuotes: quotes,
-        userQuote: null,
-        advanceBestQuote,
-        maxAdvances: DEFAULT_MAX
-      })
+      useAutoAdvanceOnFeeValidationError(
+        props({
+          feeValidationError: providerSpecificError(),
+          activeQuote: null,
+          allQuotes: quotes,
+          advanceBestQuote
+        })
+      )
     )
 
     expect(advanceBestQuote).not.toHaveBeenCalled()
@@ -226,28 +240,25 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
     const error = providerSpecificError()
 
     const { rerender } = renderHook(
-      props => useAutoAdvanceOnFeeValidationError(props),
+      p => useAutoAdvanceOnFeeValidationError(p),
       {
-        initialProps: {
+        initialProps: props({
           feeValidationError: error,
           activeQuote: quotes[0] as Quote,
           allQuotes: quotes,
-          userQuote: null as Quote | null,
-          advanceBestQuote,
-          maxAdvances: DEFAULT_MAX
-        }
+          advanceBestQuote
+        })
       }
     )
 
-    // Re-render with same inputs should not trigger another advance
-    rerender({
-      feeValidationError: error,
-      activeQuote: quotes[0] as Quote,
-      allQuotes: quotes,
-      userQuote: null,
-      advanceBestQuote,
-      maxAdvances: DEFAULT_MAX
-    })
+    rerender(
+      props({
+        feeValidationError: error,
+        activeQuote: quotes[0] as Quote,
+        allQuotes: quotes,
+        advanceBestQuote
+      })
+    )
 
     expect(advanceBestQuote).toHaveBeenCalledTimes(1)
     expect(mockShowSnackbar).toHaveBeenCalledTimes(1)
@@ -264,48 +275,48 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
     const advanceBestQuote = jest.fn()
     const error = providerSpecificError()
 
-    // Simulate: advance from a → b → c → d (3 advances = maxAdvances)
     const { rerender } = renderHook(
-      props => useAutoAdvanceOnFeeValidationError(props),
+      p => useAutoAdvanceOnFeeValidationError(p),
       {
-        initialProps: {
+        initialProps: props({
           feeValidationError: error,
           activeQuote: quotes[0] as Quote,
           allQuotes: quotes,
-          userQuote: null as Quote | null,
           advanceBestQuote,
           maxAdvances: 3
-        }
+        })
       }
     )
-    rerender({
-      feeValidationError: error,
-      activeQuote: quotes[1] as Quote,
-      allQuotes: quotes,
-      userQuote: null,
-      advanceBestQuote,
-      maxAdvances: 3
-    })
-    rerender({
-      feeValidationError: error,
-      activeQuote: quotes[2] as Quote,
-      allQuotes: quotes,
-      userQuote: null,
-      advanceBestQuote,
-      maxAdvances: 3
-    })
+    rerender(
+      props({
+        feeValidationError: error,
+        activeQuote: quotes[1] as Quote,
+        allQuotes: quotes,
+        advanceBestQuote,
+        maxAdvances: 3
+      })
+    )
+    rerender(
+      props({
+        feeValidationError: error,
+        activeQuote: quotes[2] as Quote,
+        allQuotes: quotes,
+        advanceBestQuote,
+        maxAdvances: 3
+      })
+    )
 
     expect(advanceBestQuote).toHaveBeenCalledTimes(3)
 
-    // Fourth attempt — should stop
-    rerender({
-      feeValidationError: error,
-      activeQuote: quotes[3] as Quote,
-      allQuotes: quotes,
-      userQuote: null,
-      advanceBestQuote,
-      maxAdvances: 3
-    })
+    rerender(
+      props({
+        feeValidationError: error,
+        activeQuote: quotes[3] as Quote,
+        allQuotes: quotes,
+        advanceBestQuote,
+        maxAdvances: 3
+      })
+    )
 
     expect(advanceBestQuote).toHaveBeenCalledTimes(3)
   })
@@ -316,52 +327,159 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
     const error = providerSpecificError()
 
     const { rerender } = renderHook(
-      props => useAutoAdvanceOnFeeValidationError(props),
+      p => useAutoAdvanceOnFeeValidationError(p),
       {
-        initialProps: {
-          feeValidationError: error as FusionQuoteError | undefined,
+        initialProps: props({
+          feeValidationError: error,
           activeQuote: quotes[0] as Quote,
           allQuotes: quotes,
-          userQuote: null as Quote | null,
           advanceBestQuote,
           maxAdvances: 1
-        }
+        })
       }
     )
 
-    // 1 advance, then hit the cap
     expect(advanceBestQuote).toHaveBeenCalledTimes(1)
-    rerender({
-      feeValidationError: error,
-      activeQuote: quotes[1] as Quote,
-      allQuotes: quotes,
-      userQuote: null,
-      advanceBestQuote,
-      maxAdvances: 1
-    })
+    rerender(
+      props({
+        feeValidationError: error,
+        activeQuote: quotes[1] as Quote,
+        allQuotes: quotes,
+        advanceBestQuote,
+        maxAdvances: 1
+      })
+    )
     expect(advanceBestQuote).toHaveBeenCalledTimes(1)
 
-    // Error clears (e.g. user fixed input) — counter resets
-    rerender({
-      feeValidationError: undefined,
-      activeQuote: quotes[1] as Quote,
-      allQuotes: quotes,
-      userQuote: null,
-      advanceBestQuote,
-      maxAdvances: 1
-    })
+    // Stable clear: error gone AND not validating → counter resets
+    rerender(
+      props({
+        feeValidationError: undefined,
+        activeQuote: quotes[1] as Quote,
+        allQuotes: quotes,
+        advanceBestQuote,
+        maxAdvances: 1
+      })
+    )
 
-    // New provider-specific error — should advance again (counter was reset)
-    rerender({
-      feeValidationError: error,
-      activeQuote: quotes[1] as Quote,
-      allQuotes: quotes,
-      userQuote: null,
-      advanceBestQuote,
-      maxAdvances: 1
-    })
+    rerender(
+      props({
+        feeValidationError: error,
+        activeQuote: quotes[1] as Quote,
+        allQuotes: quotes,
+        advanceBestQuote,
+        maxAdvances: 1
+      })
+    )
     expect(advanceBestQuote).toHaveBeenCalledTimes(2)
     expect(advanceBestQuote).toHaveBeenLastCalledWith('c')
+  })
+
+  it('does NOT reset the counter while validation is in flight', () => {
+    // Regression: every quote-stream refresh briefly sets feeValidationError
+    // to undefined while React Query refetches. Resetting on that transient
+    // gap re-armed the budget on each cycle and let the hook walk the whole
+    // list every few seconds — the JS-thread churn behind the freeze.
+    const quotes = [makeQuote('a'), makeQuote('b'), makeQuote('c')]
+    const advanceBestQuote = jest.fn()
+    const error = providerSpecificError()
+
+    const { rerender } = renderHook(
+      p => useAutoAdvanceOnFeeValidationError(p),
+      {
+        initialProps: props({
+          feeValidationError: error,
+          activeQuote: quotes[0] as Quote,
+          allQuotes: quotes,
+          advanceBestQuote,
+          maxAdvances: 1
+        })
+      }
+    )
+    expect(advanceBestQuote).toHaveBeenCalledTimes(1)
+
+    // Mid-flight: error is undefined ONLY because React Query is refetching.
+    // Counter must hold.
+    rerender(
+      props({
+        feeValidationError: undefined,
+        isValidating: true,
+        activeQuote: quotes[1] as Quote,
+        allQuotes: quotes,
+        advanceBestQuote,
+        maxAdvances: 1
+      })
+    )
+
+    // New provider-specific error — budget already spent, must NOT advance.
+    rerender(
+      props({
+        feeValidationError: error,
+        activeQuote: quotes[1] as Quote,
+        allQuotes: quotes,
+        advanceBestQuote,
+        maxAdvances: 1
+      })
+    )
+
+    expect(advanceBestQuote).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not advance while a swap is in flight', () => {
+    // Once the user has pressed Next, SwapContext.swap() captured a quote and
+    // is awaiting transferAsset. Changing activeQuote underneath that call
+    // would race the in-flight transfer and spam Zustand updates while the
+    // JS thread is already busy.
+    const quotes = [makeQuote('a'), makeQuote('b'), makeQuote('c')]
+    const advanceBestQuote = jest.fn()
+
+    renderHook(() =>
+      useAutoAdvanceOnFeeValidationError(
+        props({
+          feeValidationError: providerSpecificError(),
+          isSwapping: true,
+          activeQuote: quotes[0] as Quote,
+          allQuotes: quotes,
+          advanceBestQuote
+        })
+      )
+    )
+
+    expect(advanceBestQuote).not.toHaveBeenCalled()
+    expect(mockShowSnackbar).not.toHaveBeenCalled()
+    expect(mockLoggerError).not.toHaveBeenCalled()
+  })
+
+  it('resumes advancing once the swap is no longer in flight', () => {
+    const quotes = [makeQuote('a'), makeQuote('b'), makeQuote('c')]
+    const advanceBestQuote = jest.fn()
+    const error = providerSpecificError()
+
+    const { rerender } = renderHook(
+      p => useAutoAdvanceOnFeeValidationError(p),
+      {
+        initialProps: props({
+          feeValidationError: error,
+          isSwapping: true,
+          activeQuote: quotes[0] as Quote,
+          allQuotes: quotes,
+          advanceBestQuote
+        })
+      }
+    )
+    expect(advanceBestQuote).not.toHaveBeenCalled()
+
+    rerender(
+      props({
+        feeValidationError: error,
+        isSwapping: false,
+        activeQuote: quotes[0] as Quote,
+        allQuotes: quotes,
+        advanceBestQuote
+      })
+    )
+
+    expect(advanceBestQuote).toHaveBeenCalledWith('b')
   })
 
   it('does not advance twice from the same quote when allQuotes identity changes but contents do not', () => {
@@ -373,65 +491,57 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
     const error = providerSpecificError()
 
     const { rerender } = renderHook(
-      props => useAutoAdvanceOnFeeValidationError(props),
+      p => useAutoAdvanceOnFeeValidationError(p),
       {
-        initialProps: {
+        initialProps: props({
           feeValidationError: error,
           activeQuote: quotesV1[0] as Quote,
           allQuotes: quotesV1,
-          userQuote: null as Quote | null,
-          advanceBestQuote,
-          maxAdvances: DEFAULT_MAX
-        }
+          advanceBestQuote
+        })
       }
     )
     expect(advanceBestQuote).toHaveBeenCalledTimes(1)
 
-    // Stream refresh: new array identity, identical contents, same active
-    // quote by id (imagine autoAdvance hasn't propagated yet in this tick).
-    rerender({
-      feeValidationError: error,
-      activeQuote: quotesV1[0] as Quote,
-      allQuotes: quotesV2,
-      userQuote: null,
-      advanceBestQuote,
-      maxAdvances: DEFAULT_MAX
-    })
+    rerender(
+      props({
+        feeValidationError: error,
+        activeQuote: quotesV1[0] as Quote,
+        allQuotes: quotesV2,
+        advanceBestQuote
+      })
+    )
 
     expect(advanceBestQuote).toHaveBeenCalledTimes(1)
     expect(mockShowSnackbar).toHaveBeenCalledTimes(1)
   })
 
   it('advances again once activeQuote has moved on', () => {
-    // After the hook advances from a → b and activeQuote transitions to b,
-    // a later render with the new activeQuote should be free to advance.
     const quotes = [makeQuote('a'), makeQuote('b'), makeQuote('c')]
     const advanceBestQuote = jest.fn()
     const error = providerSpecificError()
 
     const { rerender } = renderHook(
-      props => useAutoAdvanceOnFeeValidationError(props),
+      p => useAutoAdvanceOnFeeValidationError(p),
       {
-        initialProps: {
+        initialProps: props({
           feeValidationError: error,
           activeQuote: quotes[0] as Quote,
           allQuotes: quotes,
-          userQuote: null as Quote | null,
-          advanceBestQuote,
-          maxAdvances: DEFAULT_MAX
-        }
+          advanceBestQuote
+        })
       }
     )
     expect(advanceBestQuote).toHaveBeenCalledWith('b')
 
-    rerender({
-      feeValidationError: error,
-      activeQuote: quotes[1] as Quote,
-      allQuotes: quotes,
-      userQuote: null,
-      advanceBestQuote,
-      maxAdvances: DEFAULT_MAX
-    })
+    rerender(
+      props({
+        feeValidationError: error,
+        activeQuote: quotes[1] as Quote,
+        allQuotes: quotes,
+        advanceBestQuote
+      })
+    )
 
     expect(advanceBestQuote).toHaveBeenCalledTimes(2)
     expect(advanceBestQuote).toHaveBeenLastCalledWith('c')
@@ -443,40 +553,40 @@ describe('useAutoAdvanceOnFeeValidationError', () => {
     const error = providerSpecificError()
 
     const { rerender } = renderHook(
-      props => useAutoAdvanceOnFeeValidationError(props),
+      p => useAutoAdvanceOnFeeValidationError(p),
       {
-        initialProps: {
+        initialProps: props({
           feeValidationError: error,
           activeQuote: quotes[0] as Quote,
           allQuotes: quotes,
-          userQuote: null as Quote | null,
           advanceBestQuote,
           maxAdvances: 1
-        }
+        })
       }
     )
     expect(advanceBestQuote).toHaveBeenCalledTimes(1)
 
-    // User manually picks — advance is disabled and counter resets
-    rerender({
-      feeValidationError: error,
-      activeQuote: quotes[2] as Quote,
-      allQuotes: quotes,
-      userQuote: quotes[2] as Quote,
-      advanceBestQuote,
-      maxAdvances: 1
-    })
+    rerender(
+      props({
+        feeValidationError: error,
+        activeQuote: quotes[2] as Quote,
+        allQuotes: quotes,
+        userQuote: quotes[2] as Quote,
+        advanceBestQuote,
+        maxAdvances: 1
+      })
+    )
     expect(advanceBestQuote).toHaveBeenCalledTimes(1)
 
-    // User clears manual selection back to Auto — counter should be fresh
-    rerender({
-      feeValidationError: error,
-      activeQuote: quotes[0] as Quote,
-      allQuotes: quotes,
-      userQuote: null,
-      advanceBestQuote,
-      maxAdvances: 1
-    })
+    rerender(
+      props({
+        feeValidationError: error,
+        activeQuote: quotes[0] as Quote,
+        allQuotes: quotes,
+        advanceBestQuote,
+        maxAdvances: 1
+      })
+    )
     expect(advanceBestQuote).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.ts
@@ -12,13 +12,19 @@ import type { Quote } from '../types'
  * swap-time retry and analytics stay correctly classified as 'auto'.
  *
  * Bounded by maxAdvances to avoid churning through every provider on a bad
- * token pair or amount. The counter resets whenever the error clears or the
- * user takes manual control via the Pricing sheet.
+ * token pair or amount. The counter resets only on a *stable* clear — when
+ * the error is gone AND fee validation isn't mid-flight — or when the user
+ * takes manual control via the Pricing sheet.
  *
- * No-op when userQuote is set — respect the user's explicit pick.
+ * No-op when:
+ * - `userQuote` is set — respect the user's explicit pick.
+ * - `isSwapping` is true — once the user has committed to a swap, the active
+ *   quote must not change underneath the in-flight `transferAsset` call.
  */
 export const useAutoAdvanceOnFeeValidationError = ({
   feeValidationError,
+  isValidating,
+  isSwapping,
   activeQuote,
   allQuotes,
   userQuote,
@@ -26,6 +32,8 @@ export const useAutoAdvanceOnFeeValidationError = ({
   maxAdvances
 }: {
   feeValidationError: FusionQuoteError | undefined
+  isValidating: boolean
+  isSwapping: boolean
   activeQuote: Quote | null
   allQuotes: Quote[]
   userQuote: Quote | null
@@ -39,6 +47,11 @@ export const useAutoAdvanceOnFeeValidationError = ({
   const lastAdvancedFromRef = useRef<string | null>(null)
 
   useEffect(() => {
+    // Swap is in flight — leave activeQuote alone. Otherwise advancing would
+    // race the captured quote inside SwapContext.swap() and spam Zustand
+    // updates while the JS thread is already busy with the transfer.
+    if (isSwapping) return
+
     // User has manually picked a quote — don't override their choice.
     if (userQuote) {
       advanceCountRef.current = 0
@@ -47,8 +60,14 @@ export const useAutoAdvanceOnFeeValidationError = ({
     }
 
     if (feeValidationError?.kind !== 'provider-specific') {
-      // Non-blocking or non-provider-specific error → reset so a fresh run of
-      // failures can advance up to maxAdvances again.
+      // While a fee estimation is in flight, `feeValidationError` is briefly
+      // undefined — that's not a real "error cleared", it's just a gap. If
+      // we reset the counter here, every quote-stream refresh re-arms the
+      // budget and the hook can walk the whole list again on each cycle.
+      if (isValidating) return
+
+      // Stable clear (validation finished with no error, or the error is
+      // non-provider-specific) → arm a fresh budget for the next failure.
       advanceCountRef.current = 0
       lastAdvancedFromRef.current = null
       return
@@ -84,6 +103,8 @@ export const useAutoAdvanceOnFeeValidationError = ({
     showSnackbar('Quote failed, trying next available')
   }, [
     feeValidationError,
+    isValidating,
+    isSwapping,
     activeQuote,
     allQuotes,
     userQuote,

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -247,8 +247,12 @@ export const SwapScreen = (): JSX.Element => {
 
   const maxQuoteAdvances = useSelector(selectMarkrSwapMaxRetries)
 
+  const isSwapping = swapStatus === SwapStatus.Swapping
+
   useAutoAdvanceOnFeeValidationError({
     feeValidationError,
+    isValidating: isFeeValidating,
+    isSwapping,
     activeQuote,
     allQuotes,
     userQuote,
@@ -276,8 +280,6 @@ export const SwapScreen = (): JSX.Element => {
     !!activeQuote &&
     !isPriceImpactCalculating &&
     !isPriceImpactTooHigh
-
-  const isSwapping = swapStatus === SwapStatus.Swapping
 
   const coreFeeMessage = useMemo(() => {
     if (!activeQuote) return


### PR DESCRIPTION
## Description

**Ticket: [CP-14162](https://ava-labs.atlassian.net/browse/CP-14162)**

QA hit an app-freeze during swap on 1.0.29-rc1 (USDC→AVAX endless spinner; max BTC.b→AVAX freeze after the spend-limit approval, before the swap-tx popup). Bottom-nav was unresponsive in both, which means the JS thread was busy.

Root cause is in [`useAutoAdvanceOnFeeValidationError`](https://github.com/ava-labs/core-mobile/blob/main/packages/core-mobile/app/new/features/swap/hooks/useAutoAdvanceOnFeeValidationError.ts) (added in #3789). The hook reset its advance budget whenever `feeValidationError` was not `provider-specific` — including `undefined`. But `feeValidationError` comes from a React Query keyed on `quote.id`, and on every quote-stream refresh that query refetches, briefly transitioning `error` to `undefined` while `isFetching=true`. That transient gap re-armed the budget on each cycle, so the hook walked the entire quote list every few seconds. Each advance writes Zustand state → re-renders → fires a new fee estimation → repeat. That's what kept the JS thread saturated and made the wallet approval popup never show.

Two changes to the hook:
1. **Hold the budget while validation is in flight.** The hook now takes `isValidating`. While `isValidating=true`, a transient `error=undefined` is treated as a gap, not a clear. Only a stable clear (error gone AND not validating) resets the counter.
2. **Skip the hook entirely while a swap is in flight.** The hook now takes `isSwapping`. Once `SwapContext.swap()` has captured a quote and is awaiting `transferAsset`, mutating `activeQuote` underneath it would race the in-flight transfer and add render churn at the worst possible time.

The change is contained to the hook and one extra prop wired in from `SwapScreen`. No SDK bump, no behaviour change for the happy path.

## Screenshots/Videos

N/A — no UI changes. Behavioural fix.

## Testing

**Dev Testing**

Repro from the original report (consistent on a wallet with BTC.b on C-chain):
1. Open Swap, select max BTC.b → AVAX.
2. Tap Next, approve the spend-limit transaction.
3. **Before fix:** spinner on Next, the swap-tx popup never appears, bottom nav unresponsive.
4. **After fix:** swap-tx popup appears, swap completes (or the user can reject and the form returns to idle).

Form-stage repro (USDC→AVAX, small amount, on a wallet that hits provider-specific fee errors):
1. Enter an amount that triggers the auto-advance flow.
2. **Before fix:** snackbar fires repeatedly (every refresh ~every few seconds), Next button toggles enabled/disabled, screen visibly busy.
3. **After fix:** snackbar fires at most `MARKR_SWAP_MAX_RETRIES` times per real failure-streak, then settles. If the user changes amount/token and the new pair validates cleanly, a fresh budget arms.

**QA Testing**

Re-run the steps from CP-14162 against the new build:
- Repeat the BTC.b → AVAX max swap several times. The swap-tx prompt must appear within a few seconds of approving the spend limit.
- Try the original USDC ↔ AVAX flows. The Next button should not show an endless spinner; bottom nav should remain responsive throughout.
- Verify auto-advance still works when a top quote genuinely fails (e.g. force a Solana-side `EstimateNativeFeeError`). The Pricing sheet should advance to the next provider, and the snackbar should fire.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14162]: https://ava-labs.atlassian.net/browse/CP-14162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ