### PR TITLE
CP-13969: disable spend limit dropdown during Ledger review

### DIFF
--- a/packages/core-mobile/app/new/features/approval/components/SpendLimits/SpendLimitOptions.tsx
+++ b/packages/core-mobile/app/new/features/approval/components/SpendLimits/SpendLimitOptions.tsx
@@ -128,28 +128,38 @@ export const SpendLimitOptions = ({
     [customSpendLimit, token, onSelect, defaultSpendLimitValue]
   )
 
+  const content = (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'flex-end'
+      }}>
+      <Text
+        variant="body1"
+        numberOfLines={1}
+        sx={{ ...sharedValueStyle, marginRight: onSelect ? 16 : 0 }}>
+        {`${displayValue} ${token.symbol}`}
+      </Text>
+      {onSelect && (
+        <Icons.Navigation.ChevronRight
+          color={colors.$textSecondary}
+          style={{ position: 'absolute', right: -8 }}
+        />
+      )}
+    </View>
+  )
+
+  if (!onSelect) {
+    return content
+  }
+
   return (
     <DropdownMenu
       onPressAction={onPressAction}
       groups={menuItems}
       style={{ flexDirection: 'row', alignItems: 'center' }}>
-      <View
-        style={{
-          flexDirection: 'row',
-          alignItems: 'center',
-          justifyContent: 'flex-end'
-        }}>
-        <Text
-          variant="body1"
-          numberOfLines={1}
-          sx={{ ...sharedValueStyle, marginRight: 16 }}>
-          {`${displayValue} ${token.symbol}`}
-        </Text>
-        <Icons.Navigation.ChevronRight
-          color={colors.$textSecondary}
-          style={{ position: 'absolute', right: -8 }}
-        />
-      </View>
+      {content}
     </DropdownMenu>
   )
 }

--- a/packages/core-mobile/app/new/features/approval/hooks/useLedgerApproval.tsx
+++ b/packages/core-mobile/app/new/features/approval/hooks/useLedgerApproval.tsx
@@ -13,6 +13,7 @@ type UseLedgerApprovalReturn = {
   renderLedgerFooter: () => JSX.Element | null
   cancelLedger: () => void
   dismissLedger: () => void
+  isLedgerActive: boolean
 }
 
 export const useLedgerApproval = (
@@ -162,5 +163,7 @@ export const useLedgerApproval = (
     cancelLedger
   ])
 
-  return { renderLedgerFooter, cancelLedger, dismissLedger }
+  const isLedgerActive = ledgerPhase !== LedgerReviewPhase.IDLE
+
+  return { renderLedgerFooter, cancelLedger, dismissLedger, isLedgerActive }
 }

--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
@@ -57,7 +57,7 @@ const ApprovalScreen = ({
   const activeWallet = useActiveWallet()
   const isLedger = useSelector(selectIsWalletLedger(activeWallet.id))
   const isGaslessInstantBlocked = useSelector(selectIsGaslessInstantBlocked)
-  const { renderLedgerFooter, cancelLedger, dismissLedger } =
+  const { renderLedgerFooter, cancelLedger, dismissLedger, isLedgerActive } =
     useLedgerApproval(isLedger)
 
   const symbol = chainId
@@ -391,7 +391,11 @@ const ApprovalScreen = ({
       <SpendLimits
         spendLimits={spendLimits}
         hasBalanceChange={hasBalanceChange}
-        onSelect={canEdit ? updateSpendLimit : undefined}
+        onSelect={
+          canEdit && !submitting && !isLedgerActive
+            ? updateSpendLimit
+            : undefined
+        }
       />
     )
   }


### PR DESCRIPTION
iOS: 8402
Android: 8403

## Description

**Ticket: [CP-13969]**

Prevent the spend limit dropdown menu from opening while the Ledger device is reviewing a transaction. Previously, only the onSelect callback was nullified but the zeego DropdownMenu still responded to taps. Now the DropdownMenu is not rendered at all when editing is disabled, and the chevron indicator is hidden.

## Screenshots/Videos


https://github.com/user-attachments/assets/fc299bba-a118-4d54-8d85-e7e1027b1780


## Testing

**Dev Testing (if applicable)**

- Connect a Ledger device and initiate a token approval (e.g. ERC-20 approve) transaction
- Before signing begins, verify the spend limit row shows a chevron and opens the dropdown on tap (Default / Unlimited / Custom options)
- Tap "Approve" to start Ledger review — the Ledger footer should appear
- While the Ledger footer is visible, tap the spend limit row and verify nothing happens (no dropdown, no chevron)

**QA Testing (if applicable)**

- Provide instructions for QA to test this feature thoroughly
- State expected behavior / acceptance criteria

## Checklist

Please check all that apply (if applicable)

- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-13969]: https://ava-labs.atlassian.net/browse/CP-13969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ