### PR TITLE
CP-14178: fix P/X-chain signing for imported private-key wallets

### DIFF
--- a/packages/core-mobile/app/services/wallet/PrivateKeyWallet.test.ts
+++ b/packages/core-mobile/app/services/wallet/PrivateKeyWallet.test.ts
@@ -1,0 +1,71 @@
+// @ts-nocheck
+import { Avalanche } from '@avalabs/core-wallets-sdk'
+import NetworkService from 'services/network/NetworkService'
+import { PrivateKeyWallet } from './PrivateKeyWallet'
+
+const MOCK_PRIVATE_KEY =
+  '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
+
+const MOCK_CONTEXT = {
+  networkID: 1,
+  hrp: 'avax',
+  xBlockchainID: 'xBlockchainID',
+  pBlockchainID: 'pBlockchainID',
+  cBlockchainID: 'cBlockchainID',
+  avaxAssetID: 'avaxAssetID',
+  baseTxFee: BigInt(1),
+  createAssetTxFee: BigInt(1),
+  createSubnetTxFee: BigInt(1),
+  transformSubnetTxFee: BigInt(1),
+  createBlockchainTxFee: BigInt(1),
+  addPrimaryNetworkValidatorFee: BigInt(1),
+  addPrimaryNetworkDelegatorFee: BigInt(1),
+  addSubnetValidatorFee: BigInt(1),
+  addSubnetDelegatorFee: BigInt(1)
+}
+
+jest.mock('services/network/NetworkService', () => ({
+  __esModule: true,
+  default: {
+    getAvalancheProviderXP: jest.fn()
+  }
+}))
+
+describe('PrivateKeyWallet', () => {
+  let wallet: PrivateKeyWallet
+  let provXP: Avalanche.JsonRpcProvider
+
+  beforeEach(() => {
+    wallet = new PrivateKeyWallet(MOCK_PRIVATE_KEY)
+    provXP = new Avalanche.JsonRpcProvider('http://example.test', MOCK_CONTEXT)
+    ;(NetworkService.getAvalancheProviderXP as jest.Mock).mockResolvedValue(
+      provXP
+    )
+
+    jest
+      .spyOn(Avalanche.StaticSigner.prototype, 'signTx')
+      .mockImplementation(() => ({
+        toJSON: () => ({ signedTx: 'signedTx' })
+      }))
+    jest
+      .spyOn(Avalanche.StaticSigner.prototype, 'signMessage')
+      .mockImplementation(() => Buffer.from([0x01, 0x02, 0x03]))
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('signAvalancheTransaction', () => {
+    it('signs a P-chain transaction with an imported private key', async () => {
+      const signedTx = await wallet.signAvalancheTransaction({
+        accountIndex: 0,
+        transaction: { tx: {}, externalIndices: [], internalIndices: [] },
+        network: { vmName: 'PVM', isTestnet: false },
+        provider: provXP
+      })
+
+      expect(signedTx).toBe('{"signedTx":"signedTx"}')
+    })
+  })
+})

--- a/packages/core-mobile/app/services/wallet/PrivateKeyWallet.test.ts
+++ b/packages/core-mobile/app/services/wallet/PrivateKeyWallet.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
-import { Avalanche } from '@avalabs/core-wallets-sdk'
+import { Avalanche, JsonRpcBatchInternal } from '@avalabs/core-wallets-sdk'
 import NetworkService from 'services/network/NetworkService'
+import { RpcMethod } from '@avalabs/vm-module-types'
 import { PrivateKeyWallet } from './PrivateKeyWallet'
 
 const MOCK_PRIVATE_KEY =
@@ -66,6 +67,22 @@ describe('PrivateKeyWallet', () => {
       })
 
       expect(signedTx).toBe('{"signedTx":"signedTx"}')
+    })
+  })
+
+  describe('signAvalancheMessage', () => {
+    it('signs a P-chain message with an imported private key', async () => {
+      const result = await wallet.signMessage({
+        rpcMethod: RpcMethod.AVALANCHE_SIGN_MESSAGE,
+        data: '0x68656c6c6f',
+        accountIndex: 0,
+        network: { vmName: 'PVM', isTestnet: false, chainId: 1 },
+        provider: {} as JsonRpcBatchInternal
+      })
+
+      expect(typeof result).toBe('string')
+      expect(result.length).toBeGreaterThan(0)
+      expect(NetworkService.getAvalancheProviderXP).toHaveBeenCalledWith(false)
     })
   })
 })

--- a/packages/core-mobile/app/services/wallet/PrivateKeyWallet.ts
+++ b/packages/core-mobile/app/services/wallet/PrivateKeyWallet.ts
@@ -72,6 +72,10 @@ export class PrivateKeyWallet implements Wallet {
     provider: Avalanche.JsonRpcProvider
   ): Promise<Avalanche.StaticSigner> {
     const keyBuffer = Buffer.from(strip0x(this.privateKey), 'hex')
+    // An imported private key is a single secp256k1 keypair with no BIP-44
+    // derivation; the same key produces both the X/P (bech32) and C-chain
+    // (EVM) addresses, so we pass it to StaticSigner's X/P and C slots
+    // identically. Mirrors Core Extension's WalletService PrivateKey path.
     return new Avalanche.StaticSigner(keyBuffer, keyBuffer, provider)
   }
 

--- a/packages/core-mobile/app/services/wallet/PrivateKeyWallet.ts
+++ b/packages/core-mobile/app/services/wallet/PrivateKeyWallet.ts
@@ -68,9 +68,10 @@ export class PrivateKeyWallet implements Wallet {
   }
 
   private async getAvaSigner(
-    accountIndex: number
-  ): Promise<Avalanche.SimpleSigner> {
-    return new Avalanche.SimpleSigner(this.privateKey, accountIndex)
+    provider: Avalanche.JsonRpcProvider
+  ): Promise<Avalanche.StaticSigner> {
+    const keyBuffer = Buffer.from(strip0x(this.privateKey), 'hex')
+    return new Avalanche.StaticSigner(keyBuffer, keyBuffer, provider)
   }
 
   private async getSvmSigner(): Promise<SolanaSigner> {
@@ -79,7 +80,7 @@ export class PrivateKeyWallet implements Wallet {
   }
 
   private async getSigner({
-    accountIndex,
+    accountIndex: _accountIndex,
     network,
     provider
   }: {
@@ -87,7 +88,7 @@ export class PrivateKeyWallet implements Wallet {
     network: Network
     provider: JsonRpcBatchInternal | BitcoinProvider | Avalanche.JsonRpcProvider
   }): Promise<
-    BitcoinWallet | BaseWallet | Avalanche.SimpleSigner | SolanaSigner
+    BitcoinWallet | BaseWallet | Avalanche.StaticSigner | SolanaSigner
   > {
     switch (network.vmName) {
       case NetworkVMType.EVM:
@@ -111,7 +112,7 @@ export class PrivateKeyWallet implements Wallet {
             `Unable to get signer: wrong provider obtained for network ${network.vmName}`
           )
         }
-        return await this.getAvaSigner(accountIndex)
+        return await this.getAvaSigner(provider)
       case NetworkVMType.SVM:
         return this.getSvmSigner()
       default:
@@ -254,7 +255,7 @@ export class PrivateKeyWallet implements Wallet {
   }): Promise<string> {
     const signer = await this.getSigner({ accountIndex, network, provider })
 
-    if (!(signer instanceof Avalanche.SimpleSigner)) {
+    if (!(signer instanceof Avalanche.StaticSigner)) {
       throw new Error('Unable to sign avalanche transaction: invalid signer')
     }
 
@@ -395,7 +396,8 @@ export class PrivateKeyWallet implements Wallet {
     chainAlias: Avalanche.ChainIDAlias
   ): Promise<string> => {
     const message = toUtf8(data)
-    const signer = await this.getAvaSigner(accountIndex)
+    // TODO(CP-14178 Task 3): replace with StaticSigner + fetched XP provider
+    const signer = new Avalanche.SimpleSigner(this.privateKey, accountIndex)
     const buffer = await signer.signMessage({
       message,
       chain: chainAlias

--- a/packages/core-mobile/app/services/wallet/PrivateKeyWallet.ts
+++ b/packages/core-mobile/app/services/wallet/PrivateKeyWallet.ts
@@ -26,6 +26,7 @@ import { assertNotUndefined } from 'utils/assertions'
 import { utils } from '@avalabs/avalanchejs'
 import { toUtf8 } from 'ethereumjs-util'
 import { getChainAliasFromNetwork } from 'services/network/utils/getChainAliasFromNetwork'
+import NetworkService from 'services/network/NetworkService'
 import {
   TypedDataV1,
   TypedData,
@@ -169,7 +170,11 @@ export class PrivateKeyWallet implements Wallet {
         const chainAlias = getChainAliasFromNetwork(network)
         if (!chainAlias) throw new Error('invalid chain alias')
 
-        return await this.signAvalancheMessage(accountIndex, data, chainAlias)
+        return await this.signAvalancheMessage(
+          data,
+          chainAlias,
+          network.isTestnet ?? false
+        )
       }
       case RpcMethod.ETH_SIGN:
       case RpcMethod.PERSONAL_SIGN:
@@ -390,14 +395,14 @@ export class PrivateKeyWallet implements Wallet {
   }
 
   private signAvalancheMessage = async (
-    accountIndex: number,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     data: any,
-    chainAlias: Avalanche.ChainIDAlias
+    chainAlias: Avalanche.ChainIDAlias,
+    isTestnet: boolean
   ): Promise<string> => {
     const message = toUtf8(data)
-    // TODO(CP-14178 Task 3): replace with StaticSigner + fetched XP provider
-    const signer = new Avalanche.SimpleSigner(this.privateKey, accountIndex)
+    const provXP = await NetworkService.getAvalancheProviderXP(isTestnet)
+    const signer = await this.getAvaSigner(provXP)
     const buffer = await signer.signMessage({
       message,
       chain: chainAlias


### PR DESCRIPTION
## Summary

`PrivateKeyWallet.getAvaSigner` was passing a hex private key into `Avalanche.SimpleSigner`, which only accepts a BIP-39 mnemonic. Every P/X-chain action (claim, delegate, send, import/export) for imported-key wallets threw `Invalid mnemonic phrase.`

Switched the X/P signer to `Avalanche.StaticSigner` with raw key buffers, mirroring the Core extension's pattern in `core-extension` `packages/service-worker/src/services/wallet/WalletService.ts`. Added regression tests for both `signAvalancheTransaction` and `signAvalancheMessage` on the imported-key path.

Real user reported in Slack 2026-05-04 with 52.21 AVAX stuck on P-chain after their stake matured.

Ticket: [CP-14178](https://ava-labs.atlassian.net/browse/CP-14178)

https://github.com/user-attachments/assets/54c1fa50-9a19-4fa9-8fb0-65b7449df868


## Changes

- `PrivateKeyWallet.getAvaSigner(provider)` now returns `Avalanche.StaticSigner` constructed with raw key buffers.
- `getSigner` PVM/AVM case forwards the provider through.
- `signAvalancheTransaction` `instanceof` check widened from `SimpleSigner` to `StaticSigner`.
- `signAvalancheMessage` fetches an Avalanche XP provider via `NetworkService.getAvalancheProviderXP(network.isTestnet)` since `signMessage` only receives an EVM provider.
- New `PrivateKeyWallet.test.ts` regression tests for both signing paths.

`MnemonicWallet`, `SeedlessWallet`, `LedgerWallet`, and `KeystoneWallet` are untouched.

## Dev testing 
iOS: 8411
Android: 8412

1. Install the QA build.
2. Onboard a fresh wallet via **Import private key** using a key that holds some P-chain AVAX.
3. On P-chain, send a small amount to another address. Tx should sign and broadcast (previously threw `Invalid mnemonic phrase`).
4. On P-chain, stake/delegate to any node. Signing should succeed.
5. Wipe the wallet and re-onboard with a 24-word mnemonic that has P-chain funds.
6. Repeat the P-chain send and stake to confirm the mnemonic flow still works (regression check on `MnemonicWallet`).

Watch for any `Invalid mnemonic phrase` or `invalid signer` toast or red error during steps 3, 4, and 6. There should be none.


## Test plan

- [x] `yarn test app/services/wallet/PrivateKeyWallet.test.ts` — 2/2 passing
- [x] `yarn test app/services/wallet` — 9/9 suites, 208/208 passing
- [x] `yarn lint` — 0 errors in changed files
- [x] `yarn tsc` — no new errors
- [x] Manual smoke (Android, internalDebug): imported private key — stake and send on P-chain both work
- [x] Manual regression smoke: mnemonic wallet — stake and send on P-chain both still work

[CP-14178]: https://ava-labs.atlassian.net/browse/CP-14178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ