### PR TITLE
CP-13970: fix Ledger staking hang after first signing

### DIFF
--- a/packages/core-mobile/app/hooks/earn/useDelegation.ts
+++ b/packages/core-mobile/app/hooks/earn/useDelegation.ts
@@ -240,8 +240,8 @@ export const useDelegation = (): {
         }
 
         // Update progress after operation completes
-        // Use setTimeout pattern (proven successful in commit 0c60ac513)
-        // This ensures React Native has time to flush state updates before next operation
+        // 500ms delay gives BLE transport time to settle between sequential
+        // Ledger signings and ensures React Native flushes state updates
         stepIndex++
         const nextStep = steps[stepIndex]
 
@@ -249,7 +249,7 @@ export const useDelegation = (): {
           setTimeout(() => {
             onProgress?.(stepIndex, nextStep?.operation ?? null)
             resolve()
-          }, 10)
+          }, 500)
         })
       }
 

--- a/packages/core-mobile/app/new/features/ledger/consts.ts
+++ b/packages/core-mobile/app/new/features/ledger/consts.ts
@@ -84,7 +84,8 @@ export const LEDGER_TIMEOUTS = {
   APP_CHECK_DELAY: 1000, // 1 second delay between app detection attempts
   REQUEST_DELAY: 3000, // 3s delay between APDU commands
   RECONNECT_MAX_RETRIES: 3, // max auto-reconnect attempts after unexpected disconnect
-  RECONNECT_BASE_DELAY: 1000 // 1s base delay between reconnect attempts (doubles each retry)
+  RECONNECT_BASE_DELAY: 1000, // 1s base delay between reconnect attempts (doubles each retry)
+  SIGN_TIMEOUT: 120000 // 2 minutes for user to review and approve on device
 } as const
 
 export const LEDGER_DEVICE_BRIEF_DELAY_MS = 1000

--- a/packages/core-mobile/app/services/ledger/LedgerService.test.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.test.ts
@@ -1030,21 +1030,14 @@ describe('LedgerService', () => {
           version: '0.9.1'
         })
 
-      // Bypass the #transport null-check inside the polling interval by
-      // stubbing the internal field check. The polling callback does:
-      //   if (!this.#transport || !this.#transport.isConnected) { ... }
-      // We can't set #transport from outside, so we override the entire
-      // polling method to remove that guard while keeping pause/resume logic.
-      // Instead, we set #transport indirectly by calling the prototype setter.
-      const protoDesc = Object.getOwnPropertyDescriptor(
-        Object.getPrototypeOf(LedgerService),
-        'transport'
-      )
-      if (protoDesc?.set) {
-        // The setter does: this.#transport = transport
-        // We pass a minimal object that satisfies the isConnected check.
-        protoDesc.set.call(LedgerService, { isConnected: true })
-      }
+      // Bypass the #transport null-check inside the polling interval.
+      // #transport is a true-private field with no public setter; stub
+      // the isTransportConnected() seam so the callback proceeds to
+      // getCurrentAppInfo (or the pause check) on each tick.
+      jest
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .spyOn(LedgerService as any, 'isTransportConnected')
+        .mockReturnValue(true)
     })
 
     afterEach(() => {
@@ -1102,7 +1095,6 @@ describe('LedgerService', () => {
       close: jest.Mock
       exchangeBusyPromise: Promise<void> | null
     }
-    let protoDesc: PropertyDescriptor | undefined
 
     beforeEach(() => {
       jest.useFakeTimers()
@@ -1118,24 +1110,11 @@ describe('LedgerService', () => {
       jest.spyOn(Logger, 'info').mockImplementation(() => {})
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       jest.spyOn(Logger, 'error').mockImplementation(() => {})
-
-      // Use the prototype setter to set the real #transport private field
-      protoDesc = Object.getOwnPropertyDescriptor(
-        Object.getPrototypeOf(LedgerService),
-        'transport'
-      )
-      if (protoDesc?.set) {
-        protoDesc.set.call(LedgerService, mockTransport)
-      }
     })
 
     afterEach(() => {
       jest.useRealTimers()
       jest.clearAllMocks()
-      // Clear transport to avoid leaking state
-      if (protoDesc?.set) {
-        protoDesc.set.call(LedgerService, null)
-      }
     })
 
     it('should await exchangeBusyPromise before sending APDU', async () => {
@@ -1151,8 +1130,10 @@ describe('LedgerService', () => {
       })
       mockTransport.exchange = originalExchange
 
+      // wrapTransportExchange accepts a transport arg (default this.#transport)
+      // so tests can inject a mock without touching the true-private field.
       // @ts-ignore - accessing private
-      LedgerService.wrapTransportExchange()
+      LedgerService.wrapTransportExchange(mockTransport)
 
       const exchangePromise = mockTransport.exchange(Buffer.from([0xe0, 0x01]))
 

--- a/packages/core-mobile/app/services/ledger/LedgerService.test.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.test.ts
@@ -1008,6 +1008,94 @@ describe('LedgerService', () => {
     })
   })
 
+  describe('app polling pause/resume', () => {
+    let getCurrentAppInfoSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      jest.useFakeTimers()
+
+      jest.spyOn(Logger, 'info').mockImplementation(() => {})
+      jest.spyOn(Logger, 'error').mockImplementation(() => {})
+
+      // Mock getCurrentAppInfo to simulate a connected transport returning
+      // valid app info. This avoids needing to set the true-private #transport
+      // field which the polling callback checks before calling getCurrentAppInfo.
+      getCurrentAppInfoSpy = jest
+        .spyOn(LedgerService as any, 'getCurrentAppInfo')
+        .mockResolvedValue({
+          applicationName: 'Avalanche',
+          version: '0.9.1'
+        })
+
+      // Bypass the #transport null-check inside the polling interval by
+      // stubbing the internal field check. The polling callback does:
+      //   if (!this.#transport || !this.#transport.isConnected) { ... }
+      // We can't set #transport from outside, so we override the entire
+      // polling method to remove that guard while keeping pause/resume logic.
+      // Instead, we set #transport indirectly by calling the prototype setter.
+      const protoDesc = Object.getOwnPropertyDescriptor(
+        Object.getPrototypeOf(LedgerService),
+        'transport'
+      )
+      if (protoDesc?.set) {
+        // The setter does: this.#transport = transport
+        // We pass a minimal object that satisfies the isConnected check.
+        protoDesc.set.call(LedgerService, { isConnected: true })
+      }
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+      jest.clearAllMocks()
+      LedgerService.stopAppPolling()
+    })
+
+    it('should skip getCurrentAppInfo when polling is paused', async () => {
+      // @ts-ignore - accessing private for testing
+      LedgerService.appPollingEnabled = false
+      // @ts-ignore
+      LedgerService.startAppPolling()
+
+      // Normal polling should fire and call getCurrentAppInfo
+      await jest.advanceTimersByTimeAsync(
+        LEDGER_TIMEOUTS.APP_POLLING_INTERVAL + 100
+      )
+      expect(getCurrentAppInfoSpy).toHaveBeenCalled()
+
+      // Pause polling
+      LedgerService.pauseAppPolling()
+
+      // Advance past several polling intervals
+      getCurrentAppInfoSpy.mockClear()
+      await jest.advanceTimersByTimeAsync(
+        LEDGER_TIMEOUTS.APP_POLLING_INTERVAL * 3
+      )
+
+      // No new calls should have been made while paused
+      expect(getCurrentAppInfoSpy).not.toHaveBeenCalled()
+    })
+
+    it('should resume getCurrentAppInfo after resumeAppPolling', async () => {
+      // @ts-ignore
+      LedgerService.appPollingEnabled = false
+      // @ts-ignore
+      LedgerService.startAppPolling()
+
+      // Pause then resume
+      LedgerService.pauseAppPolling()
+      LedgerService.resumeAppPolling()
+
+      // Advance past a polling interval
+      getCurrentAppInfoSpy.mockClear()
+      await jest.advanceTimersByTimeAsync(
+        LEDGER_TIMEOUTS.APP_POLLING_INTERVAL + 100
+      )
+
+      // Calls should have resumed
+      expect(getCurrentAppInfoSpy).toHaveBeenCalled()
+    })
+  })
+
   describe('getSolanaKeysForRange', () => {
     beforeEach(() => {
       // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/core-mobile/app/services/ledger/LedgerService.test.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.test.ts
@@ -1096,6 +1096,86 @@ describe('LedgerService', () => {
     })
   })
 
+  describe('wrapTransportExchange', () => {
+    let mockTransport: {
+      exchange: jest.Mock
+      isConnected: boolean
+      close: jest.Mock
+      exchangeBusyPromise: Promise<void> | null
+    }
+    let protoDesc: PropertyDescriptor | undefined
+
+    beforeEach(() => {
+      jest.useFakeTimers()
+
+      mockTransport = {
+        exchange: jest.fn(),
+        isConnected: true,
+        close: jest.fn(),
+        exchangeBusyPromise: null
+      }
+
+      jest.spyOn(Logger, 'info').mockImplementation(() => {})
+      jest.spyOn(Logger, 'error').mockImplementation(() => {})
+
+      // Use the prototype setter to set the real #transport private field
+      protoDesc = Object.getOwnPropertyDescriptor(
+        Object.getPrototypeOf(LedgerService),
+        'transport'
+      )
+      if (protoDesc?.set) {
+        protoDesc.set.call(LedgerService, mockTransport)
+      }
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+      jest.clearAllMocks()
+      // Clear transport to avoid leaking state
+      if (protoDesc?.set) {
+        protoDesc.set.call(LedgerService, null)
+      }
+    })
+
+    it('should await exchangeBusyPromise before sending APDU', async () => {
+      const callOrder: string[] = []
+      let resolveBusy!: () => void
+      mockTransport.exchangeBusyPromise = new Promise<void>(resolve => {
+        resolveBusy = resolve
+      })
+
+      const originalExchange = jest.fn().mockImplementation(async () => {
+        callOrder.push('exchange')
+        return Buffer.from([0x90, 0x00])
+      })
+      mockTransport.exchange = originalExchange
+
+      // @ts-ignore - accessing private
+      LedgerService.wrapTransportExchange()
+
+      const exchangePromise = mockTransport.exchange(Buffer.from([0xe0, 0x01]))
+
+      // Advance past the fixed REQUEST_DELAY timeout.
+      // With the buggy implementation, this causes the exchange to fire
+      // even though the busy promise hasn't resolved yet.
+      await jest.advanceTimersByTimeAsync(LEDGER_TIMEOUTS.REQUEST_DELAY + 100)
+
+      // The exchange should NOT have been called yet because
+      // the busy promise is still unresolved
+      // @ts-ignore - Detox expect overloads conflict with Jest expect
+      expect(originalExchange).not.toHaveBeenCalled()
+
+      // Now resolve the busy promise
+      callOrder.push('busy-resolved')
+      resolveBusy()
+
+      await exchangePromise
+
+      // @ts-ignore - Detox expect overloads conflict with Jest expect for arrays
+      expect(callOrder).toEqual(['busy-resolved', 'exchange'])
+    })
+  })
+
   describe('getSolanaKeysForRange', () => {
     beforeEach(() => {
       // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/core-mobile/app/services/ledger/LedgerService.test.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.test.ts
@@ -1055,8 +1055,6 @@ describe('LedgerService', () => {
 
     it('should skip getCurrentAppInfo when polling is paused', async () => {
       // @ts-ignore - accessing private for testing
-      LedgerService.appPollingEnabled = false
-      // @ts-ignore
       LedgerService.startAppPolling()
 
       // Normal polling should fire and call getCurrentAppInfo
@@ -1079,9 +1077,7 @@ describe('LedgerService', () => {
     })
 
     it('should resume getCurrentAppInfo after resumeAppPolling', async () => {
-      // @ts-ignore
-      LedgerService.appPollingEnabled = false
-      // @ts-ignore
+      // @ts-ignore - accessing private for testing
       LedgerService.startAppPolling()
 
       // Pause then resume

--- a/packages/core-mobile/app/services/ledger/LedgerService.test.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.test.ts
@@ -1009,12 +1009,15 @@ describe('LedgerService', () => {
   })
 
   describe('app polling pause/resume', () => {
-    let getCurrentAppInfoSpy: jest.SpyInstance
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let getCurrentAppInfoSpy: any
 
     beforeEach(() => {
       jest.useFakeTimers()
 
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
       jest.spyOn(Logger, 'info').mockImplementation(() => {})
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
       jest.spyOn(Logger, 'error').mockImplementation(() => {})
 
       // Mock getCurrentAppInfo to simulate a connected transport returning
@@ -1115,7 +1118,9 @@ describe('LedgerService', () => {
         exchangeBusyPromise: null
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
       jest.spyOn(Logger, 'info').mockImplementation(() => {})
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
       jest.spyOn(Logger, 'error').mockImplementation(() => {})
 
       // Use the prototype setter to set the real #transport private field

--- a/packages/core-mobile/app/services/ledger/LedgerService.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.ts
@@ -66,6 +66,8 @@ class LedgerService {
 
   private appPollingInterval: number | null = null
   private disconnectHandler: (() => void) | null = null
+  private appPollingEnabled = false
+  private appPollingPaused = false
 
   // Reconnection state & policy
   private connectedDeviceId: string | null = null
@@ -391,6 +393,8 @@ class LedgerService {
           return
         }
 
+        if (this.appPollingPaused) return
+
         const appInfo = await this.getCurrentAppInfo()
         const newAppType = this.mapAppNameToType(appInfo.applicationName)
 
@@ -414,6 +418,18 @@ class LedgerService {
       clearInterval(this.appPollingInterval)
       this.appPollingInterval = null
     }
+    this.appPollingEnabled = false
+    this.appPollingPaused = false
+  }
+
+  pauseAppPolling(): void {
+    this.appPollingPaused = true
+    Logger.info('App polling paused for signing')
+  }
+
+  resumeAppPolling(): void {
+    this.appPollingPaused = false
+    Logger.info('App polling resumed after signing')
   }
 
   // Handle scan errors (matching original implementation)

--- a/packages/core-mobile/app/services/ledger/LedgerService.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.ts
@@ -94,9 +94,9 @@ class LedgerService {
 
     // Replace exchange method with wrapped version
     this.#transport.exchange = async (apdu: Buffer): Promise<Buffer> => {
-      // If transport is busy, wait before sending next command
+      // If transport is busy, wait for the in-flight exchange to complete
       if (this.#transport?.exchangeBusyPromise) {
-        await new Promise(res => setTimeout(res, LEDGER_TIMEOUTS.REQUEST_DELAY))
+        await this.#transport.exchangeBusyPromise
       }
       try {
         return await originalExchange(apdu)
@@ -112,9 +112,13 @@ class LedgerService {
               .includes(LEDGER_ERROR_CODES.TRANSPORT_RACE_CONDITION))
         ) {
           // wait for the transport and retry
-          await new Promise(res =>
-            setTimeout(res, LEDGER_TIMEOUTS.REQUEST_DELAY)
-          )
+          if (this.#transport?.exchangeBusyPromise) {
+            await this.#transport.exchangeBusyPromise
+          } else {
+            await new Promise(res =>
+              setTimeout(res, LEDGER_TIMEOUTS.REQUEST_DELAY)
+            )
+          }
           return await originalExchange(apdu)
         }
         // Other errors should be thrown immediately

--- a/packages/core-mobile/app/services/ledger/LedgerService.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.ts
@@ -86,16 +86,20 @@ class LedgerService {
   private currentDevices: LedgerDevice[] = []
   private isScanning = false
 
-  // Wrap transport's exchange method to automatically handle busy state
-  private wrapTransportExchange(): void {
-    if (!this.#transport) return
-    const originalExchange = this.#transport.exchange.bind(this.#transport)
+  // Wrap transport's exchange method to automatically handle busy state.
+  // Accepts an explicit transport so tests can inject a mock; production
+  // callers omit the argument and operate on the captured #transport.
+  private wrapTransportExchange(
+    transport: TransportBLE | null = this.#transport
+  ): void {
+    if (!transport) return
+    const originalExchange = transport.exchange.bind(transport)
 
     // Replace exchange method with wrapped version
-    this.#transport.exchange = async (apdu: Buffer): Promise<Buffer> => {
+    transport.exchange = async (apdu: Buffer): Promise<Buffer> => {
       // If transport is busy, wait for the in-flight exchange to complete
-      if (this.#transport?.exchangeBusyPromise) {
-        await this.#transport.exchangeBusyPromise
+      if (transport.exchangeBusyPromise) {
+        await transport.exchangeBusyPromise
       }
       try {
         return await originalExchange(apdu)
@@ -111,8 +115,8 @@ class LedgerService {
               .includes(LEDGER_ERROR_CODES.TRANSPORT_RACE_CONDITION))
         ) {
           // wait for the transport and retry
-          if (this.#transport?.exchangeBusyPromise) {
-            await this.#transport.exchangeBusyPromise
+          if (transport.exchangeBusyPromise) {
+            await transport.exchangeBusyPromise
           } else {
             await new Promise(res =>
               setTimeout(res, LEDGER_TIMEOUTS.REQUEST_DELAY)
@@ -379,6 +383,12 @@ class LedgerService {
     })
   }
 
+  // Test seam — exposed (private) so polling tests can stub the
+  // true-private #transport readiness check without leaking the field.
+  private isTransportConnected(): boolean {
+    return !!this.#transport && this.#transport.isConnected
+  }
+
   // Start passive app detection polling
   private startAppPolling(): void {
     if (this.appPollingInterval !== null) {
@@ -387,7 +397,7 @@ class LedgerService {
 
     this.appPollingInterval = setInterval(async () => {
       try {
-        if (!this.#transport || !this.#transport.isConnected) {
+        if (!this.isTransportConnected()) {
           this.stopAppPolling()
 
           // Safety net: if the transport disconnect event did not fire,

--- a/packages/core-mobile/app/services/ledger/LedgerService.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.ts
@@ -66,7 +66,6 @@ class LedgerService {
 
   private appPollingInterval: number | null = null
   private disconnectHandler: (() => void) | null = null
-  private appPollingEnabled = false
   private appPollingPaused = false
 
   // Reconnection state & policy
@@ -422,7 +421,6 @@ class LedgerService {
       clearInterval(this.appPollingInterval)
       this.appPollingInterval = null
     }
-    this.appPollingEnabled = false
     this.appPollingPaused = false
   }
 

--- a/packages/core-mobile/app/services/wallet/LedgerWallet.test.ts
+++ b/packages/core-mobile/app/services/wallet/LedgerWallet.test.ts
@@ -933,9 +933,7 @@ describe('LedgerWallet', () => {
           callOrder.push('sign')
           return { signatures: new Map() }
         })
-        mockResumeAppPolling.mockImplementation(() =>
-          callOrder.push('resume')
-        )
+        mockResumeAppPolling.mockImplementation(() => callOrder.push('resume'))
 
         await ledgerWallet.signAvalancheTransaction({
           accountIndex: 0,
@@ -995,6 +993,7 @@ describe('LedgerWallet', () => {
         }
 
         // Sign never resolves — simulates dead BLE connection
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         mockSign.mockReturnValue(new Promise(() => {}))
 
         const signPromise = ledgerWallet

--- a/packages/core-mobile/app/services/wallet/LedgerWallet.test.ts
+++ b/packages/core-mobile/app/services/wallet/LedgerWallet.test.ts
@@ -43,7 +43,9 @@ jest.mock('services/ledger/LedgerService', () => ({
     isConnected: jest.fn().mockReturnValue(true),
     getCurrentAppType: jest.fn().mockReturnValue('AVALANCHE'),
     getAllAddresses: jest.fn(),
-    getExtendedPublicKeys: jest.fn()
+    getExtendedPublicKeys: jest.fn(),
+    pauseAppPolling: jest.fn(),
+    resumeAppPolling: jest.fn()
   }
 }))
 
@@ -179,6 +181,8 @@ const mockGetCurrentAppType = LedgerService.getCurrentAppType as jest.Mock
 const mockGetAllAddresses = LedgerService.getAllAddresses as jest.Mock
 const mockGetExtendedPublicKeys =
   LedgerService.getExtendedPublicKeys as jest.Mock
+const mockPauseAppPolling = LedgerService.pauseAppPolling as jest.Mock
+const mockResumeAppPolling = LedgerService.resumeAppPolling as jest.Mock
 
 // Mock transport
 class MockTransport {
@@ -907,6 +911,108 @@ describe('LedgerWallet', () => {
           LedgerAppType.AVALANCHE,
           expect.any(Number)
         )
+      })
+    })
+
+    describe('polling pause/resume during signing', () => {
+      it('should pause app polling before signing and resume after', async () => {
+        const mockTx = {
+          getVM: jest.fn().mockReturnValue('PVM'),
+          toBytes: jest.fn().mockReturnValue(new Uint8Array()),
+          addSignature: jest.fn(),
+          toJSON: jest.fn().mockReturnValue({})
+        }
+        const transaction: AvalancheTransactionRequest = {
+          tx: mockTx as unknown as AvalancheTransactionRequest['tx'],
+          externalIndices: [0]
+        }
+
+        const callOrder: string[] = []
+        mockPauseAppPolling.mockImplementation(() => callOrder.push('pause'))
+        mockSign.mockImplementation(async () => {
+          callOrder.push('sign')
+          return { signatures: new Map() }
+        })
+        mockResumeAppPolling.mockImplementation(() =>
+          callOrder.push('resume')
+        )
+
+        await ledgerWallet.signAvalancheTransaction({
+          accountIndex: 0,
+          transaction,
+          network: { vmName: 'PVM', isTestnet: false } as Network,
+          provider: {} as Avalanche.JsonRpcProvider
+        })
+
+        expect(callOrder).toEqual(['pause', 'sign', 'resume'])
+      })
+
+      it('should resume app polling even when signing fails', async () => {
+        const mockTx = {
+          getVM: jest.fn().mockReturnValue('PVM'),
+          toBytes: jest.fn().mockReturnValue(new Uint8Array()),
+          addSignature: jest.fn(),
+          toJSON: jest.fn().mockReturnValue({})
+        }
+        const transaction: AvalancheTransactionRequest = {
+          tx: mockTx as unknown as AvalancheTransactionRequest['tx'],
+          externalIndices: [0]
+        }
+
+        mockSign.mockRejectedValue(new Error('User rejected'))
+
+        await expect(
+          ledgerWallet.signAvalancheTransaction({
+            accountIndex: 0,
+            transaction,
+            network: { vmName: 'PVM', isTestnet: false } as Network,
+            provider: {} as Avalanche.JsonRpcProvider
+          })
+        ).rejects.toThrow('User rejected')
+
+        expect(mockPauseAppPolling).toHaveBeenCalled()
+        expect(mockResumeAppPolling).toHaveBeenCalled()
+      })
+    })
+
+    describe('signing timeout', () => {
+      afterEach(() => {
+        jest.useRealTimers()
+      })
+
+      it('should reject with timeout error when signing hangs', async () => {
+        jest.useFakeTimers()
+
+        const mockTx = {
+          getVM: jest.fn().mockReturnValue('PVM'),
+          toBytes: jest.fn().mockReturnValue(new Uint8Array()),
+          addSignature: jest.fn(),
+          toJSON: jest.fn().mockReturnValue({})
+        }
+        const transaction: AvalancheTransactionRequest = {
+          tx: mockTx as unknown as AvalancheTransactionRequest['tx'],
+          externalIndices: [0]
+        }
+
+        // Sign never resolves — simulates dead BLE connection
+        mockSign.mockReturnValue(new Promise(() => {}))
+
+        const signPromise = ledgerWallet
+          .signAvalancheTransaction({
+            accountIndex: 0,
+            transaction,
+            network: { vmName: 'PVM', isTestnet: false } as Network,
+            provider: {} as Avalanche.JsonRpcProvider
+          })
+          .catch((e: Error) => e)
+
+        // Advance past the signing timeout (120s)
+        await jest.advanceTimersByTimeAsync(120_001)
+
+        const error = await signPromise
+        expect(error).toBeInstanceOf(Error)
+        expect((error as Error).message).toBe('Ledger signing timed out')
+        expect(mockResumeAppPolling).toHaveBeenCalled()
       })
     })
   })

--- a/packages/core-mobile/app/services/wallet/LedgerWallet.ts
+++ b/packages/core-mobile/app/services/wallet/LedgerWallet.ts
@@ -634,13 +634,16 @@ export class LedgerWallet implements Wallet {
     const txBuffer = Buffer.from(transaction.tx.toBytes())
 
     Logger.info('Calling avaxApp.sign...')
+    LedgerService.pauseAppPolling()
     try {
       // Sign directly with the Ledger device
-      const signResult = await avaxApp.sign(
-        accountPath,
-        signingPaths,
-        txBuffer,
-        changePaths.length > 0 ? changePaths : undefined
+      const signResult = await this.withSigningTimeout(
+        avaxApp.sign(
+          accountPath,
+          signingPaths,
+          txBuffer,
+          changePaths.length > 0 ? changePaths : undefined
+        )
       )
       Logger.info('avaxApp.sign completed')
 
@@ -658,6 +661,8 @@ export class LedgerWallet implements Wallet {
         handleLedgerError({ error: signError, appType })
       }
       throw signError
+    } finally {
+      LedgerService.resumeAppPolling()
     }
   }
 
@@ -684,6 +689,7 @@ export class LedgerWallet implements Wallet {
     // Get transport
     const transport = await this.handleAppConnection(appType)
 
+    LedgerService.pauseAppPolling()
     try {
       // Get the derivation path for this account
       const derivationPath = this.getDerivationPath(
@@ -715,9 +721,11 @@ export class LedgerWallet implements Wallet {
       Logger.info('Full serialized transaction:', serializedTx)
       Logger.info('Unsigned transaction hex:', unsignedTx)
 
-      const signature: SignatureRSV = await (isAvalanche
-        ? this.getCChainSignature({ transport, derivationPath, unsignedTx })
-        : this.getEvmSignature({ transport, derivationPath, unsignedTx }))
+      const signature: SignatureRSV = await this.withSigningTimeout(
+        isAvalanche
+          ? this.getCChainSignature({ transport, derivationPath, unsignedTx })
+          : this.getEvmSignature({ transport, derivationPath, unsignedTx })
+      )
 
       // Create the signed EIP-1559 transaction
       const signedTx = Transaction.from({
@@ -742,6 +750,8 @@ export class LedgerWallet implements Wallet {
       }
 
       throw error
+    } finally {
+      LedgerService.resumeAppPolling()
     }
   }
 
@@ -762,6 +772,7 @@ export class LedgerWallet implements Wallet {
     const solanaApp = new AppSolana(transport as Transport)
     Logger.info('Created AppSolana instance')
 
+    LedgerService.pauseAppPolling()
     try {
       // Get the derivation path for this account
       const derivationPath = getSolanaDerivationPath(accountIndex)
@@ -810,10 +821,12 @@ export class LedgerWallet implements Wallet {
       }
 
       Logger.info('Signing transaction with Ledger')
-      const signResult = await solanaApp.signTransaction(
-        derivationPath,
-        Buffer.from(messageBytes),
-        userInputType
+      const signResult = await this.withSigningTimeout(
+        solanaApp.signTransaction(
+          derivationPath,
+          Buffer.from(messageBytes),
+          userInputType
+        )
       )
       Logger.info('Got signature from Ledger')
 
@@ -838,6 +851,8 @@ export class LedgerWallet implements Wallet {
       }
 
       throw error
+    } finally {
+      LedgerService.resumeAppPolling()
     }
   }
 
@@ -994,6 +1009,7 @@ export class LedgerWallet implements Wallet {
     // Get transport and create Avalanche app instance directly
     const transport = await this.handleAppConnection(appType)
 
+    LedgerService.pauseAppPolling()
     try {
       const avaxApp = new AppAvax(transport as Transport)
       Logger.info('Created AppAvax instance')
@@ -1014,10 +1030,8 @@ export class LedgerWallet implements Wallet {
 
       Logger.info('Signing message with AppAvax.signMsg')
       // Sign the message using the Avalanche app
-      const signResult = await avaxApp.signMsg(
-        accountPath,
-        signingPaths,
-        messageString
+      const signResult = await this.withSigningTimeout(
+        avaxApp.signMsg(accountPath, signingPaths, messageString)
       )
 
       // Extract the signature from the result
@@ -1037,6 +1051,8 @@ export class LedgerWallet implements Wallet {
         handleLedgerError({ error, appType })
       }
       throw error
+    } finally {
+      LedgerService.resumeAppPolling()
     }
   }
 
@@ -1292,13 +1308,16 @@ export class LedgerWallet implements Wallet {
       filteredTypes: Object.keys(filteredTypes)
     })
 
-    const hexSignature = await this.signEIP712WithFallback(
-      app,
-      derivationPath,
-      eip712Message
-    )
-    Logger.info('Successfully signed typed data')
-    return hexSignature
+    LedgerService.pauseAppPolling()
+    try {
+      const hexSignature = await this.withSigningTimeout(
+        this.signEIP712WithFallback(app, derivationPath, eip712Message)
+      )
+      Logger.info('Successfully signed typed data')
+      return hexSignature
+    } finally {
+      LedgerService.resumeAppPolling()
+    }
   }
 
   private async handleEthAndPersonalSign({
@@ -1328,12 +1347,19 @@ export class LedgerWallet implements Wallet {
       ? messageToSign.slice(2)
       : Buffer.from(messageToSign, 'utf8').toString('hex')
 
-    const signature = await app.signPersonalMessage(derivationPath, messageHex)
+    LedgerService.pauseAppPolling()
+    try {
+      const signature = await this.withSigningTimeout(
+        app.signPersonalMessage(derivationPath, messageHex)
+      )
 
-    // Convert signature to hex format (0x-prefixed)
-    const hexSignature = this.getHexSignature(signature)
-    Logger.info('Successfully signed personal message')
-    return hexSignature
+      // Convert signature to hex format (0x-prefixed)
+      const hexSignature = this.getHexSignature(signature)
+      Logger.info('Successfully signed personal message')
+      return hexSignature
+    } finally {
+      LedgerService.resumeAppPolling()
+    }
   }
 
   private async signEvmMessage({
@@ -1577,6 +1603,23 @@ export class LedgerWallet implements Wallet {
     }
     Logger.info('Got signature from Ethereum app:', signature)
     return signature
+  }
+
+  /**
+   * Race a signing promise against a timeout. Prevents indefinite hangs
+   * when the BLE connection silently dies during user review on the device.
+   */
+  private withSigningTimeout<T>(signingPromise: Promise<T>): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout>
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new Error('Ledger signing timed out')),
+        LEDGER_TIMEOUTS.SIGN_TIMEOUT
+      )
+    })
+    return Promise.race([signingPromise, timeoutPromise]).finally(() =>
+      clearTimeout(timeoutId)
+    )
   }
 
   private handleAppConnection = async (


### PR DESCRIPTION
## Description

Bitrise: https://app.bitrise.io/app/7d7ca5af7066e290/pipelines/4cc57c71-6df6-4cc8-b024-0740469e269a
iOS: 8438
Android: 8439

**Ticket: [CP-13970]**

- **Summary**: Fix intermittent (~40%) hang during Ledger staking after signing the first transaction (Export from C-Chain). The root cause is APDU contention — LedgerService's background app polling (every 2s) sends `getCurrentAppInfo` APDUs that collide with signing operations on the same BLE transport, destabilizing the connection. After the first signing completes, the second signing (`importP`) attempts to use the degraded transport, and `avaxApp.sign()` hangs indefinitely since it has no timeout.
- **Changes**:
  - Add `pauseAppPolling()`/`resumeAppPolling()` to LedgerService and wrap all 6 signing methods in LedgerWallet to prevent APDU contention during signing
  - Add 120s timeout safety net around all device signing calls so a dead BLE connection rejects instead of hanging forever
  - Fix `wrapTransportExchange` to properly `await exchangeBusyPromise` instead of a fixed 3s `setTimeout`
  - Increase inter-transaction delay from 10ms to 500ms to let BLE settle between sequential signings
- **Motivation**: Users reported staking getting stuck after the first Ledger signing ~40% of the time. Funds end up stranded in atomic memory, requiring a restart of the staking flow.
- **Dependencies**: None

## Screenshots/Videos

N/A — no UI changes. This is a BLE transport timing fix.

## Testing

**Dev Testing (if applicable)**

- [ ] Connect Ledger, run staking flow 5+ times — all 3 signings (exportC → importP → addDelegator) should complete reliably without getting stuck
- [ ] Reject a transaction on the Ledger device mid-signing — app should recover and show reconnect flow
- [ ] Walk away from Ledger during signing to force BLE disconnect — app should timeout after ~2 min and recover
- [ ] Verify non-staking Ledger flows still work: send transaction, swap, message signing (personal sign, typed data)

**QA Testing (if applicable)**

- Onboard a Ledger via Ledger Live
- Navigate to staking and complete the full staking flow with Ledger
- Repeat 5+ times — the flow should never get stuck after the first signing
- Expected: All 3 signings complete sequentially, delegation succeeds

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-13970]: https://ava-labs.atlassian.net/browse/CP-13970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ