### PR TITLE
CP-14204: render base64-encoded SVG NFTs without re-decoding

### DIFF
--- a/packages/core-mobile/app/services/nft/NftProcessor.test.ts
+++ b/packages/core-mobile/app/services/nft/NftProcessor.test.ts
@@ -36,7 +36,7 @@ describe('NftProcessor.fetchImage', () => {
     const result = await NftProcessor.fetchImage(base64)
 
     expect(result.type).toBe(NftContentType.SVG)
-    expect(result.uri).toContain('data:image/svg+xml;base64,')
+    expect(result.uri).toBe(base64)
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 

--- a/packages/core-mobile/app/services/nft/NftProcessor.ts
+++ b/packages/core-mobile/app/services/nft/NftProcessor.ts
@@ -2,31 +2,20 @@ import { NftContentType, NftImageData, NftItemExternalData } from './types'
 import { convertIPFSResolver } from './utils'
 
 export class NftProcessor {
-  private base64 = require('base-64')
-  private base64Prefix = 'data:image/svg+xml;base64,'
+  private base64SvgPrefix = 'data:image/svg+xml;base64,'
 
   async fetchImage(imageData: string): Promise<NftImageData> {
     if (!imageData) {
       throw new Error('[NftProcessor] fetchImage called with empty uri')
     }
 
-    if (this.isBase64Svg(imageData)) {
-      const svg = this.decodeBase64Svg(imageData)
-      return { uri: svg, type: NftContentType.SVG }
+    if (imageData.startsWith(this.base64SvgPrefix)) {
+      return { uri: imageData, type: NftContentType.SVG }
     }
 
     const imageUrl = convertIPFSResolver(imageData)
     const type = await this.identifyByMagicNumber(imageUrl)
     return { uri: imageUrl, type }
-  }
-
-  private isBase64Svg(imageData: string): boolean {
-    return imageData.startsWith(this.base64Prefix)
-  }
-
-  private decodeBase64Svg(svgData: string): string {
-    const base64Data = svgData.substring(this.base64Prefix.length)
-    return this.base64Prefix + this.base64.decode(base64Data).toString()
   }
 
   private async identifyByMagicNumber(url: string): Promise<NftContentType> {

--- a/packages/core-mobile/app/services/nft/NftProcessor.ts
+++ b/packages/core-mobile/app/services/nft/NftProcessor.ts
@@ -1,15 +1,15 @@
 import { NftContentType, NftImageData, NftItemExternalData } from './types'
 import { convertIPFSResolver } from './utils'
 
-export class NftProcessor {
-  private base64SvgPrefix = 'data:image/svg+xml;base64,'
+const BASE64_SVG_PREFIX = 'data:image/svg+xml;base64,'
 
+export class NftProcessor {
   async fetchImage(imageData: string): Promise<NftImageData> {
     if (!imageData) {
       throw new Error('[NftProcessor] fetchImage called with empty uri')
     }
 
-    if (imageData.startsWith(this.base64SvgPrefix)) {
+    if (imageData.startsWith(BASE64_SVG_PREFIX)) {
       return { uri: imageData, type: NftContentType.SVG }
     }
 


### PR DESCRIPTION
## Description

**Ticket: [CP-14204]**

- Simplify `NftProcessor.fetchImage` so that base64-encoded SVG NFTs (`data:image/svg+xml;base64,...`) are returned as-is instead of being decoded with `base-64` and re-wrapped with the data URI prefix. The previous flow produced a malformed URI (prefix + decoded XML string) that downstream consumers couldn't render.
- Drop the runtime `require('base-64')` dependency from this path, hoist the `BASE64_SVG_PREFIX` constant out of the class, and remove the now-unused `isBase64Svg` / `decodeBase64Svg` helpers.
- Tighten the corresponding unit test to assert the returned `uri` equals the original base64 data URI, locking in the new contract.

## Screenshots/Videos
| | before | after |
| --- | --- | --- |
| iOS | <img width="320" alt="IMG_1368" src="https://github.com/user-attachments/assets/4ec83b14-2c75-481e-a7f4-e7d8daea4400" /> | <img width="320" alt="IMG_1367" src="https://github.com/user-attachments/assets/8f7dbcd3-3f0a-4ec5-9bd4-c5796a554506" /> |
| Android | <img width="320" alt="Screenshot_20260507-140129" src="https://github.com/user-attachments/assets/06c6ac4d-669c-4cd2-ba8d-77016fb96fda" /> | <img width="320" alt="Screenshot_20260507-140237" src="https://github.com/user-attachments/assets/6a81bc64-b347-4665-89b5-2fd7c40e26a5" /> |

## Testing
iOS: 8445
Android: 8446

- Acceptance criteria: collectibles whose image is a base64-encoded inline SVG render correctly on the Collectibles list and on the Collectible Details screen, on both iOS and Android.
- Regression check: collectibles served via HTTPS and IPFS (PNG, JPG, GIF, MP4) continue to render as before.
- Regression check: empty / invalid image URIs still surface an error rather than rendering a broken state.

## Checklist
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14204]: https://ava-labs.atlassian.net/browse/CP-14204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ