### PR TITLE
CP-14170: add listener reconciler infrastructure

### DIFF
--- a/packages/core-mobile/app/services/sentry/types.ts
+++ b/packages/core-mobile/app/services/sentry/types.ts
@@ -53,7 +53,8 @@ export const SentryTag = {
  * — breadcrumbs without a listed category get dropped.
  */
 export const AllowedSentryBreadcrumbCategory = {
-  ListenerMigration: 'listenerMigration'
+  ListenerMigration: 'listenerMigration',
+  ListenerReconciler: 'listenerReconciler'
 } as const
 
 export type AllowedSentryBreadcrumbCategory =

--- a/packages/core-mobile/app/services/sentry/types.ts
+++ b/packages/core-mobile/app/services/sentry/types.ts
@@ -49,8 +49,9 @@ export const SentryTag = {
 
 /**
  * Breadcrumb categories explicitly allowed by `SentryService.beforeBreadcrumb`.
- * Add new categories here AND update the allowlist in `SentryService.ts`
- * — breadcrumbs without a listed category get dropped.
+ * `SentryService` derives its allowlist from `Object.values(...)` of this
+ * object at module load, so adding a new entry here is enough — no other
+ * file needs to change. Breadcrumbs whose category isn't listed get dropped.
  */
 export const AllowedSentryBreadcrumbCategory = {
   ListenerMigration: 'listenerMigration',

--- a/packages/core-mobile/app/store/app/listeners.ts
+++ b/packages/core-mobile/app/store/app/listeners.ts
@@ -18,6 +18,7 @@ import {
   setWalletState,
   WalletState
 } from 'store/app'
+import { listenerReconcilerExecutor } from 'store/listenerReconcilers'
 import { reduxStorage } from 'store/reduxStorage'
 import type { ColorSchemeName } from 'store/settings/appearance'
 import {
@@ -207,6 +208,12 @@ export const addAppListeners = (startListening: AppStartListening): void => {
   startListening({
     actionCreator: onAppUnlocked,
     effect: setStateToUnlocked
+  })
+
+  startListening({
+    actionCreator: onAppUnlocked,
+    effect: (_, listenerApi) =>
+      listenerReconcilerExecutor.executeAll(listenerApi)
   })
 
   startListening({

--- a/packages/core-mobile/app/store/listenerReconcilers/executor.test.ts
+++ b/packages/core-mobile/app/store/listenerReconcilers/executor.test.ts
@@ -101,39 +101,33 @@ describe('ListenerReconcilerExecutor', () => {
       expect(reconcile).toHaveBeenCalledTimes(2)
     })
 
-    it('clears the in-flight slot even when the run throws', async () => {
+    it('clears the in-flight slot on the same executor even when the run throws', async () => {
       // A throw inside the iteration phase must not leave the executor
-      // permanently locked. Use a reconciler whose reconcile() returns a
-      // rejected promise so the IIFE rejects.
-      const throwing = makeReconciler({
-        name: 'throwing',
-        reconcile: () => Promise.reject(new Error('boom'))
-      })
-      const recovering = jest.fn(async () => ({
-        outcome: 'applied' as const
-      }))
-      // Note: `runReconciler` catches reconcile() errors and converts to
-      // outcome=failed, so this case actually never propagates out of
-      // executeAll today. To test the cleanup path we override
-      // `runReconciler` indirectly by stubbing the reconcile() to throw
-      // synchronously inside the for-loop's await. We do that by mocking
-      // the iterator: simpler — make `Sentry.addBreadcrumb` throw once,
-      // which propagates out of recordOutcome → out of the IIFE.
+      // permanently locked. `runReconciler` catches reconcile() errors and
+      // converts to outcome=failed, so to surface a throw out of the IIFE
+      // we make `Sentry.addBreadcrumb` throw — once — which propagates out
+      // of recordOutcome → out of the IIFE. The same executor is used for
+      // both calls so we're actually asserting `inFlight` was cleared on it.
+      const reconcile = jest.fn(async () => ({ outcome: 'applied' as const }))
+      const executor = new ListenerReconcilerExecutor([
+        makeReconciler({ name: 'r', reconcile })
+      ])
+
       mockBreadcrumb.mockImplementationOnce(() => {
         throw new Error('breadcrumb sink blew up')
       })
 
-      const executor = new ListenerReconcilerExecutor([throwing])
       await expect(executor.executeAll(buildListenerApi())).rejects.toThrow(
         'breadcrumb sink blew up'
       )
 
-      // Subsequent call must work normally — the in-flight slot was cleared.
-      const executor2 = new ListenerReconcilerExecutor([
-        makeReconciler({ name: 'r2', reconcile: recovering })
-      ])
-      await executor2.executeAll(buildListenerApi())
-      expect(recovering).toHaveBeenCalledTimes(1)
+      // Second call on the same executor must not be short-circuited by a
+      // stale in-flight promise. It should run the reconciler again and
+      // resolve normally now that the breadcrumb mock no longer throws.
+      await expect(
+        executor.executeAll(buildListenerApi())
+      ).resolves.toBeUndefined()
+      expect(reconcile).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/packages/core-mobile/app/store/listenerReconcilers/executor.test.ts
+++ b/packages/core-mobile/app/store/listenerReconcilers/executor.test.ts
@@ -1,0 +1,307 @@
+import { addBreadcrumb } from '@sentry/react-native'
+import { AppListenerEffectAPI } from 'store/types'
+import { ListenerReconcilerExecutor } from './executor'
+import { Reconciler, ReconcilerResult } from './types'
+
+jest.mock('@sentry/react-native', () => ({
+  addBreadcrumb: jest.fn(),
+  init: jest.fn(),
+  reactNavigationIntegration: jest.fn(() => ({})),
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+  withScope: jest.fn(
+    (cb: (scope: { setContext: jest.Mock; setTags: jest.Mock }) => void) =>
+      cb({ setContext: jest.fn(), setTags: jest.fn() })
+  ),
+  getGlobalScope: jest.fn(() => ({ setUser: jest.fn() }))
+}))
+
+const mockBreadcrumb = addBreadcrumb as jest.Mock
+
+const buildListenerApi = (): AppListenerEffectAPI =>
+  ({
+    getState: () => ({}),
+    dispatch: jest.fn()
+  } as unknown as AppListenerEffectAPI)
+
+const makeReconciler = (overrides: Partial<Reconciler> = {}): Reconciler => ({
+  name: overrides.name ?? 'reconciler',
+  description: overrides.description ?? 'description',
+  reconcile:
+    overrides.reconcile ??
+    (async () => ({ outcome: 'applied' } as ReconcilerResult)),
+  ...overrides
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('ListenerReconcilerExecutor', () => {
+  describe('empty registry', () => {
+    it('exits cleanly — no reconcilers run, no Sentry breadcrumb emitted', async () => {
+      const executor = new ListenerReconcilerExecutor([])
+
+      await executor.executeAll(buildListenerApi())
+
+      expect(mockBreadcrumb).not.toHaveBeenCalled()
+    })
+
+    it('returns a resolved promise without entering the loop', async () => {
+      // Sentinel reconciler whose presence in the array would be visible if
+      // the empty-registry guard ever stopped short-circuiting.
+      const sentinel = jest.fn(async () => ({ outcome: 'applied' as const }))
+      const executorEmpty = new ListenerReconcilerExecutor([])
+      const executorWith = new ListenerReconcilerExecutor([
+        makeReconciler({ reconcile: sentinel })
+      ])
+
+      await executorEmpty.executeAll(buildListenerApi())
+      await executorWith.executeAll(buildListenerApi())
+
+      // Only the non-empty registry called the reconciler.
+      expect(sentinel).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('reentrancy', () => {
+    it('returns the in-flight promise when called again before the first run finishes', async () => {
+      let resolveReconcile: () => void = () => undefined
+      const reconcile = jest.fn(
+        () =>
+          new Promise<ReconcilerResult>(resolve => {
+            resolveReconcile = () => resolve({ outcome: 'applied' })
+          })
+      )
+      const r = makeReconciler({ reconcile })
+      const executor = new ListenerReconcilerExecutor([r])
+
+      const first = executor.executeAll(buildListenerApi())
+      const second = executor.executeAll(buildListenerApi())
+
+      // Both callers get the same promise — no parallel pass.
+      expect(first).toBe(second)
+      // Reconciler was only kicked off once.
+      expect(reconcile).toHaveBeenCalledTimes(1)
+
+      resolveReconcile()
+      await first
+    })
+
+    it('clears the in-flight slot after completion so a later call re-runs', async () => {
+      const reconcile = jest.fn(async () => ({ outcome: 'applied' as const }))
+      const r = makeReconciler({ reconcile })
+      const executor = new ListenerReconcilerExecutor([r])
+
+      await executor.executeAll(buildListenerApi())
+      await executor.executeAll(buildListenerApi())
+
+      // Reconcilers run on every unlock (no completion tracking) — so two
+      // sequential `executeAll` calls invoke the reconciler twice.
+      expect(reconcile).toHaveBeenCalledTimes(2)
+    })
+
+    it('clears the in-flight slot even when the run throws', async () => {
+      // A throw inside the iteration phase must not leave the executor
+      // permanently locked. Use a reconciler whose reconcile() returns a
+      // rejected promise so the IIFE rejects.
+      const throwing = makeReconciler({
+        name: 'throwing',
+        reconcile: () => Promise.reject(new Error('boom'))
+      })
+      const recovering = jest.fn(async () => ({
+        outcome: 'applied' as const
+      }))
+      // Note: `runReconciler` catches reconcile() errors and converts to
+      // outcome=failed, so this case actually never propagates out of
+      // executeAll today. To test the cleanup path we override
+      // `runReconciler` indirectly by stubbing the reconcile() to throw
+      // synchronously inside the for-loop's await. We do that by mocking
+      // the iterator: simpler — make `Sentry.addBreadcrumb` throw once,
+      // which propagates out of recordOutcome → out of the IIFE.
+      mockBreadcrumb.mockImplementationOnce(() => {
+        throw new Error('breadcrumb sink blew up')
+      })
+
+      const executor = new ListenerReconcilerExecutor([throwing])
+      await expect(executor.executeAll(buildListenerApi())).rejects.toThrow(
+        'breadcrumb sink blew up'
+      )
+
+      // Subsequent call must work normally — the in-flight slot was cleared.
+      const executor2 = new ListenerReconcilerExecutor([
+        makeReconciler({ name: 'r2', reconcile: recovering })
+      ])
+      await executor2.executeAll(buildListenerApi())
+      expect(recovering).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('execution', () => {
+    it('runs reconcilers sequentially in registration order', async () => {
+      const callOrder: string[] = []
+      const a = makeReconciler({
+        name: 'a',
+        reconcile: async () => {
+          callOrder.push('a')
+          return { outcome: 'applied' as const }
+        }
+      })
+      const b = makeReconciler({
+        name: 'b',
+        reconcile: async () => {
+          callOrder.push('b')
+          return { outcome: 'applied' as const }
+        }
+      })
+      const c = makeReconciler({
+        name: 'c',
+        reconcile: async () => {
+          callOrder.push('c')
+          return { outcome: 'applied' as const }
+        }
+      })
+      const executor = new ListenerReconcilerExecutor([a, b, c])
+
+      await executor.executeAll(buildListenerApi())
+
+      expect(callOrder).toEqual(['a', 'b', 'c'])
+    })
+
+    it('passes listenerApi to each reconciler', async () => {
+      const reconcile = jest.fn(async () => ({ outcome: 'applied' as const }))
+      const r = makeReconciler({ reconcile })
+      const executor = new ListenerReconcilerExecutor([r])
+      const listenerApi = buildListenerApi()
+
+      await executor.executeAll(listenerApi)
+
+      expect(reconcile).toHaveBeenCalledWith({ listenerApi })
+    })
+
+    it('runs every reconciler on every call (no completion tracking)', async () => {
+      const reconcile = jest.fn(async () => ({ outcome: 'applied' as const }))
+      const r = makeReconciler({ reconcile })
+      const executor = new ListenerReconcilerExecutor([r])
+
+      await executor.executeAll(buildListenerApi())
+      await executor.executeAll(buildListenerApi())
+      await executor.executeAll(buildListenerApi())
+
+      expect(reconcile).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('failure isolation', () => {
+    it('continues running subsequent reconcilers after one returns outcome=failed', async () => {
+      const aReconcile = jest.fn(async () => ({
+        outcome: 'failed' as const,
+        error: new Error('boom')
+      }))
+      const bReconcile = jest.fn(async () => ({ outcome: 'applied' as const }))
+      const a = makeReconciler({ name: 'a-fail', reconcile: aReconcile })
+      const b = makeReconciler({ name: 'b-ok', reconcile: bReconcile })
+      const executor = new ListenerReconcilerExecutor([a, b])
+
+      await executor.executeAll(buildListenerApi())
+
+      expect(aReconcile).toHaveBeenCalledTimes(1)
+      expect(bReconcile).toHaveBeenCalledTimes(1)
+    })
+
+    it('catches thrown errors and continues — coerces into outcome=failed', async () => {
+      const aReconcile = jest.fn(async () => {
+        throw new Error('uncaught')
+      })
+      const bReconcile = jest.fn(async () => ({ outcome: 'applied' as const }))
+      const a = makeReconciler({ name: 'a-throws', reconcile: aReconcile })
+      const b = makeReconciler({ name: 'b-ok', reconcile: bReconcile })
+      const executor = new ListenerReconcilerExecutor([a, b])
+
+      await executor.executeAll(buildListenerApi())
+
+      expect(bReconcile).toHaveBeenCalledTimes(1)
+      expect(mockBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('a-throws — failed'),
+          level: 'error',
+          data: expect.objectContaining({ errorMessage: 'uncaught' })
+        })
+      )
+    })
+  })
+
+  describe('Sentry breadcrumbs', () => {
+    it('emits a breadcrumb with outcome=applied at info level', async () => {
+      const r = makeReconciler({
+        name: 'r',
+        reconcile: async () => ({
+          outcome: 'applied' as const,
+          metadata: { accountsAdded: 3 }
+        })
+      })
+      const executor = new ListenerReconcilerExecutor([r])
+
+      await executor.executeAll(buildListenerApi())
+
+      expect(mockBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: 'listenerReconciler',
+          message: 'r — applied',
+          level: 'info',
+          data: expect.objectContaining({
+            metadata: { accountsAdded: 3 }
+          })
+        })
+      )
+    })
+
+    it('emits outcome=noOp at info level', async () => {
+      const r = makeReconciler({
+        name: 'r',
+        reconcile: async () => ({ outcome: 'noOp' as const })
+      })
+      const executor = new ListenerReconcilerExecutor([r])
+
+      await executor.executeAll(buildListenerApi())
+
+      expect(mockBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'r — noOp',
+          level: 'info'
+        })
+      )
+    })
+
+    it('emits outcome=failed at error level with errorMessage', async () => {
+      const r = makeReconciler({
+        name: 'r',
+        reconcile: async () => ({
+          outcome: 'failed' as const,
+          error: new Error('boom')
+        })
+      })
+      const executor = new ListenerReconcilerExecutor([r])
+
+      await executor.executeAll(buildListenerApi())
+
+      expect(mockBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'r — failed',
+          level: 'error',
+          data: expect.objectContaining({ errorMessage: 'boom' })
+        })
+      )
+    })
+
+    it('emits one breadcrumb per reconciler execution', async () => {
+      const a = makeReconciler({ name: 'a' })
+      const b = makeReconciler({ name: 'b' })
+      const executor = new ListenerReconcilerExecutor([a, b])
+
+      await executor.executeAll(buildListenerApi())
+
+      expect(mockBreadcrumb).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/packages/core-mobile/app/store/listenerReconcilers/executor.ts
+++ b/packages/core-mobile/app/store/listenerReconcilers/executor.ts
@@ -1,0 +1,115 @@
+import * as Sentry from '@sentry/react-native'
+import { AllowedSentryBreadcrumbCategory } from 'services/sentry/types'
+import { AppListenerEffectAPI } from 'store/types'
+import Logger from 'utils/Logger'
+import { Reconciler, ReconcilerResult } from './types'
+
+/**
+ * Runs all registered listener reconcilers sequentially on every
+ * `onAppUnlocked`. Each reconciler is responsible for its own
+ * idempotency check (read state → return `noOp` if no work needed).
+ *
+ * Errors are isolated per reconciler — a failure does not stop the next
+ * reconciler from running. Failures emit a Sentry breadcrumb at
+ * `error` level and an error log; no rate-limiting (low reconciler
+ * count + per-execution failure volume makes it unnecessary).
+ *
+ * No state is persisted: reconcilers don't track completion. Per-execution
+ * timeline lives in Sentry breadcrumbs and analytics events.
+ *
+ * One instance per app session is exported as the
+ * `listenerReconcilerExecutor` singleton from `./index.ts`. Tests
+ * construct their own with a custom reconciler array.
+ */
+export class ListenerReconcilerExecutor {
+  /**
+   * Promise of the currently-running `executeAll` call, or `null` when
+   * idle. Concurrent calls return this same promise so a rapid
+   * unlock-after-unlock doesn't double-emit breadcrumbs/analytics or
+   * run the same reconciler twice in parallel.
+   */
+  private inFlight: Promise<void> | null = null
+
+  constructor(private readonly reconcilers: Reconciler[]) {}
+
+  /**
+   * Runs every registered reconciler in registration order. Errors
+   * thrown by a reconciler are caught and recorded as `'failed'`;
+   * subsequent reconcilers still run.
+   *
+   * Two early-return guards:
+   * - Empty registry: skip the loop entirely (no breadcrumb noise).
+   * - Already running: return the in-flight promise so a second
+   *   `onAppUnlocked` doesn't run the chain in parallel.
+   */
+  executeAll(listenerApi: AppListenerEffectAPI): Promise<void> {
+    if (this.reconcilers.length === 0) return Promise.resolve()
+    if (this.inFlight) return this.inFlight
+
+    // Cleanup chained via `.finally()` (not an inner `try/finally`) so it
+    // runs strictly after the IIFE settles. An inner `finally` would run
+    // synchronously on a sync throw — before `this.inFlight` is even
+    // assigned — leaving the slot permanently stuck on the rejected
+    // promise.
+    const run = async (): Promise<void> => {
+      for (const reconciler of this.reconcilers) {
+        await this.runReconciler(reconciler, { listenerApi })
+      }
+    }
+
+    this.inFlight = run().finally(() => {
+      this.inFlight = null
+    })
+    return this.inFlight
+  }
+
+  private async runReconciler(
+    reconciler: Reconciler,
+    ctx: { listenerApi: AppListenerEffectAPI }
+  ): Promise<ReconcilerResult> {
+    const startedAt = Date.now()
+
+    let result: ReconcilerResult
+    try {
+      result = await reconciler.reconcile(ctx)
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err))
+      result = { outcome: 'failed', error }
+    }
+
+    this.recordOutcome({ reconciler, result, startedAt })
+    return result
+  }
+
+  /**
+   * Emits a Sentry breadcrumb (allowlisted category `listenerReconciler`)
+   * and, on failure, logs the error (single sink for both thrown and
+   * explicitly-returned `outcome: 'failed'`). No on-device persistence —
+   * reconcilers don't track completion.
+   */
+  private recordOutcome(opts: {
+    reconciler: Reconciler
+    result: ReconcilerResult
+    startedAt: number
+  }): void {
+    const { reconciler, result, startedAt } = opts
+
+    Sentry.addBreadcrumb({
+      category: AllowedSentryBreadcrumbCategory.ListenerReconciler,
+      message: `${reconciler.name} — ${result.outcome}`,
+      level: result.outcome === 'failed' ? 'error' : 'info',
+      data: {
+        durationMs: Date.now() - startedAt,
+        errorMessage: result.error?.message,
+        metadata: result.metadata
+      }
+    })
+
+    if (result.outcome === 'failed') {
+      Logger.error(
+        `[ListenerReconcilerExecutor] reconciler "${reconciler.name}" failed`,
+        result.error
+      )
+    }
+  }
+}

--- a/packages/core-mobile/app/store/listenerReconcilers/executor.ts
+++ b/packages/core-mobile/app/store/listenerReconcilers/executor.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react-native'
 import { AllowedSentryBreadcrumbCategory } from 'services/sentry/types'
 import { AppListenerEffectAPI } from 'store/types'
 import Logger from 'utils/Logger'
-import { Reconciler, ReconcilerResult } from './types'
+import { Reconciler, ReconcilerContext, ReconcilerResult } from './types'
 
 /**
  * Runs all registered listener reconcilers sequentially on every
@@ -66,7 +66,7 @@ export class ListenerReconcilerExecutor {
 
   private async runReconciler(
     reconciler: Reconciler,
-    ctx: { listenerApi: AppListenerEffectAPI }
+    ctx: ReconcilerContext
   ): Promise<ReconcilerResult> {
     const startedAt = Date.now()
 

--- a/packages/core-mobile/app/store/listenerReconcilers/executor.ts
+++ b/packages/core-mobile/app/store/listenerReconcilers/executor.ts
@@ -15,7 +15,8 @@ import { Reconciler, ReconcilerResult } from './types'
  * count + per-execution failure volume makes it unnecessary).
  *
  * No state is persisted: reconcilers don't track completion. Per-execution
- * timeline lives in Sentry breadcrumbs and analytics events.
+ * timeline lives in Sentry breadcrumbs today; an analytics event is
+ * planned but not wired up in this PR.
  *
  * One instance per app session is exported as the
  * `listenerReconcilerExecutor` singleton from `./index.ts`. Tests

--- a/packages/core-mobile/app/store/listenerReconcilers/index.ts
+++ b/packages/core-mobile/app/store/listenerReconcilers/index.ts
@@ -1,0 +1,23 @@
+import { ListenerReconcilerExecutor } from './executor'
+import { Reconciler } from './types'
+import { validateRegistry } from './utils'
+
+/**
+ * Registry of all listener reconcilers. Add new reconcilers here. They
+ * run in registration order on every `onAppUnlocked`.
+ *
+ * Reconcilers are recurring and idempotent — each one is responsible for
+ * its own short-circuit / no-op check (read state → return `noOp` if no
+ * work needed).
+ */
+export const listenerReconcilers: Reconciler[] = []
+
+validateRegistry(listenerReconcilers)
+
+/**
+ * App-wide singleton. Used from the `onAppUnlocked` integration to run
+ * the full reconciler chain on every unlock.
+ */
+export const listenerReconcilerExecutor = new ListenerReconcilerExecutor(
+  listenerReconcilers
+)

--- a/packages/core-mobile/app/store/listenerReconcilers/types.ts
+++ b/packages/core-mobile/app/store/listenerReconcilers/types.ts
@@ -1,0 +1,56 @@
+import { AppListenerEffectAPI } from 'store/types'
+
+/**
+ * Listener reconcilers are async, idempotent state-driven operations that
+ * run on every `onAppUnlocked`. They check current state and only do work
+ * if the state is incomplete (e.g. a chain is missing addresses for some
+ * accounts). They do NOT track completion and have no version — each
+ * reconciler is responsible for its own short-circuit / no-op check.
+ *
+ * For one-shot, versioned operations that should run at most once per
+ * scope (per-wallet or global), use `store/listenerMigrations/` instead.
+ *
+ * Naming note: this is the Kubernetes-flavor reconciler ("a control loop
+ * that watches state and moves it toward desired state"), not the
+ * redux-persist `stateReconciler` (which merges persisted state with
+ * `initialState` on rehydrate). They share a name but are unrelated.
+ */
+export interface Reconciler {
+  /** Stable identifier used in analytics events and Sentry breadcrumbs. */
+  name: string
+  /** Human-readable description; surfaced in the reconciler debug screen. */
+  description: string
+  reconcile: (ctx: ReconcilerContext) => Promise<ReconcilerResult>
+}
+
+export interface ReconcilerContext {
+  listenerApi: AppListenerEffectAPI
+}
+
+/**
+ * Outcome of a single reconciler execution. Aligned with
+ * `MigrationOutcome` so analytics dashboards can group by `outcome`
+ * across both systems.
+ *
+ * - `'applied'` — reconciler ran AND performed work.
+ * - `'noOp'`    — reconciler ran but state was already correct.
+ * - `'failed'`  — reconciler ran and errored.
+ */
+export type ReconcilerOutcome = 'applied' | 'noOp' | 'failed'
+
+/**
+ * Returned by every `reconcile(ctx)` call. The `outcome` field drives
+ * analytics and Sentry breadcrumb level. `metadata` is free-form
+ * per-reconciler context (e.g. `{ accountsAdded: 3 }`) — consumed by
+ * the analytics event so the team can see "what work did this
+ * reconciler do" trended over time, and used to drive the removal
+ * policy (when `applied %` stays near 0 for 30+ days, remove the
+ * reconciler).
+ */
+export interface ReconcilerResult {
+  outcome: ReconcilerOutcome
+  /** Present only when `outcome === 'failed'`. */
+  error?: Error
+  /** Free-form per-reconciler context for analytics. */
+  metadata?: Record<string, unknown>
+}

--- a/packages/core-mobile/app/store/listenerReconcilers/types.ts
+++ b/packages/core-mobile/app/store/listenerReconcilers/types.ts
@@ -40,17 +40,21 @@ export type ReconcilerOutcome = 'applied' | 'noOp' | 'failed'
 
 /**
  * Returned by every `reconcile(ctx)` call. The `outcome` field drives
- * analytics and Sentry breadcrumb level. `metadata` is free-form
- * per-reconciler context (e.g. `{ accountsAdded: 3 }`) — consumed by
- * the analytics event so the team can see "what work did this
- * reconciler do" trended over time, and used to drive the removal
+ * the Sentry breadcrumb level today and is intended to drive the future
+ * analytics event. `metadata` is free-form per-reconciler context (e.g.
+ * `{ accountsAdded: 3 }`) — currently attached to the breadcrumb only;
+ * intended to feed the future analytics event so the team can trend
+ * "what work did this reconciler do" over time and drive the removal
  * policy (when `applied %` stays near 0 for 30+ days, remove the
- * reconciler).
+ * reconciler). Analytics emission is not wired up in this PR.
  */
 export interface ReconcilerResult {
   outcome: ReconcilerOutcome
   /** Present only when `outcome === 'failed'`. */
   error?: Error
-  /** Free-form per-reconciler context for analytics. */
+  /**
+   * Free-form per-reconciler context. Currently surfaced on the Sentry
+   * breadcrumb only; intended for the future analytics event.
+   */
   metadata?: Record<string, unknown>
 }

--- a/packages/core-mobile/app/store/listenerReconcilers/utils.test.ts
+++ b/packages/core-mobile/app/store/listenerReconcilers/utils.test.ts
@@ -1,0 +1,73 @@
+import { Reconciler, ReconcilerResult } from './types'
+import { validateRegistry } from './utils'
+
+const makeReconciler = (overrides: Partial<Reconciler> = {}): Reconciler => ({
+  name: overrides.name ?? 'reconciler',
+  description: overrides.description ?? 'description',
+  reconcile:
+    overrides.reconcile ??
+    (async () => ({ outcome: 'applied' } as ReconcilerResult)),
+  ...overrides
+})
+
+describe('validateRegistry', () => {
+  it('throws on duplicate name', () => {
+    expect(() =>
+      validateRegistry([
+        makeReconciler({ name: 'same' }),
+        makeReconciler({ name: 'same' })
+      ])
+    ).toThrow(/duplicate reconciler name: same/)
+  })
+
+  it('throws on missing name', () => {
+    expect(() =>
+      validateRegistry([
+        {
+          name: '',
+          description: 'd',
+          reconcile: async () => ({ outcome: 'applied' as const })
+        }
+      ])
+    ).toThrow(/missing a name/)
+  })
+
+  it('throws on missing description', () => {
+    expect(() =>
+      validateRegistry([
+        {
+          name: 'r',
+          description: '',
+          reconcile: async () => ({ outcome: 'applied' as const })
+        }
+      ])
+    ).toThrow(/missing a description/)
+  })
+
+  it('throws on missing reconcile function', () => {
+    expect(() =>
+      validateRegistry([
+        {
+          name: 'r',
+          description: 'd',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          reconcile: undefined as any
+        }
+      ])
+    ).toThrow(/missing a reconcile function/)
+  })
+
+  it('accepts an empty registry', () => {
+    expect(() => validateRegistry([])).not.toThrow()
+  })
+
+  it('accepts a registry of distinct reconcilers', () => {
+    expect(() =>
+      validateRegistry([
+        makeReconciler({ name: 'a' }),
+        makeReconciler({ name: 'b' }),
+        makeReconciler({ name: 'c' })
+      ])
+    ).not.toThrow()
+  })
+})

--- a/packages/core-mobile/app/store/listenerReconcilers/utils.ts
+++ b/packages/core-mobile/app/store/listenerReconcilers/utils.ts
@@ -1,0 +1,42 @@
+import { Reconciler } from './types'
+
+/**
+ * Throws if a single reconciler is missing a required field. Called for
+ * each entry in the registry by `validateRegistry`.
+ */
+const assertValidShape = (r: Reconciler): void => {
+  if (!r.name) {
+    throw new Error(`[listenerReconcilers] reconciler is missing a name`)
+  }
+  if (!r.description) {
+    throw new Error(
+      `[listenerReconcilers] reconciler "${r.name}" is missing a description`
+    )
+  }
+  if (typeof r.reconcile !== 'function') {
+    throw new Error(
+      `[listenerReconcilers] reconciler "${r.name}" is missing a reconcile function`
+    )
+  }
+}
+
+/**
+ * Validates the registry at module load. Throws on a malformed reconciler
+ * or two reconcilers sharing a name. Crashing at import is intentional —
+ * a malformed registry is a programming error that must be caught before
+ * the app boots.
+ */
+export const validateRegistry = (reconcilers: Reconciler[]): void => {
+  const seenNames = new Set<string>()
+
+  for (const reconciler of reconcilers) {
+    assertValidShape(reconciler)
+
+    if (seenNames.has(reconciler.name)) {
+      throw new Error(
+        `[listenerReconcilers] duplicate reconciler name: ${reconciler.name}`
+      )
+    }
+    seenNames.add(reconciler.name)
+  }
+}


### PR DESCRIPTION
## Description

**Ticket: [CP-14170](https://ava-labs.atlassian.net/browse/CP-14170)**

Adds the recurring, idempotent counterpart to the versioned listener migration system from [CP-13980](https://ava-labs.atlassian.net/browse/CP-13980).

**What's a reconciler?**
- Runs on every `onAppUnlocked`
- Does NOT track completion (no version, no MMKV state)
- Each reconciler is responsible for its own no-op short-circuit (read state → return `noOp` if nothing to do)
- Industry analog: Kubernetes-style reconciliation loop / Flyway "repeatable" / Fowler's Idempotent Receiver

This is intentionally distinct from listener migrations, which are versioned one-shot operations. The decision rule for future code is documented in the spike output (CP-13981).

**What this PR ships**
- New `app/store/listenerReconcilers/` package
  - `types.ts` — `Reconciler`, `ReconcilerContext`, `ReconcilerResult`, outcome enum (`applied | noOp | failed`, mirrors migrations for cross-system analytics)
  - `utils.ts` — `validateRegistry` (unique names, required fields)
  - `executor.ts` — `ListenerReconcilerExecutor` with sequential per-reconciler try/catch, Sentry breadcrumb per run, `Logger.error` on failure (single sink), no rate-limiting
  - `index.ts` — empty registry + `listenerReconcilerExecutor` singleton
- New `'listenerReconciler'` entry in `AllowedSentryBreadcrumbCategory` (auto-allowlisted by `SentryService.beforeBreadcrumb`)
- Wired into `onAppUnlocked` in `addAppListeners`

## Screenshots/Videos

No user-facing change — infrastructure only.

## Testing

No manual testing needed for this PR — the registry ships empty and `executeAll` short-circuits to `Promise.resolve()`. Real testing happens when concrete reconcilers are added (CP-13988).

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios (N/A — no UI)
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation (deferred — will land alongside the docs page covering "when to use migration vs reconciler")

[CP-14170]: https://ava-labs.atlassian.net/browse/CP-14170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-13980]: https://ava-labs.atlassian.net/browse/CP-13980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-13988]: https://ava-labs.atlassian.net/browse/CP-13988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ