### PR TITLE
CP-13946: use screen-enter hook for swap auto-focus

### DIFF
--- a/packages/core-mobile/app/new/common/components/TokenInputWidget.tsx
+++ b/packages/core-mobile/app/new/common/components/TokenInputWidget.tsx
@@ -14,7 +14,14 @@ import {
   useTheme,
   View
 } from '@avalabs/k2-alpine'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState
+} from 'react'
 import Animated, {
   Easing,
   FadeIn,
@@ -23,27 +30,12 @@ import Animated, {
 } from 'react-native-reanimated'
 import { LogoWithNetwork } from './LogoWithNetwork'
 
-export const TokenInputWidget = ({
-  title,
-  token,
-  balance,
-  shouldShowBalance,
-  network,
-  maximum,
-  amount,
-  onAmountChange,
-  formatInCurrency,
-  onSelectToken,
-  onFocus,
-  onBlur,
-  sx,
-  disabled,
-  editable = true,
-  isLoadingAmount = false,
-  autoFocus,
-  valid = true,
-  amountInputTestID = 'token_amount_input_field'
-}: {
+export type TokenInputWidgetRef = {
+  focus: () => void
+  blur: () => void
+}
+
+type TokenInputWidgetProps = {
   title: string
   amount?: bigint
   maximum?: bigint
@@ -60,10 +52,36 @@ export const TokenInputWidget = ({
   disabled?: boolean
   editable?: boolean
   isLoadingAmount?: boolean
-  autoFocus?: boolean
   valid?: boolean
   amountInputTestID?: string
-}): JSX.Element => {
+}
+
+export const TokenInputWidget = forwardRef<
+  TokenInputWidgetRef,
+  TokenInputWidgetProps
+>(function TokenInputWidget(
+  {
+    title,
+    token,
+    balance,
+    shouldShowBalance,
+    network,
+    maximum,
+    amount,
+    onAmountChange,
+    formatInCurrency,
+    onSelectToken,
+    onFocus,
+    onBlur,
+    sx,
+    disabled,
+    editable = true,
+    isLoadingAmount = false,
+    valid = true,
+    amountInputTestID = 'token_amount_input_field'
+  },
+  ref
+): JSX.Element {
   const {
     theme: { colors }
   } = useTheme()
@@ -73,6 +91,15 @@ export const TokenInputWidget = ({
   >([])
 
   const tokenAmountInputRef = useRef<TokenAmountInputRef>(null)
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      focus: () => tokenAmountInputRef.current?.focus(),
+      blur: () => tokenAmountInputRef.current?.blur()
+    }),
+    []
+  )
 
   const handlePressPercentageButton = (
     button: PercentageButton,
@@ -217,7 +244,6 @@ export const TokenInputWidget = ({
                     <TokenAmountInput
                       ref={tokenAmountInputRef}
                       testID={amountInputTestID}
-                      autoFocus={autoFocus}
                       editable={editable}
                       denomination={token?.decimals ?? 0}
                       textAlign="right"
@@ -326,7 +352,7 @@ export const TokenInputWidget = ({
       </Animated.View>
     </View>
   )
-}
+})
 
 type PercentageButton = {
   text: string

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -18,8 +18,15 @@ import { SwapSide } from '@paraswap/sdk'
 import { useNavigation } from '@react-navigation/native'
 import { ErrorState } from 'common/components/ErrorState'
 import { ScrollScreen } from 'common/components/ScrollScreen'
-import { TokenInputWidget } from 'common/components/TokenInputWidget'
+import {
+  TokenInputWidget,
+  TokenInputWidgetRef
+} from 'common/components/TokenInputWidget'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
+import {
+  FORM_SHEET_FOCUS_BUFFER_MS,
+  useAfterScreenEnterTransition
+} from 'common/hooks/useAfterScreenEnterTransition'
 import { usePreventScreenRemoval } from 'common/hooks/usePreventScreenRemoval'
 import { dismissKeyboardIfNeeded } from 'common/utils/dismissKeyboardIfNeeded'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
@@ -462,8 +469,23 @@ export const SwapScreen = (): JSX.Element => {
     [formatCurrency]
   )
 
-  // Track if we've already auto-focused in this session
-  const hasAutoFocused = useRef(false)
+  // Defer auto-focus until the modal's enter transition has completed.
+  // Focusing during the transition races the keyboard spring-up and the
+  // KeyboardAwareScrollView's input-into-view scroll, which on Android can
+  // collapse the fading header into a half-broken state where the "Swap"
+  // title disappears and "You pay" is clipped by the navigation bar (CP-13946).
+  const fromTokenInputRef = useRef<TokenInputWidgetRef>(null)
+  const hasAutoFocusedRef = useRef(false)
+  useAfterScreenEnterTransition(
+    () => {
+      if (hasAutoFocusedRef.current) return
+      hasAutoFocusedRef.current = true
+      fromTokenInputRef.current?.focus()
+    },
+    {
+      layoutBufferMs: FORM_SHEET_FOCUS_BUFFER_MS
+    }
+  )
 
   const renderFromSection = useCallback(() => {
     return (
@@ -476,10 +498,10 @@ export const SwapScreen = (): JSX.Element => {
           paddingBottom: 4
         }}>
         <TokenInputWidget
+          ref={fromTokenInputRef}
           amountInputTestID="token_amount_input_field__you_pay"
           disabled={isSwapping}
           editable={!isSwapping}
-          autoFocus={!hasAutoFocused.current} // Only auto-focus if we haven't done it yet
           amount={fromTokenValue}
           balance={fromToken?.balance}
           shouldShowBalance={true}
@@ -496,10 +518,6 @@ export const SwapScreen = (): JSX.Element => {
           network={getNetwork(fromToken?.networkChainId)}
           formatInCurrency={amount => formatInCurrency(fromToken, amount)}
           onAmountChange={handleFromAmountChange}
-          onFocus={() => {
-            // Mark that we've auto-focused
-            hasAutoFocused.current = true
-          }}
           onSelectToken={handleSelectFromToken}
           maximum={fromMaxSwapAmount}
           valid={!validationError}


### PR DESCRIPTION
## Description

**Ticket: [CP-13946]**

- Refactor `TokenInputWidget` from a function component to `forwardRef`, exposing an imperative `focus()` / `blur()` handle via `useImperativeHandle`. The previous `autoFocus` prop is removed.
- In `SwapScreen`, replace the `autoFocus` prop on the "You pay" `TokenInputWidget` with an imperative focus call wired through `useAfterScreenEnterTransition` (with `layoutBufferMs: FORM_SHEET_FOCUS_BUFFER_MS`). A `hasAutoFocusedRef` guard ensures the field is only auto-focused on the first screen entry — not every time the screen regains focus (e.g. after returning from the token selector).

## Testing
iOS: 8451
Android: 8452

- "You pay" is auto-focused after the Swap modal finishes opening, and the behavior is consistent between iOS and Android.
- No keyboard bounce / double-open on iOS.
- Returning to Swap from the token selector does not re-trigger the keyboard.


## Checklist
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-13946]: https://ava-labs.atlassian.net/browse/CP-13946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ