### PR TITLE
Preserve sign-in error detail and split SeedlessLoginFailed by stage

### DIFF
--- a/packages/core-mobile/app/new/features/onboarding/hooks/useSeedlessRegister.test.ts
+++ b/packages/core-mobile/app/new/features/onboarding/hooks/useSeedlessRegister.test.ts
@@ -1,0 +1,394 @@
+import { renderHook, act } from '@testing-library/react-hooks'
+import AnalyticsService from 'services/analytics/AnalyticsService'
+import SeedlessService from 'seedless/services/SeedlessService'
+import CoreSeedlessAPIService, {
+  SeedlessUserRegistrationResult
+} from 'seedless/services/CoreSeedlessAPIService'
+import SecureStorageService from 'security/SecureStorageService'
+import { OidcProviders } from 'seedless/consts'
+import { useSeedlessRegister } from './useSeedlessRegister'
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(() => false)
+}))
+
+jest.mock('services/analytics/AnalyticsService', () => ({
+  __esModule: true,
+  default: { capture: jest.fn() }
+}))
+
+jest.mock('seedless/services/SeedlessService', () => ({
+  __esModule: true,
+  default: {
+    session: {
+      oidcProveIdentity: jest.fn(),
+      requestOidcAuth: jest.fn()
+    }
+  }
+}))
+
+jest.mock('seedless/services/CoreSeedlessAPIService', () => ({
+  __esModule: true,
+  default: { register: jest.fn() },
+  SeedlessUserRegistrationResult: {
+    ALREADY_REGISTERED: 'ALREADY_REGISTERED',
+    APPROVED: 'APPROVED',
+    ERROR: 'ERROR'
+  }
+}))
+
+jest.mock('security/SecureStorageService', () => ({
+  __esModule: true,
+  default: { store: jest.fn() },
+  KeySlot: { OidcUserId: 'OidcUserId', OidcProvider: 'OidcProvider' }
+}))
+
+jest.mock('services/passkey/PasskeyService', () => ({
+  __esModule: true,
+  default: { isSupported: false }
+}))
+
+jest.mock('utils/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn()
+  }
+}))
+
+jest.mock('new/common/utils/toast', () => ({
+  showSnackbar: jest.fn()
+}))
+
+jest.mock('common/hooks/useLogoModal', () => ({
+  useLogoModal: () => ({
+    showLogoModal: jest.fn(),
+    hideLogoModal: jest.fn()
+  })
+}))
+
+const mockSetIsNewSeedlessUser = jest.fn()
+jest.mock('../contexts/RecoveryMethodProvider', () => ({
+  useRecoveryMethodContext: () => ({
+    setIsNewSeedlessUser: mockSetIsNewSeedlessUser
+  })
+}))
+
+const captureMock = AnalyticsService.capture as jest.Mock
+const oidcProveIdentityMock = SeedlessService.session
+  .oidcProveIdentity as jest.Mock
+const requestOidcAuthMock = SeedlessService.session.requestOidcAuth as jest.Mock
+const apiRegisterMock = CoreSeedlessAPIService.register as jest.Mock
+const secureStoreMock = SecureStorageService.store as jest.Mock
+
+const callbacks = {
+  onRegisterMfaMethods: jest.fn(),
+  onVerifyMfaMethod: jest.fn(),
+  onAccountVerified: jest.fn()
+}
+
+const validIdentity = {
+  email: 'user@example.test',
+  user_info: { configured_mfa: [] }
+}
+
+describe('useSeedlessRegister.register', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    oidcProveIdentityMock.mockResolvedValue(validIdentity)
+    apiRegisterMock.mockResolvedValue(SeedlessUserRegistrationResult.APPROVED)
+    requestOidcAuthMock.mockResolvedValue({
+      requiresMfa: () => false,
+      mfaId: () => undefined
+    })
+    secureStoreMock.mockResolvedValue(undefined)
+  })
+
+  describe('per-stage failure capture', () => {
+    it('captures stage="oidc-token" when getOidcToken throws', async () => {
+      const getOidcToken = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('Google sign in error: empty token'))
+
+      const { result } = renderHook(() => useSeedlessRegister())
+
+      await act(async () => {
+        await expect(
+          result.current.register({
+            getOidcToken,
+            oidcProvider: OidcProviders.GOOGLE,
+            ...callbacks
+          })
+        ).rejects.toThrow()
+      })
+
+      expect(captureMock).toHaveBeenCalledWith(
+        'SeedlessLoginFailed',
+        expect.objectContaining({
+          stage: 'oidc-token',
+          oidcProvider: OidcProviders.GOOGLE,
+          reason: 'Google sign in error: empty token'
+        })
+      )
+    })
+
+    it('captures stage="identity-proof" when oidcProveIdentity throws', async () => {
+      oidcProveIdentityMock.mockRejectedValueOnce(
+        new Error('cubist_unreachable')
+      )
+      const getOidcToken = jest.fn().mockResolvedValue({ oidcToken: 'tok' })
+
+      const { result } = renderHook(() => useSeedlessRegister())
+
+      await act(async () => {
+        await expect(
+          result.current.register({
+            getOidcToken,
+            oidcProvider: OidcProviders.APPLE,
+            ...callbacks
+          })
+        ).rejects.toThrow()
+      })
+
+      expect(captureMock).toHaveBeenCalledWith(
+        'SeedlessLoginFailed',
+        expect.objectContaining({
+          stage: 'identity-proof',
+          oidcProvider: OidcProviders.APPLE,
+          reason: 'cubist_unreachable'
+        })
+      )
+    })
+
+    it('captures stage="register" when CoreSeedlessAPIService.register throws', async () => {
+      apiRegisterMock.mockRejectedValueOnce(new Error('app_check_failure'))
+      const getOidcToken = jest.fn().mockResolvedValue({ oidcToken: 'tok' })
+
+      const { result } = renderHook(() => useSeedlessRegister())
+
+      await act(async () => {
+        await expect(
+          result.current.register({
+            getOidcToken,
+            oidcProvider: OidcProviders.GOOGLE,
+            ...callbacks
+          })
+        ).rejects.toThrow()
+      })
+
+      expect(captureMock).toHaveBeenCalledWith(
+        'SeedlessLoginFailed',
+        expect.objectContaining({
+          stage: 'register',
+          oidcProvider: OidcProviders.GOOGLE,
+          reason: 'app_check_failure'
+        })
+      )
+    })
+
+    it('captures stage="auth" when requestOidcAuth throws', async () => {
+      requestOidcAuthMock.mockRejectedValueOnce(new Error('INTERNAL_ERROR'))
+      const getOidcToken = jest.fn().mockResolvedValue({ oidcToken: 'tok' })
+
+      const { result } = renderHook(() => useSeedlessRegister())
+
+      await act(async () => {
+        await expect(
+          result.current.register({
+            getOidcToken,
+            oidcProvider: OidcProviders.APPLE,
+            ...callbacks
+          })
+        ).rejects.toThrow()
+      })
+
+      expect(captureMock).toHaveBeenCalledWith(
+        'SeedlessLoginFailed',
+        expect.objectContaining({
+          stage: 'auth',
+          reason: 'INTERNAL_ERROR'
+        })
+      )
+    })
+
+    it('captures stage="secure-store" when SecureStorageService.store throws', async () => {
+      secureStoreMock.mockRejectedValueOnce(new Error('keychain_locked'))
+      const getOidcToken = jest.fn().mockResolvedValue({ oidcToken: 'tok' })
+
+      const { result } = renderHook(() => useSeedlessRegister())
+
+      await act(async () => {
+        await expect(
+          result.current.register({
+            getOidcToken,
+            oidcProvider: OidcProviders.GOOGLE,
+            ...callbacks
+          })
+        ).rejects.toThrow()
+      })
+
+      expect(captureMock).toHaveBeenCalledWith(
+        'SeedlessLoginFailed',
+        expect.objectContaining({
+          stage: 'secure-store',
+          reason: 'keychain_locked'
+        })
+      )
+    })
+
+    it('captures errorCode when the underlying error has an errorCode property', async () => {
+      const sdkError = Object.assign(new Error('boom'), {
+        errorCode: 'NETWORK_ERROR'
+      })
+      apiRegisterMock.mockRejectedValueOnce(sdkError)
+      const getOidcToken = jest.fn().mockResolvedValue({ oidcToken: 'tok' })
+
+      const { result } = renderHook(() => useSeedlessRegister())
+
+      await act(async () => {
+        await expect(
+          result.current.register({
+            getOidcToken,
+            oidcProvider: OidcProviders.GOOGLE,
+            ...callbacks
+          })
+        ).rejects.toThrow()
+      })
+
+      expect(captureMock).toHaveBeenCalledWith(
+        'SeedlessLoginFailed',
+        expect.objectContaining({
+          stage: 'register',
+          errorCode: 'NETWORK_ERROR'
+        })
+      )
+    })
+
+    it('captures errorCode when the underlying error has a code property', async () => {
+      const sdkError = Object.assign(new Error('cancelled by os'), {
+        code: 'GMS_FAILED'
+      })
+      apiRegisterMock.mockRejectedValueOnce(sdkError)
+      const getOidcToken = jest.fn().mockResolvedValue({ oidcToken: 'tok' })
+
+      const { result } = renderHook(() => useSeedlessRegister())
+
+      await act(async () => {
+        await expect(
+          result.current.register({
+            getOidcToken,
+            oidcProvider: OidcProviders.APPLE,
+            ...callbacks
+          })
+        ).rejects.toThrow()
+      })
+
+      expect(captureMock).toHaveBeenCalledWith(
+        'SeedlessLoginFailed',
+        expect.objectContaining({
+          stage: 'register',
+          errorCode: 'GMS_FAILED'
+        })
+      )
+    })
+
+    it('captures stage="register" when register() returns the ERROR sentinel', async () => {
+      apiRegisterMock.mockResolvedValueOnce(
+        SeedlessUserRegistrationResult.ERROR
+      )
+      const getOidcToken = jest.fn().mockResolvedValue({ oidcToken: 'tok' })
+
+      const { result } = renderHook(() => useSeedlessRegister())
+
+      await act(async () => {
+        await expect(
+          result.current.register({
+            getOidcToken,
+            oidcProvider: OidcProviders.GOOGLE,
+            ...callbacks
+          })
+        ).rejects.toThrow()
+      })
+
+      expect(captureMock).toHaveBeenCalledWith(
+        'SeedlessLoginFailed',
+        expect.objectContaining({
+          stage: 'register',
+          reason: 'ERROR'
+        })
+      )
+    })
+
+    it('still captures analytics when underlying error has hostile getter on .message/.code', async () => {
+      class Hostile extends Error {
+        get code(): string {
+          throw new Error('getter blew up')
+        }
+      }
+      apiRegisterMock.mockRejectedValueOnce(new Hostile('readable'))
+      const getOidcToken = jest.fn().mockResolvedValue({ oidcToken: 'tok' })
+
+      const { result } = renderHook(() => useSeedlessRegister())
+
+      await act(async () => {
+        await expect(
+          result.current.register({
+            getOidcToken,
+            oidcProvider: OidcProviders.GOOGLE,
+            ...callbacks
+          })
+        ).rejects.toThrow()
+      })
+
+      expect(captureMock).toHaveBeenCalledWith(
+        'SeedlessLoginFailed',
+        expect.objectContaining({ stage: 'register' })
+      )
+    })
+  })
+
+  describe('preserved behavior', () => {
+    it('does not capture analytics when user cancels (USER_CANCELED)', async () => {
+      const getOidcToken = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('USER_CANCELED'))
+
+      const { result } = renderHook(() => useSeedlessRegister())
+
+      await act(async () => {
+        await expect(
+          result.current.register({
+            getOidcToken,
+            oidcProvider: OidcProviders.GOOGLE,
+            ...callbacks
+          })
+        ).rejects.toThrow()
+      })
+
+      expect(captureMock).not.toHaveBeenCalledWith(
+        'SeedlessLoginFailed',
+        expect.anything()
+      )
+    })
+
+    it('does not capture SeedlessLoginFailed on the success path', async () => {
+      const getOidcToken = jest.fn().mockResolvedValue({ oidcToken: 'tok' })
+
+      const { result } = renderHook(() => useSeedlessRegister())
+
+      await act(async () => {
+        await result.current.register({
+          getOidcToken,
+          oidcProvider: OidcProviders.GOOGLE,
+          ...callbacks
+        })
+      })
+
+      expect(captureMock).not.toHaveBeenCalledWith(
+        'SeedlessLoginFailed',
+        expect.anything()
+      )
+    })
+  })
+})

--- a/packages/core-mobile/app/new/features/onboarding/hooks/useSeedlessRegister.ts
+++ b/packages/core-mobile/app/new/features/onboarding/hooks/useSeedlessRegister.ts
@@ -20,6 +20,44 @@ import { useLogoModal } from 'common/hooks/useLogoModal'
 import { useRecoveryMethodContext } from '../contexts/RecoveryMethodProvider'
 import { MfaType } from '../types/types'
 
+type SeedlessRegisterStage =
+  | 'oidc-token'
+  | 'identity-proof'
+  | 'register'
+  | 'auth'
+  | 'secure-store'
+  | 'post-auth'
+
+type ErrorContext = {
+  reason: string
+  errorName?: string
+  errorCode?: string
+}
+
+// Exception-safe extraction. Errors with throwing getters on .message / .code
+// (or hostile Proxies, etc.) must not blow up the catch handler itself.
+const extractErrorContext = (error: unknown): ErrorContext => {
+  try {
+    const reason = error instanceof Error ? error.message : String(error)
+    const errorName = error instanceof Error ? error.name : undefined
+    let errorCode: string | undefined
+    if (error && typeof error === 'object') {
+      for (const key of ['code', 'errorCode']) {
+        if (key in error) {
+          const value = (error as Record<string, unknown>)[key]
+          if (value !== undefined && value !== null) {
+            errorCode = String(value)
+            break
+          }
+        }
+      }
+    }
+    return { reason, errorName, errorCode }
+  } catch {
+    return { reason: 'unserializable error' }
+  }
+}
+
 type RegisterProps = {
   getOidcToken: () => Promise<OidcPayload>
   oidcProvider: OidcProviders
@@ -80,23 +118,33 @@ export const useSeedlessRegister = (): ReturnType => {
   RegisterProps): Promise<void> => {
     setIsRegistering(true)
 
+    let stage: SeedlessRegisterStage = 'oidc-token'
+
     try {
       const { oidcToken } = await getOidcToken()
+
+      stage = 'identity-proof'
       const identity = await SeedlessService.session.oidcProveIdentity(
         oidcToken
       )
+
+      stage = 'register'
       const result = await CoreSeedlessAPIService.register(identity)
+
+      stage = 'auth'
       const signResponse = await SeedlessService.session.requestOidcAuth(
         oidcToken
       )
       const isMfaRequired = signResponse.requiresMfa()
 
+      stage = 'secure-store'
       // persist email and provider for later use with refresh token flow
       // email is always the same on the cubist's side
       // even if user changes it in the provider, it doesn't change
       await SecureStorageService.store(KeySlot.OidcUserId, identity.email)
       await SecureStorageService.store(KeySlot.OidcProvider, oidcProvider)
 
+      stage = 'post-auth'
       const mfaId = signResponse.mfaId()
 
       if (result === SeedlessUserRegistrationResult.ALREADY_REGISTERED) {
@@ -138,13 +186,20 @@ export const useSeedlessRegister = (): ReturnType => {
           })
         }
       } else {
+        stage = 'register'
         throw new Error(SeedlessUserRegistrationResult.ERROR)
       }
     } catch (error) {
-      const reason = error instanceof Error ? error.message : String(error)
-      if (reason !== 'USER_CANCELED') {
-        AnalyticsService.capture('SeedlessLoginFailed', { reason })
-        Logger.error('useSeedlessRegister error', error)
+      const ctx = extractErrorContext(error)
+      if (ctx.reason !== 'USER_CANCELED') {
+        AnalyticsService.capture('SeedlessLoginFailed', {
+          reason: ctx.reason,
+          stage,
+          oidcProvider,
+          ...(ctx.errorName ? { errorName: ctx.errorName } : {}),
+          ...(ctx.errorCode ? { errorCode: ctx.errorCode } : {})
+        })
+        Logger.error(`useSeedlessRegister error [${stage}]`, error)
       }
       throw new Error(SeedlessUserRegistrationResult.ERROR)
     } finally {

--- a/packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.android.test.ts
+++ b/packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.android.test.ts
@@ -1,0 +1,98 @@
+import { appleAuthAndroid } from '@invertase/react-native-apple-authentication'
+import Logger from 'utils/Logger'
+
+jest.mock('@invertase/react-native-apple-authentication', () => ({
+  appleAuthAndroid: {
+    isSupported: true,
+    configure: jest.fn(),
+    signIn: jest.fn(),
+    Scope: { EMAIL: 'EMAIL' },
+    ResponseType: { ALL: 'ALL' },
+    Error: { SIGNIN_CANCELLED: 'SIGNIN_CANCELLED' }
+  }
+}))
+
+jest.mock('react-native-config', () => ({
+  __esModule: true,
+  default: {
+    APPLE_OAUTH_CLIENT_ID: 'test-client-id',
+    APPLE_OAUTH_REDIRECT_URL: 'https://test.example/redirect'
+  }
+}))
+
+jest.mock('services/deviceInfo/DeviceInfoService', () => ({
+  __esModule: true,
+  default: { getAppNameSpace: () => 'test.app' }
+}))
+
+jest.spyOn(Logger, 'error').mockImplementation(jest.fn())
+jest.spyOn(Logger, 'warn').mockImplementation(jest.fn())
+
+const signInMock = appleAuthAndroid.signIn as jest.Mock
+
+const AppleSignInService = require('./AppleSignInService.android').default as {
+  signIn: () => Promise<{ oidcToken: string }>
+  isSupported: () => boolean
+}
+
+describe('AppleSignInService.android', () => {
+  describe('generic catch (non-cancellation, non-empty-token)', () => {
+    it('preserves the underlying error message in the rethrown error', async () => {
+      signInMock.mockRejectedValueOnce(new Error('apple_sdk_timeout'))
+
+      await expect(AppleSignInService.signIn()).rejects.toThrow(
+        /Android Apple sign in error.*apple_sdk_timeout/
+      )
+    })
+
+    it('includes the underlying error code when present', async () => {
+      const sdkError = Object.assign(new Error('network down'), {
+        code: 'ERR_NO_NETWORK'
+      })
+      signInMock.mockRejectedValueOnce(sdkError)
+
+      await expect(AppleSignInService.signIn()).rejects.toThrow(
+        /ERR_NO_NETWORK|network down/
+      )
+    })
+
+    it('passes the original error to Logger.error so Sentry sees the cause', async () => {
+      const underlying = new Error('cubist_unreachable')
+      signInMock.mockRejectedValueOnce(underlying)
+
+      await expect(AppleSignInService.signIn()).rejects.toThrow()
+
+      expect(Logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('cubist_unreachable'),
+        underlying
+      )
+    })
+  })
+
+  describe('preserved behavior', () => {
+    it('still throws USER_CANCELED when the user cancels', async () => {
+      const cancelled = Object.assign(new Error('cancelled'), {
+        code: 'SIGNIN_CANCELLED'
+      })
+      signInMock.mockRejectedValueOnce(cancelled)
+
+      await expect(AppleSignInService.signIn()).rejects.toThrow('USER_CANCELED')
+    })
+
+    it('throws "empty token" when id_token is missing', async () => {
+      signInMock.mockResolvedValueOnce({ id_token: undefined })
+
+      await expect(AppleSignInService.signIn()).rejects.toThrow(
+        /Android Apple sign in error: empty token/
+      )
+    })
+
+    it('returns the oidcToken on success', async () => {
+      signInMock.mockResolvedValueOnce({ id_token: 'real-token' })
+
+      await expect(AppleSignInService.signIn()).resolves.toEqual({
+        oidcToken: 'real-token'
+      })
+    })
+  })
+})

--- a/packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.android.ts
+++ b/packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.android.ts
@@ -3,6 +3,7 @@ import Config from 'react-native-config'
 import DeviceInfoService from 'services/deviceInfo/DeviceInfoService'
 import Logger from 'utils/Logger'
 import { OidcPayload } from 'seedless/types'
+import { formatSignInErrorReason } from '../formatSignInErrorReason'
 import { AppleSigninServiceInterface } from './types'
 
 if (!Config.APPLE_OAUTH_CLIENT_ID) {
@@ -52,8 +53,15 @@ class AppleSigninService implements AppleSigninServiceInterface {
       ) {
         throw new Error('USER_CANCELED')
       }
-      Logger.error('Android Apple sign in error', error)
-      throw new Error('Android Apple sign in error')
+      if (
+        error instanceof Error &&
+        error.message.startsWith('Android Apple sign in error')
+      ) {
+        throw error
+      }
+      const reason = formatSignInErrorReason(error)
+      Logger.error(`Android Apple sign in error: ${reason}`, error)
+      throw new Error(`Android Apple sign in error: ${reason}`)
     }
   }
 }

--- a/packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.test.ts
+++ b/packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.test.ts
@@ -1,0 +1,116 @@
+import appleAuth from '@invertase/react-native-apple-authentication'
+import Logger from 'utils/Logger'
+
+jest.mock('@invertase/react-native-apple-authentication', () => {
+  const mock = {
+    isSupported: true,
+    performRequest: jest.fn(),
+    getCredentialStateForUser: jest.fn(),
+    Operation: { LOGIN: 'LOGIN' },
+    Scope: { EMAIL: 'EMAIL' },
+    State: { AUTHORIZED: 'AUTHORIZED' },
+    Error: { CANCELED: 'CANCELED' }
+  }
+  return { __esModule: true, default: mock }
+})
+
+jest.spyOn(Logger, 'error').mockImplementation(jest.fn())
+
+const performRequestMock = appleAuth.performRequest as jest.Mock
+const getCredentialStateMock = appleAuth.getCredentialStateForUser as jest.Mock
+
+const AppleSignInService = require('./AppleSignInService').default as {
+  signIn: () => Promise<{ oidcToken: string }>
+}
+
+describe('AppleSignInService (iOS)', () => {
+  describe('generic catch (non-cancellation, non-structured)', () => {
+    it('preserves the underlying error message in the rethrown error', async () => {
+      performRequestMock.mockRejectedValueOnce(new Error('apple_sdk_timeout'))
+
+      await expect(AppleSignInService.signIn()).rejects.toThrow(
+        /iOS Apple sign in error.*apple_sdk_timeout/
+      )
+    })
+
+    it('includes the underlying error code when present', async () => {
+      const sdkError = Object.assign(new Error('failure'), {
+        code: 'ERR_KEYCHAIN'
+      })
+      performRequestMock.mockRejectedValueOnce(sdkError)
+
+      await expect(AppleSignInService.signIn()).rejects.toThrow(
+        /ERR_KEYCHAIN|failure/
+      )
+    })
+
+    it('passes the original error to Logger.error so Sentry sees the cause', async () => {
+      const underlying = new Error('cubist_unreachable')
+      performRequestMock.mockRejectedValueOnce(underlying)
+
+      await expect(AppleSignInService.signIn()).rejects.toThrow()
+
+      expect(Logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('cubist_unreachable'),
+        underlying
+      )
+    })
+  })
+
+  describe('preserved behavior', () => {
+    it('still throws USER_CANCELED when the user cancels', async () => {
+      const cancelled = Object.assign(new Error('cancelled'), {
+        code: 'CANCELED'
+      })
+      performRequestMock.mockRejectedValueOnce(cancelled)
+
+      await expect(AppleSignInService.signIn()).rejects.toThrow('USER_CANCELED')
+    })
+
+    it('preserves "empty token" detail through the catch', async () => {
+      performRequestMock.mockResolvedValueOnce({
+        identityToken: undefined,
+        user: 'u1'
+      })
+
+      await expect(AppleSignInService.signIn()).rejects.toThrow(
+        /iOS Apple sign in error: empty token/
+      )
+    })
+
+    it('preserves "user not found" detail through the catch', async () => {
+      performRequestMock.mockResolvedValueOnce({
+        identityToken: 'tok',
+        user: null
+      })
+
+      await expect(AppleSignInService.signIn()).rejects.toThrow(
+        /iOS Apple sign in error: user not found/
+      )
+    })
+
+    it('preserves "unauthorized user" detail through the catch', async () => {
+      performRequestMock.mockResolvedValueOnce({
+        identityToken: 'tok',
+        user: 'u1'
+      })
+      getCredentialStateMock.mockResolvedValueOnce('NOT_FOUND')
+
+      await expect(AppleSignInService.signIn()).rejects.toThrow(
+        /iOS Apple sign in error.*unauthorized user/
+      )
+    })
+
+    it('returns the oidcToken on success', async () => {
+      performRequestMock.mockResolvedValueOnce({
+        identityToken: 'real-token',
+        user: 'u1'
+      })
+      getCredentialStateMock.mockResolvedValueOnce('AUTHORIZED')
+
+      await expect(AppleSignInService.signIn()).resolves.toEqual({
+        oidcToken: 'real-token'
+      })
+    })
+  })
+})

--- a/packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.ts
+++ b/packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.ts
@@ -1,6 +1,7 @@
 import appleAuth from '@invertase/react-native-apple-authentication'
 import { OidcPayload } from 'seedless/types'
 import Logger from 'utils/Logger'
+import { formatSignInErrorReason } from '../formatSignInErrorReason'
 import { AppleSigninServiceInterface } from './types'
 
 class AppleSigninService implements AppleSigninServiceInterface {
@@ -31,7 +32,7 @@ class AppleSigninService implements AppleSigninServiceInterface {
 
       if (credentialState !== appleAuth.State.AUTHORIZED) {
         Logger.error('iOS Apple sign in error: unauthorized user')
-        throw new Error('iOS Apple sign in error unauthorized user')
+        throw new Error('iOS Apple sign in error: unauthorized user')
       }
 
       return { oidcToken: identityToken }
@@ -43,8 +44,15 @@ class AppleSigninService implements AppleSigninServiceInterface {
       ) {
         throw new Error('USER_CANCELED')
       }
-      Logger.error('iOS Apple sign in error', error)
-      throw new Error('iOS Apple sign in error')
+      if (
+        error instanceof Error &&
+        error.message.startsWith('iOS Apple sign in error')
+      ) {
+        throw error
+      }
+      const reason = formatSignInErrorReason(error)
+      Logger.error(`iOS Apple sign in error: ${reason}`, error)
+      throw new Error(`iOS Apple sign in error: ${reason}`)
     }
   }
 }

--- a/packages/core-mobile/app/services/socialSignIn/formatSignInErrorReason.test.ts
+++ b/packages/core-mobile/app/services/socialSignIn/formatSignInErrorReason.test.ts
@@ -1,0 +1,63 @@
+import { formatSignInErrorReason } from './formatSignInErrorReason'
+
+describe('formatSignInErrorReason', () => {
+  it('returns the message for a plain Error', () => {
+    expect(formatSignInErrorReason(new Error('boom'))).toBe('boom')
+  })
+
+  it('prefixes with code when present', () => {
+    const e = Object.assign(new Error('boom'), { code: 'ERR_X' })
+    expect(formatSignInErrorReason(e)).toBe('ERR_X: boom')
+  })
+
+  it('omits code when value is undefined', () => {
+    const e = Object.assign(new Error('boom'), { code: undefined })
+    expect(formatSignInErrorReason(e)).toBe('boom')
+  })
+
+  it('omits code when value is null', () => {
+    const e = Object.assign(new Error('boom'), { code: null })
+    expect(formatSignInErrorReason(e)).toBe('boom')
+  })
+
+  it('handles non-Error throwables (string)', () => {
+    expect(formatSignInErrorReason('something failed')).toBe('something failed')
+  })
+
+  it('handles non-Error throwables (plain object with code)', () => {
+    expect(
+      formatSignInErrorReason({ code: 'X', toString: () => 'plainObj' })
+    ).toBe('X: plainObj')
+  })
+
+  it('does NOT throw when error has a getter that throws on .message', () => {
+    class HostileMessage extends Error {
+      get message(): string {
+        throw new Error('inner failure')
+      }
+    }
+    const e = new HostileMessage()
+    expect(() => formatSignInErrorReason(e)).not.toThrow()
+    expect(typeof formatSignInErrorReason(e)).toBe('string')
+  })
+
+  it('does NOT throw when error has a getter that throws on .code', () => {
+    class HostileCode extends Error {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      get code(): any {
+        throw new Error('inner failure')
+      }
+    }
+    const e = new HostileCode('readable')
+    expect(() => formatSignInErrorReason(e)).not.toThrow()
+    expect(typeof formatSignInErrorReason(e)).toBe('string')
+  })
+
+  it('does NOT throw when error is null', () => {
+    expect(() => formatSignInErrorReason(null)).not.toThrow()
+  })
+
+  it('does NOT throw when error is undefined', () => {
+    expect(() => formatSignInErrorReason(undefined)).not.toThrow()
+  })
+})

--- a/packages/core-mobile/app/services/socialSignIn/formatSignInErrorReason.ts
+++ b/packages/core-mobile/app/services/socialSignIn/formatSignInErrorReason.ts
@@ -1,0 +1,14 @@
+export const formatSignInErrorReason = (error: unknown): string => {
+  try {
+    const detail = error instanceof Error ? error.message : String(error)
+    if (error && typeof error === 'object' && 'code' in error) {
+      const value = (error as { code: unknown }).code
+      if (value !== undefined && value !== null) {
+        return `${String(value)}: ${detail}`
+      }
+    }
+    return detail
+  } catch {
+    return 'unserializable error'
+  }
+}

--- a/packages/core-mobile/app/services/socialSignIn/google/GoogleSigninService.test.ts
+++ b/packages/core-mobile/app/services/socialSignIn/google/GoogleSigninService.test.ts
@@ -72,6 +72,17 @@ describe('GoogleSigninService', () => {
         sdkError
       )
     })
+
+    it('preserves detail when the SDK throws a non-Error value', async () => {
+      signInMock.mockRejectedValueOnce({
+        code: 'PLAY_SERVICES_NOT_AVAILABLE',
+        message: 'play services missing'
+      })
+
+      await expect(GoogleSigninService.signin()).rejects.toThrow(
+        /PLAY_SERVICES_NOT_AVAILABLE/
+      )
+    })
   })
 
   describe('preserved behavior', () => {

--- a/packages/core-mobile/app/services/socialSignIn/google/GoogleSigninService.test.ts
+++ b/packages/core-mobile/app/services/socialSignIn/google/GoogleSigninService.test.ts
@@ -1,0 +1,105 @@
+import Logger from 'utils/Logger'
+
+jest.mock('@react-native-google-signin/google-signin', () => {
+  const SIGN_IN_CANCELLED = 'SIGN_IN_CANCELLED'
+  return {
+    __esModule: true,
+    GoogleSignin: {
+      configure: jest.fn(),
+      signIn: jest.fn()
+    },
+    statusCodes: { SIGN_IN_CANCELLED },
+    isErrorWithCode: (e: unknown) =>
+      typeof e === 'object' && e !== null && 'code' in e
+  }
+})
+
+jest.mock('react-native-config', () => ({
+  __esModule: true,
+  default: {
+    GOOGLE_OAUTH_CLIENT_WEB_ID: 'test-web-id',
+    GOOGLE_OAUTH_CLIENT_IOS_ID: 'test-ios-id'
+  }
+}))
+
+jest.spyOn(Logger, 'error').mockImplementation(jest.fn())
+jest.spyOn(Logger, 'warn').mockImplementation(jest.fn())
+
+const {
+  GoogleSignin,
+  statusCodes
+} = require('@react-native-google-signin/google-signin')
+
+const signInMock = GoogleSignin.signIn as jest.Mock
+
+const GoogleSigninService = require('./GoogleSigninService').default as {
+  signin: () => Promise<{ oidcToken: string }>
+}
+
+describe('GoogleSigninService', () => {
+  describe('generic catch (non-cancellation, non-empty-token)', () => {
+    it('rethrows the original Error so the caller sees underlying detail', async () => {
+      const underlying = new Error('Network request failed')
+      signInMock.mockRejectedValueOnce(underlying)
+
+      await expect(GoogleSigninService.signin()).rejects.toThrow(
+        'Network request failed'
+      )
+    })
+
+    it('logs the underlying error message to Sentry (not just generic title)', async () => {
+      const underlying = new Error('Network request failed')
+      signInMock.mockRejectedValueOnce(underlying)
+
+      await expect(GoogleSigninService.signin()).rejects.toThrow()
+
+      expect(Logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Network request failed'),
+        underlying
+      )
+    })
+
+    it('logs the underlying error code to Sentry when present', async () => {
+      const sdkError = Object.assign(new Error('something bad'), {
+        code: 'NETWORK_ERROR'
+      })
+      signInMock.mockRejectedValueOnce(sdkError)
+
+      await expect(GoogleSigninService.signin()).rejects.toThrow()
+
+      expect(Logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('NETWORK_ERROR'),
+        sdkError
+      )
+    })
+  })
+
+  describe('preserved behavior', () => {
+    it('still throws USER_CANCELED when the user cancels', async () => {
+      const cancelled = Object.assign(new Error('cancelled'), {
+        code: statusCodes.SIGN_IN_CANCELLED
+      })
+      signInMock.mockRejectedValueOnce(cancelled)
+
+      await expect(GoogleSigninService.signin()).rejects.toThrow(
+        'USER_CANCELED'
+      )
+    })
+
+    it('throws "empty token" when idToken is missing', async () => {
+      signInMock.mockResolvedValueOnce({ data: { idToken: undefined } })
+
+      await expect(GoogleSigninService.signin()).rejects.toThrow(
+        /Google sign in error: empty token/
+      )
+    })
+
+    it('returns the oidcToken on success', async () => {
+      signInMock.mockResolvedValueOnce({ data: { idToken: 'real-token' } })
+
+      await expect(GoogleSigninService.signin()).resolves.toEqual({
+        oidcToken: 'real-token'
+      })
+    })
+  })
+})

--- a/packages/core-mobile/app/services/socialSignIn/google/GoogleSigninService.ts
+++ b/packages/core-mobile/app/services/socialSignIn/google/GoogleSigninService.ts
@@ -6,6 +6,7 @@ import {
 import Config from 'react-native-config'
 import Logger from 'utils/Logger'
 import { OidcPayload } from 'seedless/types'
+import { formatSignInErrorReason } from '../formatSignInErrorReason'
 
 if (!Config.GOOGLE_OAUTH_CLIENT_WEB_ID) {
   Logger.warn(
@@ -56,7 +57,8 @@ class GoogleSigninService {
       ) {
         throw error
       }
-      Logger.error('Google sign in error', error)
+      const reason = formatSignInErrorReason(error)
+      Logger.error(`Google sign in error: ${reason}`, error)
       throw error instanceof Error ? error : new Error('Google sign in error')
     }
   }

--- a/packages/core-mobile/app/services/socialSignIn/google/GoogleSigninService.ts
+++ b/packages/core-mobile/app/services/socialSignIn/google/GoogleSigninService.ts
@@ -59,7 +59,9 @@ class GoogleSigninService {
       }
       const reason = formatSignInErrorReason(error)
       Logger.error(`Google sign in error: ${reason}`, error)
-      throw error instanceof Error ? error : new Error('Google sign in error')
+      throw error instanceof Error
+        ? error
+        : new Error(`Google sign in error: ${reason}`)
     }
   }
 

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -101,7 +101,19 @@ export type AnalyticsEvents = {
   SeedlessExportPhraseHidden: undefined
   SeedlessExportPhraseRevealed: undefined
   SeedlessMfaVerified: { type: string }
-  SeedlessLoginFailed: { reason: string }
+  SeedlessLoginFailed: {
+    reason: string
+    stage?:
+      | 'oidc-token'
+      | 'identity-proof'
+      | 'register'
+      | 'auth'
+      | 'secure-store'
+      | 'post-auth'
+    oidcProvider?: number
+    errorName?: string
+    errorCode?: string
+  }
   SeedlessRegisterTOTPStartFailed: undefined
   SeedlessSignIn: { oidcProvider: number }
   SeedlessSignUp: { oidcProvider: number }


### PR DESCRIPTION
## Summary

Observability-only PR for the seedless login/register flow. Two coupled changes that, together, take `SeedlessLoginFailed` from a single 1,485-event umbrella into a structured, per-stage signal — and tighten Sentry grouping so we can finally see what's actually breaking.

**Context:** Investigation of Android failure analytics for March 1 – April 15, 2026 found `SeedlessLoginFailed` was 53% of all failure-devices but had a single `reason: string` umbrella for *every* error along the OIDC pipeline. A second PostHog export with the plaintext `reason` revealed that 35% are Google sign-in errors, 34% are Apple sign-in errors (previously hidden — Apple Sentry issue `CORE-REACT-NATIVE-574` has 875 users since 2025-03-28), 12% are network failures, 10% are cubesigner `INTERNAL_ERROR`. Per-stage tagging plus preserving underlying error detail unblocks the next round of fixes.

### What changed

- **`packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.android.ts`** — generic catch now preserves the underlying SDK error message and code, both in the rethrown `Error` and in the `Logger.error` message that goes to Sentry. Pass-through for already-structured errors (empty token) so detail isn't double-wrapped.
- **`packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.ts`** — same fix for iOS. Plus drive-by punctuation fix on the unauthorized-user message (was missing a colon).
- **`packages/core-mobile/app/services/socialSignIn/google/GoogleSigninService.ts`** — `Logger.error` now interpolates underlying detail so Sentry stops grouping all SDK errors under one fingerprint.
- **`packages/core-mobile/app/services/socialSignIn/formatSignInErrorReason.ts`** (new) — small, exception-safe helper that formats `${code}: ${detail}` from any error shape (including hostile getters). Shared by all three services.
- **`packages/core-mobile/app/new/features/onboarding/hooks/useSeedlessRegister.ts`** — `register()` now tracks a `stage` (`oidc-token` → `identity-proof` → `register` → `auth` → `secure-store` → `post-auth`) through the pipeline and includes it plus `oidcProvider`, `errorName`, and `errorCode` in the captured `SeedlessLoginFailed` event. Extraction is via an exception-safe `extractErrorContext` so hostile error shapes don't take down the catch block. Stage label is set to `'register'` when `register()` returns the `ERROR` sentinel (previously misattributed to `'post-auth'`).
- **`packages/core-mobile/app/types/analytics.ts`** — extends `SeedlessLoginFailed` with optional `stage`, `oidcProvider`, `errorName`, `errorCode`. Additive; existing PostHog dashboards reading only `reason` keep working.

### Behavior change?

User-facing flow unchanged. `USER_CANCELED` still skips analytics. Empty-token / user-not-found / unauthorized branches still throw their existing structured messages (now passed through the outer catch instead of being swallowed). Same routing on success.

The Sentry fingerprints **will shift** for the affected services — alerts pinned to the constant string `'Android Apple sign in error'` (etc.) will stop firing as the per-detail buckets emerge. This is the whole point. Flagged here so SRE/observability folks aren't surprised.

### Tests

46 tests in 6 suites, all passing:

- `formatSignInErrorReason.test.ts` (new) — 10 tests, including hostile-getter / null / undefined inputs.
- `AppleSignInService.android.test.ts` (new) — 6 tests covering generic catch, USER_CANCELED, empty-token, success.
- `AppleSignInService.test.ts` (new) — 8 tests including the iOS structured paths (empty token / user not found / unauthorized).
- `GoogleSigninService.test.ts` (new) — 6 tests covering Sentry-detail capture and existing rethrow behavior.
- `useSeedlessRegister.test.ts` (new) — 11 tests, one per pipeline stage plus the `result === ERROR` and hostile-getter cases.
- `app/seedless/store/listeners.test.ts` (existing, regression check) — 5 tests, all still pass.

## Dev testing

**Build numbers:**
iOS: 8470
Android: 8471


Reviewer steps:

- [ ] **Smoke: Google sign-up.** Fresh app, tap Continue with Google, complete sign-in. Verify normal flow + a `SeedlessSignUp` event.
- [ ] **Smoke: Apple sign-up (Android).** Fresh app, tap Continue with Apple. Verify normal flow + a `SeedlessSignUp` event.
- [ ] **Smoke: Apple sign-up (iOS).** Same as above on iOS.
- [ ] **Smoke: Google sign-in (existing user).** Verify a `SeedlessSignIn` event.
- [ ] **Cancel path:** Tap Continue with Google, cancel out of the OAuth sheet. Verify NO `SeedlessLoginFailed` analytics event fires.
- [ ] **Failure visibility (Apple Android):** Force a failure (e.g. block network in OS settings) and trigger Continue with Apple. Verify the `SeedlessLoginFailed` PostHog event now has populated `stage`, `oidcProvider`, and a `reason` containing actual detail (not just `'Android Apple sign in error'`).
- [ ] **Sentry side:** After a forced failure, find the corresponding event in Sentry and confirm the issue title now includes the underlying SDK detail (not just the generic title).
- [ ] **Existing PostHog dashboards:** Confirm dashboards reading `reason` still work (additive change only).