### PR TITLE
Auto-retry Fusion 5006 source-tx reverts; friendlier error message

### DIFF
--- a/packages/core-mobile/app/new/features/swap/utils/fusionErrors.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/fusionErrors.test.ts
@@ -285,6 +285,40 @@ describe('shouldRetryWithNextQuote', () => {
     ).toBe(true)
   })
 
+  it('should return true for transaction-reverted errors (errorCode 5006)', () => {
+    // SwapContext rethrow shape: `Transfer failed: ${errorReason ?? errorCode}`
+    expect(
+      shouldRetryWithNextQuote(
+        new Error('Transfer failed: Source transaction was reverted')
+      )
+    ).toBe(true)
+    expect(shouldRetryWithNextQuote(new Error('Transfer failed: 5006'))).toBe(
+      true
+    )
+    // Direct SDK errorReason text (case-insensitive)
+    expect(
+      shouldRetryWithNextQuote(new Error('source transaction was reverted'))
+    ).toBe(true)
+    expect(
+      shouldRetryWithNextQuote(new Error('Target transaction was reverted'))
+    ).toBe(true)
+  })
+
+  it('should NOT retry on ERC20 approval reverts or other generic "transaction was reverted" phrasings', () => {
+    // The SDK's Markr handler also emits "transaction was reverted" phrasings
+    // for ERC20 approval reverts. Those are not gas-OOG and shouldn't auto-retry.
+    expect(
+      shouldRetryWithNextQuote(
+        new Error('Transfer failed: ERC20 approval transaction was reverted')
+      )
+    ).toBe(false)
+    expect(
+      shouldRetryWithNextQuote(
+        new Error('the transaction was reverted by the EVM')
+      )
+    ).toBe(false)
+  })
+
   it('should return false for user rejection errors', () => {
     expect(shouldRetryWithNextQuote(new Error('user rejected'))).toBe(false)
   })
@@ -336,6 +370,32 @@ describe('getSwapErrorMessage', () => {
     expect(getSwapErrorMessage(new Error('gas estimation failed'))).toBe(
       'Unable to estimate gas. The swap may fail.'
     )
+  })
+
+  it('should return retry-friendly message for transaction-reverted errors', () => {
+    expect(
+      getSwapErrorMessage(
+        new Error('Transfer failed: Source transaction was reverted')
+      )
+    ).toBe('Swap failed on-chain. Please try again with a fresh quote.')
+    expect(
+      getSwapErrorMessage(new Error('Target transaction was reverted'))
+    ).toBe('Swap failed on-chain. Please try again with a fresh quote.')
+    expect(getSwapErrorMessage(new Error('Transfer failed: 5006'))).toBe(
+      'Swap failed on-chain. Please try again with a fresh quote.'
+    )
+  })
+
+  it('lets sibling branches win when they match earlier in the cascade', () => {
+    // If a future SDK message contains both "slippage" and "5006", the
+    // slippage branch wins — locks in current cascade order so behaviour
+    // doesn't silently flip if the cascade is reordered later.
+    expect(
+      getSwapErrorMessage(new Error('slippage tolerance exceeded (code 5006)'))
+    ).toBe('Price moved too much. Try increasing slippage tolerance.')
+    expect(
+      getSwapErrorMessage(new Error('quote expired during 5006 path'))
+    ).toBe('Quote expired. Please try again.')
   })
 
   it('should return original message for unrecognized errors', () => {

--- a/packages/core-mobile/app/new/features/swap/utils/fusionErrors.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/fusionErrors.ts
@@ -228,11 +228,45 @@ export function isInvalidResponseError(error: unknown): boolean {
 }
 
 /**
+ * Check if error is a Fusion `TRANSACTION_REVERTED` (errorCode 5006) on the
+ * source or target leg. Matches:
+ *   - "Source transaction was reverted" (SDK errorReason for source leg)
+ *   - "Target transaction was reverted" (SDK errorReason for target leg)
+ *   - The numeric `5006` token from `SwapContext.swap`'s
+ *     `Transfer failed: ${errorReason ?? errorCode}` rethrow when only the
+ *     code is present (no errorReason)
+ *
+ * Scope intentionally narrow: leaves out generic "transaction was reverted"
+ * substrings to avoid catching ERC20 approval reverts, user-rejection
+ * phrasings, or unrelated SDK messages.
+ *
+ * Effective only on synchronously-reverted paths (AVALANCHE_EVM same-chain
+ * `waitForTransactionReceipt` returning `reverted`, and Markr ERC20 approval
+ * reverts). 5006s surfaced via the post-`source-pending` tracking listener
+ * resolve through a different code path and are not retried by this hook.
+ */
+export function isTransactionRevertedError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+
+  const message = error.message
+  const lower = message.toLowerCase()
+  return (
+    lower.includes('source transaction was reverted') ||
+    lower.includes('target transaction was reverted') ||
+    /\b5006\b/.test(message)
+  )
+}
+
+/**
  * Determine if we should retry with next quote
  * Only retry for specific error types
  */
 export function shouldRetryWithNextQuote(error: unknown): boolean {
-  return isGasEstimationError(error) || isInvalidResponseError(error)
+  return (
+    isGasEstimationError(error) ||
+    isInvalidResponseError(error) ||
+    isTransactionRevertedError(error)
+  )
 }
 
 /**
@@ -261,6 +295,13 @@ export function getSwapErrorMessage(error: unknown): string {
   }
   if (message.includes('gas estimation')) {
     return 'Unable to estimate gas. The swap may fail.'
+  }
+  // Fusion errorCode 5006 — most commonly OOG sub-call failures upstream of
+  // our gas-margin clamp. The helper handles case-insensitive matching
+  // against the same walked error so the SDK's Title-Case
+  // "Source transaction was reverted" is recognised.
+  if (isTransactionRevertedError(actualError ?? error)) {
+    return 'Swap failed on-chain. Please try again with a fresh quote.'
   }
 
   // Default to original message


### PR DESCRIPTION
## Summary

Small UX-only change to the Fusion swap flow that handles errorCode 5006 (`TRANSACTION_REVERTED`) more gracefully:

1. **Auto-retry with next quote** when the swap-execute path throws a 5006 source/target-tx revert. `shouldRetryWithNextQuote` already auto-advances on gas-estimation and aggregator-response errors; this adds the on-chain revert family to the same hook.
2. **Friendlier error message.** When the user does see a 5006 (e.g. retries exhausted, or no alternate quote available), `getSwapErrorMessage` now returns `"Swap failed on-chain. Please try again with a fresh quote."` instead of the raw SDK string.

## Why

A May 2026 root-cause investigation on `SwapFailed` (375 Android + 40 iOS devices) decoded 100 random source-tx hashes against Avalanche RPC + Routescan:

- **98 of 100 (98%) reverted by exhausting their gas limit** (gasUsed ≥ 95% of gasLimit; most pinned at 99-100%).
- The on-chain return data is `0x1425ea42` (`FailedInnerCall()`, OZ `Address.sol`) — the exact signature of a sub-call running out of gas.
- The Fusion SDK's `estimateNativeFee` is consistently under-reporting actual gas consumption on AVAX C-Chain same-chain swaps; our existing 20% client-side margin (`FUSION_TRANSFER_GAS_MARGIN_BPS`) is not enough.

Re-quoting and re-estimating on the next quote has a real chance of succeeding, so auto-retry is a sensible UX. The companion change is a PostHog feature-flag bump on `FUSION_TRANSFER_GAS_MARGIN_BPS` (out of scope here — different surface, different owner). The slippage default is unchanged because the data does not support slippage being the cause.

## Scope (what this PR does NOT do)

The retry hook only fires when `transferAsset` resolves with `transfer.status === 'failed'` synchronously. That covers two paths in the Fusion SDK:

- **AVALANCHE_EVM same-chain swaps** where `waitForTransactionReceipt` reports `reverted` synchronously (the dominant 98% in our data — reverts to `Transfer failed: 5006`).
- **Markr ERC20 approval reverts** that synchronously return `{errorCode:5006, errorReason:'Source transaction was reverted'}`.

5006s that surface **after** `transferAsset` resolves with `source-pending` — i.e. observed via the SDK's tracking listener (Markr/Lombard/wrap-unwrap cross-chain swaps) — flow through `swap/store/listeners.ts` rather than `SwapContext.swap`'s catch, and are NOT retried by this PR. Those would need a separate change to the listener path.

The "ERC20 approval transaction was reverted" Markr handler emission is **deliberately not retried** — approval failures aren't gas-related and re-quoting wouldn't help. The substring matchers are scoped narrowly to `'source transaction was reverted'` and `'target transaction was reverted'` plus the word-bounded `5006` token to keep approval reverts out.

## Behavior caveats worth noting in review

- **Auto-retry consumes gas.** When the retry path fires, the user has already paid gas for one reverted on-chain attempt and will pay again for the second. `swap()` shows the snackbar `'Swap failed, trying next available'`, but there's no opt-out. Reasonable trade-off given the 98% gas-OOG rate, but worth being explicit.
- **Sentry fingerprint impact:** none. This change doesn't add or modify `Logger.error` calls — only the error-message path that's surfaced to the UI.
- **Cascade priority in `getSwapErrorMessage`:** the new branch is at the bottom of the if-cascade. If a future SDK message contains both `slippage` and `5006`, slippage wins (locked in by a new test).

## Files

- `packages/core-mobile/app/new/features/swap/utils/fusionErrors.ts` — new `isTransactionRevertedError` helper, added to `shouldRetryWithNextQuote`, new branch in `getSwapErrorMessage`.
- `packages/core-mobile/app/new/features/swap/utils/fusionErrors.test.ts` — 4 new tests: positive matches, negative match for ERC20 approval reverts, error-message coverage, cascade priority.

## Tests

- 52/52 fusionErrors tests pass (4 new).
- 441/441 swap tests pass overall.
- `yarn tsc` clean.
- ESLint clean.

## Dev testing

**Build numbers:** _to be filled in once Bitrise has built this branch._

Reviewer steps:

- [ ] **Unit:** confirm new tests pass on CI.
- [ ] **Manual: simulate a 5006-style failure** by lowering `FUSION_TRANSFER_GAS_MARGIN_BPS` to 0 in PostHog for your test user, then attempting an AVAX→AVAX swap on a route likely to OOG. Verify: snackbar `'Swap failed, trying next available'`, then second attempt fires automatically. If both attempts fail, confirm the user-facing error reads `"Swap failed on-chain. Please try again with a fresh quote."` rather than the raw SDK message.
- [ ] **Manual: cancellation still works.** Cancel a swap during the wallet sheet. Confirm no retry fires (existing `isUserRejectionError` short-circuits the catch path).
- [ ] **Manual: legacy retry paths unchanged.** Trigger a gas-estimation error or aggregator-invalid-response error on a route. Verify the auto-advance still fires as before.
- [ ] **Sentry/PostHog after deploy:** SwapFailed event count should drop modestly even before the gas-margin flag is bumped, because the auto-retry recovers a fraction of the synchronous 5006s.