### PR TITLE
skip fee estimation when quote has already expired

### DIFF
--- a/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.test.ts
@@ -1,0 +1,200 @@
+import type { Quote } from '../types'
+import { isQuoteUsable, isUserStateError } from './useFeeEstimation.helpers'
+
+describe('isQuoteUsable', () => {
+  const buildQuote = (expiresAt: number): Quote => ({ expiresAt } as Quote)
+
+  it('returns true when expiresAt is comfortably in the future', () => {
+    const future = Math.floor(Date.now() / 1000) + 60
+    expect(isQuoteUsable(buildQuote(future))).toBe(true)
+  })
+
+  it('returns false when expiresAt has already passed', () => {
+    const past = Math.floor(Date.now() / 1000) - 60
+    expect(isQuoteUsable(buildQuote(past))).toBe(false)
+  })
+
+  it('returns false when expiresAt equals current second (matches SDK throw condition `<=`)', () => {
+    const now = Math.floor(Date.now() / 1000)
+    expect(isQuoteUsable(buildQuote(now))).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isQuoteUsable(null)).toBe(false)
+  })
+
+  it('returns false when expiresAt is 0 (epoch — long past)', () => {
+    expect(isQuoteUsable(buildQuote(0))).toBe(false)
+  })
+
+  it('returns false when expiresAt is negative', () => {
+    expect(isQuoteUsable(buildQuote(-1))).toBe(false)
+  })
+
+  it('returns false when expiresAt is NaN', () => {
+    expect(isQuoteUsable(buildQuote(Number.NaN))).toBe(false)
+  })
+})
+
+describe('isUserStateError', () => {
+  it('matches raw RPC -32000 insufficient funds', () => {
+    const error = {
+      code: -32000,
+      message:
+        'failed with 40000000 gas: insufficient funds for gas * price + value: address 0x... have 0 want 1000'
+    }
+    expect(isUserStateError(error)).toBe(true)
+  })
+
+  it('matches wrapped SDK error via causedByInsufficientFunds', () => {
+    const error = {
+      causedByInsufficientFunds: () => true
+    }
+    expect(isUserStateError(error)).toBe(true)
+  })
+
+  it('matches transfer amount exceeds balance via details.cause.shortMessage', () => {
+    const error = {
+      details: {
+        cause: { shortMessage: 'ERC20: transfer amount exceeds balance' }
+      }
+    }
+    expect(isUserStateError(error)).toBe(true)
+  })
+
+  it('matches transfer amount exceeds allowance', () => {
+    const error = {
+      details: {
+        cause: { shortMessage: 'ERC20: transfer amount exceeds allowance' }
+      }
+    }
+    expect(isUserStateError(error)).toBe(true)
+  })
+
+  it('matches WAVAX unwrap burn balance', () => {
+    const error = {
+      details: {
+        cause: { shortMessage: 'ERC20: burn amount exceeds balance' }
+      }
+    }
+    expect(isUserStateError(error)).toBe(true)
+  })
+
+  it('matches Pangolin transferFrom insufficient allowance', () => {
+    const error = {
+      details: {
+        cause: {
+          shortMessage:
+            'Png::transferFrom: transfer amount exceeds spender allowance'
+        }
+      }
+    }
+    expect(isUserStateError(error)).toBe(true)
+  })
+
+  it('matches Pangolin _transferTokens insufficient balance', () => {
+    const error = {
+      details: {
+        cause: {
+          shortMessage: 'Png::_transferTokens: transfer amount exceeds balance'
+        }
+      }
+    }
+    expect(isUserStateError(error)).toBe(true)
+  })
+
+  it('does NOT match bug-class Pangolin reverts (zero-address transfer)', () => {
+    const error = {
+      details: {
+        cause: {
+          shortMessage:
+            'Png::_transferTokens: cannot transfer from the zero address'
+        }
+      }
+    }
+    expect(isUserStateError(error)).toBe(false)
+  })
+
+  it('does NOT match TargetCallFailed (the 5006 SDK family)', () => {
+    const error = {
+      details: {
+        data: '0xeda86850',
+        cause: { shortMessage: 'Execution reverted: TargetCallFailed()' }
+      }
+    }
+    expect(isUserStateError(error)).toBe(false)
+  })
+
+  it('does NOT match Panic(17) reverts', () => {
+    const error = {
+      details: {
+        cause: { shortMessage: 'Panic(17)' }
+      }
+    }
+    expect(isUserStateError(error)).toBe(false)
+  })
+
+  it('does NOT match UnsupportedTokenOut', () => {
+    const error = {
+      details: {
+        cause: { shortMessage: 'Execution reverted: UnsupportedTokenOut()' }
+      }
+    }
+    expect(isUserStateError(error)).toBe(false)
+  })
+
+  it('does NOT match unknown errors (fail open, capture by default)', () => {
+    expect(isUserStateError(new Error('something unexpected'))).toBe(false)
+  })
+
+  it('does NOT match QUOTE_EXPIRED (different fix path)', () => {
+    const error = {
+      name: 'InvalidParamsError',
+      message: 'Quote expired 5 seconds ago.'
+    }
+    expect(isUserStateError(error)).toBe(false)
+  })
+
+  it('does NOT match null', () => {
+    expect(isUserStateError(null)).toBe(false)
+  })
+
+  it('does NOT match a primitive', () => {
+    expect(isUserStateError('oops')).toBe(false)
+  })
+
+  it('does NOT match -32000 without insufficient funds in message', () => {
+    expect(
+      isUserStateError({ code: -32000, message: 'some other failure' })
+    ).toBe(false)
+  })
+
+  it('matches string-coded -32000 (some RPC providers emit code as a string)', () => {
+    const error = {
+      code: '-32000',
+      message: 'insufficient funds for gas * price + value'
+    }
+    expect(isUserStateError(error)).toBe(true)
+  })
+
+  it('does not throw when code is a symbol (Number(symbol) would throw)', () => {
+    const error = {
+      code: Symbol('-32000'),
+      message: 'insufficient funds for gas * price + value'
+    }
+    expect(() => isUserStateError(error)).not.toThrow()
+    expect(isUserStateError(error)).toBe(false)
+  })
+
+  it('falls through when causedByInsufficientFunds throws', () => {
+    const error = {
+      causedByInsufficientFunds: () => {
+        throw new Error('boom')
+      }
+    }
+    // Should NOT crash and should NOT silently match — fall through to other
+    // matchers; with no other match it returns false so caller still captures.
+    expect(() => isUserStateError(error)).not.toThrow()
+    expect(isUserStateError(error)).toBe(false)
+  })
+})

--- a/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.test.ts
@@ -1,4 +1,43 @@
-import { getFingerprintForFeeEstimationError } from './useFeeEstimation.helpers'
+import type { Quote } from '../types'
+import {
+  getFingerprintForFeeEstimationError,
+  isQuoteUsable
+} from './useFeeEstimation.helpers'
+
+describe('isQuoteUsable', () => {
+  const buildQuote = (expiresAt: number): Quote => ({ expiresAt } as Quote)
+
+  it('returns true when expiresAt is comfortably in the future', () => {
+    const future = Math.floor(Date.now() / 1000) + 60
+    expect(isQuoteUsable(buildQuote(future))).toBe(true)
+  })
+
+  it('returns false when expiresAt has already passed', () => {
+    const past = Math.floor(Date.now() / 1000) - 60
+    expect(isQuoteUsable(buildQuote(past))).toBe(false)
+  })
+
+  it('returns false when expiresAt equals current second (matches SDK throw condition `<=`)', () => {
+    const now = Math.floor(Date.now() / 1000)
+    expect(isQuoteUsable(buildQuote(now))).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isQuoteUsable(null)).toBe(false)
+  })
+
+  it('returns false when expiresAt is 0 (epoch — long past)', () => {
+    expect(isQuoteUsable(buildQuote(0))).toBe(false)
+  })
+
+  it('returns false when expiresAt is negative', () => {
+    expect(isQuoteUsable(buildQuote(-1))).toBe(false)
+  })
+
+  it('returns false when expiresAt is NaN', () => {
+    expect(isQuoteUsable(buildQuote(Number.NaN))).toBe(false)
+  })
+})
 
 describe('getFingerprintForFeeEstimationError', () => {
   it('returns details.data when present', () => {

--- a/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.ts
@@ -1,0 +1,105 @@
+import type { Quote } from '../types'
+
+/**
+ * Type guard mirroring the SDK's expired-quote check from
+ * `transferManager.estimateNativeFee`: the SDK throws
+ * `InvalidParamsError(QUOTE_EXPIRED)` when
+ * `quote.expiresAt <= Math.floor(Date.now() / 1000)`. Use this guard before
+ * calling `FusionService.estimateNativeFee` so we skip the round-trip entirely
+ * for stale quotes. The narrowing form lets callers use the narrowed `Quote`
+ * inside the truthy branch without a non-null assertion.
+ */
+export const isQuoteUsable = (quote: Quote | null): quote is Quote => {
+  if (!quote) return false
+  const now = Math.floor(Date.now() / 1000)
+  return quote.expiresAt > now
+}
+
+/**
+ * Allowlist of contract revert reasons that represent expected user state
+ * (insufficient balance, insufficient allowance) rather than SDK or contract
+ * bugs. Each entry was sourced from the cross-platform investigation by
+ * inspecting the corresponding contract source — anything balance- or
+ * allowance-related is user state. Bug-class reverts (`TargetCallFailed`,
+ * `Panic`, `UnsupportedTokenOut`) are deliberately excluded so they continue
+ * to fire Sentry events.
+ */
+const USER_STATE_REVERT_REASONS: readonly string[] = [
+  'ERC20: transfer amount exceeds balance',
+  'ERC20: transfer amount exceeds allowance',
+  'TRANSFER_AMOUNT_EXCEEDS_ALLOWANCE',
+  // Pangolin: explicit full-message matches per contract source. A bare
+  // `Png::transferFrom` prefix would also swallow bug-class reverts that share
+  // it (zero-address transfers, blacklists, paused-token, etc.), which we
+  // still want to capture.
+  'Png::transferFrom: transfer amount exceeds spender allowance',
+  'Png::_transferTokens: transfer amount exceeds balance',
+  'ERC20: burn amount exceeds balance'
+]
+
+/**
+ * Returns true when `error` represents an expected user-state rejection
+ * (insufficient native funds, insufficient ERC20 balance/allowance) rather
+ * than an SDK or contract bug. The Sentry capture path in `useFeeEstimation`
+ * skips capture when this returns true — the user already gets an inline
+ * validation error via `useFeeValidation → canSwap`, so Sentry doesn't add
+ * value here and the noise pollutes the issue list.
+ *
+ * Fails open: returns false for unknown shapes so we never silence something
+ * we haven't classified.
+ */
+export const isUserStateError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') return false
+
+  // Raw RPC -32000 insufficient funds (the un-wrapped path that lands in 9X6).
+  // Coerce `code` via Number() because some RPC providers emit it as a string;
+  // narrow the type first because `Number(symbol)` throws and would break the
+  // fails-open contract.
+  if (
+    'code' in error &&
+    (typeof error.code === 'string' ||
+      typeof error.code === 'number' ||
+      typeof error.code === 'bigint') &&
+    Number(error.code) === -32000 &&
+    'message' in error &&
+    typeof error.message === 'string' &&
+    error.message.includes('insufficient funds')
+  ) {
+    return true
+  }
+
+  // SDK wrapper helper for insufficient-funds-causing errors. Wrapped in
+  // try/catch because the SDK helper is invoked on a foreign object and a
+  // future SDK regression could throw — we'd rather fall through and capture
+  // the error than let the helper take down the useEffect.
+  try {
+    if (
+      'causedByInsufficientFunds' in error &&
+      typeof error.causedByInsufficientFunds === 'function' &&
+      error.causedByInsufficientFunds() === true
+    ) {
+      return true
+    }
+  } catch {
+    // Helper threw; fall through to the next matcher. If nothing else matches
+    // we return false and the caller captures as before.
+  }
+
+  // Allowlisted contract revert reasons surfaced through the SDK's
+  // EstimateNativeFeeError → cause chain.
+  if (
+    'details' in error &&
+    error.details &&
+    typeof error.details === 'object' &&
+    'cause' in error.details &&
+    error.details.cause &&
+    typeof error.details.cause === 'object' &&
+    'shortMessage' in error.details.cause &&
+    typeof error.details.cause.shortMessage === 'string'
+  ) {
+    const msg = error.details.cause.shortMessage
+    return USER_STATE_REVERT_REASONS.some(reason => msg.includes(reason))
+  }
+
+  return false
+}

--- a/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.ts
@@ -1,3 +1,20 @@
+import type { Quote } from '../types'
+
+/**
+ * Type guard mirroring the SDK's expired-quote check from
+ * `transferManager.estimateNativeFee`: the SDK throws
+ * `InvalidParamsError(QUOTE_EXPIRED)` when
+ * `quote.expiresAt <= Math.floor(Date.now() / 1000)`. Use this guard before
+ * calling `FusionService.estimateNativeFee` so we skip the round-trip entirely
+ * for stale quotes. The narrowing form lets callers use the narrowed `Quote`
+ * inside the truthy branch without a non-null assertion.
+ */
+export const isQuoteUsable = (quote: Quote | null): quote is Quote => {
+  if (!quote) return false
+  const now = Math.floor(Date.now() / 1000)
+  return quote.expiresAt > now
+}
+
 /**
  * Builds a Sentry fingerprint for fee-estimation errors that propagated through
  * the SDK's EstimateNativeFeeError wrap. The on-chain revert signature

--- a/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.ts
@@ -6,13 +6,18 @@ import { selectFusionFeeUnitsMarginBps } from 'store/posthog'
 import type { NetworkWithCaip2ChainId } from 'store/network'
 import { useNetworkFee } from 'hooks/useNetworkFee'
 import { isEstimateNativeFeeError } from '@avalabs/fusion-sdk'
+import * as Sentry from '@sentry/react-native'
 import Logger from 'utils/Logger'
 import SentryService from 'services/sentry/SentryService'
 import { buildSentryFingerprint } from 'services/sentry/fingerprint'
-import { SentryTag } from 'services/sentry/types'
+import {
+  AllowedSentryBreadcrumbCategory,
+  SentryTag
+} from 'services/sentry/types'
 import FusionService from '../services/FusionService'
 import { logSdkError } from '../utils/fusionLogger'
 import type { Quote } from '../types'
+import { isQuoteUsable, isUserStateError } from './useFeeEstimation.helpers'
 import { buildFeeOptions } from './useMaxSwapAmount/utils'
 
 /**
@@ -46,20 +51,38 @@ export const useFeeEstimation = ({
     [feeUnitsMarginBps, networkFee]
   )
 
+  // Capture the usable quote up-front so the queryFn closure can rely on
+  // narrowing without a runtime re-check. TanStack v5 invokes the latest
+  // queryFn from the most recent `setOptions`, so each render's closure
+  // sees that render's `usableQuote`. Re-checking inside the closure would
+  // require returning `undefined` on the stale path, which v5 rejects with
+  // "data cannot be undefined" and would re-introduce the double-capture
+  // this guard is meant to eliminate.
+  const usableQuote = isQuoteUsable(quote) ? quote : null
+
   const { data, error, isFetching } = useQuery({
+    // Key on `usableQuote?.id` (not `quote?.id`) so the cache identity
+    // tracks usability: when a quote expires, the key flips to one with
+    // `undefined` in the id slot — a key that has never been fetched, so
+    // `data` is `undefined` instead of the previously-cached fee estimate.
+    // Without this, the queryFn would correctly switch to `skipToken` but
+    // React Query would still surface the cached `data` under the old key,
+    // and downstream consumers (`useFeeValidation`, `useMaxSwapAmount`)
+    // would validate against a stale estimate during the window between
+    // expiry and the next quote-stream push.
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: [
       ReactQueryKeys.FUSION_SWAP_FEE_ESTIMATE,
-      quote?.id,
+      usableQuote?.id,
       feeOptions.feeUnitsMarginBps,
       feeOptions.overrides?.maxFeePerGas.toString(),
       feeOptions.overrides?.maxPriorityFeePerGas.toString(),
       gasSafetyBps
     ],
-    queryFn: quote
+    queryFn: usableQuote
       ? async () => {
           const { totalFee, totalFeeWithoutMargin } =
-            await FusionService.estimateNativeFee(quote, feeOptions)
+            await FusionService.estimateNativeFee(usableQuote, feeOptions)
           const buffered =
             gasSafetyBps > 0
               ? (totalFee * (10000n + BigInt(gasSafetyBps))) / 10000n
@@ -73,6 +96,22 @@ export const useFeeEstimation = ({
 
   useEffect(() => {
     if (!error) return
+
+    // Suppress capture for known user-state errors (insufficient native AVAX,
+    // insufficient ERC20 balance/allowance). The UI already surfaces these via
+    // `useFeeValidation → canSwap`; Sentry doesn't add value and the noise
+    // dominates the swap-feature issue list when not filtered. We still leave
+    // a breadcrumb so investigators retain forensic context if a downstream
+    // (non-suppressed) error fires later in the same session.
+    if (isUserStateError(error)) {
+      Sentry.addBreadcrumb({
+        category: AllowedSentryBreadcrumbCategory.FeeEstimationUserState,
+        level: 'info',
+        message: '[useFeeEstimation] skipped user-state error'
+      })
+      return
+    }
+
     if (isEstimateNativeFeeError(error) && error.details) {
       Logger.warn('[useFeeEstimation] estimateNativeFee revert error', error)
       // Use captureMessage (not Logger.error) for Sentry so that BigInt values
@@ -88,9 +127,15 @@ export const useFeeEstimation = ({
     }
   }, [error])
 
+  // Belt-and-suspenders on top of the `usableQuote?.id` queryKey: even if a
+  // future TanStack option (placeholderData, keepPreviousData) ever surfaces
+  // cross-key data, gating the return on `usableQuote` keeps downstream
+  // consumers (`useFeeValidation`, `useMaxSwapAmount`) from validating /
+  // computing Max against a stale estimate. Returning `undefined` matches
+  // the existing "fee unavailable" semantics for the loading state.
   return {
-    gasFee: data?.buffered,
-    rawGasFee: data?.raw,
+    gasFee: usableQuote ? data?.buffered : undefined,
+    rawGasFee: usableQuote ? data?.raw : undefined,
     error,
     isFetching
   }

--- a/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.ts
@@ -12,7 +12,10 @@ import { SentryTag } from 'services/sentry/types'
 import FusionService from '../services/FusionService'
 import { logSdkError } from '../utils/fusionLogger'
 import type { Quote } from '../types'
-import { getFingerprintForFeeEstimationError } from './useFeeEstimation.helpers'
+import {
+  getFingerprintForFeeEstimationError,
+  isQuoteUsable
+} from './useFeeEstimation.helpers'
 import { buildFeeOptions } from './useMaxSwapAmount/utils'
 
 /**
@@ -46,6 +49,15 @@ export const useFeeEstimation = ({
     [feeUnitsMarginBps, networkFee]
   )
 
+  // Capture the usable quote up-front so the queryFn closure can rely on
+  // narrowing without a runtime re-check. TanStack v5 invokes the latest
+  // queryFn from the most recent `setOptions`, so each render's closure
+  // sees that render's `usableQuote`. Re-checking inside the closure would
+  // require returning `undefined` on the stale path, which v5 rejects with
+  // "data cannot be undefined" and would re-introduce the double-capture
+  // this guard is meant to eliminate.
+  const usableQuote = isQuoteUsable(quote) ? quote : null
+
   const { data, error, isFetching } = useQuery({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: [
@@ -56,10 +68,10 @@ export const useFeeEstimation = ({
       feeOptions.overrides?.maxPriorityFeePerGas.toString(),
       gasSafetyBps
     ],
-    queryFn: quote
+    queryFn: usableQuote
       ? async () => {
           const { totalFee, totalFeeWithoutMargin } =
-            await FusionService.estimateNativeFee(quote, feeOptions)
+            await FusionService.estimateNativeFee(usableQuote, feeOptions)
           const buffered =
             gasSafetyBps > 0
               ? (totalFee * (10000n + BigInt(gasSafetyBps))) / 10000n

--- a/packages/core-mobile/app/services/sentry/types.ts
+++ b/packages/core-mobile/app/services/sentry/types.ts
@@ -60,7 +60,8 @@ export const SentryTag = {
  */
 export const AllowedSentryBreadcrumbCategory = {
   ListenerMigration: 'listenerMigration',
-  ListenerReconciler: 'listenerReconciler'
+  ListenerReconciler: 'listenerReconciler',
+  FeeEstimationUserState: 'feeEstimationUserState'
 } as const
 
 export type AllowedSentryBreadcrumbCategory =


### PR DESCRIPTION
## Summary
- Adds an `isQuoteUsable(quote)` type guard in `useFeeEstimation` so we skip `FusionService.estimateNativeFee` when `quote.expiresAt <= now`. The Fusion SDK's `transferManager.estimateNativeFee` enforces the same check and throws `InvalidParamsError(QUOTE_EXPIRED)` when stale.
- Captures `usableQuote` in a `const` before the `useQuery` so the queryFn closure relies purely on the outer guard — no inner re-check (returning `undefined` from a v5 queryFn raises "data cannot be undefined" and would re-introduce double-capture).

## Why
The mobile hook has `staleTime: 0` and `retry: false`. TanStack v5 re-fires the queryFn on subscribe/focus/setOptions and the closure captures whatever `quote` was on the most recent render. If `useQuoteStreaming` hasn't rotated the quote since `expiresAt` passed, the SDK throws and we double-capture (unhandled rejection + useEffect logger).

Sentry impact, last 30d:
- `CORE-REACT-NATIVE-A95` (Android, `InvalidParamsError: QUOTE_EXPIRED`) — 960 users
- `CORE-REACT-NATIVE-9X8` (iOS, same throw, different bundle) — 353 users
- Combined unique users: 1,237

Investigation: https://www.notion.so/35a0e2bd518081908722e62e029170a7 (Findings revisions, Hypothesis A).

## Also includes: user-state error suppression (PR #3827)
PR #3827 was squash-merged onto this branch's head before this PR landed, so it now ships together. It adds:

- `isUserStateError(error)` helper that classifies fee-estimation errors as user state (insufficient native funds, insufficient ERC20 balance/allowance, allowlisted contract revert reasons) rather than SDK/contract bugs.
- A new `FeeEstimationUserState` breadcrumb category — when `isUserStateError` matches, the `useEffect` capture path drops a breadcrumb (so forensic context is retained if a later, non-suppressed error fires) and skips the Sentry `captureMessage`/`logSdkError` call. The UI still surfaces these to users via `useFeeValidation → canSwap`.
- Tightened Pangolin allowlist (responding to Copilot review): the bare `'Png::transferFrom'` substring was replaced with explicit full-message matches (`Png::transferFrom: transfer amount exceeds spender allowance` and `Png::_transferTokens: transfer amount exceeds balance`), so bug-class Pangolin reverts (zero-address transfers, blacklists, paused-token) are no longer swallowed by the allowlist. Test coverage added for both positive matches and the negative zero-address case.

Risk surface: `isUserStateError` fails open — any unknown shape returns false and the existing Sentry capture runs. The matchers are deliberately specific (raw RPC `-32000` insufficient-funds, SDK `causedByInsufficientFunds()`, `details.cause.shortMessage` ∈ allowlist) to avoid silencing real bugs.

## Stacked PR
Base: `worktree-fusion-presubmit-fixes` (PR #3824 — A8W fingerprint-split). When that merges, this PR will auto-retarget to `main`.

## Notes / future considerations
- The guard does not help in the streaming-refresh case where `useQuoteStreaming` re-emits the *same* `quote.id` with a refreshed `expiresAt` — TanStack won't refetch because the queryKey didn't change. In practice fresh SDK quotes have new IDs; if that ever changes this guard becomes a no-op for that path. Including `quote.expiresAt` in the queryKey would close that hole.
- Network/signing latency between our `>` check and the SDK's later `<=` check means a vanishing edge case can still hit; expect Sentry volume to drop sharply, not zero.

## Dev testing

**Bitrise builds:** _Fill in after CI runs._

- [ ] iOS build: 8514
- [ ] Android build: 8515

**Steps (quote expiry — primary fix):**
1. Open the swap form on a quote-streaming pair (e.g. AVAX → USDC) and produce a quote.
2. Wait past the quote TTL (typically 30-60 seconds without the screen producing fresh quote events). Lock/unlock the device or background+foreground the app to trigger the TanStack subscribe/focus refetch path.
3. Before this fix: a `QUOTE_EXPIRED` event fires into Sentry (CORE-REACT-NATIVE-A95 / 9X8). After: the queryFn becomes `skipToken` silently and the UI shows the existing "fee unavailable" / loading state until a fresh quote arrives via the stream.
4. Confirm the golden path still works on a fresh quote: type an amount, get a quote, swap submits and completes.

**Steps (user-state suppression — bundled from #3827):**
1. Attempt a swap larger than the wallet's balance for a token that goes through `estimateNativeFee` (ERC20 → ERC20 on Avalanche works). The UI should show the existing "insufficient balance" inline error via `useFeeValidation`.
2. Before this fix: Sentry receives a `[useFeeEstimation] estimateNativeFee revert error` event for `ERC20: transfer amount exceeds balance` (and similar) on every keystroke. After: no Sentry event; a single `feeEstimation.userState` breadcrumb is dropped instead.
3. Trigger an unrelated, non-user-state error (e.g. force a TargetCallFailed by swapping into an unsupported token-out): confirm a Sentry event still fires (capture-by-default behavior).

## Related
- Jira: [CP-14260](https://ava-labs.atlassian.net/browse/CP-14260) (2 of 3 stacked PRs)


[CP-14260]: https://ava-labs.atlassian.net/browse/CP-14260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
