### PR TITLE
skip Sentry capture for known user-state fee-estimation errors

### DIFF
--- a/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.test.ts
@@ -1,7 +1,8 @@
 import type { Quote } from '../types'
 import {
   getFingerprintForFeeEstimationError,
-  isQuoteUsable
+  isQuoteUsable,
+  isUserStateError
 } from './useFeeEstimation.helpers'
 
 describe('isQuoteUsable', () => {
@@ -78,5 +79,124 @@ describe('getFingerprintForFeeEstimationError', () => {
     expect(getFingerprintForFeeEstimationError('oops')).toEqual([
       '{{ default }}'
     ])
+  })
+})
+
+describe('isUserStateError', () => {
+  it('matches raw RPC -32000 insufficient funds', () => {
+    const error = {
+      code: -32000,
+      message:
+        'failed with 40000000 gas: insufficient funds for gas * price + value: address 0x... have 0 want 1000'
+    }
+    expect(isUserStateError(error)).toBe(true)
+  })
+
+  it('matches wrapped SDK error via causedByInsufficientFunds', () => {
+    const error = {
+      causedByInsufficientFunds: () => true
+    }
+    expect(isUserStateError(error)).toBe(true)
+  })
+
+  it('matches transfer amount exceeds balance via details.cause.shortMessage', () => {
+    const error = {
+      details: {
+        cause: { shortMessage: 'ERC20: transfer amount exceeds balance' }
+      }
+    }
+    expect(isUserStateError(error)).toBe(true)
+  })
+
+  it('matches transfer amount exceeds allowance', () => {
+    const error = {
+      details: {
+        cause: { shortMessage: 'ERC20: transfer amount exceeds allowance' }
+      }
+    }
+    expect(isUserStateError(error)).toBe(true)
+  })
+
+  it('matches WAVAX unwrap burn balance', () => {
+    const error = {
+      details: {
+        cause: { shortMessage: 'ERC20: burn amount exceeds balance' }
+      }
+    }
+    expect(isUserStateError(error)).toBe(true)
+  })
+
+  it('does NOT match TargetCallFailed (the 5006 SDK family)', () => {
+    const error = {
+      details: {
+        data: '0xeda86850',
+        cause: { shortMessage: 'Execution reverted: TargetCallFailed()' }
+      }
+    }
+    expect(isUserStateError(error)).toBe(false)
+  })
+
+  it('does NOT match Panic(17) reverts', () => {
+    const error = {
+      details: {
+        cause: { shortMessage: 'Panic(17)' }
+      }
+    }
+    expect(isUserStateError(error)).toBe(false)
+  })
+
+  it('does NOT match UnsupportedTokenOut', () => {
+    const error = {
+      details: {
+        cause: { shortMessage: 'Execution reverted: UnsupportedTokenOut()' }
+      }
+    }
+    expect(isUserStateError(error)).toBe(false)
+  })
+
+  it('does NOT match unknown errors (fail open, capture by default)', () => {
+    expect(isUserStateError(new Error('something unexpected'))).toBe(false)
+  })
+
+  it('does NOT match QUOTE_EXPIRED (different fix path)', () => {
+    const error = {
+      name: 'InvalidParamsError',
+      message: 'Quote expired 5 seconds ago.'
+    }
+    expect(isUserStateError(error)).toBe(false)
+  })
+
+  it('does NOT match null', () => {
+    expect(isUserStateError(null)).toBe(false)
+  })
+
+  it('does NOT match a primitive', () => {
+    expect(isUserStateError('oops')).toBe(false)
+  })
+
+  it('does NOT match -32000 without insufficient funds in message', () => {
+    expect(
+      isUserStateError({ code: -32000, message: 'some other failure' })
+    ).toBe(false)
+  })
+
+  it('matches string-coded -32000 (some RPC providers emit code as a string)', () => {
+    const error = {
+      code: '-32000',
+      message: 'insufficient funds for gas * price + value'
+    }
+    expect(isUserStateError(error)).toBe(true)
+  })
+
+  it('falls through when causedByInsufficientFunds throws', () => {
+    const error = {
+      causedByInsufficientFunds: () => {
+        throw new Error('boom')
+      }
+    }
+    // Should NOT crash and should NOT silently match — fall through to other
+    // matchers; with no other match it returns false so caller still captures.
+    expect(() => isUserStateError(error)).not.toThrow()
+    expect(isUserStateError(error)).toBe(false)
   })
 })

--- a/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.test.ts
@@ -188,6 +188,15 @@ describe('isUserStateError', () => {
     expect(isUserStateError(error)).toBe(true)
   })
 
+  it('does not throw when code is a symbol (Number(symbol) would throw)', () => {
+    const error = {
+      code: Symbol('-32000'),
+      message: 'insufficient funds for gas * price + value'
+    }
+    expect(() => isUserStateError(error)).not.toThrow()
+    expect(isUserStateError(error)).toBe(false)
+  })
+
   it('falls through when causedByInsufficientFunds throws', () => {
     const error = {
       causedByInsufficientFunds: () => {

--- a/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.ts
@@ -45,3 +45,82 @@ export const getFingerprintForFeeEstimationError = (
   }
   return ['{{ default }}']
 }
+
+/**
+ * Allowlist of contract revert reasons that represent expected user state
+ * (insufficient balance, insufficient allowance) rather than SDK or contract
+ * bugs. Each entry was sourced from the cross-platform investigation by
+ * inspecting the corresponding contract source — anything balance- or
+ * allowance-related is user state. Bug-class reverts (`TargetCallFailed`,
+ * `Panic`, `UnsupportedTokenOut`) are deliberately excluded so they continue
+ * to fire Sentry events.
+ */
+const USER_STATE_REVERT_REASONS: readonly string[] = [
+  'ERC20: transfer amount exceeds balance',
+  'ERC20: transfer amount exceeds allowance',
+  'TRANSFER_AMOUNT_EXCEEDS_ALLOWANCE',
+  'Png::transferFrom',
+  'ERC20: burn amount exceeds balance'
+]
+
+/**
+ * Returns true when `error` represents an expected user-state rejection
+ * (insufficient native funds, insufficient ERC20 balance/allowance) rather
+ * than an SDK or contract bug. The Sentry capture path in `useFeeEstimation`
+ * skips capture when this returns true — the user already gets an inline
+ * validation error via `useFeeValidation → canSwap`, so Sentry doesn't add
+ * value here and the noise pollutes the issue list.
+ *
+ * Fails open: returns false for unknown shapes so we never silence something
+ * we haven't classified.
+ */
+export const isUserStateError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') return false
+
+  // Raw RPC -32000 insufficient funds (the un-wrapped path that lands in 9X6).
+  // Coerce `code` via Number() because some RPC providers emit it as a string.
+  if (
+    'code' in error &&
+    Number(error.code) === -32000 &&
+    'message' in error &&
+    typeof error.message === 'string' &&
+    error.message.includes('insufficient funds')
+  ) {
+    return true
+  }
+
+  // SDK wrapper helper for insufficient-funds-causing errors. Wrapped in
+  // try/catch because the SDK helper is invoked on a foreign object and a
+  // future SDK regression could throw — we'd rather fall through and capture
+  // the error than let the helper take down the useEffect.
+  try {
+    if (
+      'causedByInsufficientFunds' in error &&
+      typeof error.causedByInsufficientFunds === 'function' &&
+      error.causedByInsufficientFunds() === true
+    ) {
+      return true
+    }
+  } catch {
+    // Helper threw; fall through to the next matcher. If nothing else matches
+    // we return false and the caller captures as before.
+  }
+
+  // Allowlisted contract revert reasons surfaced through the SDK's
+  // EstimateNativeFeeError → cause chain.
+  if (
+    'details' in error &&
+    error.details &&
+    typeof error.details === 'object' &&
+    'cause' in error.details &&
+    error.details.cause &&
+    typeof error.details.cause === 'object' &&
+    'shortMessage' in error.details.cause &&
+    typeof error.details.cause.shortMessage === 'string'
+  ) {
+    const msg = error.details.cause.shortMessage
+    return USER_STATE_REVERT_REASONS.some(reason => msg.includes(reason))
+  }
+
+  return false
+}

--- a/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.helpers.ts
@@ -78,9 +78,14 @@ export const isUserStateError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') return false
 
   // Raw RPC -32000 insufficient funds (the un-wrapped path that lands in 9X6).
-  // Coerce `code` via Number() because some RPC providers emit it as a string.
+  // Coerce `code` via Number() because some RPC providers emit it as a string;
+  // narrow the type first because `Number(symbol)` throws and would break the
+  // fails-open contract.
   if (
     'code' in error &&
+    (typeof error.code === 'string' ||
+      typeof error.code === 'number' ||
+      typeof error.code === 'bigint') &&
     Number(error.code) === -32000 &&
     'message' in error &&
     typeof error.message === 'string' &&

--- a/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFeeEstimation.ts
@@ -6,15 +6,20 @@ import { selectFusionFeeUnitsMarginBps } from 'store/posthog'
 import type { NetworkWithCaip2ChainId } from 'store/network'
 import { useNetworkFee } from 'hooks/useNetworkFee'
 import { isEstimateNativeFeeError } from '@avalabs/fusion-sdk'
+import * as Sentry from '@sentry/react-native'
 import Logger from 'utils/Logger'
 import SentryService from 'services/sentry/SentryService'
-import { SentryTag } from 'services/sentry/types'
+import {
+  AllowedSentryBreadcrumbCategory,
+  SentryTag
+} from 'services/sentry/types'
 import FusionService from '../services/FusionService'
 import { logSdkError } from '../utils/fusionLogger'
 import type { Quote } from '../types'
 import {
   getFingerprintForFeeEstimationError,
-  isQuoteUsable
+  isQuoteUsable,
+  isUserStateError
 } from './useFeeEstimation.helpers'
 import { buildFeeOptions } from './useMaxSwapAmount/utils'
 
@@ -85,6 +90,22 @@ export const useFeeEstimation = ({
 
   useEffect(() => {
     if (!error) return
+
+    // Suppress capture for known user-state errors (insufficient native AVAX,
+    // insufficient ERC20 balance/allowance). The UI already surfaces these via
+    // `useFeeValidation → canSwap`; Sentry doesn't add value and the noise
+    // dominates the swap-feature issue list when not filtered. We still leave
+    // a breadcrumb so investigators retain forensic context if a downstream
+    // (non-suppressed) error fires later in the same session.
+    if (isUserStateError(error)) {
+      Sentry.addBreadcrumb({
+        category: AllowedSentryBreadcrumbCategory.FeeEstimationUserState,
+        level: 'info',
+        message: '[useFeeEstimation] skipped user-state error'
+      })
+      return
+    }
+
     if (isEstimateNativeFeeError(error) && error.details) {
       Logger.warn('[useFeeEstimation] estimateNativeFee revert error', error)
       // Use captureMessage (not Logger.error) for Sentry so that BigInt values

--- a/packages/core-mobile/app/services/sentry/types.ts
+++ b/packages/core-mobile/app/services/sentry/types.ts
@@ -53,7 +53,8 @@ export const SentryTag = {
  * — breadcrumbs without a listed category get dropped.
  */
 export const AllowedSentryBreadcrumbCategory = {
-  ListenerMigration: 'listenerMigration'
+  ListenerMigration: 'listenerMigration',
+  FeeEstimationUserState: 'feeEstimationUserState'
 } as const
 
 export type AllowedSentryBreadcrumbCategory =

--- a/packages/core-mobile/app/services/sentry/types.ts
+++ b/packages/core-mobile/app/services/sentry/types.ts
@@ -49,8 +49,9 @@ export const SentryTag = {
 
 /**
  * Breadcrumb categories explicitly allowed by `SentryService.beforeBreadcrumb`.
- * Add new categories here AND update the allowlist in `SentryService.ts`
- * — breadcrumbs without a listed category get dropped.
+ * This enum is the single source of truth — `SentryService.ts` derives its
+ * runtime allowlist from `Object.values(AllowedSentryBreadcrumbCategory)`.
+ * Breadcrumbs without a listed category get dropped.
  */
 export const AllowedSentryBreadcrumbCategory = {
   ListenerMigration: 'listenerMigration',


### PR DESCRIPTION
## Summary

- Adds `isUserStateError(error)` to short-circuit Sentry capture in `useFeeEstimation` for expected user-state rejections: raw RPC `-32000` insufficient funds, the SDK's `causedByInsufficientFunds()` helper, and an allowlist of contract revert reasons (`ERC20: transfer amount exceeds balance/allowance`, `Png::transferFrom`, `ERC20: burn amount exceeds balance`, `TRANSFER_AMOUNT_EXCEEDS_ALLOWANCE`).
- Wraps the `causedByInsufficientFunds()` invocation in try/catch so a future SDK regression in that helper can't take down the useEffect.
- Coerces `code` via `Number()` for RPC providers that emit it as a string.
- Replaces the would-be `Logger.info` (console-only) with a Sentry breadcrumb on a new allowlisted category (`feeEstimationUserState`) so investigators retain forensic context for downstream issues without creating a Sentry issue.

## Why
Mobile already gates the swap button via `useFeeValidation → canSwap` when the user lacks native AVAX or ERC20 balance/allowance. Sentry capture of those rejection paths adds nothing — the user sees an inline validation error and adjusts. These false positives currently dominate the swap-feature Sentry issue list (~2,000 unique users / 30d across CORE-REACT-NATIVE-9X6 / A92 / A9D and the user-state subset of A8W). Investigation: https://www.notion.so/35a0e2bd518081908722e62e029170a7 (Findings revisions, Hypothesis B refuted).

The allowlist starts conservative — bug-class reverts (`TargetCallFailed`, `Panic`, `UnsupportedTokenOut`) are explicitly excluded so they continue to fire Sentry events.

## Stacked PR
Base: `worktree-fusion-presubmit-fixes-pr2` (PR #3826 — quote-staleness guard). When that merges, this PR will auto-retarget upstream.

## Notes
- 29 unit tests cover the helper (positive cases + bug-class negatives + null/primitive/throw-in-helper edge cases).
- A new `AllowedSentryBreadcrumbCategory.FeeEstimationUserState` entry was added so the breadcrumb passes the project's `beforeBreadcrumb` filter.
- `Logger.info` in this useEffect was *not* sending to Sentry by default (`Logger.info` is console-only). The breadcrumb replacement strictly *increases* forensic capture without restoring the noise.

## Dev testing

**Bitrise builds:** _Fill in after CI runs._

- [ ] iOS build: 8522
- [ ] Android build: 8523

**Steps:**
1. Reproduce the noise scenario: a wallet with 0 native AVAX (or wallet with insufficient ERC20 balance for the source token) attempts a Markr swap.
2. Confirm UI behavior is unchanged: inline validation error shown, Next button disabled.
3. After deploy, Sentry inspection: no event fires for this user-state path. The breadcrumb \"[useFeeEstimation] skipped user-state error\" appears on subsequent (non-suppressed) events from the same session.
4. Regression check: trigger a non-user-state error (e.g. a real on-chain revert with TargetCallFailed). Confirm capture STILL fires — the per-signature fingerprint from PR #3824 still works.

## Related
- Jira: [CP-14260](https://ava-labs.atlassian.net/browse/CP-14260) (3 of 3 stacked PRs)


[CP-14260]: https://ava-labs.atlassian.net/browse/CP-14260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ