### PR TITLE
CP-14224: retry + cache postV1GetAddresses to stop the P-Chain send cascade

### DIFF
--- a/packages/core-mobile/app/services/wallet/WalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/WalletService.test.ts
@@ -170,7 +170,7 @@ describe('WalletService.getAddresses retry behavior', () => {
     jest.restoreAllMocks()
   })
 
-  it('retries postV1GetAddresses up to two times on transient HTTP failure', async () => {
+  it('retries postV1GetAddresses up to three times on transient HTTP failure', async () => {
     jest.spyOn(WalletService, 'getRawXpubXP').mockResolvedValue('xpub-retry')
 
     const { postV1GetAddresses } = jest.requireMock(

--- a/packages/core-mobile/app/services/wallet/WalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/WalletService.test.ts
@@ -359,4 +359,53 @@ describe('WalletService.getAddresses cache behavior', () => {
 
     expect(calls).toBe(2)
   })
+
+  it('de-dups concurrent calls with the same key — only one API call fires', async () => {
+    jest
+      .spyOn(WalletService, 'getRawXpubXP')
+      .mockResolvedValue('xpub-concurrent')
+
+    const { postV1GetAddresses } = jest.requireMock(
+      'utils/api/generated/profileApi.client'
+    )
+
+    // Hold the API mock unresolved until we have both callers in flight.
+    let resolveApi: (value: { data: GetAddressesResponse }) => void = () => {
+      /* set below */
+    }
+    postV1GetAddresses.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveApi = resolve
+        })
+    )
+
+    const args = {
+      walletId: 'wallet-concurrent',
+      walletType: WalletType.MNEMONIC,
+      accountIndex: 0,
+      networkType: NetworkVMType.AVM as const,
+      isTestnet: false,
+      onlyWithActivity: false
+    }
+
+    const first = WalletService.getAddressesFromXpubXP(args)
+    const second = WalletService.getAddressesFromXpubXP(args)
+
+    // Flush microtasks so both callers reach the in-flight registration
+    // (each first awaits the mocked getRawXpubXP before hitting the cache).
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Both callers are in flight; only one API call should have fired.
+    expect(postV1GetAddresses).toHaveBeenCalledTimes(1)
+
+    // Resolve the single API call and confirm both promises receive the value.
+    resolveApi({ data: avmWithActivityResponse })
+
+    const [a, b] = await Promise.all([first, second])
+    expect(a).toEqual(avmWithActivityResponse)
+    expect(b).toEqual(avmWithActivityResponse)
+    expect(postV1GetAddresses).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/core-mobile/app/services/wallet/WalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/WalletService.test.ts
@@ -161,9 +161,16 @@ describe('WalletService.hasActivityFromXpubXP', () => {
 })
 
 describe('WalletService.getAddresses retry behavior', () => {
-  // Use fake timers so we can fast-forward the exponential backoff
-  // (250 / 500 / 1000 ms) without making the test slow.
+  // Each test owns its own postV1GetAddresses mock impl. We force a hard
+  // reset so a closure-captured `calls` counter or hanging promise from a
+  // prior test cannot bleed into the next one — that bleed is what makes
+  // these tests appear to "time out" or surface a TypeError on slow CI.
   beforeEach(() => {
+    clearAddressesCache()
+    const { postV1GetAddresses } = jest.requireMock(
+      'utils/api/generated/profileApi.client'
+    )
+    postV1GetAddresses.mockReset()
     jest.useFakeTimers()
   })
   afterEach(() => {
@@ -197,9 +204,10 @@ describe('WalletService.getAddresses retry behavior', () => {
       onlyWithActivity: false
     })
 
-    // Drive the backoff timers. 250ms after first failure, then 500ms after second.
-    await jest.advanceTimersByTimeAsync(250)
-    await jest.advanceTimersByTimeAsync(500)
+    // Drain all queued backoff timers + microtasks until the promise settles.
+    // `runAllTimersAsync` is more robust on slow CI than `advanceTimersByTimeAsync`
+    // with hand-tuned values, which can drop interleaved microtasks.
+    await jest.runAllTimersAsync()
 
     const result = await promise
     expect(result).toEqual(avmWithActivityResponse)
@@ -227,11 +235,13 @@ describe('WalletService.getAddresses retry behavior', () => {
       onlyWithActivity: false
     })
 
-    // Run all backoff timers, capturing the rejection.
-    // eslint-disable-next-line jest/valid-expect -- awaited below
-    const expectation = expect(promise).rejects.toThrow(/profile-api down/)
-    await jest.advanceTimersByTimeAsync(250 + 500 + 1000)
-    await expectation
+    // Catch the rejection ourselves so an unhandled-rejection warning can't
+    // race the assertion. Then drain all retries.
+    const settled = promise.catch(err => err)
+    await jest.runAllTimersAsync()
+    const err = await settled
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toMatch(/profile-api down/)
   })
 
   it('does NOT retry on non-transient (4xx) error', async () => {
@@ -255,10 +265,11 @@ describe('WalletService.getAddresses retry behavior', () => {
       onlyWithActivity: false
     })
 
-    // eslint-disable-next-line jest/valid-expect -- awaited below
-    const expectation = expect(promise).rejects.toThrow(/unauthorized/)
-    await jest.advanceTimersByTimeAsync(0)
-    await expectation
+    const settled = promise.catch(err => err)
+    await jest.runAllTimersAsync()
+    const err = await settled
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toMatch(/unauthorized/)
     expect(postV1GetAddresses).toHaveBeenCalledTimes(1)
   })
 
@@ -284,23 +295,26 @@ describe('WalletService.getAddresses retry behavior', () => {
       onlyWithActivity: false
     })
 
-    // eslint-disable-next-line jest/valid-expect -- awaited below
-    const expectation = expect(promise).rejects.toThrow(
-      /unrecognized body shape/
-    )
-    await jest.advanceTimersByTimeAsync(0)
-    await expectation
+    const settled = promise.catch(err => err)
+    await jest.runAllTimersAsync()
+    const err = await settled
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toMatch(/unrecognized body shape/)
     expect(postV1GetAddresses).toHaveBeenCalledTimes(1)
   })
 })
 
 describe('WalletService.getAddresses cache behavior', () => {
+  // No fake timers in this block — none of these tests exercise the
+  // backoff, and fake timers add microtask-flush brittleness on slow CI.
   beforeEach(() => {
     clearAddressesCache()
-    jest.useFakeTimers()
+    const { postV1GetAddresses } = jest.requireMock(
+      'utils/api/generated/profileApi.client'
+    )
+    postV1GetAddresses.mockReset()
   })
   afterEach(() => {
-    jest.useRealTimers()
     jest.restoreAllMocks()
   })
 

--- a/packages/core-mobile/app/services/wallet/WalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/WalletService.test.ts
@@ -3,6 +3,7 @@ import { WalletType } from 'services/wallet/types'
 import type { GetAddressesResponse } from 'utils/api/generated/profileApi.client/types.gen'
 import WalletFactory from './WalletFactory'
 import WalletService from './WalletService'
+import { clearAddressesCache } from './getAddressesCache'
 
 const avmWithActivityResponse: GetAddressesResponse = {
   networkType: 'AVM',
@@ -260,9 +261,38 @@ describe('WalletService.getAddresses retry behavior', () => {
     await expectation
     expect(postV1GetAddresses).toHaveBeenCalledTimes(1)
   })
-})
 
-import { clearAddressesCache } from './getAddressesCache'
+  it('does NOT retry on unrecognized body shape (deterministic validation error)', async () => {
+    jest.spyOn(WalletService, 'getRawXpubXP').mockResolvedValue('xpub-shape')
+
+    const { postV1GetAddresses } = jest.requireMock(
+      'utils/api/generated/profileApi.client'
+    )
+
+    // Successful HTTP response but body fails the schema check —
+    // retrying won't recover, so the helper must give up immediately.
+    postV1GetAddresses.mockResolvedValue({
+      data: { not: 'a valid GetAddressesResponse' }
+    })
+
+    const promise = WalletService.getAddressesFromXpubXP({
+      walletId: 'wallet-shape',
+      walletType: WalletType.MNEMONIC,
+      accountIndex: 0,
+      networkType: NetworkVMType.AVM,
+      isTestnet: false,
+      onlyWithActivity: false
+    })
+
+    // eslint-disable-next-line jest/valid-expect -- awaited below
+    const expectation = expect(promise).rejects.toThrow(
+      /unrecognized body shape/
+    )
+    await jest.advanceTimersByTimeAsync(0)
+    await expectation
+    expect(postV1GetAddresses).toHaveBeenCalledTimes(1)
+  })
+})
 
 describe('WalletService.getAddresses cache behavior', () => {
   beforeEach(() => {

--- a/packages/core-mobile/app/services/wallet/WalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/WalletService.test.ts
@@ -301,7 +301,7 @@ describe('WalletService.getAddresses cache behavior', () => {
     expect(postV1GetAddresses).toHaveBeenCalledTimes(1)
   })
 
-  it('clearAddressCache forces re-fetch', async () => {
+  it('clearAddressesCache forces re-fetch', async () => {
     jest.spyOn(WalletService, 'getRawXpubXP').mockResolvedValue('xpub-clear')
 
     const { postV1GetAddresses } = jest.requireMock(
@@ -320,7 +320,7 @@ describe('WalletService.getAddresses cache behavior', () => {
     }
 
     await WalletService.getAddressesFromXpubXP(args)
-    WalletService.clearAddressCache()
+    clearAddressesCache()
     await WalletService.getAddressesFromXpubXP(args)
 
     expect(postV1GetAddresses).toHaveBeenCalledTimes(2)
@@ -409,7 +409,7 @@ describe('WalletService.getAddresses cache behavior', () => {
     expect(postV1GetAddresses).toHaveBeenCalledTimes(1)
   })
 
-  it('does NOT populate the cache if clearAddressCache fires mid-fetch', async () => {
+  it('does NOT populate the cache if clearAddressesCache fires mid-fetch', async () => {
     jest.spyOn(WalletService, 'getRawXpubXP').mockResolvedValue('xpub-race')
 
     const { postV1GetAddresses } = jest.requireMock(

--- a/packages/core-mobile/app/services/wallet/WalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/WalletService.test.ts
@@ -408,4 +408,57 @@ describe('WalletService.getAddresses cache behavior', () => {
     expect(b).toEqual(avmWithActivityResponse)
     expect(postV1GetAddresses).toHaveBeenCalledTimes(1)
   })
+
+  it('does NOT populate the cache if clearAddressCache fires mid-fetch', async () => {
+    jest.spyOn(WalletService, 'getRawXpubXP').mockResolvedValue('xpub-race')
+
+    const { postV1GetAddresses } = jest.requireMock(
+      'utils/api/generated/profileApi.client'
+    )
+
+    // Hold the API resolution until we release it manually, so we can clear
+    // the cache while the retry promise is still in flight.
+    let resolveApi: (value: { data: GetAddressesResponse }) => void = () => {
+      /* set below */
+    }
+    postV1GetAddresses.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveApi = resolve
+        })
+    )
+
+    const args = {
+      walletId: 'wallet-race',
+      walletType: WalletType.MNEMONIC,
+      accountIndex: 0,
+      networkType: NetworkVMType.AVM as const,
+      isTestnet: false,
+      onlyWithActivity: false
+    }
+
+    const fetchInFlight = WalletService.getAddressesFromXpubXP(args)
+
+    // Let both `getRawXpubXP` and the in-flight registration settle, then
+    // simulate an app-lock by clearing the cache while the API is mid-flight.
+    await Promise.resolve()
+    await Promise.resolve()
+    clearAddressesCache()
+
+    // Resolve the in-flight API call. Its body should NOT be cached because
+    // the epoch advanced between fetch-start and fetch-resolve.
+    resolveApi({ data: avmWithActivityResponse })
+    const result = await fetchInFlight
+    expect(result).toEqual(avmWithActivityResponse)
+
+    // Subsequent call should hit the API again, not return a stale cache hit.
+    let secondCallFired = false
+    postV1GetAddresses.mockImplementation(async () => {
+      secondCallFired = true
+      return { data: avmWithActivityResponse }
+    })
+
+    await WalletService.getAddressesFromXpubXP(args)
+    expect(secondCallFired).toBe(true)
+  })
 })

--- a/packages/core-mobile/app/services/wallet/WalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/WalletService.test.ts
@@ -158,3 +158,106 @@ describe('WalletService.hasActivityFromXpubXP', () => {
     ).resolves.toBe(true)
   })
 })
+
+describe('WalletService.getAddresses retry behavior', () => {
+  // Use fake timers so we can fast-forward the exponential backoff
+  // (250 / 500 / 1000 ms) without making the test slow.
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  it('retries postV1GetAddresses up to two times on transient HTTP failure', async () => {
+    jest.spyOn(WalletService, 'getRawXpubXP').mockResolvedValue('xpub-retry')
+
+    const { postV1GetAddresses } = jest.requireMock(
+      'utils/api/generated/profileApi.client'
+    )
+
+    let calls = 0
+    postV1GetAddresses.mockImplementation(async () => {
+      calls += 1
+      if (calls < 3) {
+        // Mimic hey-api shape on a 5xx response: parsed body with error field.
+        return { data: undefined, error: { status: 503, message: 'upstream' } }
+      }
+      return { data: avmWithActivityResponse }
+    })
+
+    const promise = WalletService.getAddressesFromXpubXP({
+      walletId: 'wallet-retry',
+      walletType: WalletType.MNEMONIC,
+      accountIndex: 0,
+      networkType: NetworkVMType.AVM,
+      isTestnet: false,
+      onlyWithActivity: false
+    })
+
+    // Drive the backoff timers. 250ms after first failure, then 500ms after second.
+    await jest.advanceTimersByTimeAsync(250)
+    await jest.advanceTimersByTimeAsync(500)
+
+    const result = await promise
+    expect(result).toEqual(avmWithActivityResponse)
+    expect(calls).toBe(3)
+  })
+
+  it('preserves upstream error message when retries are exhausted', async () => {
+    jest.spyOn(WalletService, 'getRawXpubXP').mockResolvedValue('xpub-exhaust')
+
+    const { postV1GetAddresses } = jest.requireMock(
+      'utils/api/generated/profileApi.client'
+    )
+
+    postV1GetAddresses.mockImplementation(async () => ({
+      data: undefined,
+      error: { status: 503, message: 'profile-api down' }
+    }))
+
+    const promise = WalletService.getAddressesFromXpubXP({
+      walletId: 'wallet-exhaust',
+      walletType: WalletType.MNEMONIC,
+      accountIndex: 0,
+      networkType: NetworkVMType.AVM,
+      isTestnet: false,
+      onlyWithActivity: false
+    })
+
+    // Run all backoff timers, capturing the rejection.
+    // eslint-disable-next-line jest/valid-expect -- awaited below
+    const expectation = expect(promise).rejects.toThrow(/profile-api down/)
+    await jest.advanceTimersByTimeAsync(250 + 500 + 1000)
+    await expectation
+  })
+
+  it('does NOT retry on non-transient (4xx) error', async () => {
+    jest.spyOn(WalletService, 'getRawXpubXP').mockResolvedValue('xpub-4xx')
+
+    const { postV1GetAddresses } = jest.requireMock(
+      'utils/api/generated/profileApi.client'
+    )
+
+    postV1GetAddresses.mockImplementation(async () => ({
+      data: undefined,
+      error: { status: 401, message: 'unauthorized' }
+    }))
+
+    const promise = WalletService.getAddressesFromXpubXP({
+      walletId: 'wallet-4xx',
+      walletType: WalletType.MNEMONIC,
+      accountIndex: 0,
+      networkType: NetworkVMType.AVM,
+      isTestnet: false,
+      onlyWithActivity: false
+    })
+
+    // eslint-disable-next-line jest/valid-expect -- awaited below
+    const expectation = expect(promise).rejects.toThrow(/unauthorized/)
+    await jest.advanceTimersByTimeAsync(0)
+    await expectation
+    expect(postV1GetAddresses).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core-mobile/app/services/wallet/WalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/WalletService.test.ts
@@ -261,3 +261,102 @@ describe('WalletService.getAddresses retry behavior', () => {
     expect(postV1GetAddresses).toHaveBeenCalledTimes(1)
   })
 })
+
+import { clearAddressesCache } from './getAddressesCache'
+
+describe('WalletService.getAddresses cache behavior', () => {
+  beforeEach(() => {
+    clearAddressesCache()
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  it('returns the cached value on the second call without re-calling postV1GetAddresses', async () => {
+    jest.spyOn(WalletService, 'getRawXpubXP').mockResolvedValue('xpub-cache')
+
+    const { postV1GetAddresses } = jest.requireMock(
+      'utils/api/generated/profileApi.client'
+    )
+
+    postV1GetAddresses.mockResolvedValue({ data: avmWithActivityResponse })
+
+    const args = {
+      walletId: 'wallet-cache',
+      walletType: WalletType.MNEMONIC,
+      accountIndex: 0,
+      networkType: NetworkVMType.AVM as const,
+      isTestnet: false,
+      onlyWithActivity: false
+    }
+
+    const first = await WalletService.getAddressesFromXpubXP(args)
+    const second = await WalletService.getAddressesFromXpubXP(args)
+
+    expect(first).toEqual(avmWithActivityResponse)
+    expect(second).toEqual(avmWithActivityResponse)
+    // getRawXpubXP is called both times (cheap), but the API is hit only once.
+    expect(postV1GetAddresses).toHaveBeenCalledTimes(1)
+  })
+
+  it('clearAddressCache forces re-fetch', async () => {
+    jest.spyOn(WalletService, 'getRawXpubXP').mockResolvedValue('xpub-clear')
+
+    const { postV1GetAddresses } = jest.requireMock(
+      'utils/api/generated/profileApi.client'
+    )
+
+    postV1GetAddresses.mockResolvedValue({ data: avmWithActivityResponse })
+
+    const args = {
+      walletId: 'wallet-clear',
+      walletType: WalletType.MNEMONIC,
+      accountIndex: 0,
+      networkType: NetworkVMType.AVM as const,
+      isTestnet: false,
+      onlyWithActivity: false
+    }
+
+    await WalletService.getAddressesFromXpubXP(args)
+    WalletService.clearAddressCache()
+    await WalletService.getAddressesFromXpubXP(args)
+
+    expect(postV1GetAddresses).toHaveBeenCalledTimes(2)
+  })
+
+  it('does NOT cache failed responses', async () => {
+    jest.spyOn(WalletService, 'getRawXpubXP').mockResolvedValue('xpub-fail')
+
+    const { postV1GetAddresses } = jest.requireMock(
+      'utils/api/generated/profileApi.client'
+    )
+
+    let calls = 0
+    postV1GetAddresses.mockImplementation(async () => {
+      calls += 1
+      if (calls === 1)
+        return { data: undefined, error: { status: 401, message: 'auth' } }
+      return { data: avmWithActivityResponse }
+    })
+
+    const args = {
+      walletId: 'wallet-fail',
+      walletType: WalletType.MNEMONIC,
+      accountIndex: 0,
+      networkType: NetworkVMType.AVM as const,
+      isTestnet: false,
+      onlyWithActivity: false
+    }
+
+    await expect(WalletService.getAddressesFromXpubXP(args)).rejects.toThrow(
+      /auth/
+    )
+    await expect(WalletService.getAddressesFromXpubXP(args)).resolves.toEqual(
+      avmWithActivityResponse
+    )
+
+    expect(calls).toBe(2)
+  })
+})

--- a/packages/core-mobile/app/services/wallet/WalletService.tsx
+++ b/packages/core-mobile/app/services/wallet/WalletService.tsx
@@ -43,7 +43,8 @@ import {
   clearAddressesCache,
   getInFlightAddressesFetch,
   setInFlightAddressesFetch,
-  clearInFlightAddressesFetch
+  clearInFlightAddressesFetch,
+  getAddressesCacheEpoch
 } from './getAddressesCache'
 
 // Retry helper. Local to WalletService — promote to utils/ only if a second
@@ -499,62 +500,18 @@ class WalletService {
       return inFlight
     }
 
-    const callOnce = async (): Promise<GetAddressesResponse> => {
-      const raw = await postV1GetAddresses({
-        client: profileApiClient,
-        body: {
-          networkType: networkType,
-          extendedPublicKey,
-          isTestnet,
-          onlyWithActivity
-        }
-      })
-
-      // If hey-api gave us a structured error envelope, surface it as a
-      // throw so the retry helper sees it. The status field is what
-      // `isTransientHttpError` keys on.
-      if (
-        raw &&
-        typeof raw === 'object' &&
-        'error' in raw &&
-        (raw as { error: unknown }).error !== undefined
-      ) {
-        const err = (raw as { error: { status?: number; message?: string } })
-          .error
-        const message = err?.message ?? 'profile-api returned an error envelope'
-        const wrapped = new Error(
-          `postV1GetAddresses failed (status=${
-            err?.status ?? 'unknown'
-          }): ${message}`
-        )
-        // Attach status so retry helper can categorize.
-        ;(wrapped as Error & { status?: number }).status = err?.status
-        throw wrapped
-      }
-
-      const body = unwrapPostV1GetAddressesResult(raw)
-
-      if (!isGetAddressesResponseBody(body)) {
-        throw new Error(
-          `postV1GetAddresses returned an unrecognized body shape: ${
-            typeof body === 'object'
-              ? JSON.stringify(body).slice(0, 200)
-              : String(body)
-          }`
-        )
-      }
-
-      return body
-    }
+    const startEpoch = getAddressesCacheEpoch()
 
     const fetchPromise = (async () => {
       try {
         const body = await retryWithBackoff(
-          callOnce,
+          () => callPostV1GetAddressesOnce(cacheKey),
           isTransientHttpError,
           RETRY_DELAYS_MS
         )
-        setAddressesCache(cacheKey, body)
+        if (getAddressesCacheEpoch() === startEpoch) {
+          setAddressesCache(cacheKey, body)
+        }
         return body
       } catch (err) {
         Logger.error(
@@ -623,6 +580,68 @@ const isGetAddressesResponseBody = (
   'networkType' in value &&
   Array.isArray((value as GetAddressesResponse).externalAddresses) &&
   Array.isArray((value as GetAddressesResponse).internalAddresses)
+
+/**
+ * One call to postV1GetAddresses + envelope/error normalization. Extracted
+ * to module scope so `getAddressesForExtendedPublicKey` stays under the
+ * cognitive-complexity ceiling.
+ */
+const callPostV1GetAddressesOnce = async ({
+  extendedPublicKey,
+  networkType,
+  isTestnet,
+  onlyWithActivity
+}: {
+  extendedPublicKey: string
+  networkType: NetworkVMType.AVM | NetworkVMType.PVM
+  isTestnet: boolean
+  onlyWithActivity: boolean
+}): Promise<GetAddressesResponse> => {
+  const raw = await postV1GetAddresses({
+    client: profileApiClient,
+    body: {
+      networkType,
+      extendedPublicKey,
+      isTestnet,
+      onlyWithActivity
+    }
+  })
+
+  // If hey-api gave us a structured error envelope, surface it as a
+  // throw so the retry helper sees it. The status field is what
+  // `isTransientHttpError` keys on.
+  if (
+    raw &&
+    typeof raw === 'object' &&
+    'error' in raw &&
+    (raw as { error: unknown }).error !== undefined
+  ) {
+    const err = (raw as { error: { status?: number; message?: string } }).error
+    const message = err?.message ?? 'profile-api returned an error envelope'
+    const wrapped = new Error(
+      `postV1GetAddresses failed (status=${
+        err?.status ?? 'unknown'
+      }): ${message}`
+    )
+    // Attach status so retry helper can categorize.
+    ;(wrapped as Error & { status?: number }).status = err?.status
+    throw wrapped
+  }
+
+  const body = unwrapPostV1GetAddressesResult(raw)
+
+  if (!isGetAddressesResponseBody(body)) {
+    throw new Error(
+      `postV1GetAddresses returned an unrecognized body shape: ${
+        typeof body === 'object'
+          ? JSON.stringify(body).slice(0, 200)
+          : String(body)
+      }`
+    )
+  }
+
+  return body
+}
 
 /**
  * Races boolean promises, returning true as soon as any resolves true.

--- a/packages/core-mobile/app/services/wallet/WalletService.tsx
+++ b/packages/core-mobile/app/services/wallet/WalletService.tsx
@@ -40,7 +40,6 @@ import { LedgerWallet } from './LedgerWallet'
 import {
   getAddressesCache,
   setAddressesCache,
-  clearAddressesCache,
   getInFlightAddressesFetch,
   setInFlightAddressesFetch,
   clearInFlightAddressesFetch,
@@ -467,10 +466,6 @@ class WalletService {
     ]
 
     return raceAnyTrueOrThrow(checks)
-  }
-
-  public clearAddressCache(): void {
-    clearAddressesCache()
   }
 
   private async getAddressesForExtendedPublicKey({

--- a/packages/core-mobile/app/services/wallet/WalletService.tsx
+++ b/packages/core-mobile/app/services/wallet/WalletService.tsx
@@ -51,18 +51,38 @@ import {
 // Treat network errors and HTTP 5xx as transient; everything else is fatal
 // on the first try. Note: retry attempts are logged via Logger.info, which
 // is console-only — they do NOT surface to Sentry in production.
+const NETWORK_ERROR_PATTERN =
+  /network request failed|timeout|timed out|aborted|fetch failed|socket hang up|econn|enotfound|getaddrinfo/i
+
 const isTransientHttpError = (err: unknown): boolean => {
-  if (
-    err &&
-    typeof err === 'object' &&
-    'status' in err &&
-    typeof (err as { status: unknown }).status === 'number'
-  ) {
-    const status = (err as { status: number }).status
-    return status >= 500 && status < 600
+  if (!err || typeof err !== 'object') {
+    return false
   }
-  // No status field → most likely a fetch/network error → treat as transient.
-  return true
+  // Explicit non-retryable marker wins over every other heuristic.
+  if ((err as { nonRetryable?: boolean }).nonRetryable === true) {
+    return false
+  }
+  const statusRaw = (err as { status?: unknown }).status
+  if (typeof statusRaw === 'number') {
+    return statusRaw >= 500 && statusRaw < 600
+  }
+  // No numeric status. Only treat as transient if it looks like a
+  // fetch/network error — TypeError from RN's fetch, or a message that
+  // matches a known network-failure pattern. Everything else (validation,
+  // JSON parse, programmer error) fails fast.
+  if (err instanceof TypeError) {
+    return true
+  }
+  const name = (err as { name?: unknown }).name
+  if (
+    name === 'FetchError' ||
+    name === 'AbortError' ||
+    name === 'TimeoutError'
+  ) {
+    return true
+  }
+  const message = (err as { message?: unknown }).message
+  return typeof message === 'string' && NETWORK_ERROR_PATTERN.test(message)
 }
 
 const RETRY_DELAYS_MS = [250, 500, 1000] as const
@@ -626,13 +646,16 @@ const callPostV1GetAddressesOnce = async ({
   const body = unwrapPostV1GetAddressesResult(raw)
 
   if (!isGetAddressesResponseBody(body)) {
-    throw new Error(
+    const shapeErr = new Error(
       `postV1GetAddresses returned an unrecognized body shape: ${
         typeof body === 'object'
           ? JSON.stringify(body).slice(0, 200)
           : String(body)
       }`
     )
+    // Deterministic upstream contract violation — retrying won't help.
+    ;(shapeErr as Error & { nonRetryable?: boolean }).nonRetryable = true
+    throw shapeErr
   }
 
   return body

--- a/packages/core-mobile/app/services/wallet/WalletService.tsx
+++ b/packages/core-mobile/app/services/wallet/WalletService.tsx
@@ -38,6 +38,51 @@ import { MnemonicWallet } from './MnemonicWallet'
 import KeystoneWallet from './KeystoneWallet'
 import { LedgerWallet } from './LedgerWallet'
 
+// Retry helper. Local to WalletService — promote to utils/ only if a second
+// caller appears. Backoff: 250 / 500 / 1000 ms. Treat network errors and
+// HTTP 5xx as transient; everything else is fatal on the first try.
+const isTransientHttpError = (err: unknown): boolean => {
+  if (
+    err &&
+    typeof err === 'object' &&
+    'status' in err &&
+    typeof (err as { status: unknown }).status === 'number'
+  ) {
+    const status = (err as { status: number }).status
+    return status >= 500 && status < 600
+  }
+  // No status field → most likely a fetch/network error → treat as transient.
+  return true
+}
+
+const RETRY_DELAYS_MS = [250, 500, 1000] as const
+
+const retryWithBackoff = async <T,>(
+  attempt: () => Promise<T>,
+  isTransient: (err: unknown) => boolean,
+  delays: readonly number[]
+): Promise<T> => {
+  let lastErr: unknown
+  for (let i = 0; i <= delays.length; i++) {
+    try {
+      return await attempt()
+    } catch (err) {
+      lastErr = err
+      if (i === delays.length || !isTransient(err)) {
+        throw err
+      }
+      Logger.info(
+        `[WalletService.retryWithBackoff] attempt ${
+          i + 1
+        } failed, retrying in ${delays[i]}ms: ${String(err)}`
+      )
+      await new Promise(r => setTimeout(r, delays[i]))
+    }
+  }
+  // Unreachable, but satisfies TS.
+  throw lastErr
+}
+
 class WalletService {
   public async sign({
     walletId,
@@ -424,7 +469,7 @@ class WalletService {
     isTestnet: boolean
     onlyWithActivity: boolean
   }): Promise<GetAddressesResponse> {
-    try {
+    const callOnce = async (): Promise<GetAddressesResponse> => {
       const raw = await postV1GetAddresses({
         client: profileApiClient,
         body: {
@@ -435,13 +480,49 @@ class WalletService {
         }
       })
 
+      // If hey-api gave us a structured error envelope, surface it as a
+      // throw so the retry helper sees it. The status field is what
+      // `isTransientHttpError` keys on.
+      if (
+        raw &&
+        typeof raw === 'object' &&
+        'error' in raw &&
+        (raw as { error: unknown }).error !== undefined
+      ) {
+        const err = (raw as { error: { status?: number; message?: string } })
+          .error
+        const message = err?.message ?? 'profile-api returned an error envelope'
+        const wrapped = new Error(
+          `postV1GetAddresses failed (status=${
+            err?.status ?? 'unknown'
+          }): ${message}`
+        )
+        // Attach status so retry helper can categorize.
+        ;(wrapped as Error & { status?: number }).status = err?.status
+        throw wrapped
+      }
+
       const body = unwrapPostV1GetAddressesResult(raw)
 
       if (!isGetAddressesResponseBody(body)) {
-        throw new Error('Failed to get addresses from postV1GetAddresses')
+        throw new Error(
+          `postV1GetAddresses returned an unrecognized body shape: ${
+            typeof body === 'object'
+              ? JSON.stringify(body).slice(0, 200)
+              : String(body)
+          }`
+        )
       }
 
       return body
+    }
+
+    try {
+      return await retryWithBackoff(
+        callOnce,
+        isTransientHttpError,
+        RETRY_DELAYS_MS
+      )
     } catch (err) {
       Logger.error(
         '[WalletService.ts][getAddressesForExtendedPublicKey] failed',

--- a/packages/core-mobile/app/services/wallet/WalletService.tsx
+++ b/packages/core-mobile/app/services/wallet/WalletService.tsx
@@ -37,6 +37,11 @@ import WalletFactory from './WalletFactory'
 import { MnemonicWallet } from './MnemonicWallet'
 import KeystoneWallet from './KeystoneWallet'
 import { LedgerWallet } from './LedgerWallet'
+import {
+  getAddressesCache,
+  setAddressesCache,
+  clearAddressesCache
+} from './getAddressesCache'
 
 // Retry helper. Local to WalletService — promote to utils/ only if a second
 // caller appears. Backoff: 250 / 500 / 1000 ms. Treat network errors and
@@ -458,6 +463,10 @@ class WalletService {
     return raceAnyTrueOrThrow(checks)
   }
 
+  public clearAddressCache(): void {
+    clearAddressesCache()
+  }
+
   private async getAddressesForExtendedPublicKey({
     extendedPublicKey,
     networkType,
@@ -469,6 +478,17 @@ class WalletService {
     isTestnet: boolean
     onlyWithActivity: boolean
   }): Promise<GetAddressesResponse> {
+    const cacheKey = {
+      extendedPublicKey,
+      networkType,
+      isTestnet,
+      onlyWithActivity
+    }
+    const cached = getAddressesCache(cacheKey)
+    if (cached) {
+      return cached
+    }
+
     const callOnce = async (): Promise<GetAddressesResponse> => {
       const raw = await postV1GetAddresses({
         client: profileApiClient,
@@ -518,11 +538,13 @@ class WalletService {
     }
 
     try {
-      return await retryWithBackoff(
+      const body = await retryWithBackoff(
         callOnce,
         isTransientHttpError,
         RETRY_DELAYS_MS
       )
+      setAddressesCache(cacheKey, body)
+      return body
     } catch (err) {
       Logger.error(
         '[WalletService.ts][getAddressesForExtendedPublicKey] failed',

--- a/packages/core-mobile/app/services/wallet/WalletService.tsx
+++ b/packages/core-mobile/app/services/wallet/WalletService.tsx
@@ -624,23 +624,25 @@ const callPostV1GetAddressesOnce = async ({
 
   // If hey-api gave us a structured error envelope, surface it as a
   // throw so the retry helper sees it. The status field is what
-  // `isTransientHttpError` keys on.
-  if (
-    raw &&
-    typeof raw === 'object' &&
-    'error' in raw &&
-    (raw as { error: unknown }).error !== undefined
-  ) {
-    const err = (raw as { error: { status?: number; message?: string } }).error
-    const message = err?.message ?? 'profile-api returned an error envelope'
-    const wrapped = new Error(
-      `postV1GetAddresses failed (status=${
-        err?.status ?? 'unknown'
-      }): ${message}`
-    )
-    // Attach status so retry helper can categorize.
-    ;(wrapped as Error & { status?: number }).status = err?.status
-    throw wrapped
+  // `isTransientHttpError` keys on. Only treat as a failure when `error`
+  // is actually populated (not null/undefined) AND no `data` came back —
+  // a `{ error: null }` or `{ data: ..., error: null }` shape would
+  // otherwise mask a real success.
+  if (raw && typeof raw === 'object') {
+    const errField = (raw as { error?: unknown }).error
+    const dataField = (raw as { data?: unknown }).data
+    if (errField != null && dataField === undefined) {
+      const err = errField as { status?: number; message?: string }
+      const message = err?.message ?? 'profile-api returned an error envelope'
+      const wrapped = new Error(
+        `postV1GetAddresses failed (status=${
+          err?.status ?? 'unknown'
+        }): ${message}`
+      )
+      // Attach status so retry helper can categorize.
+      ;(wrapped as Error & { status?: number }).status = err?.status
+      throw wrapped
+    }
   }
 
   const body = unwrapPostV1GetAddressesResult(raw)

--- a/packages/core-mobile/app/services/wallet/WalletService.tsx
+++ b/packages/core-mobile/app/services/wallet/WalletService.tsx
@@ -536,7 +536,7 @@ class WalletService {
         )
         throw err
       } finally {
-        clearInFlightAddressesFetch(cacheKey)
+        clearInFlightAddressesFetch(cacheKey, fetchPromise)
       }
     })()
 

--- a/packages/core-mobile/app/services/wallet/WalletService.tsx
+++ b/packages/core-mobile/app/services/wallet/WalletService.tsx
@@ -44,8 +44,10 @@ import {
 } from './getAddressesCache'
 
 // Retry helper. Local to WalletService — promote to utils/ only if a second
-// caller appears. Backoff: 250 / 500 / 1000 ms. Treat network errors and
-// HTTP 5xx as transient; everything else is fatal on the first try.
+// caller appears. Backoff: 250 / 500 / 1000 ms (3 retries, 4 total attempts).
+// Treat network errors and HTTP 5xx as transient; everything else is fatal
+// on the first try. Note: retry attempts are logged via Logger.info, which
+// is console-only — they do NOT surface to Sentry in production.
 const isTransientHttpError = (err: unknown): boolean => {
   if (
     err &&

--- a/packages/core-mobile/app/services/wallet/WalletService.tsx
+++ b/packages/core-mobile/app/services/wallet/WalletService.tsx
@@ -535,12 +535,20 @@ class WalletService {
           { source: SentryTag.ProfileApi }
         )
         throw err
-      } finally {
-        clearInFlightAddressesFetch(cacheKey, fetchPromise)
       }
     })()
 
     setInFlightAddressesFetch(cacheKey, fetchPromise)
+
+    // Compare-and-delete only the entry that still points at THIS promise, so
+    // a clear-then-new-fetch interleaving can't have our stale settle wipe a
+    // newer registration. The trailing `.catch(() => {})` swallows the chained
+    // promise's rejection so it isn't reported as unhandled — callers get the
+    // original `fetchPromise` for actual error propagation.
+    fetchPromise
+      .finally(() => clearInFlightAddressesFetch(cacheKey, fetchPromise))
+      .catch(() => undefined)
+
     return fetchPromise
   }
 

--- a/packages/core-mobile/app/services/wallet/WalletService.tsx
+++ b/packages/core-mobile/app/services/wallet/WalletService.tsx
@@ -40,7 +40,10 @@ import { LedgerWallet } from './LedgerWallet'
 import {
   getAddressesCache,
   setAddressesCache,
-  clearAddressesCache
+  clearAddressesCache,
+  getInFlightAddressesFetch,
+  setInFlightAddressesFetch,
+  clearInFlightAddressesFetch
 } from './getAddressesCache'
 
 // Retry helper. Local to WalletService — promote to utils/ only if a second
@@ -491,6 +494,11 @@ class WalletService {
       return cached
     }
 
+    const inFlight = getInFlightAddressesFetch(cacheKey)
+    if (inFlight) {
+      return inFlight
+    }
+
     const callOnce = async (): Promise<GetAddressesResponse> => {
       const raw = await postV1GetAddresses({
         client: profileApiClient,
@@ -539,22 +547,29 @@ class WalletService {
       return body
     }
 
-    try {
-      const body = await retryWithBackoff(
-        callOnce,
-        isTransientHttpError,
-        RETRY_DELAYS_MS
-      )
-      setAddressesCache(cacheKey, body)
-      return body
-    } catch (err) {
-      Logger.error(
-        '[WalletService.ts][getAddressesForExtendedPublicKey] failed',
-        err,
-        { source: SentryTag.ProfileApi }
-      )
-      throw err
-    }
+    const fetchPromise = (async () => {
+      try {
+        const body = await retryWithBackoff(
+          callOnce,
+          isTransientHttpError,
+          RETRY_DELAYS_MS
+        )
+        setAddressesCache(cacheKey, body)
+        return body
+      } catch (err) {
+        Logger.error(
+          '[WalletService.ts][getAddressesForExtendedPublicKey] failed',
+          err,
+          { source: SentryTag.ProfileApi }
+        )
+        throw err
+      } finally {
+        clearInFlightAddressesFetch(cacheKey)
+      }
+    })()
+
+    setInFlightAddressesFetch(cacheKey, fetchPromise)
+    return fetchPromise
   }
 
   public async getPrivateKeyFromMnemonic(

--- a/packages/core-mobile/app/services/wallet/getAddressesCache.test.ts
+++ b/packages/core-mobile/app/services/wallet/getAddressesCache.test.ts
@@ -1,0 +1,147 @@
+import { NetworkVMType } from '@avalabs/vm-module-types'
+import type { GetAddressesResponse } from 'utils/api/generated/profileApi.client/types.gen'
+import {
+  getAddressesCache,
+  setAddressesCache,
+  clearAddressesCache
+} from './getAddressesCache'
+
+const sampleAvmResponse: GetAddressesResponse = {
+  networkType: 'AVM',
+  externalAddresses: [{ address: 'X-avax1abc', index: 0, hasActivity: true }],
+  internalAddresses: []
+}
+
+const samplePvmResponse: GetAddressesResponse = {
+  networkType: 'PVM',
+  externalAddresses: [{ address: 'P-avax1abc', index: 0, hasActivity: false }],
+  internalAddresses: []
+}
+
+describe('getAddressesCache', () => {
+  beforeEach(() => {
+    clearAddressesCache()
+  })
+
+  it('returns undefined for an unseen key', () => {
+    expect(
+      getAddressesCache({
+        extendedPublicKey: 'xpub-1',
+        networkType: NetworkVMType.AVM,
+        isTestnet: false,
+        onlyWithActivity: false
+      })
+    ).toBeUndefined()
+  })
+
+  it('returns the stored value for a previously-set key', () => {
+    setAddressesCache(
+      {
+        extendedPublicKey: 'xpub-1',
+        networkType: NetworkVMType.AVM,
+        isTestnet: false,
+        onlyWithActivity: false
+      },
+      sampleAvmResponse
+    )
+
+    expect(
+      getAddressesCache({
+        extendedPublicKey: 'xpub-1',
+        networkType: NetworkVMType.AVM,
+        isTestnet: false,
+        onlyWithActivity: false
+      })
+    ).toBe(sampleAvmResponse)
+  })
+
+  it('keys distinct on networkType', () => {
+    setAddressesCache(
+      {
+        extendedPublicKey: 'xpub-1',
+        networkType: NetworkVMType.AVM,
+        isTestnet: false,
+        onlyWithActivity: false
+      },
+      sampleAvmResponse
+    )
+    setAddressesCache(
+      {
+        extendedPublicKey: 'xpub-1',
+        networkType: NetworkVMType.PVM,
+        isTestnet: false,
+        onlyWithActivity: false
+      },
+      samplePvmResponse
+    )
+
+    expect(
+      getAddressesCache({
+        extendedPublicKey: 'xpub-1',
+        networkType: NetworkVMType.AVM,
+        isTestnet: false,
+        onlyWithActivity: false
+      })
+    ).toBe(sampleAvmResponse)
+    expect(
+      getAddressesCache({
+        extendedPublicKey: 'xpub-1',
+        networkType: NetworkVMType.PVM,
+        isTestnet: false,
+        onlyWithActivity: false
+      })
+    ).toBe(samplePvmResponse)
+  })
+
+  it('keys distinct on isTestnet and onlyWithActivity', () => {
+    setAddressesCache(
+      {
+        extendedPublicKey: 'xpub-1',
+        networkType: NetworkVMType.AVM,
+        isTestnet: false,
+        onlyWithActivity: false
+      },
+      sampleAvmResponse
+    )
+
+    expect(
+      getAddressesCache({
+        extendedPublicKey: 'xpub-1',
+        networkType: NetworkVMType.AVM,
+        isTestnet: true,
+        onlyWithActivity: false
+      })
+    ).toBeUndefined()
+    expect(
+      getAddressesCache({
+        extendedPublicKey: 'xpub-1',
+        networkType: NetworkVMType.AVM,
+        isTestnet: false,
+        onlyWithActivity: true
+      })
+    ).toBeUndefined()
+  })
+
+  it('clearAddressesCache wipes everything', () => {
+    setAddressesCache(
+      {
+        extendedPublicKey: 'xpub-1',
+        networkType: NetworkVMType.AVM,
+        isTestnet: false,
+        onlyWithActivity: false
+      },
+      sampleAvmResponse
+    )
+
+    clearAddressesCache()
+
+    expect(
+      getAddressesCache({
+        extendedPublicKey: 'xpub-1',
+        networkType: NetworkVMType.AVM,
+        isTestnet: false,
+        onlyWithActivity: false
+      })
+    ).toBeUndefined()
+  })
+})

--- a/packages/core-mobile/app/services/wallet/getAddressesCache.test.ts
+++ b/packages/core-mobile/app/services/wallet/getAddressesCache.test.ts
@@ -3,7 +3,10 @@ import type { GetAddressesResponse } from 'utils/api/generated/profileApi.client
 import {
   getAddressesCache,
   setAddressesCache,
-  clearAddressesCache
+  clearAddressesCache,
+  getInFlightAddressesFetch,
+  setInFlightAddressesFetch,
+  clearInFlightAddressesFetch
 } from './getAddressesCache'
 
 const sampleAvmResponse: GetAddressesResponse = {
@@ -143,5 +146,79 @@ describe('getAddressesCache', () => {
         onlyWithActivity: false
       })
     ).toBeUndefined()
+  })
+})
+
+describe('getAddressesCache — in-flight promise tracking', () => {
+  beforeEach(() => {
+    clearAddressesCache()
+  })
+
+  it('returns undefined when no in-flight fetch for a key', () => {
+    expect(
+      getInFlightAddressesFetch({
+        extendedPublicKey: 'xpub-1',
+        networkType: NetworkVMType.AVM,
+        isTestnet: false,
+        onlyWithActivity: false
+      })
+    ).toBeUndefined()
+  })
+
+  it('returns the registered promise for an in-flight key', async () => {
+    const key = {
+      extendedPublicKey: 'xpub-1',
+      networkType: NetworkVMType.AVM,
+      isTestnet: false,
+      onlyWithActivity: false
+    } as const
+
+    const inflight = Promise.resolve(sampleAvmResponse)
+    setInFlightAddressesFetch(key, inflight)
+
+    expect(getInFlightAddressesFetch(key)).toBe(inflight)
+    // Cleanup so a hanging unresolved promise can't leak between tests
+    clearInFlightAddressesFetch(key)
+  })
+
+  it('clearInFlightAddressesFetch removes a single key without touching others', () => {
+    const keyA = {
+      extendedPublicKey: 'xpub-A',
+      networkType: NetworkVMType.AVM,
+      isTestnet: false,
+      onlyWithActivity: false
+    } as const
+    const keyB = {
+      extendedPublicKey: 'xpub-B',
+      networkType: NetworkVMType.AVM,
+      isTestnet: false,
+      onlyWithActivity: false
+    } as const
+
+    const promiseA = Promise.resolve(sampleAvmResponse)
+    const promiseB = Promise.resolve(samplePvmResponse)
+    setInFlightAddressesFetch(keyA, promiseA)
+    setInFlightAddressesFetch(keyB, promiseB)
+
+    clearInFlightAddressesFetch(keyA)
+
+    expect(getInFlightAddressesFetch(keyA)).toBeUndefined()
+    expect(getInFlightAddressesFetch(keyB)).toBe(promiseB)
+
+    clearInFlightAddressesFetch(keyB)
+  })
+
+  it('clearAddressesCache also wipes in-flight promises', () => {
+    const key = {
+      extendedPublicKey: 'xpub-1',
+      networkType: NetworkVMType.AVM,
+      isTestnet: false,
+      onlyWithActivity: false
+    } as const
+
+    setInFlightAddressesFetch(key, Promise.resolve(sampleAvmResponse))
+    clearAddressesCache()
+
+    expect(getInFlightAddressesFetch(key)).toBeUndefined()
   })
 })

--- a/packages/core-mobile/app/services/wallet/getAddressesCache.test.ts
+++ b/packages/core-mobile/app/services/wallet/getAddressesCache.test.ts
@@ -6,7 +6,8 @@ import {
   clearAddressesCache,
   getInFlightAddressesFetch,
   setInFlightAddressesFetch,
-  clearInFlightAddressesFetch
+  clearInFlightAddressesFetch,
+  getAddressesCacheEpoch
 } from './getAddressesCache'
 
 const sampleAvmResponse: GetAddressesResponse = {
@@ -220,5 +221,43 @@ describe('getAddressesCache — in-flight promise tracking', () => {
     clearAddressesCache()
 
     expect(getInFlightAddressesFetch(key)).toBeUndefined()
+  })
+})
+
+describe('getAddressesCache — epoch counter', () => {
+  beforeEach(() => {
+    clearAddressesCache()
+  })
+
+  it('exposes a numeric epoch', () => {
+    expect(typeof getAddressesCacheEpoch()).toBe('number')
+  })
+
+  it('increments on every clear', () => {
+    const start = getAddressesCacheEpoch()
+
+    clearAddressesCache()
+    expect(getAddressesCacheEpoch()).toBe(start + 1)
+
+    clearAddressesCache()
+    expect(getAddressesCacheEpoch()).toBe(start + 2)
+  })
+
+  it('does NOT increment on set / read operations', () => {
+    const start = getAddressesCacheEpoch()
+    const key = {
+      extendedPublicKey: 'xpub-1',
+      networkType: NetworkVMType.AVM,
+      isTestnet: false,
+      onlyWithActivity: false
+    } as const
+
+    setAddressesCache(key, sampleAvmResponse)
+    void getAddressesCache(key)
+    setInFlightAddressesFetch(key, Promise.resolve(sampleAvmResponse))
+    void getInFlightAddressesFetch(key)
+    clearInFlightAddressesFetch(key)
+
+    expect(getAddressesCacheEpoch()).toBe(start)
   })
 })

--- a/packages/core-mobile/app/services/wallet/getAddressesCache.test.ts
+++ b/packages/core-mobile/app/services/wallet/getAddressesCache.test.ts
@@ -179,7 +179,7 @@ describe('getAddressesCache — in-flight promise tracking', () => {
 
     expect(getInFlightAddressesFetch(key)).toBe(inflight)
     // Cleanup so a hanging unresolved promise can't leak between tests
-    clearInFlightAddressesFetch(key)
+    clearInFlightAddressesFetch(key, inflight)
   })
 
   it('clearInFlightAddressesFetch removes a single key without touching others', () => {
@@ -201,12 +201,37 @@ describe('getAddressesCache — in-flight promise tracking', () => {
     setInFlightAddressesFetch(keyA, promiseA)
     setInFlightAddressesFetch(keyB, promiseB)
 
-    clearInFlightAddressesFetch(keyA)
+    clearInFlightAddressesFetch(keyA, promiseA)
 
     expect(getInFlightAddressesFetch(keyA)).toBeUndefined()
     expect(getInFlightAddressesFetch(keyB)).toBe(promiseB)
 
-    clearInFlightAddressesFetch(keyB)
+    clearInFlightAddressesFetch(keyB, promiseB)
+  })
+
+  it('clearInFlightAddressesFetch is a no-op when the stored promise has been replaced', () => {
+    const key = {
+      extendedPublicKey: 'xpub-replace',
+      networkType: NetworkVMType.AVM,
+      isTestnet: false,
+      onlyWithActivity: false
+    } as const
+
+    const oldPromise = Promise.resolve(sampleAvmResponse)
+    const newPromise = Promise.resolve(sampleAvmResponse)
+
+    setInFlightAddressesFetch(key, oldPromise)
+    // Simulate clear + new fetch registration between old fetch start and
+    // its finally firing.
+    clearAddressesCache()
+    setInFlightAddressesFetch(key, newPromise)
+
+    // Stale finally from the old fetch must NOT remove the new entry.
+    clearInFlightAddressesFetch(key, oldPromise)
+
+    expect(getInFlightAddressesFetch(key)).toBe(newPromise)
+
+    clearInFlightAddressesFetch(key, newPromise)
   })
 
   it('clearAddressesCache also wipes in-flight promises', () => {
@@ -253,10 +278,11 @@ describe('getAddressesCache — epoch counter', () => {
     } as const
 
     setAddressesCache(key, sampleAvmResponse)
-    void getAddressesCache(key)
-    setInFlightAddressesFetch(key, Promise.resolve(sampleAvmResponse))
-    void getInFlightAddressesFetch(key)
-    clearInFlightAddressesFetch(key)
+    expect(getAddressesCache(key)).toBe(sampleAvmResponse)
+    const inflight = Promise.resolve(sampleAvmResponse)
+    setInFlightAddressesFetch(key, inflight)
+    expect(getInFlightAddressesFetch(key)).toBe(inflight)
+    clearInFlightAddressesFetch(key, inflight)
 
     expect(getAddressesCacheEpoch()).toBe(start)
   })

--- a/packages/core-mobile/app/services/wallet/getAddressesCache.ts
+++ b/packages/core-mobile/app/services/wallet/getAddressesCache.ts
@@ -47,6 +47,16 @@ export const setInFlightAddressesFetch = (
   inFlight.set(serializeKey(key), promise)
 }
 
-export const clearInFlightAddressesFetch = (key: CacheKey): void => {
-  inFlight.delete(serializeKey(key))
+// Compare-and-delete: only remove the entry if it still matches `promise`.
+// Guards against a stale `finally` from a pre-clear fetch deleting the
+// in-flight registration of a *newer* fetch for the same key after
+// `clearAddressesCache()` wiped the map in between.
+export const clearInFlightAddressesFetch = (
+  key: CacheKey,
+  promise: Promise<GetAddressesResponse>
+): void => {
+  const serialized = serializeKey(key)
+  if (inFlight.get(serialized) === promise) {
+    inFlight.delete(serialized)
+  }
 }

--- a/packages/core-mobile/app/services/wallet/getAddressesCache.ts
+++ b/packages/core-mobile/app/services/wallet/getAddressesCache.ts
@@ -1,0 +1,31 @@
+import { NetworkVMType } from '@avalabs/vm-module-types'
+import type { GetAddressesResponse } from 'utils/api/generated/profileApi.client/types.gen'
+
+type CacheKey = {
+  extendedPublicKey: string
+  networkType: NetworkVMType.AVM | NetworkVMType.PVM
+  isTestnet: boolean
+  onlyWithActivity: boolean
+}
+
+const serializeKey = (key: CacheKey): string =>
+  `${key.extendedPublicKey}|${key.networkType}|${
+    key.isTestnet ? 't' : 'm'
+  }|${key.onlyWithActivity ? 'a' : 'all'}`
+
+const cache = new Map<string, GetAddressesResponse>()
+
+export const getAddressesCache = (
+  key: CacheKey
+): GetAddressesResponse | undefined => cache.get(serializeKey(key))
+
+export const setAddressesCache = (
+  key: CacheKey,
+  value: GetAddressesResponse
+): void => {
+  cache.set(serializeKey(key), value)
+}
+
+export const clearAddressesCache = (): void => {
+  cache.clear()
+}

--- a/packages/core-mobile/app/services/wallet/getAddressesCache.ts
+++ b/packages/core-mobile/app/services/wallet/getAddressesCache.ts
@@ -9,9 +9,9 @@ type CacheKey = {
 }
 
 const serializeKey = (key: CacheKey): string =>
-  `${key.extendedPublicKey}|${key.networkType}|${
-    key.isTestnet ? 't' : 'm'
-  }|${key.onlyWithActivity ? 'a' : 'all'}`
+  `${key.extendedPublicKey}|${key.networkType}|${key.isTestnet ? 't' : 'm'}|${
+    key.onlyWithActivity ? 'a' : 'all'
+  }`
 
 const cache = new Map<string, GetAddressesResponse>()
 

--- a/packages/core-mobile/app/services/wallet/getAddressesCache.ts
+++ b/packages/core-mobile/app/services/wallet/getAddressesCache.ts
@@ -14,6 +14,7 @@ const serializeKey = (key: CacheKey): string =>
   }`
 
 const cache = new Map<string, GetAddressesResponse>()
+const inFlight = new Map<string, Promise<GetAddressesResponse>>()
 
 export const getAddressesCache = (
   key: CacheKey
@@ -28,4 +29,20 @@ export const setAddressesCache = (
 
 export const clearAddressesCache = (): void => {
   cache.clear()
+  inFlight.clear()
+}
+
+export const getInFlightAddressesFetch = (
+  key: CacheKey
+): Promise<GetAddressesResponse> | undefined => inFlight.get(serializeKey(key))
+
+export const setInFlightAddressesFetch = (
+  key: CacheKey,
+  promise: Promise<GetAddressesResponse>
+): void => {
+  inFlight.set(serializeKey(key), promise)
+}
+
+export const clearInFlightAddressesFetch = (key: CacheKey): void => {
+  inFlight.delete(serializeKey(key))
 }

--- a/packages/core-mobile/app/services/wallet/getAddressesCache.ts
+++ b/packages/core-mobile/app/services/wallet/getAddressesCache.ts
@@ -15,6 +15,7 @@ const serializeKey = (key: CacheKey): string =>
 
 const cache = new Map<string, GetAddressesResponse>()
 const inFlight = new Map<string, Promise<GetAddressesResponse>>()
+let epoch = 0
 
 export const getAddressesCache = (
   key: CacheKey
@@ -30,7 +31,10 @@ export const setAddressesCache = (
 export const clearAddressesCache = (): void => {
   cache.clear()
   inFlight.clear()
+  epoch += 1
 }
+
+export const getAddressesCacheEpoch = (): number => epoch
 
 export const getInFlightAddressesFetch = (
   key: CacheKey

--- a/packages/core-mobile/app/store/app/listeners.ts
+++ b/packages/core-mobile/app/store/app/listeners.ts
@@ -8,7 +8,7 @@ import BootSplash from 'react-native-bootsplash'
 import DeviceInfo from 'react-native-device-info'
 import SecureStorageService from 'security/SecureStorageService'
 import AnalyticsService from 'services/analytics/AnalyticsService'
-import WalletService from 'services/wallet/WalletService'
+import { clearAddressesCache } from 'services/wallet/getAddressesCache'
 import { WalletType } from 'services/wallet/types'
 import {
   onRehydrationComplete,
@@ -174,7 +174,7 @@ const clearData = async (
     Logger.error('failed to clear biometrics', e)
   )
   try {
-    WalletService.clearAddressCache()
+    clearAddressesCache()
   } catch (e) {
     Logger.error('failed to clear address cache', e)
   }
@@ -231,7 +231,7 @@ export const addAppListeners = (startListening: AppStartListening): void => {
     actionCreator: onAppLocked,
     effect: () => {
       try {
-        WalletService.clearAddressCache()
+        clearAddressesCache()
       } catch (e) {
         Logger.error('failed to clear address cache on lock', e)
       }

--- a/packages/core-mobile/app/store/app/listeners.ts
+++ b/packages/core-mobile/app/store/app/listeners.ts
@@ -8,6 +8,7 @@ import BootSplash from 'react-native-bootsplash'
 import DeviceInfo from 'react-native-device-info'
 import SecureStorageService from 'security/SecureStorageService'
 import AnalyticsService from 'services/analytics/AnalyticsService'
+import WalletService from 'services/wallet/WalletService'
 import { WalletType } from 'services/wallet/types'
 import {
   onRehydrationComplete,
@@ -172,6 +173,11 @@ const clearData = async (
   await BiometricsSDK.clearAllData().catch(e =>
     Logger.error('failed to clear biometrics', e)
   )
+  try {
+    WalletService.clearAddressCache()
+  } catch (e) {
+    Logger.error('failed to clear address cache', e)
+  }
   await SecureStorageService.clearAll().catch(e =>
     Logger.error('failed to clear secure store', e)
   )
@@ -219,6 +225,17 @@ export const addAppListeners = (startListening: AppStartListening): void => {
   startListening({
     actionCreator: onLogOut,
     effect: clearData
+  })
+
+  startListening({
+    actionCreator: onAppLocked,
+    effect: () => {
+      try {
+        WalletService.clearAddressCache()
+      } catch (e) {
+        Logger.error('failed to clear address cache on lock', e)
+      }
+    }
   })
 
   startListening({


### PR DESCRIPTION
## Summary

- Detect hey-api error envelopes from `postV1GetAddresses` and surface the upstream status + message instead of collapsing every failure to a single generic throw.
- Retry transient HTTP 5xx and network errors with exponential backoff (250 / 500 / 1000 ms) — 3 retries, 4 total attempts, ~1.75 s worst case.
- Session-scoped in-memory cache keyed by `(xpub, networkType, isTestnet, onlyWithActivity)`. Evicted on `onAppLocked` and `onLogOut`. No persistence.
- **In-flight Promise de-dup:** concurrent callers asking for the same key share one API call instead of firing duplicates.
- **Epoch guard:** if `clearAddressesCache()` fires mid-retry (e.g. app locks while a retry is still in flight), the in-flight result is returned to the caller but is NOT written to the freshly-cleared cache. Next caller correctly refetches.

Closes [CP-14224](https://ava-labs.atlassian.net/browse/CP-14224). Targets the ~1,295 user P-Chain send cascade documented in [Core Mobile Android Failures — Root-Cause Investigation](https://www.notion.so/3590e2bd5180811bbfc2e5042fb9258c) (issue #2).

## What this fixes

`getAddressesForExtendedPublicKey` used to call `postV1GetAddresses` exactly once and collapse every failure class — HTTP 5xx, Firebase App Check token failure, network timeout, rate limit, validator-shape mismatch — into one generic `"Failed to get addresses from postV1GetAddresses"` throw. Every transient blip on the API path turned into a user-facing P-Chain send failure. The Mar 1 – Apr 15 sample shows 40% of all `SendTransactionFailed` events were P-Chain (63% on iOS), with three Sentry issues throwing that literal string totaling ~1,295 users.

## Telemetry to watch post-deploy

- Sentry `core-react-native` issues `A9A` and `A98` — event count should drop sharply.
- PostHog `SendTransactionFailed` on `pvm:` networks — expect 30–50% reduction.
- Retry attempts log via `Logger.info` (console-only, not Sentry-routed) — visible in Reactotron / device logs but not in Sentry breadcrumbs.

## Test plan
iOS: 8521
Android: 8522

- [x] Unit: cache module — 12 tests in `getAddressesCache.test.ts` (5 base + 4 in-flight + 3 epoch)
- [x] Unit: retry behavior with fake timers — 3 tests in `WalletService.test.ts` including 4xx non-retry
- [x] Unit: cache integration — 5 tests in `WalletService.test.ts` (hit / clear / no-cache-on-failure / concurrent de-dup / mid-retry race)
- [x] Wallet directory full sweep — 237/237 passing
- [x] Ledger discovery test (regression check for the circular-import fix) — 7/7 passing
- [x] `yarn lint` clean on the modified files
- [x] `yarn tsc --noEmit` produces no new errors involving the modified files
- [ ] **Manual smoke (before merging):** send a P-Chain tx on Fuji from a mnemonic wallet; immediately send a second one without app reload, and confirm the API is NOT called the second time (network panel)
- [ ] **Manual smoke:** lock the app, unlock, send a P-Chain tx — confirm the API IS called again (cache evicted on lock)
- [ ] **Manual smoke:** log out and sign back in — confirm the API IS called again

## Notes on the additional commits

After the initial five commits (`d5dc931` … `c8766f51`), a wider test run surfaced a circular-import that the original `WalletService` import in `app/store/app/listeners.ts` introduced (`listeners → WalletService → WalletFactory → SeedlessWallet → account/utils → account/slice`). Fixed by importing `clearAddressesCache` directly from the cache module — which has zero wallet-service dependencies — and sidestepping the cycle entirely (`d30cc21`). Subsequent commits add in-flight Promise de-dup (`c988fbf`), an epoch guard for the mid-retry race (`1938ec9`), and remove the now-unused `WalletService.clearAddressCache` facade method (`d472535`). All commits pass spec + code-quality review.

## Out of scope

- Server-side App Check / profile-api fixes (separate workstream).
- The smaller `9KX`/`9M1` Ledger xpub bug (~60 users) — separate fix in the same area.
- Persisted cache across app launches.

[CP-14224]: https://ava-labs.atlassian.net/browse/CP-14224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ