### PR TITLE
CP-14225: instrument SwapFailed with userClickedMax + token metadata + quote aggregator

### DIFF
--- a/packages/core-mobile/app/new/common/components/TokenInputWidget.tsx
+++ b/packages/core-mobile/app/new/common/components/TokenInputWidget.tsx
@@ -44,6 +44,13 @@ type TokenInputWidgetProps = {
   shouldShowBalance?: boolean
   network?: Network
   onAmountChange: (amount: bigint) => void
+  /**
+   * Fires when the Max percentage button is pressed (100% of balance).
+   * Distinct from `onAmountChange` so callers can flag analytics events
+   * (e.g. SwapFailed.userClickedMax) without inferring "max" from amount
+   * equality, which is brittle.
+   */
+  onPressMax?: () => void
   formatInCurrency: (amount: bigint | undefined) => string
   onSelectToken?: () => void
   onFocus?: () => void
@@ -69,6 +76,7 @@ export const TokenInputWidget = forwardRef<
     maximum,
     amount,
     onAmountChange,
+    onPressMax,
     formatInCurrency,
     onSelectToken,
     onFocus,
@@ -113,6 +121,9 @@ export const TokenInputWidget = forwardRef<
     }
 
     onAmountChange?.(value)
+    if (button.percent === 1) {
+      onPressMax?.()
+    }
 
     setPercentageButtons(prevButtons =>
       prevButtons.map((b, i) =>

--- a/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
+++ b/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
@@ -94,6 +94,15 @@ interface SwapContextState {
   setDestination: Dispatch<SwapSide>
   swapStatus: SwapStatus
   setAmount: Dispatch<bigint | undefined>
+  /**
+   * True iff the source amount was most-recently set by the Max button.
+   * Cleared by any manual edit or by the 25%/50% percentage buttons.
+   * Captured on `SwapFailed` analytics so we can quantify the cohort Eric
+   * suspects (Markr toxic-pool quotes are more common on the small-amount
+   * "minimum probe" path the Max button takes).
+   */
+  userClickedMax: boolean
+  setUserClickedMax: Dispatch<boolean>
   /** ID of the transfer that was just successfully submitted */
   successTransferId: string | undefined
 }
@@ -119,6 +128,7 @@ export const SwapContextProvider = ({
   >()
   const isSwappingRef = useRef(false)
   const [amount, setAmount] = useState<bigint>()
+  const [userClickedMax, setUserClickedMax] = useState<boolean>(false)
 
   // Get quotes
   const [bestQuote] = useBestQuote()
@@ -265,6 +275,7 @@ export const SwapContextProvider = ({
       toTokenData: LocalTokenWithBalance
       quoteSelectionMode: 'manual' | 'auto'
       autoRetryAttempt?: number
+      userClickedMax: boolean
     }) => {
       const {
         transfer,
@@ -274,8 +285,13 @@ export const SwapContextProvider = ({
         fromTokenData,
         toTokenData,
         quoteSelectionMode,
-        autoRetryAttempt
+        autoRetryAttempt,
+        userClickedMax: maxClicked
       } = params
+      const sourceTokenAddress =
+        'address' in fromTokenData ? fromTokenData.address : undefined
+      const destinationTokenAddress =
+        'address' in toTokenData ? toTokenData.address : undefined
       audioFeedback(Audios.Send)
       AnalyticsService.capture('SwapConfirmed', {
         encrypted: {
@@ -320,8 +336,21 @@ export const SwapContextProvider = ({
       setSuccessTransferId(transfer.id)
       setSwapStatus(SwapStatus.Success)
 
-      // Dispatch trackFusionTransfer to start tracking transfer status
-      dispatch(trackFusionTransfer(transfer))
+      // Dispatch trackFusionTransfer to start tracking transfer status.
+      // Carries the analytics context the listener needs to populate the
+      // SwapFailed payload (userClickedMax, token metadata, quote aggregator)
+      // since the SDK's Transfer object doesn't expose those fields.
+      dispatch(
+        trackFusionTransfer({
+          transfer,
+          quote,
+          userClickedMax: maxClicked,
+          sourceTokenAddress,
+          sourceTokenSymbol: fromTokenData.symbol,
+          destinationTokenAddress,
+          destinationTokenSymbol: toTokenData.symbol
+        })
+      )
 
       // Dispatch swapCompleted for Nest Egg qualification tracking.
       // Computed from `transfer.amountIn` (what actually swapped) not
@@ -449,7 +478,8 @@ export const SwapContextProvider = ({
           fromTokenData: fromToken,
           toTokenData: toToken,
           quoteSelectionMode: userQuote ? 'manual' : 'auto',
-          autoRetryAttempt: !userQuote && retries > 0 ? retries : undefined
+          autoRetryAttempt: !userQuote && retries > 0 ? retries : undefined,
+          userClickedMax
         })
       } catch (error) {
         // Handle user rejection - silent exit, no error shown
@@ -506,7 +536,8 @@ export const SwapContextProvider = ({
       feeSetting,
       networkFees,
       handleSwapSuccess,
-      handleSwapError
+      handleSwapError,
+      userClickedMax
     ]
   )
 
@@ -532,6 +563,8 @@ export const SwapContextProvider = ({
     setDestination,
     swapStatus,
     setAmount,
+    userClickedMax,
+    setUserClickedMax,
     successTransferId
   }
 

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -164,7 +164,8 @@ export const SwapScreen = (): JSX.Element => {
     quoteError,
     swapStatus,
     successTransferId,
-    advanceBestQuote
+    advanceBestQuote,
+    setUserClickedMax
   } = useSwapContext()
   const [fromTokenValue, setFromTokenValue] = useState<bigint>()
   const [toTokenValue, setToTokenValue] = useState<bigint>()
@@ -404,9 +405,14 @@ export const SwapScreen = (): JSX.Element => {
     (amount: bigint): void => {
       setFromTokenValue(amount)
       setDestination(SwapSide.SELL)
+      setUserClickedMax(false)
     },
-    [setDestination]
+    [setDestination, setUserClickedMax]
   )
+
+  const handlePressMax = useCallback((): void => {
+    setUserClickedMax(true)
+  }, [setUserClickedMax])
 
   const handleToAmountChange = useCallback(
     (amount: bigint): void => {
@@ -518,6 +524,7 @@ export const SwapScreen = (): JSX.Element => {
           network={getNetwork(fromToken?.networkChainId)}
           formatInCurrency={amount => formatInCurrency(fromToken, amount)}
           onAmountChange={handleFromAmountChange}
+          onPressMax={handlePressMax}
           onSelectToken={handleSelectFromToken}
           maximum={fromMaxSwapAmount}
           valid={!validationError}
@@ -528,6 +535,7 @@ export const SwapScreen = (): JSX.Element => {
     theme,
     formatInCurrency,
     handleFromAmountChange,
+    handlePressMax,
     handleSelectFromToken,
     getNetwork,
     fromToken,
@@ -763,7 +771,14 @@ export const SwapScreen = (): JSX.Element => {
     setFromTokenValue(undefined)
     resetDebouncedFromTokenValue(undefined)
     setAmount(undefined)
-  }, [fromToken, setFromTokenValue, setAmount, resetDebouncedFromTokenValue])
+    setUserClickedMax(false)
+  }, [
+    fromToken,
+    setFromTokenValue,
+    setAmount,
+    resetDebouncedFromTokenValue,
+    setUserClickedMax
+  ])
 
   const prevFromRef = useRef(fromToken)
   const prevToRef = useRef(toToken)

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -419,8 +419,9 @@ export const SwapScreen = (): JSX.Element => {
       setToTokenValue(amount)
       setDestination(SwapSide.BUY)
       setAmount(amount)
+      setUserClickedMax(false)
     },
-    [setDestination, setAmount]
+    [setDestination, setAmount, setUserClickedMax]
   )
 
   const handleSelectFromToken = useCallback(async (): Promise<void> => {

--- a/packages/core-mobile/app/new/features/swap/store/actions.ts
+++ b/packages/core-mobile/app/new/features/swap/store/actions.ts
@@ -1,6 +1,16 @@
 import { createAction } from '@reduxjs/toolkit'
-import type { Transfer } from '../types'
+import type { Quote, Transfer } from '../types'
 
-export const trackFusionTransfer = createAction<Transfer>(
+export type TrackFusionTransferPayload = {
+  transfer: Transfer
+  quote: Quote
+  userClickedMax: boolean
+  sourceTokenAddress?: string
+  sourceTokenSymbol?: string
+  destinationTokenAddress?: string
+  destinationTokenSymbol?: string
+}
+
+export const trackFusionTransfer = createAction<TrackFusionTransferPayload>(
   'fusion/trackTransfer'
 )

--- a/packages/core-mobile/app/new/features/swap/store/listeners.test.ts
+++ b/packages/core-mobile/app/new/features/swap/store/listeners.test.ts
@@ -550,7 +550,7 @@ describe('Fusion listeners', () => {
       amountIn: 1290000000000000000n
     } as any
 
-    it('captures all 7 new fields on SwapFailed when userClickedMax is true', () => {
+    it('captures all 8 new fields on SwapFailed when userClickedMax is true', () => {
       const capture = createCaptureSwapAnalytics({
         quote: baseQuote,
         userClickedMax: true,

--- a/packages/core-mobile/app/new/features/swap/store/listeners.test.ts
+++ b/packages/core-mobile/app/new/features/swap/store/listeners.test.ts
@@ -11,6 +11,7 @@ import {
   selectFusionDisableCrossChainSwaps
 } from 'store/posthog/slice'
 import Logger from 'utils/Logger'
+import AnalyticsService from 'services/analytics/AnalyticsService'
 import FusionService from '../services/FusionService'
 import {
   useIsFusionServiceReady,
@@ -21,7 +22,8 @@ import {
 import {
   initFusionService,
   cleanupFusionService,
-  addFusionListeners
+  addFusionListeners,
+  createCaptureSwapAnalytics
 } from './listeners'
 
 // ---------------------------------------------------------------------------
@@ -53,6 +55,11 @@ jest.mock('utils/Logger', () => ({
   info: jest.fn(),
   warn: jest.fn(),
   error: jest.fn()
+}))
+
+jest.mock('services/analytics/AnalyticsService', () => ({
+  __esModule: true,
+  default: { capture: jest.fn() }
 }))
 
 jest.mock('store/rpc/utils/createInAppRequest', () => ({
@@ -468,12 +475,17 @@ describe('Fusion listeners', () => {
       )
       const effect = call[0].effect
       const transfer = { id: 'transfer-1', status: 'source-pending' } as any
+      const payload = {
+        transfer,
+        quote: { aggregator: { id: 'agg-1', name: 'KyberSwap' } } as any,
+        userClickedMax: false
+      }
 
       const mockListenerApi = {
         getState: jest.fn().mockReturnValue({}),
         delay: (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
       }
-      const effectPromise = effect({ payload: transfer }, mockListenerApi)
+      const effectPromise = effect({ payload }, mockListenerApi)
 
       // trackTransfer should not be called immediately
       expect(FusionService.trackTransfer).not.toHaveBeenCalled()
@@ -501,17 +513,131 @@ describe('Fusion listeners', () => {
         c => c[0]?.actionCreator?.type === 'fusion/trackTransfer'
       )
       const effect = call[0].effect
-      const transfer = { id: 'transfer-1', status: 'source-pending' } as any
+      const payload = {
+        transfer: { id: 'transfer-1', status: 'source-pending' } as any,
+        quote: { aggregator: { id: 'agg-1', name: 'KyberSwap' } } as any,
+        userClickedMax: false
+      }
 
       const mockListenerApi = {
         getState: jest.fn().mockReturnValue({}),
         delay: jest.fn()
       }
 
-      await effect({ payload: transfer }, mockListenerApi)
+      await effect({ payload }, mockListenerApi)
 
       expect(FusionService.trackTransfer).not.toHaveBeenCalled()
       expect(mockListenerApi.delay).not.toHaveBeenCalled()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  describe('createCaptureSwapAnalytics — SwapFailed instrumentation (CP-14225)', () => {
+    const baseFailedTransfer = {
+      status: 'failed',
+      fromAddress: '0xfromAddress',
+      toAddress: '0xtoAddress',
+      sourceChain: { chainId: 'eip155:43114' },
+      targetChain: { chainId: 'eip155:43114' },
+      source: { txHash: '0xsourceHash' },
+      target: undefined,
+      errorCode: 5006,
+      errorReason: 'TRANSACTION_REVERTED'
+    } as any
+
+    const baseQuote = {
+      aggregator: { id: 'agg-markr-odos', name: 'Odos' },
+      amountIn: 1290000000000000000n
+    } as any
+
+    it('captures all 7 new fields on SwapFailed when userClickedMax is true', () => {
+      const capture = createCaptureSwapAnalytics({
+        quote: baseQuote,
+        userClickedMax: true,
+        sourceTokenAddress: undefined,
+        sourceTokenSymbol: 'AVAX',
+        destinationTokenAddress: '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e',
+        destinationTokenSymbol: 'USDC'
+      })
+
+      capture(baseFailedTransfer)
+
+      expect(AnalyticsService.capture).toHaveBeenCalledWith(
+        'SwapFailed',
+        expect.objectContaining({
+          encrypted: expect.objectContaining({
+            sourceAddress: '0xfromAddress',
+            targetAddress: '0xtoAddress',
+            sourceChainId: 'eip155:43114',
+            targetChainId: 'eip155:43114',
+            sourceTxHash: '0xsourceHash',
+            errorCode: '5006',
+            errorReason: 'TRANSACTION_REVERTED',
+            userClickedMax: true,
+            sourceTokenSymbol: 'AVAX',
+            sourceTokenAddress: undefined,
+            sourceAmount: '1290000000000000000',
+            destinationTokenAddress:
+              '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e',
+            destinationTokenSymbol: 'USDC',
+            quoteAggregator: 'Odos',
+            quoteAggregatorId: 'agg-markr-odos'
+          })
+        })
+      )
+    })
+
+    it('captures userClickedMax=false on SwapFailed when the user did not press Max', () => {
+      const capture = createCaptureSwapAnalytics({
+        quote: baseQuote,
+        userClickedMax: false,
+        sourceTokenAddress: '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e',
+        sourceTokenSymbol: 'USDC',
+        destinationTokenAddress: undefined,
+        destinationTokenSymbol: 'AVAX'
+      })
+
+      capture(baseFailedTransfer)
+
+      expect(AnalyticsService.capture).toHaveBeenCalledWith(
+        'SwapFailed',
+        expect.objectContaining({
+          encrypted: expect.objectContaining({
+            userClickedMax: false,
+            sourceTokenSymbol: 'USDC',
+            destinationTokenSymbol: 'AVAX',
+            quoteAggregator: 'Odos'
+          })
+        })
+      )
+    })
+
+    it('does not enrich SwapSuccessful with the new fields', () => {
+      const completed = {
+        ...baseFailedTransfer,
+        status: 'completed',
+        source: { txHash: '0xsourceHash' },
+        target: { txHash: '0xtargetHash' }
+      } as any
+
+      const capture = createCaptureSwapAnalytics({
+        quote: baseQuote,
+        userClickedMax: true,
+        sourceTokenSymbol: 'AVAX',
+        destinationTokenSymbol: 'USDC'
+      })
+
+      capture(completed)
+
+      expect(AnalyticsService.capture).toHaveBeenCalledWith(
+        'SwapSuccessful',
+        expect.objectContaining({
+          encrypted: expect.not.objectContaining({
+            userClickedMax: expect.anything(),
+            quoteAggregator: expect.anything()
+          })
+        })
+      )
     })
   })
 })

--- a/packages/core-mobile/app/new/features/swap/store/listeners.ts
+++ b/packages/core-mobile/app/new/features/swap/store/listeners.ts
@@ -47,7 +47,7 @@ import {
 } from '../hooks/useZustandStore'
 import { fetchAdapter } from '../utils/fetchAdapter'
 import { logSdkError } from '../utils/fusionLogger'
-import { trackFusionTransfer, TrackFusionTransferPayload } from './actions'
+import { trackFusionTransfer, type TrackFusionTransferPayload } from './actions'
 
 /**
  * Get the current state of all Fusion feature flags

--- a/packages/core-mobile/app/new/features/swap/store/listeners.ts
+++ b/packages/core-mobile/app/new/features/swap/store/listeners.ts
@@ -47,7 +47,7 @@ import {
 } from '../hooks/useZustandStore'
 import { fetchAdapter } from '../utils/fetchAdapter'
 import { logSdkError } from '../utils/fusionLogger'
-import { trackFusionTransfer } from './actions'
+import { trackFusionTransfer, TrackFusionTransferPayload } from './actions'
 
 /**
  * Get the current state of all Fusion feature flags
@@ -109,10 +109,12 @@ const resumeTransfersTracking = (): void => {
     const pending = getPendingFusionTransfers()
     for (const { transfer } of pending) {
       Logger.info('[FusionTracking] resuming tracking for', transfer.id)
+      // Original UI state (quote, userClickedMax) is lost across reinit;
+      // resumed analytics emit without the CP-14225 enrichment fields.
       FusionService.trackTransfer(
         transfer,
         updateFusionTransfer,
-        captureSwapAnalytics
+        createCaptureSwapAnalytics()
       )
     }
   } catch (error) {
@@ -255,44 +257,67 @@ export const cleanupFusionService = async (
   useFusionServiceInitError.setState(null)
 }
 
-const captureSwapAnalytics = (
-  concludedTransfer: CompletedTransfer | FailedTransfer | RefundedTransfer
-): void => {
-  const addresses = {
-    sourceAddress: concludedTransfer.fromAddress,
-    targetAddress: concludedTransfer.toAddress,
-    sourceChainId: concludedTransfer.sourceChain.chainId,
-    targetChainId: concludedTransfer.targetChain.chainId
-  }
+/**
+ * Build a `concludedTransfer` callback for `FusionService.trackTransfer` that
+ * forwards Fusion outcomes to PostHog. The `context` carries client-side data
+ * the SDK's Transfer object does not (was-it-Max-button, token metadata,
+ * aggregator name/id) and is captured on `SwapFailed` so we can diagnose
+ * Markr toxic-pool cohorts post-hoc.
+ *
+ * Context is fully optional because `resumeTransfersTracking` re-creates the
+ * callback after an app reinit, when the original UI state (quote object,
+ * userClickedMax flag) is no longer in memory.
+ */
+export const createCaptureSwapAnalytics = (
+  context: Partial<Omit<TrackFusionTransferPayload, 'transfer'>> = {}
+) => {
+  return (
+    concludedTransfer: CompletedTransfer | FailedTransfer | RefundedTransfer
+  ): void => {
+    const addresses = {
+      sourceAddress: concludedTransfer.fromAddress,
+      targetAddress: concludedTransfer.toAddress,
+      sourceChainId: concludedTransfer.sourceChain.chainId,
+      targetChainId: concludedTransfer.targetChain.chainId
+    }
 
-  if (isCompletedTransfer(concludedTransfer)) {
-    AnalyticsService.capture('SwapSuccessful', {
-      encrypted: {
-        ...addresses,
-        sourceTxHash: concludedTransfer.source.txHash,
-        targetTxHash: concludedTransfer.target?.txHash
-      }
-    })
-  } else if (isFailedTransfer(concludedTransfer)) {
-    // source is optional on FailedTransfer — tx may not have been submitted
-    AnalyticsService.capture('SwapFailed', {
-      encrypted: {
-        ...addresses,
-        sourceTxHash: concludedTransfer.source?.txHash,
-        targetTxHash: concludedTransfer.target?.txHash,
-        errorCode: concludedTransfer.errorCode?.toString(),
-        errorReason: concludedTransfer.errorReason ?? undefined
-      }
-    })
-  } else if (isRefundedTransfer(concludedTransfer)) {
-    AnalyticsService.capture('SwapRefunded', {
-      encrypted: {
-        ...addresses,
-        sourceTxHash: concludedTransfer.source.txHash,
-        targetTxHash: concludedTransfer.target?.txHash,
-        refundTxHash: concludedTransfer.refund.txHash ?? undefined
-      }
-    })
+    if (isCompletedTransfer(concludedTransfer)) {
+      AnalyticsService.capture('SwapSuccessful', {
+        encrypted: {
+          ...addresses,
+          sourceTxHash: concludedTransfer.source.txHash,
+          targetTxHash: concludedTransfer.target?.txHash
+        }
+      })
+    } else if (isFailedTransfer(concludedTransfer)) {
+      // source is optional on FailedTransfer — tx may not have been submitted
+      AnalyticsService.capture('SwapFailed', {
+        encrypted: {
+          ...addresses,
+          sourceTxHash: concludedTransfer.source?.txHash,
+          targetTxHash: concludedTransfer.target?.txHash,
+          errorCode: concludedTransfer.errorCode?.toString(),
+          errorReason: concludedTransfer.errorReason ?? undefined,
+          userClickedMax: context.userClickedMax,
+          sourceTokenAddress: context.sourceTokenAddress,
+          sourceTokenSymbol: context.sourceTokenSymbol,
+          sourceAmount: context.quote?.amountIn.toString(),
+          destinationTokenAddress: context.destinationTokenAddress,
+          destinationTokenSymbol: context.destinationTokenSymbol,
+          quoteAggregator: context.quote?.aggregator.name,
+          quoteAggregatorId: context.quote?.aggregator.id
+        }
+      })
+    } else if (isRefundedTransfer(concludedTransfer)) {
+      AnalyticsService.capture('SwapRefunded', {
+        encrypted: {
+          ...addresses,
+          sourceTxHash: concludedTransfer.source.txHash,
+          targetTxHash: concludedTransfer.target?.txHash,
+          refundTxHash: concludedTransfer.refund.txHash ?? undefined
+        }
+      })
+    }
   }
 }
 
@@ -312,10 +337,7 @@ export const addFusionListeners = (startListening: AppStartListening): void => {
 
   startListening({
     actionCreator: trackFusionTransfer,
-    effect: async (
-      { payload: transfer },
-      listenerApi: AppListenerEffectAPI
-    ) => {
+    effect: async ({ payload }, listenerApi: AppListenerEffectAPI) => {
       if (!selectIsFusionEnabled(listenerApi.getState())) return
 
       try {
@@ -327,10 +349,11 @@ export const addFusionListeners = (startListening: AppStartListening): void => {
       }
 
       try {
+        const { transfer, ...context } = payload
         FusionService.trackTransfer(
           transfer,
           updateFusionTransfer,
-          captureSwapAnalytics
+          createCaptureSwapAnalytics(context)
         )
       } catch (error) {
         logSdkError('[trackFusionTransfer listener] error', error)

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -170,6 +170,14 @@ export type AnalyticsEvents = {
       targetTxHash?: string
       errorCode?: string
       errorReason?: string
+      userClickedMax?: boolean
+      sourceTokenAddress?: string
+      sourceTokenSymbol?: string
+      sourceAmount?: string
+      destinationTokenAddress?: string
+      destinationTokenSymbol?: string
+      quoteAggregator?: string
+      quoteAggregatorId?: string
     }
   }
   SwapRefunded: {


### PR DESCRIPTION
## Summary

- Extend `SwapFailed.encrypted` (`app/types/analytics.ts:148`) with 8 optional fields: `userClickedMax`, `sourceTokenAddress`, `sourceTokenSymbol`, `sourceAmount`, `destinationTokenAddress`, `destinationTokenSymbol`, `quoteAggregator`, `quoteAggregatorId`.
- Thread the analytics context through the `trackFusionTransfer` action payload (`store/actions.ts`) and into a new exported `createCaptureSwapAnalytics` factory (`store/listeners.ts`) so PostHog gets the enrichment alongside the existing `errorCode`/`errorReason`.
- Detect Max-button presses cleanly: new `onPressMax` callback on `TokenInputWidget` fires only for the 100% button; `SwapContext.userClickedMax` flips true on press and false on any other amount change. Resumed transfers (post-reinit) emit without the context fields — those are optional and undefined by design.

## Why

Closes the last gap from the [Fusion 5006 cross-platform investigation](https://www.notion.so/3590e2bd51808170a8e1e17cdc17a8f7). Eric Taylor (Fusion SDK) asked us to determine whether the ~305+40 mobile `SwapFailed` errorCode 5006 events are dominated by the Max-button "minimum probe" code path. Phase 1 of the follow-up proved 100% of ERC20-source failures hit the SDK's on-chain-simulation path; Phase 3 proved both `TargetCallFailed()` sample txs route to `OdosRouterV3` on chain. The remaining open question — what fraction of failures originate from a Max-button quote vs. a real user-typed amount — cannot be recovered retroactively from on-chain data; only the client knows whether the user pressed Max.

SDK source-dive (under [Update 5](https://www.notion.so/3590e2bd51808170a8e1e17cdc17a8f7) of the cross-platform doc) confirmed `Quote.aggregator` is an object `{ id, name, logoUrl? }` (not a string) and that there is no distinct Max-button code path on the SDK side, so the flag must come from UI state.

## Test plan

- [x] `yarn tsc --noEmit` clean
- [x] `yarn lint` clean on touched files (0 errors)
- [x] `yarn test app/new/features/swap/` clean — 22 suites / 440 tests pass, including 3 new tests for `createCaptureSwapAnalytics` covering `userClickedMax: true`, `userClickedMax: false`, and the non-failed branch (no enrichment on `SwapSuccessful`).
- [x] Manual verification on a Fusion swap in dev build: confirm `SwapFailed` PostHog event includes all 8 new fields when the swap fails after pressing Max.
- [ ] 7-day post-deploy PostHog re-export confirms the new fields are populated.

## Out of scope

- Extension parity (lives in `core-extension`; will be a separate ticket with the same pattern).
- SDK-side changes.
- Any client-side fix for Odos-routed quotes — Phase 3 of the investigation flagged Odos as the bad provider on chain, but the fix path is upstream in Markr (see [Update 5](https://www.notion.so/3590e2bd51808170a8e1e17cdc17a8f7)).

## Related

- Jira: [CP-14225](https://ava-labs.atlassian.net/browse/CP-14225)
- Tracker item #22
- Builds on Phase 1 + Phase 3 findings of the [Fusion 5006 follow-up](https://www.notion.so/35d0e2bd518081a68c79e596a141d747)

[CP-14225]: https://ava-labs.atlassian.net/browse/CP-14225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
