### PR TITLE
CP-14068, CP-14071, CP-14125, CP-14056: Ledger UI fixes

### DIFF
--- a/packages/core-mobile/app/new/common/components/WalletCard.tsx
+++ b/packages/core-mobile/app/new/common/components/WalletCard.tsx
@@ -239,15 +239,22 @@ const WalletCard = ({
               gap: 5,
               flex: 1
             }}>
-            <View>
-              <View sx={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+            <View style={{ flex: 1 }}>
+              <View
+                sx={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 4
+                }}>
                 <Text
                   testID={`manage_accounts_wallet_name__${wallet.name}`}
                   variant="heading4"
                   style={{
-                    lineHeight: 27
+                    lineHeight: 27,
+                    flexShrink: 1
                   }}
-                  numberOfLines={1}>
+                  numberOfLines={1}
+                  ellipsizeMode="tail">
                   {wallet.name}
                 </Text>
                 {isActive && (
@@ -266,7 +273,7 @@ const WalletCard = ({
                 style={{
                   marginTop: 4,
                   fontSize: 12,
-                  lineHeight: 12,
+                  lineHeight: 16,
                   color: colors.$textSecondary
                 }}>
                 {(() => {

--- a/packages/core-mobile/app/new/features/ledger/components/LedgerAppConnection.tsx
+++ b/packages/core-mobile/app/new/features/ledger/components/LedgerAppConnection.tsx
@@ -277,8 +277,8 @@ export const LedgerAppConnection: React.FC<LedgerAppConnectionProps> = ({
             ),
             title: 'Connect to Solana App',
             subtitle: onlySolana
-              ? `Open the Solana app on your ${deviceName}, then press Continue when ready.`
-              : `Close the Avalanche app and open the Solana app on your ${deviceName}, then press Continue when ready.`,
+              ? `Confirm "Open Solana?" on your ${deviceName}, then press Continue when ready.`
+              : `Your ${deviceName} will prompt "Open Solana?" — confirm it on the device, then press Continue when ready.`,
             showAnimation: false
           }
 

--- a/packages/core-mobile/app/new/features/ledger/screens/AppConnectionScreen.tsx
+++ b/packages/core-mobile/app/new/features/ledger/screens/AppConnectionScreen.tsx
@@ -23,6 +23,7 @@ import {
 } from 'services/ledger/LedgerBluetoothError'
 import LedgerService from 'services/ledger/LedgerService'
 import {
+  LedgerAppType,
   LedgerDerivationPathType,
   LedgerKeysByNetwork,
   LedgerMultiIndexKeys,
@@ -126,6 +127,25 @@ export default function AppConnectionScreen({
       LedgerService.stopAppPolling()
     }
   }, [])
+
+  // Auto-prompt "Open Solana?" on the Ledger device the moment the user lands
+  // on the Solana step. Without this, the device only prompts after the user
+  // taps Continue — by which time many users have already manually opened
+  // Solana, so `openApp` short-circuits and no system prompt is ever shown.
+  const hasPromptedSolanaOpenRef = useRef(false)
+  useEffect(() => {
+    if (
+      currentAppConnectionStep !== AppConnectionStep.SOLANA_CONNECT ||
+      hasPromptedSolanaOpenRef.current ||
+      !hasDeviceId
+    ) {
+      return
+    }
+    hasPromptedSolanaOpenRef.current = true
+    LedgerService.openApp(LedgerAppType.SOLANA).catch(err => {
+      Logger.info('Auto-openApp(Solana) failed (non-fatal)', err)
+    })
+  }, [currentAppConnectionStep, hasDeviceId])
 
   const headerCenterOverlay = useMemo(() => {
     if (!showProgressDots) return undefined

--- a/packages/core-mobile/app/new/features/send/components/RecentContacts.tsx
+++ b/packages/core-mobile/app/new/features/send/components/RecentContacts.tsx
@@ -21,6 +21,7 @@ import { useGlobalSearchParams } from 'expo-router'
 import { isValidAddress } from 'features/accountSettings/utils/isValidAddress'
 import React, { useCallback, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
+import { LedgerDerivationPathType } from 'services/ledger/types'
 import { WalletType } from 'services/wallet/types'
 import { selectAccountById } from 'store/account'
 import { Contact } from 'store/addressBook'
@@ -189,13 +190,30 @@ const ContactListItem = ({
   const wallets = useSelector(selectWallets)
   const walletsCount = Object.keys(wallets).length
 
+  const ledgerDerivationLabel =
+    wallet?.type === WalletType.LEDGER
+      ? LedgerDerivationPathType.BIP44
+      : wallet?.type === WalletType.LEDGER_LIVE
+      ? LedgerDerivationPathType.LedgerLive
+      : null
+  const isLedger = ledgerDerivationLabel !== null
+
+  const walletLabel =
+    wallet?.type === WalletType.PRIVATE_KEY
+      ? 'Imported'
+      : ledgerDerivationLabel
+      ? wallet?.name
+        ? `${wallet.name} · ${ledgerDerivationLabel}`
+        : ledgerDerivationLabel
+      : wallet?.name
+
   return (
     <ListViewItem
       avatar={avatar}
       title={item.name}
       renderTop={() =>
         wallet &&
-        walletsCount > 1 && (
+        (walletsCount > 1 || isLedger) && (
           <View sx={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}>
             <WalletIcon
               width={16}
@@ -210,9 +228,7 @@ const ContactListItem = ({
                 color: '$textSecondary',
                 lineHeight: 16
               }}>
-              {wallet?.type === WalletType.PRIVATE_KEY
-                ? 'Imported'
-                : wallet?.name}
+              {walletLabel}
             </Text>
           </View>
         )

--- a/packages/core-mobile/app/new/features/send/components/RecentContacts.tsx
+++ b/packages/core-mobile/app/new/features/send/components/RecentContacts.tsx
@@ -198,14 +198,8 @@ const ContactListItem = ({
       : null
   const isLedger = ledgerDerivationLabel !== null
 
-  const walletLabel =
-    wallet?.type === WalletType.PRIVATE_KEY
-      ? 'Imported'
-      : ledgerDerivationLabel
-      ? wallet?.name
-        ? `${wallet.name} · ${ledgerDerivationLabel}`
-        : ledgerDerivationLabel
-      : wallet?.name
+  const walletNameText =
+    wallet?.type === WalletType.PRIVATE_KEY ? 'Imported' : wallet?.name
 
   return (
     <ListViewItem
@@ -214,7 +208,12 @@ const ContactListItem = ({
       renderTop={() =>
         wallet &&
         (walletsCount > 1 || isLedger) && (
-          <View sx={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}>
+          <View
+            sx={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 2
+            }}>
             <WalletIcon
               width={16}
               height={16}
@@ -222,14 +221,32 @@ const ContactListItem = ({
               color={theme.colors.$textSecondary}
               isExpanded
             />
-            <Text
-              variant="buttonSmall"
-              sx={{
-                color: '$textSecondary',
-                lineHeight: 16
-              }}>
-              {walletLabel}
-            </Text>
+            {walletNameText ? (
+              <Text
+                variant="buttonSmall"
+                numberOfLines={1}
+                ellipsizeMode="tail"
+                sx={{
+                  color: '$textSecondary',
+                  lineHeight: 16,
+                  flexShrink: 1
+                }}>
+                {walletNameText}
+              </Text>
+            ) : null}
+            {ledgerDerivationLabel ? (
+              <Text
+                variant="buttonSmall"
+                numberOfLines={1}
+                sx={{
+                  color: '$textSecondary',
+                  lineHeight: 16
+                }}>
+                {walletNameText
+                  ? ` · ${ledgerDerivationLabel}`
+                  : ledgerDerivationLabel}
+              </Text>
+            ) : null}
           </View>
         )
       }


### PR DESCRIPTION
Bitrise: https://app.bitrise.io/app/7d7ca5af7066e290/pipelines/fc44116f-3990-44f3-b3fe-8c82c65f9dd5
iOS: 8496
Android: 8497

## Description

**Ticket: [CP-14068]**
**Ticket: [CP-14071]**
**Ticket: [CP-14125]**
**Ticket: [CP-14056]**

Please provide:

- CP-14068: auto-trigger "Open Solana?" prompt on Ledger when entering the Solana onboarding step + update copy so users know to confirm on-device rather than navigate apps manually
- CP-14071: bump secondary-text lineHeight from 12 to 16 in WalletCard so "LedgerLive – X accounts" descenders aren't clipped on Android
- CP-14125: add flex / flexShrink / ellipsizeMode to wallet name so it truncates before colliding with the active-wallet green dot
- CP-14056: show derivation path (BIP44 / LedgerLive) next to wallet name in Send recipient list so users can distinguish Ledger types

## Screenshots/Videos

CP-14068
https://github.com/user-attachments/assets/b4bb0033-ce45-44b9-a220-569ae61ceb21
CP-10471 | CP-14125
<img width="500" height="1000" alt="Screenshot_20260512_101618_Core Internal" src="https://github.com/user-attachments/assets/8a5b209c-ed0f-43b2-a44f-172cbcad049f" />
CP-14056
<img width="500" height="1000" alt="Screenshot_20260512_101611_Core Internal" src="https://github.com/user-attachments/assets/ac440f14-c3b3-4406-b474-17228b3270bf" />



## Testing

## Dev testing steps

### CP-14068 — Auto-trigger "Open Solana?" prompt during Ledger onboarding
1. Fresh-install / reset the wallet so you're at the entry screen.
2. Tap **Add wallet → Ledger** and pair a Ledger device over Bluetooth.
3. Open the **Avalanche** app on the Ledger, tap **Continue** in the app, and wait for Avalanche keys to load.
4. As soon as the screen flips to **"Connect to Solana App"**, your Ledger device should display **"Open Solana?"** without you touching it.
5. Confirm the prompt on the device.
6. Verify the mobile copy now reads `Your Ledger will prompt "Open Solana?" — confirm it on the device, then press Continue when ready.`
7. Tap **Continue** — Solana keys load and the wizard advances to the address-confirmation screen.

### CP-14071 — Android secondary-text cutoff in WalletCard
1. **On Android only.**
2. Import a **Ledger Live** wallet (or a BIP44 Ledger wallet — both show the secondary line).
3. Navigate to **Settings → Manage Wallets**.
4. Locate the imported Ledger wallet row.
5. Verify the small secondary text under the wallet name reads `LedgerLive – X accounts` (or `BIP44 – X accounts`) and **descenders ("g" in "Ledger") are no longer clipped** at the bottom.
6. Compare visually with iOS to confirm parity.

### CP-14125 — Long Ledger wallet name overlapping the active dot
1. Import a Ledger wallet.
2. Rename it to something long, e.g. **"My Super Long Ledger Wallet Name For Testing"** via the rename action.
3. Make sure it is the **active** wallet (the green dot should be next to its name).
4. Open **Settings → Manage Wallets**.
5. Verify the wallet name truncates with **`…`** before the green active indicator, and the green dot is fully visible (not pushed off-screen or overlapped by text).
6. Repeat on Android.
7. **Regression:** wallets with short names render unchanged — name + green dot inline as before, no extra ellipsis.


**QA Testing (if applicable)**

- Provide instructions for QA to test this feature thoroughly
- State expected behavior / acceptance criteria

## Checklist

Please check all that apply (if applicable)

- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14068]: https://ava-labs.atlassian.net/browse/CP-14068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-14071]: https://ava-labs.atlassian.net/browse/CP-14071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-14125]: https://ava-labs.atlassian.net/browse/CP-14125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-14056]: https://ava-labs.atlassian.net/browse/CP-14056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ