### PR TITLE
CP-14006: fix android `PushNotificationPressed` under-reporting

### DIFF
--- a/packages/core-mobile/app/contexts/DeeplinkContext/DeeplinkContext.tsx
+++ b/packages/core-mobile/app/contexts/DeeplinkContext/DeeplinkContext.tsx
@@ -91,7 +91,9 @@ export const DeeplinkContextProvider = ({
       handleNotificationCallback
     )
 
-    NotificationsService.onBackgroundEvent(handleNotificationCallback)
+    // The notifee background event handler is registered once in `index.js`
+    // (notifee only supports a single handler). Cold-start press handling is
+    // performed via NotificationsService.getInitialNotification above.
 
     return () => {
       unsubscribeForegroundEvent()

--- a/packages/core-mobile/app/contexts/DeeplinkContext/DeeplinkContext.tsx
+++ b/packages/core-mobile/app/contexts/DeeplinkContext/DeeplinkContext.tsx
@@ -8,7 +8,7 @@ import React, {
 import { useDispatch, useSelector } from 'react-redux'
 import { selectIsIdled, selectWalletState, WalletState } from 'store/app'
 import { noop } from '@avalabs/core-utils-sdk'
-import { Linking } from 'react-native'
+import { AppState, Linking } from 'react-native'
 import NotificationsService from 'services/notifications/NotificationsService'
 import Logger from 'utils/Logger'
 import {
@@ -92,11 +92,23 @@ export const DeeplinkContextProvider = ({
     )
 
     // The notifee background event handler is registered once in `index.js`
-    // (notifee only supports a single handler). Cold-start press handling is
-    // performed via NotificationsService.getInitialNotification above.
+    // (notifee only supports a single handler). When a background PRESS occurs
+    // while the app is alive but minimized, the data is stashed in
+    // NotificationsService.pendingBackgroundPress; we consume it here on the
+    // next AppState 'active' transition so the deeplink callback runs in a
+    // mounted React context. Cold-start press is handled separately via
+    // getInitialNotification above.
+    const appStateSub = AppState.addEventListener('change', state => {
+      if (state !== 'active') return
+      const pending = NotificationsService.consumePendingBackgroundPress()
+      if (pending) {
+        handleNotificationCallback(pending)
+      }
+    })
 
     return () => {
       unsubscribeForegroundEvent()
+      appStateSub.remove()
     }
   }, [handleNotificationCallback, isAllNotificationsBlocked])
 

--- a/packages/core-mobile/app/contexts/DeeplinkContext/DeeplinkContext.tsx
+++ b/packages/core-mobile/app/contexts/DeeplinkContext/DeeplinkContext.tsx
@@ -92,18 +92,18 @@ export const DeeplinkContextProvider = ({
     )
 
     // The notifee background event handler is registered once in `index.js`
-    // (notifee only supports a single handler). When a background PRESS occurs
-    // while the app is alive but minimized, the data is stashed in
-    // NotificationsService.pendingBackgroundPress; we consume it here on the
-    // next AppState 'active' transition so the deeplink callback runs in a
-    // mounted React context. Cold-start press is handled separately via
-    // getInitialNotification above.
+    // (notifee only supports a single handler). When a background PRESS
+    // occurs while the app is alive but minimized, that headless handler
+    // stashes the notification data; on the next AppState 'active'
+    // transition we drain it here — analytics capture + deeplink callback
+    // both happen inside NotificationsService.handlePendingBackgroundPress
+    // so they run in a React-mounted context with PostHog configured.
+    // Cold-start press is handled separately via getInitialNotification.
     const appStateSub = AppState.addEventListener('change', state => {
       if (state !== 'active') return
-      const pending = NotificationsService.consumePendingBackgroundPress()
-      if (pending) {
-        handleNotificationCallback(pending)
-      }
+      NotificationsService.handlePendingBackgroundPress(
+        handleNotificationCallback
+      )
     })
 
     return () => {

--- a/packages/core-mobile/app/services/fcm/FCMService.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.ts
@@ -15,33 +15,20 @@ import {
   BalanceChangeData,
   BalanceChangeEvents,
   NewsData,
-  NewsEvents,
   NotificationPayload,
   NotificationPayloadSchema,
   NotificationTypes
 } from 'services/fcm/types'
+import { DEFAULT_ANDROID_CHANNEL } from 'services/notifications/channels'
 import {
-  ChannelId,
-  DEFAULT_ANDROID_CHANNEL
-} from 'services/notifications/channels'
-import NotificationsService, {
+  EVENT_TO_CH_ID,
   resolveChannelId
-} from 'services/notifications/NotificationsService'
+} from 'services/notifications/eventChannelMap'
+import NotificationsService from 'services/notifications/NotificationsService'
 import { DisplayNotificationParams } from 'services/notifications/types'
 import Logger from 'utils/Logger'
 
 type UnsubscribeFunc = () => void
-
-export const EVENT_TO_CH_ID: Record<string, ChannelId> = {
-  [BalanceChangeEvents.ALLOWANCE_APPROVED]: ChannelId.BALANCE_CHANGES,
-  [BalanceChangeEvents.BALANCES_SPENT]: ChannelId.BALANCE_CHANGES,
-  [BalanceChangeEvents.BALANCES_RECEIVED]: ChannelId.BALANCE_CHANGES,
-  [BalanceChangeEvents.BALANCES_TRANSFERRED]: ChannelId.BALANCE_CHANGES,
-  [NewsEvents.MARKET_NEWS]: ChannelId.MARKET_NEWS,
-  [NewsEvents.OFFERS_AND_PROMOTIONS]: ChannelId.OFFERS_AND_PROMOTIONS,
-  [NewsEvents.PRICE_ALERTS]: ChannelId.PRICE_ALERTS,
-  [NewsEvents.PRODUCT_ANNOUNCEMENTS]: ChannelId.PRODUCT_ANNOUNCEMENTS
-}
 
 /**
  * Wrapper for @react-native-firebase/messaging

--- a/packages/core-mobile/app/services/fcm/FCMService.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.ts
@@ -24,7 +24,9 @@ import {
   ChannelId,
   DEFAULT_ANDROID_CHANNEL
 } from 'services/notifications/channels'
-import NotificationsService from 'services/notifications/NotificationsService'
+import NotificationsService, {
+  resolveChannelId
+} from 'services/notifications/NotificationsService'
 import { DisplayNotificationParams } from 'services/notifications/types'
 import Logger from 'utils/Logger'
 
@@ -199,18 +201,14 @@ class FCMService {
       const { data } = notificationData
       if (typeof data?.url !== 'string') return
 
-      // Capture analytics BEFORE the deeplink-skip decision, and use the same
-      // channelId fallback as the cold-start path
-      // (NotificationsService.getInitialNotification). Previously, both the
-      // `shouldSkipHandlingDeeplink` early-return and the strict `channelId`
-      // guard caused balance-change press events on iOS background to never
-      // reach this capture call.
-      const channelId =
-        (typeof data.channelId === 'string' && data.channelId.length > 0
-          ? data.channelId
-          : undefined) ??
-        EVENT_TO_CH_ID[result.data.data.event as string] ??
-        DEFAULT_ANDROID_CHANNEL
+      // Capture analytics BEFORE the deeplink-skip decision so balance-change
+      // and walletconnect taps are no longer dropped. Channel-id resolution
+      // is centralized in `resolveChannelId` to keep precedence consistent
+      // with the cold-start and warm-background paths.
+      const channelId = resolveChannelId({
+        data,
+        fallbackEvent: result.data.data.event
+      })
       AnalyticsService.capture('PushNotificationPressed', {
         channelId,
         deeplinkUrl: data.url,

--- a/packages/core-mobile/app/services/fcm/FCMService.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.ts
@@ -229,7 +229,8 @@ class FCMService {
       ) {
         AnalyticsService.capture('PushNotificationPressed', {
           channelId: notificationData.data.channelId,
-          deeplinkUrl: notificationData.data.url
+          deeplinkUrl: notificationData.data.url,
+          source: 'ios_background'
         })
       }
     })

--- a/packages/core-mobile/app/services/fcm/FCMService.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.ts
@@ -196,22 +196,36 @@ class FCMService {
       }
 
       const notificationData = this.#prepareNotificationData(result.data)
+      const { data } = notificationData
+      if (typeof data?.url !== 'string') return
 
-      if (
-        notificationData.data?.url === undefined ||
-        typeof notificationData.data.url !== 'string'
-      ) {
-        return
-      }
+      // Capture analytics BEFORE the deeplink-skip decision, and use the same
+      // channelId fallback as the cold-start path
+      // (NotificationsService.getInitialNotification). Previously, both the
+      // `shouldSkipHandlingDeeplink` early-return and the strict `channelId`
+      // guard caused balance-change press events on iOS background to never
+      // reach this capture call.
+      const channelId =
+        (typeof data.channelId === 'string' && data.channelId.length > 0
+          ? data.channelId
+          : undefined) ??
+        EVENT_TO_CH_ID[result.data.data.event as string] ??
+        DEFAULT_ANDROID_CHANNEL
+      AnalyticsService.capture('PushNotificationPressed', {
+        channelId,
+        deeplinkUrl: data.url,
+        appState: 'background',
+        handler: 'fcm'
+      })
 
       // we simply take user to portfolio/home page if the url is walletconnect or balanche-change events
-      if (this.shouldSkipHandlingDeeplink(notificationData.data.url)) {
+      if (this.shouldSkipHandlingDeeplink(data.url)) {
         return
       }
 
       handleDeeplink({
         deeplink: {
-          url: notificationData.data.url,
+          url: data.url,
           origin: DeepLinkOrigin.ORIGIN_NOTIFICATION
         },
         dispatch: action => action,
@@ -223,16 +237,6 @@ class FCMService {
             params: { deeplinkUrl: link.url }
           })
       })
-      if (
-        typeof notificationData.data?.channelId === 'string' &&
-        notificationData.data?.channelId.length !== 0
-      ) {
-        AnalyticsService.capture('PushNotificationPressed', {
-          channelId: notificationData.data.channelId,
-          deeplinkUrl: notificationData.data.url,
-          source: 'ios_background'
-        })
-      }
     })
   }
 

--- a/packages/core-mobile/app/services/fcm/types.ts
+++ b/packages/core-mobile/app/services/fcm/types.ts
@@ -62,8 +62,10 @@ export const NotificationPayloadSchema = object({
     })
       .optional()
       .describe(
-        'Deprecated: this is for backward compatibility, remove when https://github.com/ava-labs/core-notification-sender-service/pull/62 is released to prod '
-      ) //TODO
+        // Backend only sends this for SNS endpoints classified as UNKNOWN
+        // (legacy clients). iOS foreground path still depends on it.
+        'Legacy field for UNKNOWN-classified SNS endpoints.'
+      )
   }).optional()
 })
 

--- a/packages/core-mobile/app/services/notifications/NotificationService.test.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationService.test.ts
@@ -384,12 +384,21 @@ describe('getInitialNotification', () => {
     expect(NotificationsService.consumePendingBackgroundPress()).toBeUndefined()
   })
 
-  it('drains pendingBackgroundPress even when no initial notification is present on either source', async () => {
-    setPendingBackgroundPress({ url: 'core://stale' })
+  it('preserves pendingBackgroundPress when no cold-start notification is found, so a pending warm-background press can still be consumed by the AppState listener', async () => {
+    // Re-invocation path: if the `getInitialNotification` effect re-runs
+    // (e.g. on `isAllNotificationsBlocked` flag toggle) while a warm-
+    // background press is sitting in pending, we must NOT drain it — the
+    // DeeplinkContext AppState 'active' listener owns that press.
+    const pending = { url: 'core://portfolio', event: 'PRODUCT_ANNOUNCEMENTS' }
+    setPendingBackgroundPress(pending)
 
     await NotificationsService.getInitialNotification(callback)
 
-    expect(NotificationsService.consumePendingBackgroundPress()).toBeUndefined()
+    expect(AnalyticsService.capture).not.toHaveBeenCalled()
+    expect(callback).toHaveBeenCalledWith(undefined)
+    expect(NotificationsService.consumePendingBackgroundPress()).toEqual(
+      pending
+    )
   })
 })
 

--- a/packages/core-mobile/app/services/notifications/NotificationService.test.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationService.test.ts
@@ -107,6 +107,13 @@ describe('handleNotificationPress', () => {
   jest
     .spyOn(NotificationsService, 'cancelTriggerNotification')
     .mockImplementation(mockCancelTriggerNotification)
+
+  beforeEach(() => {
+    mockCallback.mockClear()
+    mockCancelTriggerNotification.mockClear()
+    jest.spyOn(AnalyticsService, 'capture').mockResolvedValue(undefined)
+  })
+
   it('should have called mockCallback and mockCancelTriggerNotification', async () => {
     const mockDetail = {
       notification: {
@@ -122,6 +129,44 @@ describe('handleNotificationPress', () => {
     })
     expect(mockCancelTriggerNotification).toHaveBeenCalled()
     expect(mockCallback).toHaveBeenCalled()
+  })
+
+  it('does not capture PushNotificationPressed when the foreground PRESS has no deeplink url, but still routes the callback', async () => {
+    const mockDetail = {
+      notification: {
+        id: 'testNodeId',
+        data: { event: 'PRODUCT_ANNOUNCEMENTS' }
+      }
+    }
+    await NotificationsService.handleNotificationPress({
+      detail: mockDetail,
+      callback: mockCallback
+    })
+    expect(AnalyticsService.capture).not.toHaveBeenCalled()
+    expect(mockCallback).toHaveBeenCalledWith(mockDetail.notification.data)
+  })
+
+  it('captures PushNotificationPressed (appState=foreground, handler=notifee) when the foreground PRESS has a deeplink url', async () => {
+    const mockDetail = {
+      notification: {
+        id: 'testNodeId',
+        data: { url: 'core://portfolio', event: 'PRODUCT_ANNOUNCEMENTS' },
+        android: { channelId: ChannelId.PRODUCT_ANNOUNCEMENTS }
+      }
+    }
+    await NotificationsService.handleNotificationPress({
+      detail: mockDetail,
+      callback: mockCallback
+    })
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
+        deeplinkUrl: 'core://portfolio',
+        appState: 'foreground',
+        handler: 'notifee'
+      }
+    )
   })
 })
 

--- a/packages/core-mobile/app/services/notifications/NotificationService.test.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationService.test.ts
@@ -300,6 +300,53 @@ describe('getInitialNotification', () => {
     expect(callback).toHaveBeenCalledWith(data)
   })
 
+  it('falls back to urlV2 when the FCM initial notification only has urlV2 (legacy iOS NEWS payload)', async () => {
+    // NEWS notifications can arrive with only `urlV2`; the FCM cold-start
+    // path receives the raw backend SNS payload (notifee path is normalized
+    // upstream), so without this fallback we silently drop NEWS cold-start
+    // presses on the legacy iOS APNs alert route.
+    const data = {
+      urlV2: 'core://watchlist',
+      event: 'PRICE_ALERTS'
+    }
+    setFcmInitial({ data })
+
+    await NotificationsService.getInitialNotification(callback)
+
+    expect(AnalyticsService.capture).toHaveBeenCalledTimes(1)
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: ChannelId.PRICE_ALERTS,
+        deeplinkUrl: 'core://watchlist',
+        appState: 'cold_start',
+        handler: 'fcm'
+      }
+    )
+    expect(callback).toHaveBeenCalledWith(data)
+  })
+
+  it('prefers url over urlV2 in the FCM initial notification payload', async () => {
+    const data = {
+      url: 'core://portfolio',
+      urlV2: 'core://watchlist',
+      event: 'PRICE_ALERTS'
+    }
+    setFcmInitial({ data })
+
+    await NotificationsService.getInitialNotification(callback)
+
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: ChannelId.PRICE_ALERTS,
+        deeplinkUrl: 'core://portfolio',
+        appState: 'cold_start',
+        handler: 'fcm'
+      }
+    )
+  })
+
   it('does not capture and invokes callback with undefined when no initial notification is present in either source', async () => {
     await NotificationsService.getInitialNotification(callback)
 
@@ -498,6 +545,20 @@ describe('registerBackgroundNotificationHandler', () => {
     expect(cancelSpy).toHaveBeenCalledWith('noti-1')
   })
 
+  it('decrements the badge count on PRESS events (mirrors the foreground handler)', async () => {
+    // The foreground handler decrements on PRESS; without the matching
+    // decrement here a warm-background tap (or any cold-start tap) would
+    // leave the badge inflated even after the user read the notification.
+    NotificationsService.registerBackgroundNotificationHandler()
+
+    await getHandler()({
+      type: EventType.PRESS,
+      detail: { notification: { id: 'noti-badge' } }
+    })
+
+    expect(notifee.decrementBadgeCount).toHaveBeenCalledWith(1)
+  })
+
   it('ignores non-PRESS background events (e.g. DELIVERED)', async () => {
     const cancelSpy = jest
       .spyOn(NotificationsService, 'cancelTriggerNotification')
@@ -511,6 +572,7 @@ describe('registerBackgroundNotificationHandler', () => {
     })
 
     expect(cancelSpy).not.toHaveBeenCalled()
+    expect(notifee.decrementBadgeCount).not.toHaveBeenCalled()
     expect(AnalyticsService.capture).not.toHaveBeenCalled()
   })
 

--- a/packages/core-mobile/app/services/notifications/NotificationService.test.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationService.test.ts
@@ -1,6 +1,17 @@
 import notifee, { EventDetail, EventType } from '@notifee/react-native'
-import { ChannelId } from './channels'
+import messaging from '@react-native-firebase/messaging'
+import AnalyticsService from 'services/analytics/AnalyticsService'
+import { ChannelId, DEFAULT_ANDROID_CHANNEL } from './channels'
 import NotificationsService from './NotificationsService'
+
+// Override the messaging mock from tests/jestSetup/firebase.js so its default
+// export is a jest.fn(), allowing per-test control of getInitialNotification.
+jest.mock('@react-native-firebase/messaging', () =>
+  jest.fn(() => ({
+    deleteToken: jest.fn(() => ({ token: 'fcmToken' })),
+    getInitialNotification: jest.fn().mockResolvedValue(null)
+  }))
+)
 
 describe('scheduleNotification', () => {
   it('should have scheduled notification', async () => {
@@ -142,5 +153,238 @@ describe('handleNotificationEvent', () => {
     })
     expect(mockIncrementBadgeCount).not.toHaveBeenCalled()
     expect(mockHandleNotificationPress).not.toHaveBeenCalled()
+  })
+})
+
+describe('getInitialNotification', () => {
+  const callback = jest.fn()
+  const buildNotifeeInitial = (
+    data: Record<string, unknown> | undefined,
+    androidChannelId?: string
+  ): unknown => ({
+    notification: {
+      data,
+      android: androidChannelId ? { channelId: androidChannelId } : undefined
+    },
+    pressAction: { id: 'default' }
+  })
+
+  const setFcmInitial = (value: unknown): void => {
+    ;(messaging as unknown as jest.Mock).mockReturnValue({
+      getInitialNotification: jest.fn().mockResolvedValue(value)
+    })
+  }
+
+  const setNotifeeInitial = (value: unknown): void => {
+    ;(notifee.getInitialNotification as jest.Mock).mockResolvedValue(value)
+  }
+
+  beforeEach(() => {
+    jest.spyOn(AnalyticsService, 'capture').mockResolvedValue(undefined)
+    setNotifeeInitial(null)
+    setFcmInitial(null)
+  })
+
+  it('captures press from notifee initial notification (Android data-only cold start)', async () => {
+    const data = {
+      url: 'core://portfolio',
+      event: 'PRODUCT_ANNOUNCEMENTS',
+      channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
+      title: 'New product',
+      body: 'Check it out'
+    }
+    setNotifeeInitial(
+      buildNotifeeInitial(data, ChannelId.PRODUCT_ANNOUNCEMENTS)
+    )
+
+    await NotificationsService.getInitialNotification(callback)
+
+    expect(AnalyticsService.capture).toHaveBeenCalledTimes(1)
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
+        deeplinkUrl: 'core://portfolio'
+      }
+    )
+    expect(callback).toHaveBeenCalledWith(data)
+  })
+
+  it('captures press from FCM initial notification when notifee initial is null (legacy notification payload path)', async () => {
+    const data = {
+      url: 'core://portfolio',
+      event: 'PRODUCT_ANNOUNCEMENTS'
+    }
+    setFcmInitial({ data })
+
+    await NotificationsService.getInitialNotification(callback)
+
+    expect(AnalyticsService.capture).toHaveBeenCalledTimes(1)
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
+        deeplinkUrl: 'core://portfolio'
+      }
+    )
+    expect(callback).toHaveBeenCalledWith(data)
+  })
+
+  it('does not capture and invokes callback with undefined when no initial notification is present in either source', async () => {
+    await NotificationsService.getInitialNotification(callback)
+
+    expect(AnalyticsService.capture).not.toHaveBeenCalled()
+    expect(callback).toHaveBeenCalledWith(undefined)
+  })
+
+  it('does not capture when notifee initial notification lacks a deeplink url', async () => {
+    setNotifeeInitial(
+      buildNotifeeInitial(
+        { event: 'PRODUCT_ANNOUNCEMENTS' },
+        ChannelId.PRODUCT_ANNOUNCEMENTS
+      )
+    )
+
+    await NotificationsService.getInitialNotification(callback)
+
+    expect(AnalyticsService.capture).not.toHaveBeenCalled()
+    expect(callback).toHaveBeenCalledWith(undefined)
+  })
+
+  it('prefers notifee initial notification over FCM when both are present', async () => {
+    const notifeeData = {
+      url: 'core://portfolio',
+      event: 'PRODUCT_ANNOUNCEMENTS'
+    }
+    const fcmData = { url: 'core://watchlist', event: 'PRICE_ALERTS' }
+    setNotifeeInitial(
+      buildNotifeeInitial(notifeeData, ChannelId.PRODUCT_ANNOUNCEMENTS)
+    )
+    setFcmInitial({ data: fcmData })
+
+    await NotificationsService.getInitialNotification(callback)
+
+    expect(AnalyticsService.capture).toHaveBeenCalledTimes(1)
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
+        deeplinkUrl: 'core://portfolio'
+      }
+    )
+    expect(callback).toHaveBeenCalledWith(notifeeData)
+  })
+
+  it('falls back to EVENT_TO_CH_ID mapping when no android.channelId is set on the notifee notification', async () => {
+    const data = { url: 'core://watchlist', event: 'PRICE_ALERTS' }
+    setNotifeeInitial(buildNotifeeInitial(data, undefined))
+
+    await NotificationsService.getInitialNotification(callback)
+
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: ChannelId.PRICE_ALERTS,
+        deeplinkUrl: 'core://watchlist'
+      }
+    )
+  })
+
+  it('falls back to DEFAULT_ANDROID_CHANNEL when no channel info is available at all', async () => {
+    const data = { url: 'core://portfolio' }
+    setNotifeeInitial(buildNotifeeInitial(data, undefined))
+
+    await NotificationsService.getInitialNotification(callback)
+
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: DEFAULT_ANDROID_CHANNEL,
+        deeplinkUrl: 'core://portfolio'
+      }
+    )
+  })
+
+  it('still falls back to FCM when notifee.getInitialNotification rejects', async () => {
+    ;(notifee.getInitialNotification as jest.Mock).mockRejectedValue(
+      new Error('notifee boom')
+    )
+    const fcmData = { url: 'core://portfolio', event: 'PRODUCT_ANNOUNCEMENTS' }
+    setFcmInitial({ data: fcmData })
+
+    await NotificationsService.getInitialNotification(callback)
+
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
+        deeplinkUrl: 'core://portfolio'
+      }
+    )
+    expect(callback).toHaveBeenCalledWith(fcmData)
+  })
+})
+
+describe('registerBackgroundNotificationHandler', () => {
+  it('registers a notifee.onBackgroundEvent handler exactly once per call', () => {
+    NotificationsService.registerBackgroundNotificationHandler()
+
+    expect(notifee.onBackgroundEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels the trigger notification on PRESS events', async () => {
+    const cancelSpy = jest
+      .spyOn(NotificationsService, 'cancelTriggerNotification')
+      .mockResolvedValue(undefined)
+
+    NotificationsService.registerBackgroundNotificationHandler()
+
+    const handler = (notifee.onBackgroundEvent as jest.Mock).mock.calls.at(
+      -1
+    )?.[0]
+    expect(handler).toBeDefined()
+
+    await handler({
+      type: EventType.PRESS,
+      detail: { notification: { id: 'noti-1' } }
+    })
+
+    expect(cancelSpy).toHaveBeenCalledWith('noti-1')
+  })
+
+  it('ignores non-PRESS background events (e.g. DELIVERED)', async () => {
+    const cancelSpy = jest
+      .spyOn(NotificationsService, 'cancelTriggerNotification')
+      .mockResolvedValue(undefined)
+
+    NotificationsService.registerBackgroundNotificationHandler()
+
+    const handler = (notifee.onBackgroundEvent as jest.Mock).mock.calls.at(
+      -1
+    )?.[0]
+
+    await handler({
+      type: EventType.DELIVERED,
+      detail: { notification: { id: 'noti-2' } }
+    })
+
+    expect(cancelSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not capture analytics from the headless background event (PostHog is not configured yet on cold start)', async () => {
+    jest.spyOn(AnalyticsService, 'capture').mockResolvedValue(undefined)
+
+    NotificationsService.registerBackgroundNotificationHandler()
+
+    const handler = (notifee.onBackgroundEvent as jest.Mock).mock.calls.at(
+      -1
+    )?.[0]
+
+    await handler({
+      type: EventType.PRESS,
+      detail: { notification: { id: 'noti-3', data: { url: 'core://x' } } }
+    })
+
+    expect(AnalyticsService.capture).not.toHaveBeenCalled()
   })
 })

--- a/packages/core-mobile/app/services/notifications/NotificationService.test.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationService.test.ts
@@ -205,7 +205,8 @@ describe('getInitialNotification', () => {
       {
         channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
         deeplinkUrl: 'core://portfolio',
-        source: 'notifee_initial'
+        appState: 'cold_start',
+        handler: 'notifee'
       }
     )
     expect(callback).toHaveBeenCalledWith(data)
@@ -226,7 +227,8 @@ describe('getInitialNotification', () => {
       {
         channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
         deeplinkUrl: 'core://portfolio',
-        source: 'fcm_initial'
+        appState: 'cold_start',
+        handler: 'fcm'
       }
     )
     expect(callback).toHaveBeenCalledWith(data)
@@ -272,7 +274,8 @@ describe('getInitialNotification', () => {
       {
         channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
         deeplinkUrl: 'core://portfolio',
-        source: 'notifee_initial'
+        appState: 'cold_start',
+        handler: 'notifee'
       }
     )
     expect(callback).toHaveBeenCalledWith(notifeeData)
@@ -289,7 +292,8 @@ describe('getInitialNotification', () => {
       {
         channelId: ChannelId.PRICE_ALERTS,
         deeplinkUrl: 'core://watchlist',
-        source: 'notifee_initial'
+        appState: 'cold_start',
+        handler: 'notifee'
       }
     )
   })
@@ -305,7 +309,8 @@ describe('getInitialNotification', () => {
       {
         channelId: DEFAULT_ANDROID_CHANNEL,
         deeplinkUrl: 'core://portfolio',
-        source: 'notifee_initial'
+        appState: 'cold_start',
+        handler: 'notifee'
       }
     )
   })
@@ -324,7 +329,8 @@ describe('getInitialNotification', () => {
       {
         channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
         deeplinkUrl: 'core://portfolio',
-        source: 'fcm_initial'
+        appState: 'cold_start',
+        handler: 'fcm'
       }
     )
     expect(callback).toHaveBeenCalledWith(fcmData)
@@ -332,6 +338,21 @@ describe('getInitialNotification', () => {
 })
 
 describe('registerBackgroundNotificationHandler', () => {
+  const getHandler = (): ((event: unknown) => Promise<void>) => {
+    const handler = (notifee.onBackgroundEvent as jest.Mock).mock.calls.at(
+      -1
+    )?.[0]
+    expect(handler).toBeDefined()
+    return handler as (event: unknown) => Promise<void>
+  }
+
+  beforeEach(() => {
+    jest.spyOn(AnalyticsService, 'capture').mockResolvedValue(undefined)
+    // Drain any pending press leftover from a previous test so each test starts
+    // from a known clean state.
+    NotificationsService.consumePendingBackgroundPress()
+  })
+
   it('registers a notifee.onBackgroundEvent handler exactly once per call', () => {
     NotificationsService.registerBackgroundNotificationHandler()
 
@@ -345,12 +366,7 @@ describe('registerBackgroundNotificationHandler', () => {
 
     NotificationsService.registerBackgroundNotificationHandler()
 
-    const handler = (notifee.onBackgroundEvent as jest.Mock).mock.calls.at(
-      -1
-    )?.[0]
-    expect(handler).toBeDefined()
-
-    await handler({
+    await getHandler()({
       type: EventType.PRESS,
       detail: { notification: { id: 'noti-1' } }
     })
@@ -365,32 +381,98 @@ describe('registerBackgroundNotificationHandler', () => {
 
     NotificationsService.registerBackgroundNotificationHandler()
 
-    const handler = (notifee.onBackgroundEvent as jest.Mock).mock.calls.at(
-      -1
-    )?.[0]
-
-    await handler({
+    await getHandler()({
       type: EventType.DELIVERED,
       detail: { notification: { id: 'noti-2' } }
     })
 
     expect(cancelSpy).not.toHaveBeenCalled()
+    expect(AnalyticsService.capture).not.toHaveBeenCalled()
   })
 
-  it('does not capture analytics from the headless background event (PostHog is not configured yet on cold start)', async () => {
-    jest.spyOn(AnalyticsService, 'capture').mockResolvedValue(undefined)
-
+  it('captures PushNotificationPressed (appState=background, handler=notifee) on a PRESS event with a deeplink', async () => {
     NotificationsService.registerBackgroundNotificationHandler()
 
-    const handler = (notifee.onBackgroundEvent as jest.Mock).mock.calls.at(
-      -1
-    )?.[0]
-
-    await handler({
+    await getHandler()({
       type: EventType.PRESS,
-      detail: { notification: { id: 'noti-3', data: { url: 'core://x' } } }
+      detail: {
+        notification: {
+          id: 'noti-warm',
+          data: { url: 'core://portfolio', event: 'PRODUCT_ANNOUNCEMENTS' },
+          android: { channelId: ChannelId.PRODUCT_ANNOUNCEMENTS }
+        }
+      }
+    })
+
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
+        deeplinkUrl: 'core://portfolio',
+        appState: 'background',
+        handler: 'notifee'
+      }
+    )
+  })
+
+  it('falls back to EVENT_TO_CH_ID when android.channelId is absent on the PRESS event', async () => {
+    NotificationsService.registerBackgroundNotificationHandler()
+
+    await getHandler()({
+      type: EventType.PRESS,
+      detail: {
+        notification: {
+          id: 'noti-fallback',
+          data: { url: 'core://watchlist', event: 'PRICE_ALERTS' }
+        }
+      }
+    })
+
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: ChannelId.PRICE_ALERTS,
+        deeplinkUrl: 'core://watchlist',
+        appState: 'background',
+        handler: 'notifee'
+      }
+    )
+  })
+
+  it('does not capture when the PRESS notification has no deeplink url', async () => {
+    NotificationsService.registerBackgroundNotificationHandler()
+
+    await getHandler()({
+      type: EventType.PRESS,
+      detail: {
+        notification: {
+          id: 'noti-no-url',
+          data: { event: 'PRODUCT_ANNOUNCEMENTS' }
+        }
+      }
     })
 
     expect(AnalyticsService.capture).not.toHaveBeenCalled()
+    expect(NotificationsService.consumePendingBackgroundPress()).toBeUndefined()
+  })
+
+  it('stashes the notification data so it can be consumed by the AppState active listener', async () => {
+    NotificationsService.registerBackgroundNotificationHandler()
+
+    const data = { url: 'core://portfolio', event: 'PRODUCT_ANNOUNCEMENTS' }
+    await getHandler()({
+      type: EventType.PRESS,
+      detail: {
+        notification: {
+          id: 'noti-pending',
+          data,
+          android: { channelId: ChannelId.PRODUCT_ANNOUNCEMENTS }
+        }
+      }
+    })
+
+    expect(NotificationsService.consumePendingBackgroundPress()).toEqual(data)
+    // consume is one-shot
+    expect(NotificationsService.consumePendingBackgroundPress()).toBeUndefined()
   })
 })

--- a/packages/core-mobile/app/services/notifications/NotificationService.test.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationService.test.ts
@@ -204,7 +204,8 @@ describe('getInitialNotification', () => {
       'PushNotificationPressed',
       {
         channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
-        deeplinkUrl: 'core://portfolio'
+        deeplinkUrl: 'core://portfolio',
+        source: 'notifee_initial'
       }
     )
     expect(callback).toHaveBeenCalledWith(data)
@@ -224,7 +225,8 @@ describe('getInitialNotification', () => {
       'PushNotificationPressed',
       {
         channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
-        deeplinkUrl: 'core://portfolio'
+        deeplinkUrl: 'core://portfolio',
+        source: 'fcm_initial'
       }
     )
     expect(callback).toHaveBeenCalledWith(data)
@@ -269,7 +271,8 @@ describe('getInitialNotification', () => {
       'PushNotificationPressed',
       {
         channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
-        deeplinkUrl: 'core://portfolio'
+        deeplinkUrl: 'core://portfolio',
+        source: 'notifee_initial'
       }
     )
     expect(callback).toHaveBeenCalledWith(notifeeData)
@@ -285,7 +288,8 @@ describe('getInitialNotification', () => {
       'PushNotificationPressed',
       {
         channelId: ChannelId.PRICE_ALERTS,
-        deeplinkUrl: 'core://watchlist'
+        deeplinkUrl: 'core://watchlist',
+        source: 'notifee_initial'
       }
     )
   })
@@ -300,7 +304,8 @@ describe('getInitialNotification', () => {
       'PushNotificationPressed',
       {
         channelId: DEFAULT_ANDROID_CHANNEL,
-        deeplinkUrl: 'core://portfolio'
+        deeplinkUrl: 'core://portfolio',
+        source: 'notifee_initial'
       }
     )
   })
@@ -318,7 +323,8 @@ describe('getInitialNotification', () => {
       'PushNotificationPressed',
       {
         channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
-        deeplinkUrl: 'core://portfolio'
+        deeplinkUrl: 'core://portfolio',
+        source: 'fcm_initial'
       }
     )
     expect(callback).toHaveBeenCalledWith(fcmData)

--- a/packages/core-mobile/app/services/notifications/NotificationService.test.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationService.test.ts
@@ -514,73 +514,30 @@ describe('registerBackgroundNotificationHandler', () => {
     expect(AnalyticsService.capture).not.toHaveBeenCalled()
   })
 
-  it('captures PushNotificationPressed (appState=background, handler=notifee) on a PRESS event with a deeplink', async () => {
+  it('does NOT capture analytics from the headless background handler (capture is deferred to React-mounted context)', async () => {
+    // The notifee background event runs as a headless JS task. Capture is
+    // deliberately deferred to handlePendingBackgroundPress (warm-background)
+    // or getInitialNotification (cold-start), both of which run with PostHog
+    // / redux fully initialized. This avoids the duplicate-capture observed
+    // during CP-14006 device verification (one 'background' + one
+    // 'cold_start' for the same cold-start tap).
     NotificationsService.registerBackgroundNotificationHandler()
 
     await getHandler()({
       type: EventType.PRESS,
       detail: {
         notification: {
-          id: 'noti-warm',
+          id: 'noti-press',
           data: { url: 'core://portfolio', event: 'PRODUCT_ANNOUNCEMENTS' },
           android: { channelId: ChannelId.PRODUCT_ANNOUNCEMENTS }
         }
       }
     })
 
-    expect(AnalyticsService.capture).toHaveBeenCalledWith(
-      'PushNotificationPressed',
-      {
-        channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
-        deeplinkUrl: 'core://portfolio',
-        appState: 'background',
-        handler: 'notifee'
-      }
-    )
-  })
-
-  it('falls back to EVENT_TO_CH_ID when android.channelId is absent on the PRESS event', async () => {
-    NotificationsService.registerBackgroundNotificationHandler()
-
-    await getHandler()({
-      type: EventType.PRESS,
-      detail: {
-        notification: {
-          id: 'noti-fallback',
-          data: { url: 'core://watchlist', event: 'PRICE_ALERTS' }
-        }
-      }
-    })
-
-    expect(AnalyticsService.capture).toHaveBeenCalledWith(
-      'PushNotificationPressed',
-      {
-        channelId: ChannelId.PRICE_ALERTS,
-        deeplinkUrl: 'core://watchlist',
-        appState: 'background',
-        handler: 'notifee'
-      }
-    )
-  })
-
-  it('does not capture when the PRESS notification has no deeplink url', async () => {
-    NotificationsService.registerBackgroundNotificationHandler()
-
-    await getHandler()({
-      type: EventType.PRESS,
-      detail: {
-        notification: {
-          id: 'noti-no-url',
-          data: { event: 'PRODUCT_ANNOUNCEMENTS' }
-        }
-      }
-    })
-
     expect(AnalyticsService.capture).not.toHaveBeenCalled()
-    expect(NotificationsService.consumePendingBackgroundPress()).toBeUndefined()
   })
 
-  it('stashes the notification data so it can be consumed by the AppState active listener', async () => {
+  it('stashes the notification data so it can be consumed by the React-mounted context', async () => {
     NotificationsService.registerBackgroundNotificationHandler()
 
     const data = { url: 'core://portfolio', event: 'PRODUCT_ANNOUNCEMENTS' }
@@ -598,5 +555,84 @@ describe('registerBackgroundNotificationHandler', () => {
     expect(NotificationsService.consumePendingBackgroundPress()).toEqual(data)
     // consume is one-shot
     expect(NotificationsService.consumePendingBackgroundPress()).toBeUndefined()
+  })
+
+  it('does not stash when the PRESS notification has no deeplink url', async () => {
+    NotificationsService.registerBackgroundNotificationHandler()
+
+    await getHandler()({
+      type: EventType.PRESS,
+      detail: {
+        notification: {
+          id: 'noti-no-url',
+          data: { event: 'PRODUCT_ANNOUNCEMENTS' }
+        }
+      }
+    })
+
+    expect(NotificationsService.consumePendingBackgroundPress()).toBeUndefined()
+  })
+})
+
+describe('handlePendingBackgroundPress', () => {
+  beforeEach(() => {
+    jest.spyOn(AnalyticsService, 'capture').mockResolvedValue(undefined)
+    NotificationsService.consumePendingBackgroundPress()
+  })
+
+  it('captures PushNotificationPressed (appState=background, handler=notifee) and invokes the callback when a press is pending', () => {
+    const data = { url: 'core://portfolio', event: 'PRODUCT_ANNOUNCEMENTS' }
+    setPendingBackgroundPress(data)
+    const callback = jest.fn()
+
+    NotificationsService.handlePendingBackgroundPress(callback)
+
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
+        deeplinkUrl: 'core://portfolio',
+        appState: 'background',
+        handler: 'notifee'
+      }
+    )
+    expect(callback).toHaveBeenCalledWith(data)
+  })
+
+  it('falls back to DEFAULT_ANDROID_CHANNEL when the pending press has no channelId or event mapping', () => {
+    setPendingBackgroundPress({ url: 'core://portfolio' })
+    const callback = jest.fn()
+
+    NotificationsService.handlePendingBackgroundPress(callback)
+
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: DEFAULT_ANDROID_CHANNEL,
+        deeplinkUrl: 'core://portfolio',
+        appState: 'background',
+        handler: 'notifee'
+      }
+    )
+  })
+
+  it('is a no-op when no press is pending', () => {
+    const callback = jest.fn()
+
+    NotificationsService.handlePendingBackgroundPress(callback)
+
+    expect(AnalyticsService.capture).not.toHaveBeenCalled()
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('drains the pending press after handling so subsequent calls are no-ops', () => {
+    setPendingBackgroundPress({ url: 'core://portfolio' })
+    const callback = jest.fn()
+
+    NotificationsService.handlePendingBackgroundPress(callback)
+    NotificationsService.handlePendingBackgroundPress(callback)
+
+    expect(AnalyticsService.capture).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core-mobile/app/services/notifications/NotificationService.test.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationService.test.ts
@@ -1,8 +1,28 @@
 import notifee, { EventDetail, EventType } from '@notifee/react-native'
 import messaging from '@react-native-firebase/messaging'
 import AnalyticsService from 'services/analytics/AnalyticsService'
+import Logger from 'utils/Logger'
 import { ChannelId, DEFAULT_ANDROID_CHANNEL } from './channels'
 import NotificationsService from './NotificationsService'
+
+// Helper for poking at the singleton's private state in tests. The class is
+// exported as a singleton so we cannot instantiate a fresh one per test —
+// reset the guard fields directly so each test starts from a known state.
+const resetBackgroundHandlerState = (): void => {
+  ;(
+    NotificationsService as unknown as { backgroundHandlerRegistered: boolean }
+  ).backgroundHandlerRegistered = false
+}
+
+const setPendingBackgroundPress = (
+  value: Record<string, unknown> | undefined
+): void => {
+  ;(
+    NotificationsService as unknown as {
+      pendingBackgroundPress: Record<string, unknown> | undefined
+    }
+  ).pendingBackgroundPress = value
+}
 
 // Override the messaging mock from tests/jestSetup/firebase.js so its default
 // export is a jest.fn(), allowing per-test control of getInitialNotification.
@@ -183,6 +203,7 @@ describe('getInitialNotification', () => {
     jest.spyOn(AnalyticsService, 'capture').mockResolvedValue(undefined)
     setNotifeeInitial(null)
     setFcmInitial(null)
+    setPendingBackgroundPress(undefined)
   })
 
   it('captures press from notifee initial notification (Android data-only cold start)', async () => {
@@ -335,6 +356,41 @@ describe('getInitialNotification', () => {
     )
     expect(callback).toHaveBeenCalledWith(fcmData)
   })
+
+  it('drains pendingBackgroundPress after handling a cold-start notifee press so the AppState active listener does not re-fire it', async () => {
+    // Simulate the notifee headless background handler having stashed the
+    // same press during cold start before React mounted.
+    setPendingBackgroundPress({ url: 'core://portfolio' })
+    setNotifeeInitial(
+      buildNotifeeInitial(
+        { url: 'core://portfolio' },
+        ChannelId.PRODUCT_ANNOUNCEMENTS
+      )
+    )
+
+    await NotificationsService.getInitialNotification(callback)
+
+    expect(NotificationsService.consumePendingBackgroundPress()).toBeUndefined()
+  })
+
+  it('also drains pendingBackgroundPress when handling a cold-start FCM press', async () => {
+    setPendingBackgroundPress({ url: 'core://stale' })
+    setFcmInitial({
+      data: { url: 'core://portfolio', event: 'PRODUCT_ANNOUNCEMENTS' }
+    })
+
+    await NotificationsService.getInitialNotification(callback)
+
+    expect(NotificationsService.consumePendingBackgroundPress()).toBeUndefined()
+  })
+
+  it('drains pendingBackgroundPress even when no initial notification is present on either source', async () => {
+    setPendingBackgroundPress({ url: 'core://stale' })
+
+    await NotificationsService.getInitialNotification(callback)
+
+    expect(NotificationsService.consumePendingBackgroundPress()).toBeUndefined()
+  })
 })
 
 describe('registerBackgroundNotificationHandler', () => {
@@ -348,8 +404,11 @@ describe('registerBackgroundNotificationHandler', () => {
 
   beforeEach(() => {
     jest.spyOn(AnalyticsService, 'capture').mockResolvedValue(undefined)
-    // Drain any pending press leftover from a previous test so each test starts
-    // from a known clean state.
+    // Reset the singleton's idempotence guard and clear the notifee mock so
+    // each test exercises a fresh registration. Also drain any pending press
+    // leftover from a previous test.
+    resetBackgroundHandlerState()
+    ;(notifee.onBackgroundEvent as jest.Mock).mockClear()
     NotificationsService.consumePendingBackgroundPress()
   })
 
@@ -357,6 +416,17 @@ describe('registerBackgroundNotificationHandler', () => {
     NotificationsService.registerBackgroundNotificationHandler()
 
     expect(notifee.onBackgroundEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs a warning and skips re-registration on duplicate calls (notifee only supports one handler)', () => {
+    const warnSpy = jest.spyOn(Logger, 'warn').mockImplementation()
+
+    NotificationsService.registerBackgroundNotificationHandler()
+    NotificationsService.registerBackgroundNotificationHandler()
+    NotificationsService.registerBackgroundNotificationHandler()
+
+    expect(notifee.onBackgroundEvent).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledTimes(2)
   })
 
   it('cancels the trigger notification on PRESS events', async () => {

--- a/packages/core-mobile/app/services/notifications/NotificationsService.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationsService.ts
@@ -17,13 +17,12 @@ import {
 import { fromUnixTime, isPast } from 'date-fns'
 import { Linking, Platform } from 'react-native'
 import AnalyticsService from 'services/analytics/AnalyticsService'
-import { EVENT_TO_CH_ID } from 'services/fcm/FCMService'
 import {
   ChannelId,
-  DEFAULT_ANDROID_CHANNEL,
   NewsChannelId,
   notificationChannels
 } from 'services/notifications/channels'
+import { resolveChannelId } from 'services/notifications/eventChannelMap'
 import { DisplayNotificationParams } from 'services/notifications/types'
 import { StakeCompleteNotification } from 'store/notifications'
 import { audioFiles } from 'utils/AudioFeedback'
@@ -33,43 +32,6 @@ import {
   PressActionId,
   STAKE_COMPELETE_DEEPLINK_URL
 } from './constants'
-
-/**
- * Pure helper that resolves the channel id for a `PushNotificationPressed`
- * analytics event. Centralizes the precedence rule shared by every capture
- * site (foreground, warm-background notifee, cold-start notifee, iOS
- * background FCM):
- *
- *   1. android.channelId on the displayed notifee notification, if any
- *      (Android data-only path — the notifee `Notification.android.channelId`
- *      is the most authoritative source since it's set by us at display time)
- *   2. data.channelId carried in the FCM payload (NEWS notifications)
- *   3. EVENT_TO_CH_ID lookup against the event string
- *   4. DEFAULT_ANDROID_CHANNEL as a final fallback
- *
- * Accepts loosely-typed input because notification data shapes vary across
- * the FCM SDK, notifee, and the legacy `notification` payload — narrowing
- * happens here so callers don't need unsafe `as string` casts.
- */
-export const resolveChannelId = (args: {
-  androidChannelId?: string
-  data?: Record<string, unknown>
-  fallbackEvent?: string
-}): string => {
-  const { androidChannelId, data, fallbackEvent } = args
-  const dataChannelId =
-    typeof data?.channelId === 'string' && data.channelId.length > 0
-      ? data.channelId
-      : undefined
-  const event =
-    (typeof data?.event === 'string' ? data.event : undefined) ?? fallbackEvent
-  return (
-    androidChannelId ??
-    dataChannelId ??
-    (event ? EVENT_TO_CH_ID[event] : undefined) ??
-    DEFAULT_ANDROID_CHANNEL
-  )
-}
 
 class NotificationsService {
   /**
@@ -457,6 +419,7 @@ class NotificationsService {
   getInitialNotification = async (
     callback: HandleNotificationCallback
   ): Promise<void> => {
+    let handledColdStart = false
     try {
       const [notifeeInitial, fcmInitial] = await Promise.all([
         notifee.getInitialNotification().catch(reason => {
@@ -499,6 +462,7 @@ class NotificationsService {
           handler: 'notifee'
         })
         callback(notifeeData)
+        handledColdStart = true
         return
       }
 
@@ -517,17 +481,25 @@ class NotificationsService {
           handler: 'fcm'
         })
         callback(fcmData)
+        handledColdStart = true
         return
       }
 
       callback(undefined)
     } finally {
       // On cold start the notifee headless background handler also stashes
-      // the same press into `pendingBackgroundPress`. We've handled it here,
-      // so drain it — otherwise the next AppState 'active' transition (the
-      // first time the user backgrounds and re-foregrounds the app) would
-      // re-fire the same deeplink via the listener in DeeplinkContext.
-      this.consumePendingBackgroundPress()
+      // the same press into `pendingBackgroundPress`. If we just handled it
+      // here, drain it — otherwise the next AppState 'active' transition
+      // would re-fire the same deeplink via the listener in DeeplinkContext.
+      //
+      // We deliberately do NOT drain when no cold-start press was found:
+      // the effect that calls this method re-runs on
+      // `isAllNotificationsBlocked` toggles, and a legitimate warm-background
+      // press can already be sitting in `pendingBackgroundPress` waiting for
+      // the AppState listener to consume it.
+      if (handledColdStart) {
+        this.consumePendingBackgroundPress()
+      }
     }
   }
 

--- a/packages/core-mobile/app/services/notifications/NotificationsService.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationsService.ts
@@ -279,7 +279,8 @@ class NotificationsService {
     if (detail?.notification?.data) {
       AnalyticsService.capture('PushNotificationPressed', {
         channelId: detail.notification?.data?.channelId as string,
-        deeplinkUrl: detail.notification?.data?.url as string
+        deeplinkUrl: detail.notification?.data?.url as string,
+        source: 'foreground'
       })
     }
 
@@ -374,9 +375,14 @@ class NotificationsService {
           : undefined) ??
         EVENT_TO_CH_ID[notifeeData.event as string] ??
         DEFAULT_ANDROID_CHANNEL
+      Logger.info(
+        '[NotificationsService.ts][getInitialNotification] notifee initial press',
+        { channelId, deeplinkUrl: notifeeData.url }
+      )
       AnalyticsService.capture('PushNotificationPressed', {
         channelId,
-        deeplinkUrl: String(notifeeData.url)
+        deeplinkUrl: String(notifeeData.url),
+        source: 'notifee_initial'
       })
       callback(notifeeData)
       return
@@ -385,10 +391,16 @@ class NotificationsService {
     const fcmData = fcmInitial?.data as NotificationData | undefined
 
     if (fcmData?.url) {
+      const channelId =
+        EVENT_TO_CH_ID[fcmData.event as string] ?? DEFAULT_ANDROID_CHANNEL
+      Logger.info(
+        '[NotificationsService.ts][getInitialNotification] fcm initial press',
+        { channelId, deeplinkUrl: fcmData.url }
+      )
       AnalyticsService.capture('PushNotificationPressed', {
-        channelId:
-          EVENT_TO_CH_ID[fcmData.event as string] ?? DEFAULT_ANDROID_CHANNEL,
-        deeplinkUrl: String(fcmData.url)
+        channelId,
+        deeplinkUrl: String(fcmData.url),
+        source: 'fcm_initial'
       })
       callback(fcmData)
       return

--- a/packages/core-mobile/app/services/notifications/NotificationsService.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationsService.ts
@@ -253,6 +253,8 @@ class NotificationsService {
    * Background events run as a headless JS task. This handler intentionally
    * does the minimum amount of work that is safe in that headless context:
    *
+   *  - decrement the badge count by one (mirroring the foreground PRESS
+   *    handler so a tap clears its badge on every platform / app state), then
    *  - cancel the matching trigger notification (idempotent native call), and
    *  - stash the notification data into {@link pendingBackgroundPress}.
    *
@@ -286,6 +288,12 @@ class NotificationsService {
       // headless task as an unhandled rejection.
       try {
         if (type !== EventType.PRESS) return
+
+        // Mirror the foreground PRESS handler — decrement the badge for every
+        // tap regardless of app state. Without this, taps that resume the app
+        // from background never clear their own badge, which leaves the badge
+        // permanently inflated even after the user reads the notification.
+        await this.decrementBadgeCount(1)
 
         if (detail?.notification?.id) {
           await this.cancelTriggerNotification(detail.notification.id)
@@ -498,12 +506,27 @@ class NotificationsService {
       }
 
       const fcmData = fcmInitial?.data as NotificationData | undefined
+      // The FCM cold-start path delivers the raw backend SNS payload (the
+      // notifee path is already normalized in FCMService.#extractDeepLinkData,
+      // which is why we only need the fallback here). NEWS notifications can
+      // arrive with only `urlV2` populated — accept either to avoid dropping
+      // legacy-iOS NEWS cold-start presses. DeeplinkContext already resolves
+      // `urlV2 ?? url` when routing the deeplink, so forwarding `fcmData`
+      // as-is keeps the downstream contract intact.
+      // TODO: remove `urlV2` fallback after backend is updated to send `url`
+      // for NEWS notifications.
+      const fcmDeeplinkUrl =
+        typeof fcmData?.url === 'string'
+          ? fcmData.url
+          : typeof fcmData?.urlV2 === 'string'
+          ? fcmData.urlV2
+          : undefined
 
-      if (typeof fcmData?.url === 'string') {
+      if (fcmDeeplinkUrl !== undefined) {
         const channelId = resolveChannelId({ data: fcmData })
         AnalyticsService.capture('PushNotificationPressed', {
           channelId,
-          deeplinkUrl: fcmData.url,
+          deeplinkUrl: fcmDeeplinkUrl,
           appState: 'cold_start',
           handler: 'fcm'
         })

--- a/packages/core-mobile/app/services/notifications/NotificationsService.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationsService.ts
@@ -34,6 +34,43 @@ import {
   STAKE_COMPELETE_DEEPLINK_URL
 } from './constants'
 
+/**
+ * Pure helper that resolves the channel id for a `PushNotificationPressed`
+ * analytics event. Centralizes the precedence rule shared by every capture
+ * site (foreground, warm-background notifee, cold-start notifee, iOS
+ * background FCM):
+ *
+ *   1. android.channelId on the displayed notifee notification, if any
+ *      (Android data-only path — the notifee `Notification.android.channelId`
+ *      is the most authoritative source since it's set by us at display time)
+ *   2. data.channelId carried in the FCM payload (NEWS notifications)
+ *   3. EVENT_TO_CH_ID lookup against the event string
+ *   4. DEFAULT_ANDROID_CHANNEL as a final fallback
+ *
+ * Accepts loosely-typed input because notification data shapes vary across
+ * the FCM SDK, notifee, and the legacy `notification` payload — narrowing
+ * happens here so callers don't need unsafe `as string` casts.
+ */
+export const resolveChannelId = (args: {
+  androidChannelId?: string
+  data?: Record<string, unknown>
+  fallbackEvent?: string
+}): string => {
+  const { androidChannelId, data, fallbackEvent } = args
+  const dataChannelId =
+    typeof data?.channelId === 'string' && data.channelId.length > 0
+      ? data.channelId
+      : undefined
+  const event =
+    (typeof data?.event === 'string' ? data.event : undefined) ?? fallbackEvent
+  return (
+    androidChannelId ??
+    dataChannelId ??
+    (event ? EVENT_TO_CH_ID[event] : undefined) ??
+    DEFAULT_ANDROID_CHANNEL
+  )
+}
+
 class NotificationsService {
   /**
    * Notification data from a PRESS event that was received in the background
@@ -47,6 +84,14 @@ class NotificationsService {
    * warm-resuming, the cold-start `getInitialNotification` returns null.
    */
   private pendingBackgroundPress: NotificationData | undefined
+
+  /**
+   * Notifee only supports a single background event handler. We guard against
+   * repeat calls so a future call site (e.g. an accidental import in another
+   * entry point or a hot-reload re-evaluation) cannot silently overwrite the
+   * registered handler — it would log a warning instead.
+   */
+  private backgroundHandlerRegistered = false
 
   async getNotificationSettings(): Promise<AuthorizationStatus> {
     const settings = await notifee.getNotificationSettings()
@@ -255,6 +300,14 @@ class NotificationsService {
    *     {@link getInitialNotification} once the React tree mounts.
    */
   registerBackgroundNotificationHandler = (): void => {
+    if (this.backgroundHandlerRegistered) {
+      Logger.warn(
+        '[NotificationsService.ts][registerBackgroundNotificationHandler] handler already registered; ignoring duplicate call'
+      )
+      return
+    }
+    this.backgroundHandlerRegistered = true
+
     notifee.onBackgroundEvent(async ({ type, detail }) => {
       if (type !== EventType.PRESS) return
 
@@ -268,13 +321,12 @@ class NotificationsService {
       }
 
       const data = detail?.notification?.data as NotificationData | undefined
-      if (!data?.url) return
+      if (typeof data?.url !== 'string') return
 
-      const channelId =
-        detail?.notification?.android?.channelId ??
-        (typeof data.channelId === 'string' ? data.channelId : undefined) ??
-        EVENT_TO_CH_ID[data.event as string] ??
-        DEFAULT_ANDROID_CHANNEL
+      const channelId = resolveChannelId({
+        androidChannelId: detail?.notification?.android?.channelId,
+        data
+      })
 
       Logger.info(
         '[NotificationsService.ts][registerBackgroundNotificationHandler] press',
@@ -282,7 +334,7 @@ class NotificationsService {
       )
       AnalyticsService.capture('PushNotificationPressed', {
         channelId,
-        deeplinkUrl: String(data.url),
+        deeplinkUrl: data.url,
         appState: 'background',
         handler: 'notifee'
       })
@@ -331,16 +383,21 @@ class NotificationsService {
       await this.cancelTriggerNotification(detail.notification.id)
     }
 
-    if (detail?.notification?.data) {
+    const data = detail?.notification?.data as NotificationData | undefined
+    if (data) {
+      const channelId = resolveChannelId({
+        androidChannelId: detail?.notification?.android?.channelId,
+        data
+      })
       AnalyticsService.capture('PushNotificationPressed', {
-        channelId: detail.notification?.data?.channelId as string,
-        deeplinkUrl: detail.notification?.data?.url as string,
+        channelId,
+        deeplinkUrl: typeof data.url === 'string' ? data.url : undefined,
         appState: 'foreground',
         handler: 'notifee'
       })
     }
 
-    callback(detail?.notification?.data)
+    callback(data)
   }
 
   handleNotificationEvent = async ({
@@ -400,71 +457,78 @@ class NotificationsService {
   getInitialNotification = async (
     callback: HandleNotificationCallback
   ): Promise<void> => {
-    const [notifeeInitial, fcmInitial] = await Promise.all([
-      notifee.getInitialNotification().catch(reason => {
-        Logger.error(
-          `[NotificationsService.ts][getInitialNotification:notifee]${reason}`
-        )
-        return null
-      }),
-      messaging()
-        .getInitialNotification()
-        .catch(reason => {
+    try {
+      const [notifeeInitial, fcmInitial] = await Promise.all([
+        notifee.getInitialNotification().catch(reason => {
           Logger.error(
-            `[NotificationsService.ts][getInitialNotification:fcm]${reason}`
+            `[NotificationsService.ts][getInitialNotification:notifee]${reason}`
           )
           return null
+        }),
+        messaging()
+          .getInitialNotification()
+          .catch(reason => {
+            Logger.error(
+              `[NotificationsService.ts][getInitialNotification:fcm]${reason}`
+            )
+            return null
+          })
+      ])
+
+      // Prefer notifee: notifee actually displayed the notification on the
+      // data-only Android path, so its data is the source of truth. The
+      // legacy `notification` payload (FCM-displayed) is also being phased
+      // out on the backend.
+      const notifeeData = notifeeInitial?.notification?.data as
+        | NotificationData
+        | undefined
+
+      if (typeof notifeeData?.url === 'string') {
+        const channelId = resolveChannelId({
+          androidChannelId: notifeeInitial?.notification?.android?.channelId,
+          data: notifeeData
         })
-    ])
+        Logger.info(
+          '[NotificationsService.ts][getInitialNotification] notifee initial press',
+          { channelId, deeplinkUrl: notifeeData.url }
+        )
+        AnalyticsService.capture('PushNotificationPressed', {
+          channelId,
+          deeplinkUrl: notifeeData.url,
+          appState: 'cold_start',
+          handler: 'notifee'
+        })
+        callback(notifeeData)
+        return
+      }
 
-    // Prefer notifee, since data-only is the current backend format and the
-    // legacy `notification` payload is being phased out.
-    const notifeeData = notifeeInitial?.notification?.data as
-      | NotificationData
-      | undefined
+      const fcmData = fcmInitial?.data as NotificationData | undefined
 
-    if (notifeeData?.url) {
-      const channelId =
-        notifeeInitial?.notification?.android?.channelId ??
-        (typeof notifeeData.channelId === 'string'
-          ? notifeeData.channelId
-          : undefined) ??
-        EVENT_TO_CH_ID[notifeeData.event as string] ??
-        DEFAULT_ANDROID_CHANNEL
-      Logger.info(
-        '[NotificationsService.ts][getInitialNotification] notifee initial press',
-        { channelId, deeplinkUrl: notifeeData.url }
-      )
-      AnalyticsService.capture('PushNotificationPressed', {
-        channelId,
-        deeplinkUrl: String(notifeeData.url),
-        appState: 'cold_start',
-        handler: 'notifee'
-      })
-      callback(notifeeData)
-      return
+      if (typeof fcmData?.url === 'string') {
+        const channelId = resolveChannelId({ data: fcmData })
+        Logger.info(
+          '[NotificationsService.ts][getInitialNotification] fcm initial press',
+          { channelId, deeplinkUrl: fcmData.url }
+        )
+        AnalyticsService.capture('PushNotificationPressed', {
+          channelId,
+          deeplinkUrl: fcmData.url,
+          appState: 'cold_start',
+          handler: 'fcm'
+        })
+        callback(fcmData)
+        return
+      }
+
+      callback(undefined)
+    } finally {
+      // On cold start the notifee headless background handler also stashes
+      // the same press into `pendingBackgroundPress`. We've handled it here,
+      // so drain it — otherwise the next AppState 'active' transition (the
+      // first time the user backgrounds and re-foregrounds the app) would
+      // re-fire the same deeplink via the listener in DeeplinkContext.
+      this.consumePendingBackgroundPress()
     }
-
-    const fcmData = fcmInitial?.data as NotificationData | undefined
-
-    if (fcmData?.url) {
-      const channelId =
-        EVENT_TO_CH_ID[fcmData.event as string] ?? DEFAULT_ANDROID_CHANNEL
-      Logger.info(
-        '[NotificationsService.ts][getInitialNotification] fcm initial press',
-        { channelId, deeplinkUrl: fcmData.url }
-      )
-      AnalyticsService.capture('PushNotificationPressed', {
-        channelId,
-        deeplinkUrl: String(fcmData.url),
-        appState: 'cold_start',
-        handler: 'fcm'
-      })
-      callback(fcmData)
-      return
-    }
-
-    callback(undefined)
   }
 
   cancelAllNotifications = async (): Promise<void> => {

--- a/packages/core-mobile/app/services/notifications/NotificationsService.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationsService.ts
@@ -255,11 +255,11 @@ class NotificationsService {
    *         the deeplink callback can be invoked once the React tree returns
    *         to the active state (see DeeplinkContext AppState listener).
    *
-   *  2. Cold start tap: the headless task fires before redux rehydration. The
-   *     capture below is a no-op (AnalyticsService.isEnabled is still
-   *     undefined) and the pending data is overwritten by the same
-   *     notification later anyway. The press is instead captured via
-   *     {@link getInitialNotification} once the React tree mounts.
+   *  2. Cold start tap: the headless task fires before redux rehydration.
+   *     The capture below is a no-op (AnalyticsService.isEnabled is still
+   *     undefined). The pending data is then drained by
+   *     {@link getInitialNotification} once the React tree mounts, and the
+   *     actual press is captured there with `appState: 'cold_start'`.
    */
   registerBackgroundNotificationHandler = (): void => {
     if (this.backgroundHandlerRegistered) {
@@ -356,6 +356,9 @@ class NotificationsService {
         androidChannelId: detail?.notification?.android?.channelId,
         data
       })
+      // Foreground PRESS is delivered through `notifee.onForegroundEvent` on
+      // BOTH platforms (notifee wraps the APNs alert path on iOS), so the
+      // handler is always `'notifee'` here regardless of `Platform.OS`.
       AnalyticsService.capture('PushNotificationPressed', {
         channelId,
         deeplinkUrl: data.url,

--- a/packages/core-mobile/app/services/notifications/NotificationsService.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationsService.ts
@@ -10,7 +10,10 @@ import notifee, {
   TriggerType
 } from '@notifee/react-native'
 import messaging from '@react-native-firebase/messaging'
-import { HandleNotificationCallback } from 'contexts/DeeplinkContext/types'
+import {
+  HandleNotificationCallback,
+  NotificationData
+} from 'contexts/DeeplinkContext/types'
 import { fromUnixTime, isPast } from 'date-fns'
 import { Linking, Platform } from 'react-native'
 import AnalyticsService from 'services/analytics/AnalyticsService'
@@ -213,17 +216,34 @@ class NotificationsService {
   }
 
   /**
-   * method should be registered as early on in your project as possible (e.g. the index.js file)
+   * Registers the notifee background event handler.
+   *
+   * MUST be called at the entry point of the app (e.g. index.js) BEFORE
+   * AppRegistry.registerComponent — notifee only supports a single background
+   * handler, so this should be the only call site for notifee.onBackgroundEvent.
+   *
+   * Background events run as a headless JS task without React context, so we
+   * cannot dispatch redux actions or update UI here. We also intentionally do
+   * NOT capture the press analytics event here: on cold start, PostHog /
+   * AnalyticsService is not configured yet (configure runs after redux store
+   * rehydration completes), so the call would be silently dropped because
+   * AnalyticsService.isEnabled is still undefined.
+   *
+   * Cold-start press analytics + deeplink handling is performed later, once the
+   * React tree is mounted, via {@link getInitialNotification}.
    */
-  onBackgroundEvent = (callback: HandleNotificationCallback): void => {
-    return notifee.onBackgroundEvent(async ({ type, detail }) => {
-      this.handleNotificationEvent({
-        type,
-        detail,
-        callback
-      }).catch(reason =>
-        Logger.error(`[NotificationsService.ts][onBackgroundEvent]${reason}`)
-      )
+  registerBackgroundNotificationHandler = (): void => {
+    notifee.onBackgroundEvent(async ({ type, detail }) => {
+      if (type !== EventType.PRESS) return
+
+      if (detail?.notification?.id) {
+        await this.cancelTriggerNotification(detail.notification.id).catch(
+          reason =>
+            Logger.error(
+              `[NotificationsService.ts][registerBackgroundNotificationHandler]${reason}`
+            )
+        )
+      }
     })
   }
 
@@ -297,25 +317,84 @@ class NotificationsService {
     }
   }
 
-  // only for Android to obtain the notification data when the app is in the background
-  // for iOS, it is handled in the onForegroundEvent PRESS event
+  /**
+   * Picks up a notification press that caused the app to cold-start.
+   *
+   * Two display paths exist on Android, each surfaced through a different API:
+   *
+   *  1. Data-only FCM messages (current backend format) are displayed by
+   *     notifee inside FCMService.handleBackgroundMessageAndroid. The press
+   *     on such notifications can only be retrieved via
+   *     `notifee.getInitialNotification()` — `messaging().getInitialNotification()`
+   *     returns null for them because they were NOT displayed by the FCM SDK.
+   *
+   *  2. Legacy `notification + data` FCM payloads are displayed directly by
+   *     the FCM SDK. Their press is retrievable via
+   *     `messaging().getInitialNotification()`.
+   *
+   * Previously we only checked path (2), which meant every Android push press
+   * from the data-only path was lost on cold start — the root cause of the
+   * Android `PushNotificationPressed` under-reporting (CP-14006).
+   *
+   * On iOS this method is mostly a no-op for analytics because notifee's
+   * `getInitialNotification` is deprecated on iOS and APNs-displayed
+   * notifications are handled via `onForegroundEvent` / `onNotificationOpenedApp`.
+   */
   getInitialNotification = async (
     callback: HandleNotificationCallback
   ): Promise<void> => {
-    return messaging()
-      .getInitialNotification()
-      .then(notification => {
-        // if the notification has a url, we need to capture the analytics for the push notification pressed
-        if (notification && notification.data?.url) {
-          AnalyticsService.capture('PushNotificationPressed', {
-            channelId:
-              EVENT_TO_CH_ID[notification.data.event as string] ??
-              DEFAULT_ANDROID_CHANNEL,
-            deeplinkUrl: notification.data?.url as string
-          })
-        }
-        callback(notification?.data)
+    const [notifeeInitial, fcmInitial] = await Promise.all([
+      notifee.getInitialNotification().catch(reason => {
+        Logger.error(
+          `[NotificationsService.ts][getInitialNotification:notifee]${reason}`
+        )
+        return null
+      }),
+      messaging()
+        .getInitialNotification()
+        .catch(reason => {
+          Logger.error(
+            `[NotificationsService.ts][getInitialNotification:fcm]${reason}`
+          )
+          return null
+        })
+    ])
+
+    // Prefer notifee, since data-only is the current backend format and the
+    // legacy `notification` payload is being phased out.
+    const notifeeData = notifeeInitial?.notification?.data as
+      | NotificationData
+      | undefined
+
+    if (notifeeData?.url) {
+      const channelId =
+        notifeeInitial?.notification?.android?.channelId ??
+        (typeof notifeeData.channelId === 'string'
+          ? notifeeData.channelId
+          : undefined) ??
+        EVENT_TO_CH_ID[notifeeData.event as string] ??
+        DEFAULT_ANDROID_CHANNEL
+      AnalyticsService.capture('PushNotificationPressed', {
+        channelId,
+        deeplinkUrl: String(notifeeData.url)
       })
+      callback(notifeeData)
+      return
+    }
+
+    const fcmData = fcmInitial?.data as NotificationData | undefined
+
+    if (fcmData?.url) {
+      AnalyticsService.capture('PushNotificationPressed', {
+        channelId:
+          EVENT_TO_CH_ID[fcmData.event as string] ?? DEFAULT_ANDROID_CHANNEL,
+        deeplinkUrl: String(fcmData.url)
+      })
+      callback(fcmData)
+      return
+    }
+
+    callback(undefined)
   }
 
   cancelAllNotifications = async (): Promise<void> => {

--- a/packages/core-mobile/app/services/notifications/NotificationsService.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationsService.ts
@@ -271,37 +271,37 @@ class NotificationsService {
     this.backgroundHandlerRegistered = true
 
     notifee.onBackgroundEvent(async ({ type, detail }) => {
-      if (type !== EventType.PRESS) return
+      // Wrap the entire body so a synchronous throw (e.g. analytics, future
+      // validation) doesn't escape the headless task as an unhandled
+      // rejection. Notifee logs unhandled rejections from this callback.
+      try {
+        if (type !== EventType.PRESS) return
 
-      if (detail?.notification?.id) {
-        await this.cancelTriggerNotification(detail.notification.id).catch(
-          reason =>
-            Logger.error(
-              `[NotificationsService.ts][registerBackgroundNotificationHandler]${reason}`
-            )
+        if (detail?.notification?.id) {
+          await this.cancelTriggerNotification(detail.notification.id)
+        }
+
+        const data = detail?.notification?.data as NotificationData | undefined
+        if (typeof data?.url !== 'string') return
+
+        const channelId = resolveChannelId({
+          androidChannelId: detail?.notification?.android?.channelId,
+          data
+        })
+
+        AnalyticsService.capture('PushNotificationPressed', {
+          channelId,
+          deeplinkUrl: data.url,
+          appState: 'background',
+          handler: 'notifee'
+        })
+
+        this.pendingBackgroundPress = data
+      } catch (reason) {
+        Logger.error(
+          `[NotificationsService.ts][registerBackgroundNotificationHandler]${reason}`
         )
       }
-
-      const data = detail?.notification?.data as NotificationData | undefined
-      if (typeof data?.url !== 'string') return
-
-      const channelId = resolveChannelId({
-        androidChannelId: detail?.notification?.android?.channelId,
-        data
-      })
-
-      Logger.info(
-        '[NotificationsService.ts][registerBackgroundNotificationHandler] press',
-        { channelId, deeplinkUrl: data.url }
-      )
-      AnalyticsService.capture('PushNotificationPressed', {
-        channelId,
-        deeplinkUrl: data.url,
-        appState: 'background',
-        handler: 'notifee'
-      })
-
-      this.pendingBackgroundPress = data
     })
   }
 
@@ -346,14 +346,19 @@ class NotificationsService {
     }
 
     const data = detail?.notification?.data as NotificationData | undefined
-    if (data) {
+    // Match the historical "URL or skip" volume: only capture
+    // `PushNotificationPressed` when the press has an actionable deeplink.
+    // Presses with no URL (e.g. notifications fired without an action) would
+    // otherwise inflate the foreground metric and ship `deeplinkUrl: undefined`
+    // to PostHog.
+    if (typeof data?.url === 'string') {
       const channelId = resolveChannelId({
         androidChannelId: detail?.notification?.android?.channelId,
         data
       })
       AnalyticsService.capture('PushNotificationPressed', {
         channelId,
-        deeplinkUrl: typeof data.url === 'string' ? data.url : undefined,
+        deeplinkUrl: data.url,
         appState: 'foreground',
         handler: 'notifee'
       })
@@ -451,10 +456,6 @@ class NotificationsService {
           androidChannelId: notifeeInitial?.notification?.android?.channelId,
           data: notifeeData
         })
-        Logger.info(
-          '[NotificationsService.ts][getInitialNotification] notifee initial press',
-          { channelId, deeplinkUrl: notifeeData.url }
-        )
         AnalyticsService.capture('PushNotificationPressed', {
           channelId,
           deeplinkUrl: notifeeData.url,
@@ -470,10 +471,6 @@ class NotificationsService {
 
       if (typeof fcmData?.url === 'string') {
         const channelId = resolveChannelId({ data: fcmData })
-        Logger.info(
-          '[NotificationsService.ts][getInitialNotification] fcm initial press',
-          { channelId, deeplinkUrl: fcmData.url }
-        )
         AnalyticsService.capture('PushNotificationPressed', {
           channelId,
           deeplinkUrl: fcmData.url,

--- a/packages/core-mobile/app/services/notifications/NotificationsService.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationsService.ts
@@ -35,6 +35,19 @@ import {
 } from './constants'
 
 class NotificationsService {
+  /**
+   * Notification data from a PRESS event that was received in the background
+   * headless task (notifee.onBackgroundEvent). Held until the React tree
+   * becomes active and consumes it via {@link consumePendingBackgroundPress},
+   * which then routes it through the standard deeplink callback.
+   *
+   * Cold start does NOT use this path — cold-start press is retrieved
+   * separately via {@link getInitialNotification}. They are mutually
+   * exclusive: when cold-starting, `pendingBackgroundPress` is undefined; when
+   * warm-resuming, the cold-start `getInitialNotification` returns null.
+   */
+  private pendingBackgroundPress: NotificationData | undefined
+
   async getNotificationSettings(): Promise<AuthorizationStatus> {
     const settings = await notifee.getNotificationSettings()
     return settings.authorizationStatus
@@ -223,14 +236,23 @@ class NotificationsService {
    * handler, so this should be the only call site for notifee.onBackgroundEvent.
    *
    * Background events run as a headless JS task without React context, so we
-   * cannot dispatch redux actions or update UI here. We also intentionally do
-   * NOT capture the press analytics event here: on cold start, PostHog /
-   * AnalyticsService is not configured yet (configure runs after redux store
-   * rehydration completes), so the call would be silently dropped because
-   * AnalyticsService.isEnabled is still undefined.
+   * cannot dispatch redux actions or update UI here directly. Two scenarios
+   * land here on Android (the only platform where this fires, since notifee is
+   * only used to display data-only push on Android):
    *
-   * Cold-start press analytics + deeplink handling is performed later, once the
-   * React tree is mounted, via {@link getInitialNotification}.
+   *  1. Warm background tap: the app is running but minimized. PostHog and
+   *     redux store are already configured. We:
+   *       - capture `PushNotificationPressed`
+   *         (appState: 'background', handler: 'notifee'),
+   *       - stash the notification data in {@link pendingBackgroundPress} so
+   *         the deeplink callback can be invoked once the React tree returns
+   *         to the active state (see DeeplinkContext AppState listener).
+   *
+   *  2. Cold start tap: the headless task fires before redux rehydration. The
+   *     capture below is a no-op (AnalyticsService.isEnabled is still
+   *     undefined) and the pending data is overwritten by the same
+   *     notification later anyway. The press is instead captured via
+   *     {@link getInitialNotification} once the React tree mounts.
    */
   registerBackgroundNotificationHandler = (): void => {
     notifee.onBackgroundEvent(async ({ type, detail }) => {
@@ -244,7 +266,40 @@ class NotificationsService {
             )
         )
       }
+
+      const data = detail?.notification?.data as NotificationData | undefined
+      if (!data?.url) return
+
+      const channelId =
+        detail?.notification?.android?.channelId ??
+        (typeof data.channelId === 'string' ? data.channelId : undefined) ??
+        EVENT_TO_CH_ID[data.event as string] ??
+        DEFAULT_ANDROID_CHANNEL
+
+      Logger.info(
+        '[NotificationsService.ts][registerBackgroundNotificationHandler] press',
+        { channelId, deeplinkUrl: data.url }
+      )
+      AnalyticsService.capture('PushNotificationPressed', {
+        channelId,
+        deeplinkUrl: String(data.url),
+        appState: 'background',
+        handler: 'notifee'
+      })
+
+      this.pendingBackgroundPress = data
     })
+  }
+
+  /**
+   * Returns the notification data from the most recent background PRESS event
+   * (if any) and clears it. Intended to be called from an AppState 'active'
+   * listener once the React tree resumes — see DeeplinkContext.
+   */
+  consumePendingBackgroundPress = (): NotificationData | undefined => {
+    const data = this.pendingBackgroundPress
+    this.pendingBackgroundPress = undefined
+    return data
   }
 
   incrementBadgeCount = async (incrementBy?: number): Promise<void> => {
@@ -280,7 +335,8 @@ class NotificationsService {
       AnalyticsService.capture('PushNotificationPressed', {
         channelId: detail.notification?.data?.channelId as string,
         deeplinkUrl: detail.notification?.data?.url as string,
-        source: 'foreground'
+        appState: 'foreground',
+        handler: 'notifee'
       })
     }
 
@@ -382,7 +438,8 @@ class NotificationsService {
       AnalyticsService.capture('PushNotificationPressed', {
         channelId,
         deeplinkUrl: String(notifeeData.url),
-        source: 'notifee_initial'
+        appState: 'cold_start',
+        handler: 'notifee'
       })
       callback(notifeeData)
       return
@@ -400,7 +457,8 @@ class NotificationsService {
       AnalyticsService.capture('PushNotificationPressed', {
         channelId,
         deeplinkUrl: String(fcmData.url),
-        source: 'fcm_initial'
+        appState: 'cold_start',
+        handler: 'fcm'
       })
       callback(fcmData)
       return

--- a/packages/core-mobile/app/services/notifications/NotificationsService.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationsService.ts
@@ -35,15 +35,23 @@ import {
 
 class NotificationsService {
   /**
-   * Notification data from a PRESS event that was received in the background
-   * headless task (notifee.onBackgroundEvent). Held until the React tree
-   * becomes active and consumes it via {@link consumePendingBackgroundPress},
-   * which then routes it through the standard deeplink callback.
+   * Notification data from a PRESS event delivered via the notifee background
+   * headless task. Held until either:
    *
-   * Cold start does NOT use this path — cold-start press is retrieved
-   * separately via {@link getInitialNotification}. They are mutually
-   * exclusive: when cold-starting, `pendingBackgroundPress` is undefined; when
-   * warm-resuming, the cold-start `getInitialNotification` returns null.
+   *  - The React tree becomes active (warm-background case) and consumes it
+   *    via {@link handlePendingBackgroundPress}, which captures analytics
+   *    and routes the deeplink callback.
+   *  - {@link getInitialNotification} runs on cold start and drains any
+   *    stale value via {@link consumePendingBackgroundPress} so the AppState
+   *    listener doesn't replay the same press once the user later
+   *    backgrounds and re-activates the app.
+   *
+   * Cold-start press analytics + deeplink are owned by
+   * {@link getInitialNotification}, which is why this field is intentionally
+   * not captured inside the notifee.onBackgroundEvent handler: capturing
+   * there would double-count cold-start presses (one 'background' from the
+   * headless task + one 'cold_start' from getInitialNotification — observed
+   * during CP-14006 device verification).
    */
   private pendingBackgroundPress: NotificationData | undefined
 
@@ -242,24 +250,27 @@ class NotificationsService {
    * AppRegistry.registerComponent — notifee only supports a single background
    * handler, so this should be the only call site for notifee.onBackgroundEvent.
    *
-   * Background events run as a headless JS task without React context, so we
-   * cannot dispatch redux actions or update UI here directly. Two scenarios
-   * land here on Android (the only platform where this fires, since notifee is
-   * only used to display data-only push on Android):
+   * Background events run as a headless JS task. This handler intentionally
+   * does the minimum amount of work that is safe in that headless context:
    *
-   *  1. Warm background tap: the app is running but minimized. PostHog and
-   *     redux store are already configured. We:
-   *       - capture `PushNotificationPressed`
-   *         (appState: 'background', handler: 'notifee'),
-   *       - stash the notification data in {@link pendingBackgroundPress} so
-   *         the deeplink callback can be invoked once the React tree returns
-   *         to the active state (see DeeplinkContext AppState listener).
+   *  - cancel the matching trigger notification (idempotent native call), and
+   *  - stash the notification data into {@link pendingBackgroundPress}.
    *
-   *  2. Cold start tap: the headless task fires before redux rehydration.
-   *     The capture below is a no-op (AnalyticsService.isEnabled is still
-   *     undefined). The pending data is then drained by
-   *     {@link getInitialNotification} once the React tree mounts, and the
-   *     actual press is captured there with `appState: 'cold_start'`.
+   * Analytics capture is deliberately NOT performed here. The same PRESS is
+   * surfaced to the React-mounted context through one of two paths, which
+   * handle capture there (with both PostHog and the redux store guaranteed
+   * to be initialized):
+   *
+   *  - warm-background tap: AppState 'active' transition in DeeplinkContext
+   *    invokes {@link handlePendingBackgroundPress}.
+   *  - cold-start tap: notifee.getInitialNotification() returns the same
+   *    press inside {@link getInitialNotification}, which captures it as
+   *    `appState: 'cold_start'` and then drains the stale pending value via
+   *    {@link consumePendingBackgroundPress}.
+   *
+   * This split eliminates the duplicate-capture bug observed during CP-14006
+   * device verification (cold-start press emitting both 'background' and
+   * 'cold_start') without any state flag.
    */
   registerBackgroundNotificationHandler = (): void => {
     if (this.backgroundHandlerRegistered) {
@@ -271,9 +282,8 @@ class NotificationsService {
     this.backgroundHandlerRegistered = true
 
     notifee.onBackgroundEvent(async ({ type, detail }) => {
-      // Wrap the entire body so a synchronous throw (e.g. analytics, future
-      // validation) doesn't escape the headless task as an unhandled
-      // rejection. Notifee logs unhandled rejections from this callback.
+      // Wrap the entire body so a synchronous throw doesn't escape the
+      // headless task as an unhandled rejection.
       try {
         if (type !== EventType.PRESS) return
 
@@ -283,18 +293,6 @@ class NotificationsService {
 
         const data = detail?.notification?.data as NotificationData | undefined
         if (typeof data?.url !== 'string') return
-
-        const channelId = resolveChannelId({
-          androidChannelId: detail?.notification?.android?.channelId,
-          data
-        })
-
-        AnalyticsService.capture('PushNotificationPressed', {
-          channelId,
-          deeplinkUrl: data.url,
-          appState: 'background',
-          handler: 'notifee'
-        })
 
         this.pendingBackgroundPress = data
       } catch (reason) {
@@ -306,14 +304,43 @@ class NotificationsService {
   }
 
   /**
-   * Returns the notification data from the most recent background PRESS event
-   * (if any) and clears it. Intended to be called from an AppState 'active'
-   * listener once the React tree resumes — see DeeplinkContext.
+   * Drains the most recent background PRESS data (if any) without side
+   * effects. Intended for stale-cleanup paths such as
+   * {@link getInitialNotification} on cold start, where the same press has
+   * already been captured as `appState: 'cold_start'` and we just need to
+   * prevent the AppState listener from replaying it later.
    */
   consumePendingBackgroundPress = (): NotificationData | undefined => {
     const data = this.pendingBackgroundPress
     this.pendingBackgroundPress = undefined
     return data
+  }
+
+  /**
+   * Warm-background press handler. Drains {@link pendingBackgroundPress},
+   * captures `PushNotificationPressed` (appState: 'background', handler:
+   * 'notifee'), and forwards the data to the provided callback for deeplink
+   * processing. No-op if nothing is pending.
+   *
+   * Intended to be called from an AppState 'active' transition in
+   * DeeplinkContext — that is the only point where we know the React tree
+   * is mounted and PostHog / redux are configured.
+   */
+  handlePendingBackgroundPress = (
+    callback: HandleNotificationCallback
+  ): void => {
+    const data = this.consumePendingBackgroundPress()
+    if (typeof data?.url !== 'string') return
+
+    const channelId = resolveChannelId({ data })
+    AnalyticsService.capture('PushNotificationPressed', {
+      channelId,
+      deeplinkUrl: data.url,
+      appState: 'background',
+      handler: 'notifee'
+    })
+
+    callback(data)
   }
 
   incrementBadgeCount = async (incrementBy?: number): Promise<void> => {

--- a/packages/core-mobile/app/services/notifications/eventChannelMap.ts
+++ b/packages/core-mobile/app/services/notifications/eventChannelMap.ts
@@ -1,0 +1,66 @@
+import { BalanceChangeEvents, NewsEvents } from 'services/fcm/types'
+import { ChannelId, DEFAULT_ANDROID_CHANNEL } from './channels'
+
+/**
+ * Map from a notification's `event` string (the FCM payload's `data.event`)
+ * to the on-device channel that displays it.
+ *
+ * Lives in its own module rather than `channels.ts` or `FCMService.ts`:
+ *
+ * - Putting it in `channels.ts` would create a cycle, since `channels.ts`
+ *   would have to import from `services/fcm/types`, which already imports
+ *   `ChannelId` from `channels.ts` for its Zod schema.
+ * - Putting it in `FCMService.ts` was the original layout, but that made
+ *   `NotificationsService` import from `FCMService` (which already imports
+ *   `NotificationsService.displayNotification`) — a real cycle that worked
+ *   only by accident of evaluation order.
+ *
+ * This module imports from both ends and is imported by neither.
+ */
+export const EVENT_TO_CH_ID: Record<string, ChannelId> = {
+  [BalanceChangeEvents.ALLOWANCE_APPROVED]: ChannelId.BALANCE_CHANGES,
+  [BalanceChangeEvents.BALANCES_SPENT]: ChannelId.BALANCE_CHANGES,
+  [BalanceChangeEvents.BALANCES_RECEIVED]: ChannelId.BALANCE_CHANGES,
+  [BalanceChangeEvents.BALANCES_TRANSFERRED]: ChannelId.BALANCE_CHANGES,
+  [NewsEvents.MARKET_NEWS]: ChannelId.MARKET_NEWS,
+  [NewsEvents.OFFERS_AND_PROMOTIONS]: ChannelId.OFFERS_AND_PROMOTIONS,
+  [NewsEvents.PRICE_ALERTS]: ChannelId.PRICE_ALERTS,
+  [NewsEvents.PRODUCT_ANNOUNCEMENTS]: ChannelId.PRODUCT_ANNOUNCEMENTS
+}
+
+/**
+ * Pure helper that resolves the channel id for a `PushNotificationPressed`
+ * analytics event. Centralizes the precedence rule shared by every capture
+ * site (foreground, warm-background notifee, cold-start notifee, iOS
+ * background FCM):
+ *
+ *   1. android.channelId on the displayed notifee notification, if any
+ *      (Android data-only path — the notifee `Notification.android.channelId`
+ *      is the most authoritative source since it's set by us at display time)
+ *   2. data.channelId carried in the FCM payload (NEWS notifications)
+ *   3. EVENT_TO_CH_ID lookup against the event string
+ *   4. DEFAULT_ANDROID_CHANNEL as a final fallback
+ *
+ * Accepts loosely-typed input because notification data shapes vary across
+ * the FCM SDK, notifee, and the legacy `notification` payload — narrowing
+ * happens here so callers don't need unsafe `as string` casts.
+ */
+export const resolveChannelId = (args: {
+  androidChannelId?: string
+  data?: Record<string, unknown>
+  fallbackEvent?: string
+}): string => {
+  const { androidChannelId, data, fallbackEvent } = args
+  const dataChannelId =
+    typeof data?.channelId === 'string' && data.channelId.length > 0
+      ? data.channelId
+      : undefined
+  const event =
+    (typeof data?.event === 'string' ? data.event : undefined) ?? fallbackEvent
+  return (
+    androidChannelId ??
+    dataChannelId ??
+    (event ? EVENT_TO_CH_ID[event] : undefined) ??
+    DEFAULT_ANDROID_CHANNEL
+  )
+}

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -215,17 +215,30 @@ export type AnalyticsEvents = {
     channelId: string
     deeplinkUrl?: string
     /**
-     * Which capture path the press came from. Added for CP-14006 verification.
+     * App state at the moment the press was received.
      *
-     * - `foreground`:      notifee.onForegroundEvent PRESS while the app is open
-     * - `ios_background`:  messaging().onNotificationOpenedApp (iOS background tap)
-     * - `notifee_initial`: notifee.getInitialNotification() — cold start tap on a
-     *                      notification displayed by notifee (Android data-only)
-     * - `fcm_initial`:     messaging().getInitialNotification() — cold start tap
-     *                      on a notification displayed by the FCM SDK directly
-     *                      (legacy notification payload)
+     * - `foreground`: app is open and in view.
+     * - `background`: app is alive but minimized (warm resume on tap).
+     * - `cold_start`: app was killed and was launched by the press.
+     *
+     * Combined with `handler` to identify the exact capture path. Added for
+     * CP-14006 verification — lets us break down underreporting by app state
+     * regardless of which RN API caught the press.
      */
-    source: 'foreground' | 'ios_background' | 'notifee_initial' | 'fcm_initial'
+    appState: 'foreground' | 'background' | 'cold_start'
+    /**
+     * Which RN notification API delivered the press to us.
+     *
+     * - `notifee`: notifee.onForegroundEvent / onBackgroundEvent /
+     *              getInitialNotification — used for all Android data-only
+     *              notifications and for foreground notifications on both
+     *              platforms.
+     * - `fcm`:     messaging().onNotificationOpenedApp /
+     *              getInitialNotification — used when the FCM SDK displays
+     *              the notification itself (iOS APNs alert path, or legacy
+     *              Android `notification` payload).
+     */
+    handler: 'notifee' | 'fcm'
   }
   PushNotificationUnsubscribed: {
     channelId: string

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -214,6 +214,18 @@ export type AnalyticsEvents = {
   PushNotificationPressed: {
     channelId: string
     deeplinkUrl?: string
+    /**
+     * Which capture path the press came from. Added for CP-14006 verification.
+     *
+     * - `foreground`:      notifee.onForegroundEvent PRESS while the app is open
+     * - `ios_background`:  messaging().onNotificationOpenedApp (iOS background tap)
+     * - `notifee_initial`: notifee.getInitialNotification() — cold start tap on a
+     *                      notification displayed by notifee (Android data-only)
+     * - `fcm_initial`:     messaging().getInitialNotification() — cold start tap
+     *                      on a notification displayed by the FCM SDK directly
+     *                      (legacy notification payload)
+     */
+    source: 'foreground' | 'ios_background' | 'notifee_initial' | 'fcm_initial'
   }
   PushNotificationUnsubscribed: {
     channelId: string

--- a/packages/core-mobile/index.js
+++ b/packages/core-mobile/index.js
@@ -7,6 +7,7 @@ import './polyfills'
 import Big from 'big.js'
 import FCMService from 'services/fcm/FCMService'
 import AppCheckService from 'services/fcm/AppCheckService'
+import NotificationsService from 'services/notifications/NotificationsService'
 import Bootsplash from 'react-native-bootsplash'
 import Logger, { LogLevel } from 'utils/Logger'
 import DevDebuggingConfig from 'utils/debugging/DevDebuggingConfig'
@@ -68,6 +69,10 @@ if (DevDebuggingConfig.STORYBOOK_ENABLED) {
 
 AppCheckService.init()
 FCMService.listenForMessagesBackground()
+// Notifee only supports a single background event handler and requires it to
+// be registered before AppRegistry.registerComponent so it can handle cold-start
+// PRESS events for notifications displayed by notifee (data-only Android push).
+NotificationsService.registerBackgroundNotificationHandler()
 
 AppRegistry.registerComponent(expo.name, () => AppEntryPoint)
 


### PR DESCRIPTION
## Description

**Ticket: [CP-14006]**

### Summary
Fixes Android `PushNotificationPressed` analytics under-reporting and brings parity to all four notification capture paths (foreground, warm-background, cold-start data-only, iOS background).

- **Cold-start (Android data-only)**: previously the press was lost because we only checked `messaging().getInitialNotification()`. Now we also check `notifee.getInitialNotification()`, which is where data-only notifications surface, and prefer it as the source of truth.
- **Warm background (Android data-only)**: notifee's background handler is now registered exactly once at app entry (`index.js`) — notifee only supports a single handler. The headless task captures analytics, stashes the notification data in `pendingBackgroundPress`, and a new `AppState` 'active' listener in `DeeplinkContext` consumes it on the next foreground transition so the deeplink runs in a mounted React context.
- **iOS background**: `PushNotificationPressed` capture in `FCMService.handleBackgroundMessageIos` was previously gated behind `shouldSkipHandlingDeeplink` (dropped balance-change taps) and behind a strict `data.channelId` guard. Capture is now performed before the skip decision and uses the shared channel-id resolver, so balance-change and walletconnect taps are no longer dropped.
- **Two new analytics dimensions** added to `PushNotificationPressed`:
  - `appState`: `'foreground' | 'background' | 'cold_start'`
  - `handler`: `'notifee' | 'fcm'`
  These let the dashboard slice volume by capture path independently and make future regressions detectable.
- **Refactors** to support the above:
  - New `services/notifications/eventChannelMap.ts` holding `EVENT_TO_CH_ID` and a pure `resolveChannelId(...)` helper used by every capture site. Breaks the prior `FCMService` ↔ `NotificationsService` import cycle.
  - Idempotence guard on `registerBackgroundNotificationHandler` to prevent silent overwrite if a future call site reintroduces the registration.
  - Conditional cold-start `pendingBackgroundPress` drain to avoid losing a legitimate warm-background press if the `getInitialNotification` effect re-runs (e.g. on `isAllNotificationsBlocked` toggle).
  - Headless background handler body wrapped in `try/catch` so a synchronous throw cannot escape as an unhandled rejection.

## Testing
iOS: 8480
Android: 8481

1. **Background path** — open the app, then minimize. Tap the notification → app foregrounds, deeplink routes correctly. Verify PostHog event:
   - **Android**: `appState: 'background'`, `handler: 'notifee'`
   - **iOS**: `appState: 'background'`, `handler: 'fcm'`
2. **Cold-start path** — kill the app from recents. Tap the notification → app cold-starts, deeplink routes correctly. Verify PostHog event:
   - **Android**: `appState: 'cold_start'`, `handler: 'notifee'`
   - **iOS**: `appState: 'cold_start'`, `handler: 'fcm'`

## Checklist
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [x] I have updated the documentation

[CP-14006]: https://ava-labs.atlassian.net/browse/CP-14006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ