### PR TITLE
CP-13970: restore BLE reconnect between multi-step signings

### DIFF
--- a/packages/core-mobile/app/services/ledger/LedgerService.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.ts
@@ -975,6 +975,24 @@ class LedgerService {
     return this.#transport
   }
 
+  // Ensure a live BLE transport before returning it. Multi-step signing
+  // flows (e.g. delegation, claim P→C) leave the link idle between steps;
+  // a silent BLE drop or device sleep can leave #transport stale by the
+  // time the next step calls into the signer. ensureConnection reconnects
+  // to the remembered deviceId in that case so the second prompt actually
+  // reaches the device. connect() is mutex-guarded, so joining an
+  // in-flight auto-reconnect is safe.
+  async ensureConnection(): Promise<TransportBLE> {
+    if (!this.connectedDeviceId) {
+      throw new Error(LEDGER_ERROR_CODES.TRANSPORT_INTERFACE_NOT_AVAILABLE)
+    }
+    if (!this.#transport || !this.#transport.isConnected) {
+      Logger.info('[ensureConnection] transport unavailable — reconnecting')
+      await this.connect(this.connectedDeviceId)
+    }
+    return this.getTransport()
+  }
+
   // Always-verify app readiness: skip the openApp APDU if the cached state
   // matches (minimizing BLE traffic) but always run waitForApp to verify
   // device readiness before sending the payload.

--- a/packages/core-mobile/app/services/wallet/LedgerWallet.test.ts
+++ b/packages/core-mobile/app/services/wallet/LedgerWallet.test.ts
@@ -29,23 +29,27 @@ jest.mock(
 
 // Mock LedgerService - the default export is the service instance
 // We need to create the mock inline so Jest can hoist it properly
-jest.mock('services/ledger/LedgerService', () => ({
-  __esModule: true,
-  default: {
-    openApp: jest.fn().mockResolvedValue(undefined),
-    getTransport: jest.fn().mockReturnValue({
-      send: jest.fn(),
-      close: jest.fn(),
-      isConnected: true
-    }),
-    connect: jest.fn().mockResolvedValue(undefined),
-    waitForApp: jest.fn().mockResolvedValue(undefined),
-    isConnected: jest.fn().mockReturnValue(true),
-    getCurrentAppType: jest.fn().mockReturnValue('AVALANCHE'),
-    getAllAddresses: jest.fn(),
-    getExtendedPublicKeys: jest.fn()
+jest.mock('services/ledger/LedgerService', () => {
+  const mockTransport = {
+    send: jest.fn(),
+    close: jest.fn(),
+    isConnected: true
   }
-}))
+  return {
+    __esModule: true,
+    default: {
+      openApp: jest.fn().mockResolvedValue(undefined),
+      getTransport: jest.fn().mockReturnValue(mockTransport),
+      ensureConnection: jest.fn().mockResolvedValue(mockTransport),
+      connect: jest.fn().mockResolvedValue(undefined),
+      waitForApp: jest.fn().mockResolvedValue(undefined),
+      isConnected: jest.fn().mockReturnValue(true),
+      getCurrentAppType: jest.fn().mockReturnValue('AVALANCHE'),
+      getAllAddresses: jest.fn(),
+      getExtendedPublicKeys: jest.fn()
+    }
+  }
+})
 
 // Mock AppAvax from hw-app-avalanche - defined before jest.mock for hoisting
 const mockSign = jest.fn()
@@ -173,6 +177,7 @@ import { BitcoinWalletPolicyService } from './BitcoinWalletPolicyService'
 // Get references to the mocked functions
 const mockOpenApp = LedgerService.openApp as jest.Mock
 const mockGetTransport = LedgerService.getTransport as jest.Mock
+const mockEnsureConnection = LedgerService.ensureConnection as jest.Mock
 const mockWaitForApp = LedgerService.waitForApp as jest.Mock
 const mockIsConnected = LedgerService.isConnected as jest.Mock
 const mockGetCurrentAppType = LedgerService.getCurrentAppType as jest.Mock
@@ -228,6 +233,7 @@ describe('LedgerWallet', () => {
     // Reset and configure mocks with default behavior
     mockOpenApp.mockResolvedValue(undefined)
     mockGetTransport.mockReturnValue(new MockTransport() as never)
+    mockEnsureConnection.mockResolvedValue(new MockTransport() as never)
     mockWaitForApp.mockResolvedValue(undefined)
     mockIsConnected.mockReturnValue(true)
     mockGetCurrentAppType.mockReturnValue('AVALANCHE')
@@ -745,9 +751,9 @@ describe('LedgerWallet', () => {
 
     describe('error handling', () => {
       it('should throw error when connection fails', async () => {
-        mockGetTransport.mockImplementationOnce(() => {
-          throw new Error('DisconnectedDevice')
-        })
+        mockEnsureConnection.mockRejectedValueOnce(
+          new Error('DisconnectedDevice')
+        )
 
         const mockTx = {
           getVM: jest.fn().mockReturnValue('AVM'),
@@ -854,10 +860,11 @@ describe('LedgerWallet', () => {
 
       it('should ensure transport is obtained before signing', async () => {
         // Restore the spy so the real LedgerWallet.getTransport() runs,
-        // which calls through to LedgerService.getTransport().
+        // which calls through to LedgerService.ensureConnection() — the
+        // BLE recovery hop that multi-step signing flows rely on.
         jest.restoreAllMocks()
-        mockGetTransport.mockClear()
-        mockGetTransport.mockReturnValue(new MockTransport() as never)
+        mockEnsureConnection.mockClear()
+        mockEnsureConnection.mockResolvedValue(new MockTransport() as never)
 
         const mockTx = {
           getVM: jest.fn().mockReturnValue('AVM'),
@@ -878,7 +885,7 @@ describe('LedgerWallet', () => {
           provider: mockProvider
         })
 
-        expect(mockGetTransport).toHaveBeenCalled()
+        expect(mockEnsureConnection).toHaveBeenCalled()
       })
 
       it('should wait for Avalanche app before signing', async () => {
@@ -1098,28 +1105,28 @@ describe('LedgerWallet', () => {
 
   describe('Private Methods', () => {
     describe('getTransport', () => {
-      it('should call LedgerService.getTransport', () => {
+      it('should call LedgerService.ensureConnection', async () => {
         // Remove the spy set up in beforeEach
         jest.restoreAllMocks()
 
         const mockTransport = new MockTransport()
-        mockGetTransport.mockReturnValue(mockTransport as never)
+        mockEnsureConnection.mockResolvedValue(mockTransport as never)
 
-        const result = (ledgerWallet as any).getTransport()
+        const result = await (ledgerWallet as any).getTransport()
 
-        expect(mockGetTransport).toHaveBeenCalled()
+        expect(mockEnsureConnection).toHaveBeenCalled()
         expect(result).toBe(mockTransport)
       })
 
-      it('should throw error when transport is not available', () => {
+      it('should throw error when transport is not available', async () => {
         // Remove the spy set up in beforeEach
         jest.restoreAllMocks()
 
-        mockGetTransport.mockImplementation(() => {
-          throw new Error('transport_interface_not_available')
-        })
+        mockEnsureConnection.mockRejectedValue(
+          new Error('transport_interface_not_available')
+        )
 
-        expect(() => (ledgerWallet as any).getTransport()).toThrow(
+        await expect((ledgerWallet as any).getTransport()).rejects.toThrow(
           'transport_interface_not_available'
         )
       })
@@ -1419,9 +1426,9 @@ describe('LedgerWallet', () => {
       })
 
       it('should handle app connection errors', async () => {
-        mockGetTransport.mockImplementation(() => {
-          throw new Error('Connection failed')
-        })
+        mockEnsureConnection.mockRejectedValueOnce(
+          new Error('Connection failed')
+        )
 
         await expect(
           (ledgerWallet as any).signAvalancheMessage(0, 'message')
@@ -1854,7 +1861,7 @@ describe('LedgerWallet', () => {
       it('should ensure connection and wait for app', async () => {
         await (ledgerWallet as any).handleAppConnection(LedgerAppType.AVALANCHE)
 
-        expect(mockGetTransport).toHaveBeenCalled()
+        expect(mockEnsureConnection).toHaveBeenCalled()
         expect(mockOpenApp).toHaveBeenCalledWith(LedgerAppType.AVALANCHE)
         expect(mockWaitForApp).toHaveBeenCalledWith(
           LedgerAppType.AVALANCHE,
@@ -1873,9 +1880,9 @@ describe('LedgerWallet', () => {
       })
 
       it('should throw error when connection fails', async () => {
-        mockGetTransport.mockImplementation(() => {
-          throw new Error('Device not found')
-        })
+        mockEnsureConnection.mockRejectedValueOnce(
+          new Error('Device not found')
+        )
 
         await expect(
           (ledgerWallet as any).handleAppConnection(LedgerAppType.AVALANCHE)
@@ -2104,9 +2111,7 @@ describe('LedgerWallet', () => {
       })
 
       it('should throw when app connection fails', async () => {
-        mockGetTransport.mockImplementationOnce(() => {
-          throw new Error('No device')
-        })
+        mockEnsureConnection.mockRejectedValueOnce(new Error('No device'))
 
         await expect(
           (ledgerWallet as any).handleEthAndPersonalSign({

--- a/packages/core-mobile/app/services/wallet/LedgerWallet.ts
+++ b/packages/core-mobile/app/services/wallet/LedgerWallet.ts
@@ -91,9 +91,9 @@ export class LedgerWallet implements Wallet {
     }
   }
 
-  private getTransport(): TransportBLE {
-    Logger.info('getTransport called - using LedgerService')
-    return LedgerService.getTransport()
+  private async getTransport(): Promise<TransportBLE> {
+    Logger.info('getTransport called - using LedgerService.ensureConnection')
+    return LedgerService.ensureConnection()
   }
 
   private async getBitcoinSigner(
@@ -157,7 +157,7 @@ export class LedgerWallet implements Wallet {
         throw new Error('Failed to derive Bitcoin address public key')
       }
 
-      const transport = this.getTransport()
+      const transport = await this.getTransport()
 
       this.bitcoinWallet = new BitcoinLedgerWallet(
         addressNode.publicKey,
@@ -383,7 +383,7 @@ export class LedgerWallet implements Wallet {
 
     try {
       // Ensure device is connected
-      const transport = this.getTransport()
+      const transport = await this.getTransport()
 
       // Ensure Bitcoin app is ready
       Logger.info('Ensuring Bitcoin app is ready...')
@@ -1582,11 +1582,13 @@ export class LedgerWallet implements Wallet {
   private handleAppConnection = async (
     appType: LedgerAppType
   ): Promise<TransportBLE> => {
-    // First ensure we're connected to the device
+    // First ensure we're connected to the device. ensureConnection
+    // reconnects the BLE transport if it went idle between signings —
+    // this is the safety net multi-step signing flows rely on.
     Logger.info('Ensuring connection to Ledger device...')
     let transport: TransportBLE
     try {
-      transport = LedgerService.getTransport()
+      transport = await LedgerService.ensureConnection()
       Logger.info('Successfully connected to Ledger device')
     } catch (error) {
       Logger.error('Failed to connect to Ledger device:', error)


### PR DESCRIPTION
## Description

Bitrise: https://app.bitrise.io/app/7d7ca5af7066e290/pipelines/7758cc87-d341-4e74-81f8-b50326fdc1ac
iOS: 8481
Android: 8482

**Ticket: [CP-13970]**

CP-14115 (Ledger BLE transport & lifecycle refactor) replaced `await LedgerService.ensureConnection(deviceId)` with the synchronous `LedgerService.getTransport()` inside `LedgerWallet.getTransport` and `handleAppConnection`. The pre-refactor `ensureConnection` was the safety net that reconnected the BLE transport whenever the cached link was missing or marked disconnected — exactly the case that multi-step signing flows (delegation, claim P→C) hit when the device goes idle between steps. After the refactor:

- The synchronous getter either returns a zombie transport (causing the next APDU in `waitForApp` to hang forever) or throws — with no recovery in either case.
- The new auto-reconnect machinery only fires on an explicit `disconnect` event, so silent BLE drops between signings go unrecovered.

Result on `main`: delegation and claim-reward complete step 1 but never prompt the device for step 2.

This PR:

- Adds `LedgerService.ensureConnection()` back, using the post-refactor `connectedDeviceId` field and joining the `connect()` mutex so it's safe alongside any in-flight auto-reconnect.
- Routes `LedgerWallet.getTransport` (async again) and `handleAppConnection` through `ensureConnection()`.
- Updates `LedgerWallet.test.ts` to mock `ensureConnection` and exercise the failure path through the new entry point.

No dependencies added. No breaking changes; behavior on a healthy connection is unchanged — only the previously-missing reconnect-between-steps is restored.

## Screenshots/Videos

N/A — pure transport-lifecycle fix; no UI surfaces changed. Will attach a device-screen recording of step 2 prompting if helpful.

## Testing

**Dev Testing**

- Connect a Ledger (BIP44 or Ledger Live) and open the Avalanche app.
- Stake → Delegate: complete the full flow. Verify the device prompts for the **second** signature after step 1 is confirmed on chain.
- Stake → Claim Reward: complete export-from-P. Verify the import-to-C signing prompt appears on the device after the export commits.
- Repro of the regression: between step 1 and step 2 of claim-reward, let the device screen lock (~30s idle while `getTxStatus` polls). On `main` the second prompt never appears; with this fix it does.
- Single-step Avalanche send and EVM send still sign as before.
- Bitcoin send (`signBtcTransaction` path): BTC app still signs — uses the same `getTransport()` route, now async.

**QA Testing**

- All multi-step Ledger flows (delegate, undelegate / claim reward) on iOS and Android. Acceptance: the device prompts for every signing step, including ones that follow long network waits.
- Single-step flows (basic AVAX / EVM / BTC sends and contract approvals on Ledger) are unaffected.
- Edge case: lock the Ledger screen while the app is mid-flow between signings; on returning to the device the second prompt should still surface (reconnect kicks in) rather than the flow hanging silently.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works (`yarn tsc`, lint, 164/164 Ledger unit tests)
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests (`LedgerWallet.test.ts`)


[CP-13970]: https://ava-labs.atlassian.net/browse/CP-13970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ