### PR TITLE
CP-14259: Use Ethereum Ledger app for Avalanche C-Chain contract calls

### DIFF
--- a/packages/core-mobile/app/new/features/approval/hooks/useLedgerApproval.tsx
+++ b/packages/core-mobile/app/new/features/approval/hooks/useLedgerApproval.tsx
@@ -5,8 +5,8 @@ import {
 import { UnsupportedBitcoinApp } from 'features/ledger/components/UnsupportedBitcoinApp'
 import { useLedgerBLEConnection } from 'features/ledger/hooks/useLedgerBLEConnection'
 import { ledgerParamsStore, useLedgerParams } from 'features/ledger/store'
-import { getLedgerAppName } from 'features/ledger/utils'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { LedgerAppType } from 'services/ledger/types'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { TRANSACTION_CANCELLED_BY_USER } from 'vmModule/ApprovalController/utils'
 
 type UseLedgerApprovalReturn = {
@@ -34,10 +34,10 @@ export const useLedgerApproval = (
   const { reviewTransactionParams } = useLedgerParams()
   const prevParamsRef = useRef(reviewTransactionParams)
 
-  const appType = useMemo(
-    () => getLedgerAppName(reviewTransactionParams?.network),
-    [reviewTransactionParams?.network]
-  )
+  // `appType` is pre-computed by ApprovalController which has the full
+  // request context — see `getLedgerAppForEvmTx`. We fall back to UNKNOWN
+  // only while `reviewTransactionParams` is null (sheet not active).
+  const appType = reviewTransactionParams?.appType ?? LedgerAppType.UNKNOWN
 
   const {
     isLedgerConnected,

--- a/packages/core-mobile/app/new/features/ledger/store.ts
+++ b/packages/core-mobile/app/new/features/ledger/store.ts
@@ -1,16 +1,25 @@
-import { LedgerDerivationPathType, LedgerDevice } from 'services/ledger/types'
+import {
+  LedgerAppType,
+  LedgerDerivationPathType,
+  LedgerDevice
+} from 'services/ledger/types'
 import { ZustandStorageKeys, zustandPersistStorage } from 'utils/mmkv'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { Network } from '@avalabs/core-chains-sdk'
 import { OnDelegationProgress } from 'contexts/DelegationContext'
-import { RpcMethod } from '@avalabs/vm-module-types'
 
 type WalletId = string
 
 export type LedgerReviewTransactionParams = {
-  rpcMethod?: RpcMethod
-  network: Network
+  /**
+   * Pre-computed Ledger app to prompt for this transaction. The producer
+   * (ApprovalController) has the full request context (chain + signing
+   * data) and is the right place to derive this — consumers should not
+   * have to recompute it from `network` alone, which can yield the wrong
+   * app for EVM contract calls on Avalanche C-Chain. See
+   * `getLedgerAppForEvmTx` and `getLedgerAppName`.
+   */
+  appType: LedgerAppType
   onApprove: (onProgress?: OnDelegationProgress) => Promise<void>
   onReject: (message?: string) => void
 }

--- a/packages/core-mobile/app/new/features/ledger/utils/index.test.ts
+++ b/packages/core-mobile/app/new/features/ledger/utils/index.test.ts
@@ -12,7 +12,9 @@ import {
   getFormattedAddresses,
   buildKeysFromMultiIndex,
   buildLedgerWalletSecret,
-  LedgerWalletSecretSchema
+  LedgerWalletSecretSchema,
+  isEvmContractCallData,
+  getLedgerAppForEvmTx
 } from './index'
 
 describe('isVersionExceeding', () => {
@@ -325,6 +327,7 @@ describe('buildKeysFromMultiIndex', () => {
       derivationPathType: LedgerDerivationPathType.BIP44
     })
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const keys = publicKeys[0]!
     expect(keys).toBeDefined()
     // mainnet avalanche pk + solana pk + testnet avalanche pk = 3
@@ -339,6 +342,7 @@ describe('buildKeysFromMultiIndex', () => {
   it('deduplicates public keys with the same key value', () => {
     const multiIndexKeys = makeMultiIndexKeys([0])
     // Make testnet key identical to mainnet key
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     multiIndexKeys.testnet[0]!.avalancheKeys!.publicKeys = [
       makePk('pk_mainnet_0')
     ]
@@ -349,6 +353,7 @@ describe('buildKeysFromMultiIndex', () => {
       derivationPathType: LedgerDerivationPathType.BIP44
     })
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const keyValues = publicKeys[0]!.map(k => k.key)
     expect(keyValues.filter(k => k === 'pk_mainnet_0')).toHaveLength(1)
   })
@@ -841,6 +846,7 @@ describe('buildLedgerWalletSecret', () => {
       })
 
       const parsed2 = LedgerWalletSecretSchema.parse(JSON.parse(updatedSecret))
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(Object.keys(parsed2.extendedPublicKeys!)).toHaveLength(2)
       expect(Object.keys(parsed2.publicKeys)).toHaveLength(2)
 
@@ -861,7 +867,69 @@ describe('buildLedgerWalletSecret', () => {
       // Account 1 should be untouched
       expect(parsed3.publicKeys[1]).toHaveLength(1)
       // Xpubs should still be intact
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(Object.keys(parsed3.extendedPublicKeys!)).toHaveLength(2)
     })
+  })
+})
+
+describe('isEvmContractCallData', () => {
+  it('returns false for empty / "0x" data', () => {
+    expect(isEvmContractCallData(undefined)).toBe(false)
+    expect(isEvmContractCallData(null)).toBe(false)
+    expect(isEvmContractCallData('')).toBe(false)
+    expect(isEvmContractCallData('0x')).toBe(false)
+  })
+
+  it('returns true for non-trivial calldata', () => {
+    expect(isEvmContractCallData('0xa9059cbb')).toBe(true)
+    expect(
+      isEvmContractCallData(
+        '0x3593564c0000000000000000000000000000000000000000'
+      )
+    ).toBe(true)
+  })
+
+  it('returns false for non-string values', () => {
+    expect(isEvmContractCallData(0)).toBe(false)
+    expect(isEvmContractCallData({})).toBe(false)
+  })
+})
+
+describe('getLedgerAppForEvmTx', () => {
+  // Mainnet C-Chain
+  const AVAX_C_CHAIN = 43114
+  const ETHEREUM_MAINNET = 1
+
+  it('returns Avalanche app for simple AVAX transfers on Avalanche C-Chain', () => {
+    expect(getLedgerAppForEvmTx(AVAX_C_CHAIN, '0x')).toBe(
+      LedgerAppType.AVALANCHE
+    )
+    expect(getLedgerAppForEvmTx(AVAX_C_CHAIN, undefined)).toBe(
+      LedgerAppType.AVALANCHE
+    )
+  })
+
+  it('returns Ethereum app for Avalanche C-Chain contract calls', () => {
+    // Uniswap UR `execute(...)` selector
+    expect(
+      getLedgerAppForEvmTx(
+        AVAX_C_CHAIN,
+        '0x3593564c0000000000000000000000000000000000000000'
+      )
+    ).toBe(LedgerAppType.ETHEREUM)
+    // ERC20 transfer
+    expect(getLedgerAppForEvmTx(AVAX_C_CHAIN, '0xa9059cbb')).toBe(
+      LedgerAppType.ETHEREUM
+    )
+  })
+
+  it('returns Ethereum app for non-Avalanche EVM chains regardless of data', () => {
+    expect(getLedgerAppForEvmTx(ETHEREUM_MAINNET, '0x')).toBe(
+      LedgerAppType.ETHEREUM
+    )
+    expect(getLedgerAppForEvmTx(ETHEREUM_MAINNET, '0xa9059cbb')).toBe(
+      LedgerAppType.ETHEREUM
+    )
   })
 })

--- a/packages/core-mobile/app/new/features/ledger/utils/index.ts
+++ b/packages/core-mobile/app/new/features/ledger/utils/index.ts
@@ -7,6 +7,7 @@ import {
   WalletSecretOperation,
   WalletSecretParams
 } from 'services/ledger/types'
+import { isAvalancheChainId } from 'services/network/utils/isAvalancheNetwork'
 import { z } from 'zod'
 import { Curve } from 'utils/publicKeys'
 import { MAX_BITCOIN_APP_VERSION } from '../consts'
@@ -44,6 +45,44 @@ export const isBitcoinCompatibleApp = (
     return !isVersionExceeding(appVersion, MAX_BITCOIN_APP_VERSION)
   }
   return false
+}
+
+/**
+ * Returns true if the given EVM `data` field represents a contract call
+ * (i.e. the calldata is more than just the empty `0x`). Used to disambiguate
+ * between a simple AVAX transfer and a dApp interaction.
+ */
+export const isEvmContractCallData = (data: unknown): boolean =>
+  typeof data === 'string' && data !== '0x' && data.length > 2
+
+/**
+ * Decides which Ledger app to prompt for an EVM transaction.
+ *
+ * - Non-Avalanche EVM chains → Ethereum app (unchanged).
+ * - Avalanche C-Chain simple AVAX transfer (no calldata) → Avalanche app
+ *   (preserves the native AVAX display flow on device).
+ * - Avalanche C-Chain contract call (Uniswap, ERC20 transfers, dApp calls)
+ *   → Ethereum app. The Avalanche Ledger app's EVM signing path has no
+ *   plugin support for common DeFi contracts and no blind-signing toggle
+ *   for arbitrary contract calls (only "Expert mode" which covers X/P-chain
+ *   raw display, not EVM), so it returns 0x6984 on unrecognised contracts.
+ *   Routing contract calls to the Ethereum app matches the convention used
+ *   by MetaMask and Ledger Live.
+ *
+ * Both `LedgerWallet.signEvmTransaction` (sign-time) and
+ * `ApprovalController.handleLedgerApproval` (prompt-time) call this so the
+ * UI flow doesn't briefly prompt the wrong app before switching.
+ *
+ * Refs: Sentry CORE-REACT-NATIVE-9BP, CORE-REACT-NATIVE-9D2.
+ */
+export const getLedgerAppForEvmTx = (
+  chainId: number,
+  data: unknown
+): LedgerAppType => {
+  if (isAvalancheChainId(chainId) && !isEvmContractCallData(data)) {
+    return LedgerAppType.AVALANCHE
+  }
+  return LedgerAppType.ETHEREUM
 }
 
 export const getLedgerAppName = (network?: Network): LedgerAppType => {

--- a/packages/core-mobile/app/services/wallet/LedgerWallet.test.ts
+++ b/packages/core-mobile/app/services/wallet/LedgerWallet.test.ts
@@ -1054,20 +1054,47 @@ describe('LedgerWallet', () => {
       expect(mockSignEVMTransaction).not.toHaveBeenCalled()
     })
 
-    it('uses getCChainSignature (Avalanche app) for Avalanche chains', async () => {
+    it('uses getCChainSignature (Avalanche app) for simple AVAX transfers on Avalanche C-Chain', async () => {
       ;(isAvalancheChainId as jest.Mock).mockReturnValue(true)
       mockGetETHAddress.mockResolvedValue({ address: '0xabc' })
       mockSignEVMTransaction.mockResolvedValue(mockSignature)
 
+      // Simple AVAX transfer — no calldata. Stays on Avalanche app so
+      // the device shows the native AVAX flow.
       await ledgerWallet.signEvmTransaction({
         accountIndex: 0,
-        transaction: { ...baseTransaction, chainId: 43114 },
+        transaction: { ...baseTransaction, chainId: 43114, data: '0x' },
         network: mockNetwork,
         provider: mockProvider
       })
 
       expect(mockSignEVMTransaction).toHaveBeenCalledTimes(1)
       expect(mockEthSignTransaction).not.toHaveBeenCalled()
+    })
+
+    it('uses getEvmSignature (Ethereum app) for Avalanche C-Chain contract calls', async () => {
+      // Refs: Sentry CORE-REACT-NATIVE-9BP / 9D2. The Avalanche Ledger app's
+      // EVM signing path has no plugin support for common DeFi contracts
+      // (e.g. Uniswap Universal Router) and no blind-signing toggle, so it
+      // returns 0x6984 on unrecognised contracts. We therefore route
+      // Avalanche C-Chain contract calls to the Ethereum app — matching
+      // MetaMask / Ledger Live convention.
+      ;(isAvalancheChainId as jest.Mock).mockReturnValue(true)
+
+      await ledgerWallet.signEvmTransaction({
+        accountIndex: 0,
+        transaction: {
+          ...baseTransaction,
+          chainId: 43114,
+          // Uniswap UR `execute(bytes,bytes[],uint256)` selector.
+          data: '0x3593564c0000000000000000000000000000000000000000'
+        },
+        network: mockNetwork,
+        provider: mockProvider
+      })
+
+      expect(mockEthSignTransaction).toHaveBeenCalledTimes(1)
+      expect(mockSignEVMTransaction).not.toHaveBeenCalled()
     })
 
     it('returns a serialized signed transaction string', async () => {

--- a/packages/core-mobile/app/services/wallet/LedgerWallet.ts
+++ b/packages/core-mobile/app/services/wallet/LedgerWallet.ts
@@ -49,6 +49,7 @@ import {
   LEDGER_TIMEOUTS,
   getSolanaDerivationPath
 } from 'new/features/ledger/consts'
+import { getLedgerAppForEvmTx } from 'new/features/ledger/utils'
 import { bip32, extendedPublicKeyToXpub } from 'utils/bip32'
 import Logger from 'utils/Logger'
 import {
@@ -674,12 +675,14 @@ export class LedgerWallet implements Wallet {
   }): Promise<string> {
     Logger.info('signEvmTransaction called')
 
-    // Determine chain type and required app
+    // Determine which Ledger app to use. See `getLedgerAppForEvmTx`
+    // (new/features/ledger/utils) for the full rationale — both this
+    // sign-time path and the approval-time prompt path call the same
+    // helper so the UI doesn't prompt one app and then switch to
+    // another mid-flow.
     const chainId = transaction.chainId ? Number(transaction.chainId) : 43114
-    const isAvalanche = isAvalancheChainId(chainId)
-    const appType = isAvalanche
-      ? LedgerAppType.AVALANCHE
-      : LedgerAppType.ETHEREUM
+    const appType = getLedgerAppForEvmTx(chainId, transaction.data)
+    const useAvalancheApp = appType === LedgerAppType.AVALANCHE
 
     // Get transport
     const transport = await this.handleAppConnection(appType)
@@ -715,7 +718,7 @@ export class LedgerWallet implements Wallet {
       Logger.info('Full serialized transaction:', serializedTx)
       Logger.info('Unsigned transaction hex:', unsignedTx)
 
-      const signature: SignatureRSV = await (isAvalanche
+      const signature: SignatureRSV = await (useAvalancheApp
         ? this.getCChainSignature({ transport, derivationPath, unsignedTx })
         : this.getEvmSignature({ transport, derivationPath, unsignedTx }))
 

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -1,5 +1,6 @@
 import { RpcMethod, RpcRequest } from '@avalabs/vm-module-types'
 import { AvalancheCaip2ChainId } from '@avalabs/core-chains-sdk'
+import { LedgerAppType } from 'services/ledger/types'
 import { WalletType } from 'services/wallet/types'
 import { NavigationPresentationMode } from 'new/common/types'
 import { walletConnectCache } from 'services/walletconnectv2/walletConnectCache/walletConnectCache'
@@ -886,13 +887,18 @@ describe('ApprovalController', () => {
 
       const { onApprove: capturedOnApprove } =
         mockWalletConnectCacheSet.mock.calls[0][0]
-      const params = { walletType: WalletType.LEDGER } as never
+      const params = {
+        walletType: WalletType.LEDGER,
+        network: { chainId: 1 }
+      } as never
       await capturedOnApprove(params)
 
       expect(mockSetReviewTransactionParams).toHaveBeenCalledTimes(1)
       expect(mockSetReviewTransactionParams).toHaveBeenCalledWith(
         expect.objectContaining({
-          rpcMethod: request.method,
+          // Pre-computed by ApprovalController so consumers (the review
+          // sheet) don't have to derive it from `network` again.
+          appType: LedgerAppType.ETHEREUM,
           onApprove: expect.any(Function),
           onReject: expect.any(Function)
         })
@@ -905,13 +911,16 @@ describe('ApprovalController', () => {
 
       const { onApprove: capturedOnApprove } =
         mockWalletConnectCacheSet.mock.calls[0][0]
-      const params = { walletType: WalletType.LEDGER_LIVE } as never
+      const params = {
+        walletType: WalletType.LEDGER_LIVE,
+        network: { chainId: 1 }
+      } as never
       await capturedOnApprove(params)
 
       expect(mockSetReviewTransactionParams).toHaveBeenCalledTimes(1)
       expect(mockSetReviewTransactionParams).toHaveBeenCalledWith(
         expect.objectContaining({
-          rpcMethod: request.method,
+          appType: LedgerAppType.ETHEREUM,
           onApprove: expect.any(Function),
           onReject: expect.any(Function)
         })

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -6,9 +6,12 @@ import {
   ApprovalResponse,
   BatchApprovalParams,
   BatchApprovalResponse,
+  RpcMethod,
   RpcRequest,
   RequestPublicKeyParams
 } from '@avalabs/vm-module-types'
+import { getLedgerAppForEvmTx, getLedgerAppName } from 'features/ledger/utils'
+import { LedgerAppType } from 'services/ledger/types'
 import { walletConnectCache } from 'services/walletconnectv2/walletConnectCache/walletConnectCache'
 import { transactionSnackbar } from 'new/common/utils/toast'
 import { isInAppRequest } from 'store/rpc/utils/isInAppRequest'
@@ -274,9 +277,25 @@ class ApprovalController implements VmModuleApprovalController {
       }
     }
 
+    // Compute the Ledger app to prompt up-front so the UI doesn't show
+    // the Avalanche app prompt and then immediately switch to the
+    // Ethereum app once sign-time routing kicks in.
+    //
+    // EVM `eth_sendTransaction` needs the full request context (chain +
+    // calldata) to decide between the Avalanche app (simple AVAX
+    // transfers on C-Chain) and the Ethereum app (EVM contract calls,
+    // including Uniswap on C-Chain). Other signing flows derive the app
+    // from the network alone.
+    const appType: LedgerAppType =
+      signingData.type === RpcMethod.ETH_SEND_TRANSACTION
+        ? getLedgerAppForEvmTx(
+            Number(params.network.chainId),
+            signingData.data.data
+          )
+        : getLedgerAppName(params.network)
+
     ledgerParamsStore.getState().setReviewTransactionParams({
-      rpcMethod: request.method,
-      network: params.network,
+      appType,
       onApprove: () =>
         onApprove({
           ...params,
@@ -316,24 +335,28 @@ class ApprovalController implements VmModuleApprovalController {
         request,
         displayData: enrichedDisplayData,
         signingData,
-        onApprove: async (params: OnApproveParams) => {
+        onApprove: async (approveParams: OnApproveParams) => {
           if (!isInAppRequest(request) && isTxSendMethod(request.method)) {
-            this.cacheSigningAddress(requestId, request.chainId, params.account)
+            this.cacheSigningAddress(
+              requestId,
+              request.chainId,
+              approveParams.account
+            )
           }
 
           if (
-            params.walletType === WalletType.LEDGER ||
-            params.walletType === WalletType.LEDGER_LIVE
+            approveParams.walletType === WalletType.LEDGER ||
+            approveParams.walletType === WalletType.LEDGER_LIVE
           ) {
             this.handleLedgerApproval({
               requestId,
               request,
-              params,
+              params: approveParams,
               signingData,
               resolve
             })
           } else {
-            return onApprove({ ...params, resolve, signingData })
+            return onApprove({ ...approveParams, resolve, signingData })
           }
         },
         onReject: (message?: string) => onReject({ resolve, message })


### PR DESCRIPTION
## Description

**Ticket: [CP-14259]**

Thread: https://avalancheavax.slack.com/archives/C077ML017CY/p1778617182063269

- Adds `getLedgerAppForEvmTx(chainId, data)` in `new/features/ledger/utils` which routes EVM signing as follows:
  - Avalanche C-Chain + simple AVAX transfer (no calldata) → **Avalanche** Ledger app (preserves the native AVAX display flow on device).
  - Avalanche C-Chain + contract call (Uniswap UR, ERC20 transfers, any dApp interaction) → **Ethereum** Ledger app.
  - Any non-Avalanche EVM chain → **Ethereum** Ledger app (unchanged).
- Wires the same helper into both `LedgerWallet.signEvmTransaction` (sign-time) and `ApprovalController.requestApproval` (prompt-time) so the review sheet prompts the correct app up-front and does not silently switch apps mid-flow.
- Refactors `LedgerReviewTransactionParams` to carry a pre-computed `appType: LedgerAppType` instead of `rpcMethod` + `network`. The producer (`ApprovalController`) has the full request context (chain + signing data) and is the right place to derive this — consumers (`useLedgerApproval`) should not have to recompute it from `network` alone, which can yield the wrong app for EVM contract calls on C-Chain.
- Adds tests for `isEvmContractCallData`, `getLedgerAppForEvmTx`, the new `LedgerWallet.signEvmTransaction` branch, and the updated `ApprovalController` payload shape.
- Lint hygiene (touched files only): renames a shadowed `params` callback arg in `ApprovalController` to `approveParams`, and tags pre-existing intentional non-null assertions in `ledger/utils/index.test.ts` with `eslint-disable-next-line` so `lint-staged --max-warnings=0` passes.

## Screenshots/Videos

https://github.com/user-attachments/assets/5566d1cd-9b8b-48a8-a84f-016b69bf964a


## Testing
iOS: 8513
Android: 8514

1. Pair a Ledger device with the app (BLE).
2. **C-Chain contract call (the bug):**
   - With the Ledger device on the home screen, initiate a Uniswap swap (or any ERC20 `transfer`) on **Avalanche C-Chain** from the app.
   - Verify the approval sheet prompts you to open the **Ethereum** app (not Avalanche).
   - Open the Ethereum app on the device → confirm the transaction signs and broadcasts successfully.
3. **C-Chain native AVAX transfer (regression check):**
   - Initiate a plain AVAX transfer on **Avalanche C-Chain**.
   - Verify the approval sheet prompts you to open the **Avalanche** app.
   - Open Avalanche app → confirm signing succeeds and the device displays the native AVAX flow.

## Checklist
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14259]: https://ava-labs.atlassian.net/browse/CP-14259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ