### PR TITLE
CP-14006: Replace push press `appState` field with `isColdStart`

### DIFF
--- a/packages/core-mobile/app/services/fcm/FCMService.test.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.test.ts
@@ -2,6 +2,7 @@ import messaging from '@react-native-firebase/messaging'
 import { Platform } from 'react-native'
 import AnalyticsService from 'services/analytics/AnalyticsService'
 import { ChannelId } from 'services/notifications/channels'
+import NotificationsService from 'services/notifications/NotificationsService'
 import { handleDeeplink } from 'contexts/DeeplinkContext/utils/handleDeeplink'
 import FCMService from './FCMService'
 
@@ -29,6 +30,12 @@ jest.mock('contexts/DeeplinkContext/utils/handleDeeplink', () => ({
 
 jest.mock('expo-router', () => ({
   router: { navigate: jest.fn() }
+}))
+
+jest.mock('contexts/ReactQueryProvider', () => ({
+  queryClient: {
+    invalidateQueries: jest.fn().mockResolvedValue(undefined)
+  }
 }))
 
 describe('FCMService.listenForMessagesBackground (iOS warm-background)', () => {
@@ -200,5 +207,117 @@ describe('FCMService.listenForMessagesBackground (iOS warm-background)', () => {
 
     expect(AnalyticsService.capture).not.toHaveBeenCalled()
     expect(handleDeeplink).not.toHaveBeenCalled()
+  })
+})
+
+describe('FCMService.listenForMessagesForeground (notifee data stamping)', () => {
+  let registeredForegroundHandler: (
+    remoteMessage: unknown
+  ) => Promise<void> | void
+  let displaySpy: jest.SpyInstance
+
+  /**
+   * Captures the handler passed to `messaging().onMessage(...)` so tests can
+   * drive the foreground notification pipeline end-to-end with synthetic
+   * `remoteMessage` payloads. This exercises the real
+   * `FCMService.#extractDeepLinkData` helper (private, so not directly
+   * testable) via its single public entry point. The assertions then check
+   * what `NotificationsService.displayNotification` actually receives — i.e.
+   * what notifee will surface back on later cold-start / background presses.
+   */
+  const registerForegroundHandler = (): void => {
+    const onMessage = jest.fn(handler => {
+      registeredForegroundHandler = handler
+      return jest.fn()
+    })
+    ;(messaging as unknown as jest.Mock).mockReturnValue({
+      onMessage,
+      onTokenRefresh: jest.fn()
+    })
+    FCMService.listenForMessagesForeground()
+    expect(onMessage).toHaveBeenCalledTimes(1)
+  }
+
+  beforeEach(() => {
+    displaySpy = jest
+      .spyOn(NotificationsService, 'displayNotification')
+      .mockResolvedValue(undefined)
+    registerForegroundHandler()
+  })
+
+  it('stamps channelId and event onto the notifee data payload for BALANCE_CHANGES', async () => {
+    // CP-14006 regression guard. If `#extractDeepLinkData` ever stops
+    // stamping `channelId`/`event` on the BALANCE_CHANGES branch, the
+    // notifee notification's `data` will lose channel context — causing
+    // later retrievals via `notifee.getInitialNotification` / `onBackgroundEvent`
+    // to fall back to DEFAULT_ANDROID_CHANNEL ('miscellaneous'), which is the
+    // exact bug observed on iOS cold-start during device verification.
+    await registeredForegroundHandler({
+      notification: { title: 'You received tokens', body: '0.5 AVAX' },
+      data: {
+        type: 'BALANCE_CHANGES',
+        event: 'BALANCES_RECEIVED',
+        title: 'You received tokens',
+        body: '0.5 AVAX',
+        accountAddress: '0xabc',
+        chainId: '43114',
+        transactionHash: '0xdeadbeef',
+        url: 'core://portfolio'
+      }
+    })
+
+    expect(displaySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          url: 'core://portfolio',
+          channelId: ChannelId.BALANCE_CHANGES,
+          event: 'BALANCES_RECEIVED'
+        })
+      })
+    )
+  })
+
+  it('stamps channelId and event onto the notifee data payload for NEWS', async () => {
+    await registeredForegroundHandler({
+      notification: { title: 'AVAX price alert', body: 'AVAX is up 15%' },
+      data: {
+        type: 'NEWS',
+        event: 'PRICE_ALERTS',
+        title: 'AVAX price alert',
+        body: 'AVAX is up 15%',
+        url: 'core://watchlist'
+      }
+    })
+
+    expect(displaySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          url: 'core://watchlist',
+          channelId: ChannelId.PRICE_ALERTS,
+          event: 'PRICE_ALERTS'
+        })
+      })
+    )
+  })
+
+  it('skips display for in-app spend / transfer events (existing behavior)', async () => {
+    // Sanity guard: BALANCES_SPENT / BALANCES_TRANSFERRED are intentionally
+    // suppressed in foreground because the user just performed the action
+    // in-app. The stamping fix should not change that.
+    await registeredForegroundHandler({
+      notification: { title: 'Sent', body: '0.5 AVAX' },
+      data: {
+        type: 'BALANCE_CHANGES',
+        event: 'BALANCES_SPENT',
+        title: 'Sent',
+        body: '0.5 AVAX',
+        accountAddress: '0xabc',
+        chainId: '43114',
+        transactionHash: '0xdeadbeef',
+        url: 'core://portfolio'
+      }
+    })
+
+    expect(displaySpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/core-mobile/app/services/fcm/FCMService.test.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.test.ts
@@ -1,0 +1,187 @@
+import messaging from '@react-native-firebase/messaging'
+import { Platform } from 'react-native'
+import AnalyticsService from 'services/analytics/AnalyticsService'
+import { ChannelId } from 'services/notifications/channels'
+import { handleDeeplink } from 'contexts/DeeplinkContext/utils/handleDeeplink'
+import FCMService from './FCMService'
+
+// Override the messaging mock from tests/jestSetup/firebase.js so we can
+// capture the handler passed to `onNotificationOpenedApp` and invoke it
+// directly per test, simulating the OS calling us back on iOS warm-background
+// notification taps.
+jest.mock('@react-native-firebase/messaging', () =>
+  jest.fn(() => ({
+    onNotificationOpenedApp: jest.fn(),
+    setBackgroundMessageHandler: jest.fn()
+  }))
+)
+
+jest.mock('contexts/DeeplinkContext/utils/handleDeeplink', () => ({
+  handleDeeplink: jest.fn()
+}))
+
+jest.mock('expo-router', () => ({
+  router: { navigate: jest.fn() }
+}))
+
+describe('FCMService.listenForMessagesBackground (iOS warm-background)', () => {
+  let registeredHandler: (remoteMessage: unknown) => void
+
+  /**
+   * Calls `listenForMessagesBackground` with `Platform.OS = 'ios'`, then
+   * yanks the handler that the private `handleBackgroundMessageIos` method
+   * registered with `messaging().onNotificationOpenedApp(...)`. Tests invoke
+   * it directly with synthetic `remoteMessage` payloads.
+   */
+  const registerIosHandler = (): void => {
+    const onNotificationOpenedApp = jest.fn(handler => {
+      registeredHandler = handler
+      return jest.fn()
+    })
+    ;(messaging as unknown as jest.Mock).mockReturnValue({
+      onNotificationOpenedApp,
+      setBackgroundMessageHandler: jest.fn()
+    })
+    FCMService.listenForMessagesBackground()
+    expect(onNotificationOpenedApp).toHaveBeenCalledTimes(1)
+  }
+
+  beforeAll(() => {
+    Object.defineProperty(Platform, 'OS', { value: 'ios', writable: true })
+  })
+
+  beforeEach(() => {
+    jest.spyOn(AnalyticsService, 'capture').mockResolvedValue(undefined)
+    registerIosHandler()
+  })
+
+  it('captures PushNotificationPressed (isColdStart=false, handler=fcm) for a BALANCE_CHANGES press', async () => {
+    // CP-14006 regression: previously this press was dropped because the
+    // capture call sat AFTER `shouldSkipHandlingDeeplink` returned true for
+    // the portfolio deeplink. The fix is "capture first, then route".
+    await registeredHandler({
+      notification: {
+        title: 'You received tokens',
+        body: '0.5 AVAX',
+        android: { channelId: ChannelId.BALANCE_CHANGES }
+      },
+      data: {
+        type: 'BALANCE_CHANGES',
+        event: 'BALANCES_RECEIVED',
+        title: 'You received tokens',
+        body: '0.5 AVAX',
+        accountAddress: '0xabc',
+        chainId: '43114',
+        transactionHash: '0xdeadbeef',
+        url: 'core://portfolio'
+      }
+    })
+
+    expect(AnalyticsService.capture).toHaveBeenCalledTimes(1)
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: ChannelId.BALANCE_CHANGES,
+        deeplinkUrl: 'core://portfolio',
+        isColdStart: false,
+        handler: 'fcm'
+      }
+    )
+  })
+
+  it('captures the press even when the deeplink is skipped (capture happens before the deeplink-skip decision)', async () => {
+    // `core://portfolio` matches the skip rule in `shouldSkipHandlingDeeplink`
+    // — we still want to record the press for analytics, but we should NOT
+    // route through `handleDeeplink` since the home screen surfaces it.
+    await registeredHandler({
+      notification: {
+        title: 'You received tokens',
+        body: '0.5 AVAX',
+        android: { channelId: ChannelId.BALANCE_CHANGES }
+      },
+      data: {
+        type: 'BALANCE_CHANGES',
+        event: 'BALANCES_RECEIVED',
+        title: 'You received tokens',
+        body: '0.5 AVAX',
+        accountAddress: '0xabc',
+        chainId: '43114',
+        transactionHash: '0xdeadbeef',
+        url: 'core://portfolio'
+      }
+    })
+
+    expect(AnalyticsService.capture).toHaveBeenCalledTimes(1)
+    expect(handleDeeplink).not.toHaveBeenCalled()
+  })
+
+  it('invokes handleDeeplink for NEWS notifications that do not match the skip rules', async () => {
+    await registeredHandler({
+      notification: {
+        title: 'AVAX price alert',
+        body: 'AVAX is up 15%',
+        android: { channelId: ChannelId.PRICE_ALERTS }
+      },
+      data: {
+        type: 'NEWS',
+        event: 'PRICE_ALERTS',
+        title: 'AVAX price alert',
+        body: 'AVAX is up 15%',
+        url: 'core://watchlist'
+      }
+    })
+
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: ChannelId.PRICE_ALERTS,
+        deeplinkUrl: 'core://watchlist',
+        isColdStart: false,
+        handler: 'fcm'
+      }
+    )
+    expect(handleDeeplink).toHaveBeenCalledTimes(1)
+    expect(handleDeeplink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deeplink: expect.objectContaining({ url: 'core://watchlist' })
+      })
+    )
+  })
+
+  it('falls back to EVENT_TO_CH_ID when notification.android.channelId is absent', async () => {
+    // Backend dropped the legacy `android.channelId` for new SNS endpoints;
+    // `resolveChannelId` should still pick PRICE_ALERTS from the event name.
+    await registeredHandler({
+      notification: {
+        title: 'AVAX price alert',
+        body: 'AVAX is up 15%'
+      },
+      data: {
+        type: 'NEWS',
+        event: 'PRICE_ALERTS',
+        title: 'AVAX price alert',
+        body: 'AVAX is up 15%',
+        url: 'core://watchlist'
+      }
+    })
+
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      expect.objectContaining({
+        channelId: ChannelId.PRICE_ALERTS,
+        isColdStart: false,
+        handler: 'fcm'
+      })
+    )
+  })
+
+  it('does not capture or route when the payload fails schema validation', async () => {
+    await registeredHandler({
+      // Missing `data`, which the schema requires — `safeParse` will fail.
+      notification: { title: 'oops', body: 'malformed' }
+    })
+
+    expect(AnalyticsService.capture).not.toHaveBeenCalled()
+    expect(handleDeeplink).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core-mobile/app/services/fcm/FCMService.test.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.test.ts
@@ -5,6 +5,13 @@ import { ChannelId } from 'services/notifications/channels'
 import { handleDeeplink } from 'contexts/DeeplinkContext/utils/handleDeeplink'
 import FCMService from './FCMService'
 
+// Snapshot the real Platform.OS so we can restore it in afterAll. Without
+// this restore the override leaks across files when Jest reuses a worker
+// (watch mode, --runInBand). `configurable: true` matches the pattern used
+// in BluetoothService.test.ts / useBluetooth.test.ts and is required so
+// future test additions can re-define Platform.OS without TypeError.
+const originalPlatformOS = Platform.OS
+
 // Override the messaging mock from tests/jestSetup/firebase.js so we can
 // capture the handler passed to `onNotificationOpenedApp` and invoke it
 // directly per test, simulating the OS calling us back on iOS warm-background
@@ -47,7 +54,17 @@ describe('FCMService.listenForMessagesBackground (iOS warm-background)', () => {
   }
 
   beforeAll(() => {
-    Object.defineProperty(Platform, 'OS', { value: 'ios', writable: true })
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      value: 'ios'
+    })
+  })
+
+  afterAll(() => {
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      value: originalPlatformOS
+    })
   })
 
   beforeEach(() => {

--- a/packages/core-mobile/app/services/fcm/FCMService.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.ts
@@ -19,7 +19,10 @@ import {
   NotificationPayloadSchema,
   NotificationTypes
 } from 'services/fcm/types'
-import { DEFAULT_ANDROID_CHANNEL } from 'services/notifications/channels'
+import {
+  ChannelId,
+  DEFAULT_ANDROID_CHANNEL
+} from 'services/notifications/channels'
 import {
   EVENT_TO_CH_ID,
   resolveChannelId
@@ -136,21 +139,34 @@ class FCMService {
         chainId: string
         transactionHash: string
         url: string
+        channelId: string
+        event: string
       }
-    | { url: string; channelId: string }
+    | { url: string; channelId: string; event: string }
     | undefined => {
+    // We stamp both `channelId` AND `event` on every branch so that the
+    // notification data carried into notifee.displayNotification preserves
+    // enough context for `resolveChannelId` to classify the press correctly
+    // when it later comes back via notifee.getInitialNotification /
+    // onBackgroundEvent / onForegroundEvent. Without these fields, a
+    // BALANCE_CHANGES tap retrieved through notifee would fall all the way
+    // through to the DEFAULT_ANDROID_CHANNEL ('miscellaneous') fallback —
+    // observed during CP-14006 device verification on iOS cold-start.
     if (fcmData.type === NotificationTypes.BALANCE_CHANGES) {
       return {
         accountAddress: fcmData.accountAddress,
         chainId: fcmData.chainId,
         transactionHash: fcmData.transactionHash,
-        url: `${PROTOCOLS.CORE}://${ACTIONS.Portfolio}`
+        url: `${PROTOCOLS.CORE}://${ACTIONS.Portfolio}`,
+        channelId: ChannelId.BALANCE_CHANGES,
+        event: fcmData.event
       }
     } else if (fcmData.type === NotificationTypes.NEWS) {
       return {
         // TODO: remove urlV2 after backend is updated to send just url for NEWS notifications
         url: fcmData.urlV2 ?? fcmData.url ?? '',
-        channelId: EVENT_TO_CH_ID[fcmData.event] as string
+        channelId: EVENT_TO_CH_ID[fcmData.event] as string,
+        event: fcmData.event
       }
     }
   }

--- a/packages/core-mobile/app/services/fcm/FCMService.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.ts
@@ -199,7 +199,7 @@ class FCMService {
       AnalyticsService.capture('PushNotificationPressed', {
         channelId,
         deeplinkUrl: data.url,
-        appState: 'background',
+        isColdStart: false,
         handler: 'fcm'
       })
 

--- a/packages/core-mobile/app/services/notifications/NotificationService.test.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationService.test.ts
@@ -278,6 +278,38 @@ describe('getInitialNotification', () => {
     expect(callback).toHaveBeenCalledWith(data)
   })
 
+  it('classifies a BALANCE_CHANGES notifee cold-start press as the BALANCE_CHANGES channel (not miscellaneous)', async () => {
+    // Regression: this case was observed during CP-14006 device verification.
+    // BALANCE_CHANGES notifications retrieved via `notifee.getInitialNotification`
+    // were falling through to DEFAULT_ANDROID_CHANNEL because the notifee
+    // data payload was missing both `channelId` and `event`. The fix stamps
+    // both fields in `FCMService.#extractDeepLinkData` so this test asserts
+    // the resolved channel travels end-to-end.
+    const data = {
+      url: 'core://portfolio',
+      event: 'BALANCES_RECEIVED',
+      channelId: ChannelId.BALANCE_CHANGES,
+      accountAddress: '0xabc',
+      chainId: '43114',
+      transactionHash: '0xdeadbeef'
+    }
+    // iOS notifee notifications have no `android.channelId` — pass undefined
+    // to exercise the `data.channelId` precedence in `resolveChannelId`.
+    setNotifeeInitial(buildNotifeeInitial(data, undefined))
+
+    await NotificationsService.getInitialNotification(callback)
+
+    expect(AnalyticsService.capture).toHaveBeenCalledWith(
+      'PushNotificationPressed',
+      {
+        channelId: ChannelId.BALANCE_CHANGES,
+        deeplinkUrl: 'core://portfolio',
+        isColdStart: true,
+        handler: 'notifee'
+      }
+    )
+  })
+
   it('captures press from FCM initial notification when notifee initial is null (legacy notification payload path)', async () => {
     const data = {
       url: 'core://portfolio',

--- a/packages/core-mobile/app/services/notifications/NotificationService.test.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationService.test.ts
@@ -146,7 +146,7 @@ describe('handleNotificationPress', () => {
     expect(mockCallback).toHaveBeenCalledWith(mockDetail.notification.data)
   })
 
-  it('captures PushNotificationPressed (appState=foreground, handler=notifee) when the foreground PRESS has a deeplink url', async () => {
+  it('captures PushNotificationPressed (isColdStart=false, handler=notifee) when the foreground PRESS has a deeplink url', async () => {
     const mockDetail = {
       notification: {
         id: 'testNodeId',
@@ -163,7 +163,7 @@ describe('handleNotificationPress', () => {
       {
         channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
         deeplinkUrl: 'core://portfolio',
-        appState: 'foreground',
+        isColdStart: false,
         handler: 'notifee'
       }
     )
@@ -271,7 +271,7 @@ describe('getInitialNotification', () => {
       {
         channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
         deeplinkUrl: 'core://portfolio',
-        appState: 'cold_start',
+        isColdStart: true,
         handler: 'notifee'
       }
     )
@@ -293,7 +293,7 @@ describe('getInitialNotification', () => {
       {
         channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
         deeplinkUrl: 'core://portfolio',
-        appState: 'cold_start',
+        isColdStart: true,
         handler: 'fcm'
       }
     )
@@ -319,7 +319,7 @@ describe('getInitialNotification', () => {
       {
         channelId: ChannelId.PRICE_ALERTS,
         deeplinkUrl: 'core://watchlist',
-        appState: 'cold_start',
+        isColdStart: true,
         handler: 'fcm'
       }
     )
@@ -341,7 +341,7 @@ describe('getInitialNotification', () => {
       {
         channelId: ChannelId.PRICE_ALERTS,
         deeplinkUrl: 'core://portfolio',
-        appState: 'cold_start',
+        isColdStart: true,
         handler: 'fcm'
       }
     )
@@ -387,7 +387,7 @@ describe('getInitialNotification', () => {
       {
         channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
         deeplinkUrl: 'core://portfolio',
-        appState: 'cold_start',
+        isColdStart: true,
         handler: 'notifee'
       }
     )
@@ -405,7 +405,7 @@ describe('getInitialNotification', () => {
       {
         channelId: ChannelId.PRICE_ALERTS,
         deeplinkUrl: 'core://watchlist',
-        appState: 'cold_start',
+        isColdStart: true,
         handler: 'notifee'
       }
     )
@@ -422,7 +422,7 @@ describe('getInitialNotification', () => {
       {
         channelId: DEFAULT_ANDROID_CHANNEL,
         deeplinkUrl: 'core://portfolio',
-        appState: 'cold_start',
+        isColdStart: true,
         handler: 'notifee'
       }
     )
@@ -442,7 +442,7 @@ describe('getInitialNotification', () => {
       {
         channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
         deeplinkUrl: 'core://portfolio',
-        appState: 'cold_start',
+        isColdStart: true,
         handler: 'fcm'
       }
     )
@@ -642,7 +642,7 @@ describe('handlePendingBackgroundPress', () => {
     NotificationsService.consumePendingBackgroundPress()
   })
 
-  it('captures PushNotificationPressed (appState=background, handler=notifee) and invokes the callback when a press is pending', () => {
+  it('captures PushNotificationPressed (isColdStart=false, handler=notifee) and invokes the callback when a press is pending', () => {
     const data = { url: 'core://portfolio', event: 'PRODUCT_ANNOUNCEMENTS' }
     setPendingBackgroundPress(data)
     const callback = jest.fn()
@@ -654,7 +654,7 @@ describe('handlePendingBackgroundPress', () => {
       {
         channelId: ChannelId.PRODUCT_ANNOUNCEMENTS,
         deeplinkUrl: 'core://portfolio',
-        appState: 'background',
+        isColdStart: false,
         handler: 'notifee'
       }
     )
@@ -672,7 +672,7 @@ describe('handlePendingBackgroundPress', () => {
       {
         channelId: DEFAULT_ANDROID_CHANNEL,
         deeplinkUrl: 'core://portfolio',
-        appState: 'background',
+        isColdStart: false,
         handler: 'notifee'
       }
     )

--- a/packages/core-mobile/app/services/notifications/NotificationsService.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationsService.ts
@@ -267,7 +267,7 @@ class NotificationsService {
    *    invokes {@link handlePendingBackgroundPress}.
    *  - cold-start tap: notifee.getInitialNotification() returns the same
    *    press inside {@link getInitialNotification}, which captures it as
-   *    `appState: 'cold_start'` and then drains the stale pending value via
+   *    `isColdStart: true` and then drains the stale pending value via
    *    {@link consumePendingBackgroundPress}.
    *
    * This split eliminates the duplicate-capture bug observed during CP-14006
@@ -315,7 +315,7 @@ class NotificationsService {
    * Drains the most recent background PRESS data (if any) without side
    * effects. Intended for stale-cleanup paths such as
    * {@link getInitialNotification} on cold start, where the same press has
-   * already been captured as `appState: 'cold_start'` and we just need to
+   * already been captured as `isColdStart: true` and we just need to
    * prevent the AppState listener from replaying it later.
    */
   consumePendingBackgroundPress = (): NotificationData | undefined => {
@@ -326,7 +326,7 @@ class NotificationsService {
 
   /**
    * Warm-background press handler. Drains {@link pendingBackgroundPress},
-   * captures `PushNotificationPressed` (appState: 'background', handler:
+   * captures `PushNotificationPressed` (isColdStart: false, handler:
    * 'notifee'), and forwards the data to the provided callback for deeplink
    * processing. No-op if nothing is pending.
    *
@@ -344,7 +344,7 @@ class NotificationsService {
     AnalyticsService.capture('PushNotificationPressed', {
       channelId,
       deeplinkUrl: data.url,
-      appState: 'background',
+      isColdStart: false,
       handler: 'notifee'
     })
 
@@ -394,10 +394,16 @@ class NotificationsService {
       // Foreground PRESS is delivered through `notifee.onForegroundEvent` on
       // BOTH platforms (notifee wraps the APNs alert path on iOS), so the
       // handler is always `'notifee'` here regardless of `Platform.OS`.
+      //
+      // Note: on iOS this event also fires for warm-background presses on
+      // notifee-displayed notifications (e.g. tapping a banner that was
+      // delivered while the app was in foreground and then backgrounded).
+      // That's why we deliberately don't emit a foreground/background flag
+      // here — see the `isColdStart` doc on `PushNotificationPressed`.
       AnalyticsService.capture('PushNotificationPressed', {
         channelId,
         deeplinkUrl: data.url,
-        appState: 'foreground',
+        isColdStart: false,
         handler: 'notifee'
       })
     }
@@ -497,7 +503,7 @@ class NotificationsService {
         AnalyticsService.capture('PushNotificationPressed', {
           channelId,
           deeplinkUrl: notifeeData.url,
-          appState: 'cold_start',
+          isColdStart: true,
           handler: 'notifee'
         })
         callback(notifeeData)
@@ -527,7 +533,7 @@ class NotificationsService {
         AnalyticsService.capture('PushNotificationPressed', {
           channelId,
           deeplinkUrl: fcmDeeplinkUrl,
-          appState: 'cold_start',
+          isColdStart: true,
           handler: 'fcm'
         })
         callback(fcmData)

--- a/packages/core-mobile/app/services/notifications/NotificationsService.ts
+++ b/packages/core-mobile/app/services/notifications/NotificationsService.ts
@@ -49,9 +49,9 @@ class NotificationsService {
    * Cold-start press analytics + deeplink are owned by
    * {@link getInitialNotification}, which is why this field is intentionally
    * not captured inside the notifee.onBackgroundEvent handler: capturing
-   * there would double-count cold-start presses (one 'background' from the
-   * headless task + one 'cold_start' from getInitialNotification — observed
-   * during CP-14006 device verification).
+   * there would double-count cold-start presses (one `isColdStart: false`
+   * from the headless task + one `isColdStart: true` from getInitialNotification
+   * — observed during CP-14006 device verification).
    */
   private pendingBackgroundPress: NotificationData | undefined
 
@@ -271,8 +271,8 @@ class NotificationsService {
    *    {@link consumePendingBackgroundPress}.
    *
    * This split eliminates the duplicate-capture bug observed during CP-14006
-   * device verification (cold-start press emitting both 'background' and
-   * 'cold_start') without any state flag.
+   * device verification (cold-start press emitting both `isColdStart: false`
+   * and `isColdStart: true`) without any state flag.
    */
   registerBackgroundNotificationHandler = (): void => {
     if (this.backgroundHandlerRegistered) {

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -273,17 +273,21 @@ export type AnalyticsEvents = {
     channelId: string
     deeplinkUrl?: string
     /**
-     * App state at the moment the press was received.
+     * Whether the press launched the app from a fully-killed state (cold
+     * start) as opposed to resuming it from background or being tapped while
+     * already foregrounded.
      *
-     * - `foreground`: app is open and in view.
-     * - `background`: app is alive but minimized (warm resume on tap).
-     * - `cold_start`: app was killed and was launched by the press.
-     *
-     * Combined with `handler` to identify the exact capture path. Added for
-     * CP-14006 verification — lets us break down underreporting by app state
-     * regardless of which RN API caught the press.
+     * This is the one app-state distinction we can detect with high
+     * confidence: cold-start presses come back through
+     * `notifee.getInitialNotification` / `messaging().getInitialNotification`
+     * on the very first JS evaluation, and nothing else can produce that
+     * signal. Foreground-vs-background, by contrast, can't be cleanly
+     * separated on iOS — notifee delivers warm-background presses through
+     * `onForegroundEvent` once the app reactivates, so we'd be guessing.
+     * We intentionally don't emit a (foreground|background) field rather
+     * than ship a misleading one.
      */
-    appState: 'foreground' | 'background' | 'cold_start'
+    isColdStart: boolean
     /**
      * Which RN notification API delivered the press to us.
      *


### PR DESCRIPTION
## Description

**Ticket: [CP-14006]**

- Replaces the `appState: 'foreground' | 'background' | 'cold_start'` dimension on the `PushNotificationPressed` analytics event with a simpler boolean `isColdStart`.
- Updates every capture site to emit the new field:
  - `NotificationsService.handleNotificationPress` (foreground / iOS warm-background via notifee) → `isColdStart: false`
  - `NotificationsService.handlePendingBackgroundPress` (Android warm-background) → `isColdStart: false`
  - `NotificationsService.getInitialNotification` (cold-start, both notifee and FCM branches) → `isColdStart: true`
  - `FCMService.handleBackgroundMessageIos` → `isColdStart: false`
- Updates the `AnalyticsEvents['PushNotificationPressed']` type definition with new JSDoc explaining why the foreground/background distinction is dropped.
- Updates all tests in `NotificationService.test.ts` and the JSDoc references in `NotificationsService.ts` to use the new field.

**Motivation**

Follow-up to the original CP-14006 PR (already merged). After shipping the three-state `appState` field, we realised the `foreground` vs `background` split is **not reliable on iOS**:

- notifee delivers warm-background presses through `onForegroundEvent` once the app reactivates (it wraps the APNs alert path on iOS), so the event we labelled `foreground` actually mixes "user tapped while app was on screen" with "user tapped a notifee-displayed banner that backgrounded the app". The two are indistinguishable from inside the handler.
- The only app-state distinction we can detect with high confidence is **cold start**, because `notifee.getInitialNotification` / `messaging().getInitialNotification` only resolve on the first JS evaluation after a kill, and nothing else can produce that signal.

Rather than ship a misleading enum to PostHog, we keep the high-confidence boolean (`isColdStart`) and drop the noisy axis. `handler` (`'notifee' | 'fcm'`) still tells us which RN API delivered the press, which is what we actually use for path-coverage diagnostics.

## Screenshots/Videos

N/A — analytics-only change, no UI surface.

## Testing
iOS: 8532
Android: 8533

**Dev Testing**
With PostHog dev project configured, exercise each press path and confirm the captured event shape in the PostHog live view:
   - **Cold start (Android & iOS):** kill the app from recents → tap a push (e.g. a Product Announcement) → confirm one `PushNotificationPressed` is emitted with `isColdStart: true` and the appropriate `handler` (`'notifee'` for data-only / Android, `'fcm'` for legacy FCM payloads).
   - **Warm background (Android):** open the app, send to background → tap a push → confirm one event with `isColdStart: false`, `handler: 'notifee'`.
   - **Warm background / foreground (iOS):** with the app foregrounded or backgrounded, tap a notifee-displayed banner → confirm one event with `isColdStart: false`, `handler: 'notifee'`.

## Checklist
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14006]: https://ava-labs.atlassian.net/browse/CP-14006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ