### PR TITLE
CP-14282: move BNB and Polygon out of Avalanche L1s section

### DIFF
--- a/packages/core-mobile/app/services/network/consts.ts
+++ b/packages/core-mobile/app/services/network/consts.ts
@@ -169,7 +169,13 @@ export const NETWORK_SOLANA_DEVNET = {
   caip2Id: 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1'
 } as Network
 
-// Default L2 chain IDs that are enabled for balance checks and discovery.
+// Default secondary EVM chain IDs that are auto-enabled on first unlock and
+// included in account balance discovery. Originally scoped to ETH L2s
+// (Arbitrum / Optimism / Base) — hence the name — but now also includes
+// non-L2 EVM L1s (BNB, Polygon) that share the same "show in primary section,
+// enabled by default, toggleable" UX. The constant name is preserved for
+// backward compatibility; see CP-14282 for the categorization fix that
+// expanded the set.
 // Kept here (rather than in the Redux slice) to avoid pulling store
 // implementation details into service/utility modules.
 export const defaultEnabledL2ChainIds = [

--- a/packages/core-mobile/app/services/network/consts.ts
+++ b/packages/core-mobile/app/services/network/consts.ts
@@ -177,8 +177,10 @@ export const defaultEnabledL2ChainIds = [
   // 421614, // Arbitrum Sepolia
   10, // Optimism
   // 11155420, // Optimism Sepolia
-  8453 // Base Mainnet
+  8453, // Base Mainnet
   // 84532 // Base Sepolia
+  56, // BNB Smart Chain
+  137 // Polygon
 ]
 
 // Primary networks are the ones that are always enabled in the app

--- a/packages/core-mobile/app/store/network/slice.test.ts
+++ b/packages/core-mobile/app/store/network/slice.test.ts
@@ -647,6 +647,16 @@ describe('network slice', () => {
       })
     })
 
+    describe('defaultEnabledL2ChainIds membership (CP-14282)', () => {
+      it('includes BNB Smart Chain (56) so it renders in the primary section', () => {
+        expect(defaultEnabledL2ChainIds).toContain(56)
+      })
+
+      it('includes Polygon (137) so it renders in the primary section', () => {
+        expect(defaultEnabledL2ChainIds).toContain(137)
+      })
+    })
+
     describe('always enabled chainIds', () => {
       it('should not allow toggling off always enabled chains', () => {
         alwaysEnabledChainIds.forEach(chainId => {


### PR DESCRIPTION
## Description

**Ticket: [CP-14282](https://ava-labs.atlassian.net/browse/CP-14282)**

- **Summary:** BNB Smart Chain (`56`) and Polygon (`137`) were rendering under the "Avalanche L1s" section heading in the Networks management screen because the `layer1Networks` bucket in `ManageNetworksScreen.tsx` is a denylist that catches every chain not already classified. This PR adds `56` and `137` to `defaultEnabledL2ChainIds`, which is the membership list both the primary-section filter and the L1-section denylist read from — moving the two chains to the primary section alongside Arbitrum / Optimism / Base with no filter-logic changes.
- **Motivation / context:** BNB and Polygon are not Avalanche L1 subnets; categorising them as such misled users. The fix is intentionally minimal — see "Out of scope" below for the related improvements that were considered and deferred.
- **Dependencies introduced:** None.
- **Migration / breaking notes:** None.
  - **New users (fresh install):** chains are enabled automatically on the first `onAppUnlocked` via the existing `enableL2ChainIdsIfNeeded` listener (gated by `ViewOnceKey.AUTO_ENABLE_L2_CHAINS`). They are **not** baked into `defaultEnabledChainIds` in the slice's initial state — the same flow Arbitrum / Optimism / Base already use.
  - **Existing users (already consumed `ViewOnceKey.AUTO_ENABLE_L2_CHAINS`):** the chains appear in the primary section but toggled off until enabled manually. Intentional trade-off — a follow-up could add a new ViewOnceKey to retro-enable.
  - **Account discovery:** Ledger and standard account discovery now include BNB / Polygon balance lookups during onboarding.

**Out of scope (follow-ups):** BNB / Polygon testnets (97, 80002); renaming `defaultEnabledL2ChainIds` to reflect non-L2 contents (the inline comment has been updated for clarity in this PR, but the symbol name is unchanged); replacing the Avalanche L1s denylist with a positive identifier; new `ViewOnceKey` to retro-enable BNB / Polygon for existing users.

## Screenshots/Videos

_To attach: Networks screen on iOS and Android showing BNB Chain + Polygon in the primary section, and the Avalanche L1s section no longer containing them._

## Testing

**Dev Testing**

- Open the wallet → Settings → **Networks**.
- Confirm **BNB Chain** and **Polygon** appear in the primary section at the top of the list, alongside Arbitrum / Optimism / Base.
- Confirm neither appears under the **Avalanche L1s** section heading.
- Confirm Arbitrum One / Optimism / Base placement and toggles are unchanged.
- Edge case — fresh install: after first PIN unlock, BNB and Polygon should be toggled on.
- Edge case — existing install: BNB and Polygon appear in the primary section but toggled off; user can flip them on; they then persist.
- Bitrise build: _to be triggered and referenced_.
- Ticket moved into the "Testing" column on Jira: _to be done after this PR is reviewed_.

**QA Testing**

- Same steps as Dev Testing above.
- Acceptance criteria: BNB and Polygon are only ever rendered in the primary section of the Networks screen, never under "Avalanche L1s," on both iOS and Android, in both fresh-install and upgraded-install states.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14282]: https://ava-labs.atlassian.net/browse/CP-14282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ