### PR TITLE
CP-14283: wait for approve receipt between per-tx swap signing steps

### DIFF
--- a/packages/core-mobile/app/new/features/swap/services/signers/EvmSigner.test.ts
+++ b/packages/core-mobile/app/new/features/swap/services/signers/EvmSigner.test.ts
@@ -151,6 +151,7 @@ describe('createEvmSigner.signBatch', () => {
       ]
     ] as const)(
       'marks %s token native when assetX.type is NATIVE (no address)',
+      // eslint-disable-next-line max-params
       async (_side, override, nativeField, addressField) => {
         const ctx = await callBatch(override)
         expect(ctx[nativeField]).toBe(true)
@@ -178,7 +179,7 @@ describe('createEvmSigner.signBatch', () => {
     })
   })
 
-  it('falls back to per-tx sign() when Quick Swaps is OFF (without receipt wait)', async () => {
+  it('falls back to per-tx sign() with receipt wait when Quick Swaps is OFF', async () => {
     const request = jest
       .fn<Promise<string>, [unknown]>()
       .mockResolvedValueOnce('0xhashA')
@@ -198,8 +199,12 @@ describe('createEvmSigner.signBatch', () => {
 
     expect(result).toEqual(['0xhashA', '0xhashB'])
     expect(request).toHaveBeenCalledTimes(2)
-    // Legacy path: no receipt wait between txs (preserves pre-Quick-Swaps latency)
-    expect(waitForReceipt).not.toHaveBeenCalled()
+    // Pre-CP-14211 the Fusion SDK awaited the approve receipt itself (Markr's
+    // Branch B); exposing `signBatch` flipped the SDK into Branch A which
+    // delegates ordering to us. The receipt wait must run on every
+    // intermediate per-tx step, not only on the manual-review fallback.
+    expect(waitForReceipt).toHaveBeenCalledTimes(1)
+    expect(waitForReceipt).toHaveBeenCalledWith(expect.any(Number), '0xhashA')
     expect(
       request.mock.calls.every(
         c =>

--- a/packages/core-mobile/app/new/features/swap/services/signers/EvmSigner.ts
+++ b/packages/core-mobile/app/new/features/swap/services/signers/EvmSigner.ts
@@ -195,7 +195,11 @@ const dispatchAsBatch = async (
 
 // Awaited by signEachManually between non-final txs to prevent the
 // "exceeds allowance" race when the approve hasn't mined before the
-// swap's estimateGas runs.
+// swap's estimateGas runs. Pre-CP-14211 the Fusion SDK awaited the
+// approve receipt itself (Markr's individual-sign branch); exposing
+// `signBatch` flipped the SDK into the batch branch which delegates
+// ordering to us, so we must replicate the wait on every intermediate
+// per-tx step.
 export type WaitForReceipt = (
   chainId: number,
   txHash: `0x${string}`
@@ -304,10 +308,13 @@ export function createEvmSigner(
     manualReviewReason?: string
   ): Promise<`0x${string}`[]> => {
     const hashes: `0x${string}`[] = []
-    // Only wait for receipts when we know this is a Quick Swaps batch
-    // fallback. Legacy non-bypass paths haven't waited historically and
-    // we don't want to add latency to them.
-    const isFallback = manualReviewReason !== undefined
+    // Wait between intermediate steps on every per-tx path. CP-14211
+    // moved the approve/swap pair from Markr's SDK-internal individual-sign
+    // branch (which awaited the receipt itself) onto our `signBatch`, so
+    // the wait now has to live here for the non-atomic fallback too —
+    // not just the manual-review fallback. Without this, the swap's
+    // pre-broadcast estimateGas can race the approve's confirmation and
+    // surface a false "Swap failed" toast (CP-14283).
     for (let i = 0; i < transactions.length; i++) {
       const tx = transactions[i]
       if (!tx) continue
@@ -317,7 +324,7 @@ export function createEvmSigner(
         isIntermediate
       })
       hashes.push(hash)
-      if (isIntermediate && isFallback) {
+      if (isIntermediate) {
         await maybeWaitForReceipt(tx.chainId, hash)
       }
     }


### PR DESCRIPTION
## Description

**Ticket: [CP-14283](https://ava-labs.atlassian.net/browse/CP-14283)**

After approving the spend-limit modal during an ERC20 → ERC20/AVAX swap, users see a "Swap failed" toast even though the approve succeeds and the swap can be retried successfully.

**Root cause — regression from CP-14211.** Markr's SDK has two paths: an individual-sign branch that explicitly `await waitForTransactionReceipt(approveHash)` between approve and swap, and a `signBatch` branch that delegates ordering to the signer. Before CP-14211 our `EvmSigner` exposed only `sign`, so Markr took the individual-sign branch and the SDK waited internally. CP-14211 added `signBatch`, which flipped Markr into the batch branch — but our `signBatch` fallback (`signEachManually`) only waited for receipts on the Quick Swaps manual-review fallback (`isFallback = manualReviewReason !== undefined`), not on the QS-off, cold-start, cross-chain, or <2-tx paths. The swap's pre-broadcast `estimateGas` races the approve's confirmation and surfaces a false "Swap failed" toast.

**Fix.** Drop the `isFallback` gate in `signEachManually` so the receipt wait runs between every intermediate per-tx step. `maybeWaitForReceipt` is already best-effort (60s timeout, swallows errors), so worst case we degrade to today's behavior. Adds ~1 confirmation (~2s on C-Chain) between the approve and swap modals — same latency the SDK was already paying pre-CP-14211, just back in our signer instead of inside the SDK.

Affected paths:

| Path | Today | After fix |
|---|---|---|
| QS-on atomic batch | atomic, race-free | unchanged |
| QS-on, manual-review fallback | waits, race-free | unchanged |
| QS-on, cold-start / cross-chain / <2-tx | race | waits, race-free |
| QS-off (default) | race (this bug) | waits, race-free |

No SDK bump, no API changes, no new deps.

## Screenshots/Videos

Manual testing on iOS simulator — adding before merge.

## Testing

**Dev Testing**

Primary repro (QS off, ERC20 → AVAX, no prior allowance):

1. Settings → Advanced — confirm Quick Swaps is OFF.
2. Pick an ERC20 with no allowance to the Markr router (use a token you haven't swapped before or revoke an existing allowance).
3. Start a swap: ERC20 → AVAX.
4. Tap Swap → spend-limit modal opens → Approve.
5. Expected: ~2s pause, swap modal opens, no "Swap failed" toast between the two modals.
6. Approve the swap modal → success.

Regression checks:

- Allowance already set: only one modal (swap), no delay.
- User cancels the swap modal after approving spend-limit: silent return, no toast.
- AVAX → USDC (no allowance step): one modal, no delay.
- QS on, atomic batch: one combined modal, atomic on-chain.

**QA Testing**

Acceptance: for any swap requiring a spend-limit approval, the user should never see a "Swap failed" red toast between the approve modal and the swap modal. The two modals should appear sequentially with a brief delay (~2s on C-Chain) corresponding to the approve tx confirming on-chain.

Bitrise build: triggered against this PR.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works (29/29 EvmSigner tests + 139/139 sibling swap suites green)
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14283]: https://ava-labs.atlassian.net/browse/CP-14283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ