### PR TITLE
CP-14303: fix infinite spinner for wallets with unsupported networks

### DIFF
--- a/packages/core-mobile/app/new/common/components/WalletCard.tsx
+++ b/packages/core-mobile/app/new/common/components/WalletCard.tsx
@@ -11,6 +11,7 @@ import { useManageWallet } from 'common/hooks/useManageWallet'
 import { WalletDisplayData } from 'common/types'
 import { AccountListItem } from 'features/wallets/components/AccountListItem'
 import { computeAccountBalance } from 'features/portfolio/utils/computeAccountBalance'
+import { getEnabledNetworksForAccount } from 'features/portfolio/utils/getEnabledNetworksForAccount'
 import { useWalletBalances } from 'features/portfolio/hooks/useWalletBalances'
 import { WalletBalance } from 'features/wallets/components/WalletBalance'
 import React, { useCallback, useMemo, useState } from 'react'
@@ -84,6 +85,22 @@ const WalletCard = ({
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const tokenVisibility = useFocusedSelector(selectTokenVisibility)
 
+  // Per-account count of enabled networks the account can actually produce
+  // balances for. Necessary because wallets like Keystone cannot derive an
+  // address for every globally enabled network (e.g. no Solana), so using
+  // the global enabled-networks count would cause an infinite spinner — see
+  // CP-14303.
+  const enabledNetworksCountByAccount = useMemo(() => {
+    const result: Record<string, number> = {}
+    for (const item of wallet.accounts) {
+      result[item.account.id] = getEnabledNetworksForAccount(
+        item.account,
+        enabledNetworks
+      ).length
+    }
+    return result
+  }, [wallet.accounts, enabledNetworks])
+
   const handleToggle = useCallback(() => {
     onToggleExpansion(wallet.id)
   }, [onToggleExpansion, wallet.id])
@@ -131,7 +148,8 @@ const WalletCard = ({
       const balResult = computeAccountBalance({
         accountBalances:
           walletBalancesData[item.account.id] ?? emptyAccountBalances,
-        enabledNetworksCount: enabledNetworks.length,
+        enabledNetworksCount:
+          enabledNetworksCountByAccount[item.account.id] ?? 0,
         enabledNetworksMap,
         enabledChainIds,
         isDeveloperMode,
@@ -162,7 +180,7 @@ const WalletCard = ({
     colors.$textSecondary,
     walletBalancesData,
     isBalancesError,
-    enabledNetworks.length,
+    enabledNetworksCountByAccount,
     enabledNetworksMap,
     enabledChainIds,
     isDeveloperMode,
@@ -307,7 +325,7 @@ const WalletCard = ({
             isRefreshing={isRefreshing}
             walletBalancesData={walletBalancesData}
             isBalancesError={isBalancesError}
-            enabledNetworksCount={enabledNetworks.length}
+            enabledNetworksCountByAccount={enabledNetworksCountByAccount}
             enabledNetworksMap={enabledNetworksMap}
             enabledChainIds={enabledChainIds}
             isDeveloperMode={isDeveloperMode}

--- a/packages/core-mobile/app/new/features/portfolio/utils/computeAccountBalance.test.ts
+++ b/packages/core-mobile/app/new/features/portfolio/utils/computeAccountBalance.test.ts
@@ -38,12 +38,15 @@ const defaultParams = {
 
 describe('computeAccountBalance', () => {
   describe('isLoadingBalance', () => {
-    it('returns true when enabledNetworksCount is 0', () => {
+    it('returns false when enabledNetworksCount is 0 (account supports no enabled networks)', () => {
+      // CP-14303: when an account cannot produce balance entries for any
+      // enabled network (e.g. all unsupported by the wallet type) we should
+      // show $0 instead of spinning forever.
       const result = computeAccountBalance({
         ...defaultParams,
         enabledNetworksCount: 0
       })
-      expect(result.isLoadingBalance).toBe(true)
+      expect(result.isLoadingBalance).toBe(false)
     })
 
     it('returns false when isError is true', () => {
@@ -71,7 +74,20 @@ describe('computeAccountBalance', () => {
       expect(result.isLoadingBalance).toBe(true)
     })
 
-    it('returns false when all networks have loaded', () => {
+    it('returns false when all enabled networks have loaded', () => {
+      const result = computeAccountBalance({
+        ...defaultParams,
+        enabledNetworksCount: 2,
+        accountBalances: [makeBalance(), makeBalance({ chainId: 43113 })]
+      })
+      expect(result.isLoadingBalance).toBe(false)
+    })
+
+    it('returns false when enabledNetworksCount excludes an unsupported network (Keystone + SVM)', () => {
+      // CP-14303: Keystone wallets can never produce a Solana balance entry,
+      // so the wallet card considers the account loaded once it has the
+      // entries it actually supports — even if the globally enabled set is
+      // larger.
       const result = computeAccountBalance({
         ...defaultParams,
         enabledNetworksCount: 2,

--- a/packages/core-mobile/app/new/features/portfolio/utils/computeAccountBalance.ts
+++ b/packages/core-mobile/app/new/features/portfolio/utils/computeAccountBalance.ts
@@ -40,11 +40,10 @@ export function computeAccountBalance({
   tokenVisibility: TokenVisibility
   isError: boolean
 }): AccountBalanceData {
-  const isLoadingBalance = isError
-    ? false
-    : enabledNetworksCount === 0
-    ? false
-    : accountBalances.length < enabledNetworksCount
+  const isLoadingBalance =
+    !isError &&
+    enabledNetworksCount > 0 &&
+    accountBalances.length < enabledNetworksCount
 
   const hasBalanceData = accountBalances.length > 0
 

--- a/packages/core-mobile/app/new/features/portfolio/utils/computeAccountBalance.ts
+++ b/packages/core-mobile/app/new/features/portfolio/utils/computeAccountBalance.ts
@@ -15,6 +15,13 @@ export interface AccountBalanceData {
 /**
  * Pure function that computes balance data for a single account.
  * No hooks — safe to call in a loop or inside useMemo.
+ *
+ * `enabledNetworksCount` is the number of enabled networks for which this
+ * specific account can produce balance entries (computed via
+ * `getEnabledNetworksForAccount`). Using a per-account count is required so
+ * that wallets which cannot derive an address for every globally-enabled
+ * network (e.g. Keystone for Solana) don't get stuck on an infinite spinner
+ * waiting for balance entries that will never arrive — see CP-14303.
  */
 export function computeAccountBalance({
   accountBalances,
@@ -33,13 +40,11 @@ export function computeAccountBalance({
   tokenVisibility: TokenVisibility
   isError: boolean
 }): AccountBalanceData {
-  const isLoadingBalance =
-    enabledNetworksCount === 0
-      ? true
-      : isError
-      ? false
-      : accountBalances.length === 0 ||
-        accountBalances.length < enabledNetworksCount
+  const isLoadingBalance = isError
+    ? false
+    : enabledNetworksCount === 0
+    ? false
+    : accountBalances.length < enabledNetworksCount
 
   const hasBalanceData = accountBalances.length > 0
 

--- a/packages/core-mobile/app/new/features/portfolio/utils/getEnabledNetworksForAccount.test.ts
+++ b/packages/core-mobile/app/new/features/portfolio/utils/getEnabledNetworksForAccount.test.ts
@@ -1,0 +1,99 @@
+import { Network, NetworkVMType } from '@avalabs/core-chains-sdk'
+import { CoreAccountType } from '@avalabs/types'
+import { Account } from 'store/account/types'
+import { getEnabledNetworksForAccount } from './getEnabledNetworksForAccount'
+
+const makeNetwork = (
+  vmName: NetworkVMType,
+  chainId: number,
+  overrides: Partial<Network> = {}
+): Network =>
+  ({
+    chainId,
+    vmName,
+    isTestnet: false,
+    ...overrides
+  } as Network)
+
+const makeAccount = (overrides: Partial<Account> = {}): Account =>
+  ({
+    id: 'account-1',
+    name: 'Account 1',
+    type: CoreAccountType.PRIMARY,
+    walletId: 'wallet-1',
+    index: 0,
+    addressC: '0xC',
+    addressBTC: 'btc1',
+    addressAVM: 'X-avm1',
+    addressPVM: 'P-pvm1',
+    addressCoreEth: '0xCoreEth',
+    addressSVM: 'svm1',
+    ...overrides
+  } as Account)
+
+const EVM = makeNetwork(NetworkVMType.EVM, 43114)
+const BTC = makeNetwork(NetworkVMType.BITCOIN, 1)
+const AVM = makeNetwork(NetworkVMType.AVM, 9000)
+const PVM = makeNetwork(NetworkVMType.PVM, 9001)
+const SVM = makeNetwork(NetworkVMType.SVM, 9002)
+
+describe('getEnabledNetworksForAccount', () => {
+  it('returns every enabled network when the account has all addresses', () => {
+    const account = makeAccount()
+    const enabled = [EVM, BTC, AVM, PVM, SVM]
+    expect(getEnabledNetworksForAccount(account, enabled)).toEqual(enabled)
+  })
+
+  it('excludes Solana for a Keystone-style account with no SVM address', () => {
+    // Keystone wallets cannot derive a Solana address — this is the
+    // CP-14303 scenario that previously caused the infinite spinner.
+    const keystoneAccount = makeAccount({ addressSVM: '' })
+    const enabled = [EVM, BTC, AVM, PVM, SVM]
+    expect(getEnabledNetworksForAccount(keystoneAccount, enabled)).toEqual([
+      EVM,
+      BTC,
+      AVM,
+      PVM
+    ])
+  })
+
+  it('excludes XP networks for a non-primary Keystone account', () => {
+    // The Keystone SDK only exposes the XP xpub for account index 0, so
+    // non-primary accounts have no AVM/PVM addresses.
+    const keystoneNonPrimary = makeAccount({
+      index: 1,
+      addressAVM: '',
+      addressPVM: '',
+      addressSVM: ''
+    })
+    const enabled = [EVM, BTC, AVM, PVM, SVM]
+    expect(getEnabledNetworksForAccount(keystoneNonPrimary, enabled)).toEqual([
+      EVM,
+      BTC
+    ])
+  })
+
+  it('treats whitespace-only addresses as missing', () => {
+    // Mirrors the trim-based check used in BalanceService /
+    // buildRequestItemsForAccounts so we don't count a network as enabled
+    // for the account when the request pipeline would skip it.
+    const account = makeAccount({ addressSVM: '   ' })
+    expect(getEnabledNetworksForAccount(account, [EVM, SVM])).toEqual([EVM])
+  })
+
+  it('returns an empty array when no enabled networks are supported', () => {
+    const account = makeAccount({
+      addressC: '',
+      addressBTC: '',
+      addressAVM: '',
+      addressPVM: '',
+      addressSVM: '',
+      addressCoreEth: ''
+    })
+    expect(getEnabledNetworksForAccount(account, [EVM, BTC, SVM])).toEqual([])
+  })
+
+  it('returns an empty array when no networks are enabled', () => {
+    expect(getEnabledNetworksForAccount(makeAccount(), [])).toEqual([])
+  })
+})

--- a/packages/core-mobile/app/new/features/portfolio/utils/getEnabledNetworksForAccount.ts
+++ b/packages/core-mobile/app/new/features/portfolio/utils/getEnabledNetworksForAccount.ts
@@ -13,11 +13,15 @@ import { getAddressByNetwork } from 'store/account/utils'
  * to spin forever on the My wallets screen because they can never produce
  * a balance entry for every globally-enabled network. See CP-14303.
  *
- * Address presence is resolved through `getAddressByNetwork` — the same
- * helper the balance pipeline (`BalanceService`,
- * `buildRequestItemsForAccounts`) uses to decide whether to issue a
- * balance request for an account+network pair, so this stays consistent
- * with what the backend is actually asked for.
+ * Address presence is resolved through `getAddressByNetwork`, mirroring
+ * the address-based gating `buildRequestItemsForAccounts` applies to
+ * EVM, BTC, and SVM balance requests. Avalanche X/P requests are gated
+ * separately (by `xpub` / xpAddresses, not `getAddressByNetwork`), so
+ * X/P entries from the address-based check here can be wider than what
+ * the backend is actually asked for — accounts whose `addressAVM`/
+ * `addressPVM` are populated should also have either xpub or
+ * xpAddresses available, but treat the mapping as a close approximation
+ * rather than a strict equivalence.
  */
 export function getEnabledNetworksForAccount(
   account: Account,

--- a/packages/core-mobile/app/new/features/portfolio/utils/getEnabledNetworksForAccount.ts
+++ b/packages/core-mobile/app/new/features/portfolio/utils/getEnabledNetworksForAccount.ts
@@ -1,0 +1,30 @@
+import { Network } from '@avalabs/core-chains-sdk'
+import { Account } from 'store/account/types'
+import { getAddressByNetwork } from 'store/account/utils'
+
+/**
+ * Returns the subset of the globally-enabled `enabledNetworks` that
+ * `account` can actually receive balance data for (i.e. the account has
+ * an address for that VM type).
+ *
+ * This is the source of truth for "how many balance entries should this
+ * account have before we consider it fully loaded?". Using the global
+ * `enabledNetworks.length` would cause wallets like Keystone (no Solana)
+ * to spin forever on the My wallets screen because they can never produce
+ * a balance entry for every globally-enabled network. See CP-14303.
+ *
+ * Address presence is resolved through `getAddressByNetwork` — the same
+ * helper the balance pipeline (`BalanceService`,
+ * `buildRequestItemsForAccounts`) uses to decide whether to issue a
+ * balance request for an account+network pair, so this stays consistent
+ * with what the backend is actually asked for.
+ */
+export function getEnabledNetworksForAccount(
+  account: Account,
+  enabledNetworks: Network[]
+): Network[] {
+  return enabledNetworks.filter(network => {
+    const address = getAddressByNetwork(account, network)
+    return typeof address === 'string' && address.trim() !== ''
+  })
+}

--- a/packages/core-mobile/app/new/features/rpc/components/SelectAccounts.tsx
+++ b/packages/core-mobile/app/new/features/rpc/components/SelectAccounts.tsx
@@ -67,15 +67,23 @@ export const SelectAccounts = ({
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const tokenVisibility = useFocusedSelector(selectTokenVisibility)
 
+  const enabledNetworksCountByAccount = useMemo(() => {
+    const result: Record<string, number> = {}
+    for (const account of Object.values(accounts)) {
+      result[account.id] = getEnabledNetworksForAccount(
+        account,
+        enabledNetworks
+      ).length
+    }
+    return result
+  }, [accounts, enabledNetworks])
+
   const balancesByAccountId = useMemo(() => {
     const result: Record<string, AccountBalanceData> = {}
     for (const account of Object.values(accounts)) {
       result[account.id] = computeAccountBalance({
         accountBalances: balancesData[account.id] ?? emptyAccountBalances,
-        enabledNetworksCount: getEnabledNetworksForAccount(
-          account,
-          enabledNetworks
-        ).length,
+        enabledNetworksCount: enabledNetworksCountByAccount[account.id] ?? 0,
         enabledNetworksMap,
         enabledChainIds,
         isDeveloperMode,
@@ -88,7 +96,7 @@ export const SelectAccounts = ({
     accounts,
     balancesData,
     isBalancesError,
-    enabledNetworks,
+    enabledNetworksCountByAccount,
     enabledNetworksMap,
     enabledChainIds,
     isDeveloperMode,

--- a/packages/core-mobile/app/new/features/rpc/components/SelectAccounts.tsx
+++ b/packages/core-mobile/app/new/features/rpc/components/SelectAccounts.tsx
@@ -17,6 +17,7 @@ import {
   computeAccountBalance,
   AccountBalanceData
 } from 'features/portfolio/utils/computeAccountBalance'
+import { getEnabledNetworksForAccount } from 'features/portfolio/utils/getEnabledNetworksForAccount'
 import { useAllBalances } from 'features/portfolio/hooks/useAllBalances'
 import { AdjustedNormalizedBalancesForAccount } from 'services/balance/types'
 import { TRUNCATE_ADDRESS_LENGTH } from 'common/consts/text'
@@ -71,7 +72,10 @@ export const SelectAccounts = ({
     for (const account of Object.values(accounts)) {
       result[account.id] = computeAccountBalance({
         accountBalances: balancesData[account.id] ?? emptyAccountBalances,
-        enabledNetworksCount: enabledNetworks.length,
+        enabledNetworksCount: getEnabledNetworksForAccount(
+          account,
+          enabledNetworks
+        ).length,
         enabledNetworksMap,
         enabledChainIds,
         isDeveloperMode,
@@ -84,7 +88,7 @@ export const SelectAccounts = ({
     accounts,
     balancesData,
     isBalancesError,
-    enabledNetworks.length,
+    enabledNetworks,
     enabledNetworksMap,
     enabledChainIds,
     isDeveloperMode,

--- a/packages/core-mobile/app/new/features/wallets/components/WalletBalance.tsx
+++ b/packages/core-mobile/app/new/features/wallets/components/WalletBalance.tsx
@@ -68,11 +68,14 @@ const WalletBalanceComponent = ({
       const result = computeAccountBalance({
         accountBalances: accountBalances ?? emptyAccountBalances,
         enabledNetworksCount: enabledNetworksCountByAccount[accountId] ?? 0,
-        // `?? 0` is safe here: a count of 0 means the account supports no
-        // enabled networks, so computeAccountBalance treats it as fully
-        // loaded and contributes $0 to the total. An unknown accountId
-        // (e.g. a race where balances arrive before the map is populated)
-        // falls into the same bucket — show $0 rather than spin forever.
+        // `?? 0` is safe here: a count of 0 makes computeAccountBalance
+        // treat the account as fully loaded (not loading) — any tokens
+        // already in `accountBalances` are still summed. In practice
+        // BalanceService also gates requests by `getAddressByNetwork`, so
+        // accounts that support no enabled networks have no balances to
+        // sum and naturally contribute $0. The same bucket also covers
+        // unknown accountIds from transient races where balances arrive
+        // before the per-account count map is populated.
         enabledNetworksMap,
         enabledChainIds,
         isDeveloperMode,

--- a/packages/core-mobile/app/new/features/wallets/components/WalletBalance.tsx
+++ b/packages/core-mobile/app/new/features/wallets/components/WalletBalance.tsx
@@ -68,6 +68,11 @@ const WalletBalanceComponent = ({
       const result = computeAccountBalance({
         accountBalances: accountBalances ?? emptyAccountBalances,
         enabledNetworksCount: enabledNetworksCountByAccount[accountId] ?? 0,
+        // `?? 0` is safe here: a count of 0 means the account supports no
+        // enabled networks, so computeAccountBalance treats it as fully
+        // loaded and contributes $0 to the total. An unknown accountId
+        // (e.g. a race where balances arrive before the map is populated)
+        // falls into the same bucket — show $0 rather than spin forever.
         enabledNetworksMap,
         enabledChainIds,
         isDeveloperMode,

--- a/packages/core-mobile/app/new/features/wallets/components/WalletBalance.tsx
+++ b/packages/core-mobile/app/new/features/wallets/components/WalletBalance.tsx
@@ -27,7 +27,12 @@ interface WalletBalanceProps {
   isRefreshing: boolean
   walletBalancesData: AdjustedNormalizedBalancesForAccounts
   isBalancesError: boolean
-  enabledNetworksCount: number
+  /**
+   * Map from accountId to the number of enabled networks that account can
+   * actually produce balance entries for (see CP-14303). The wallet total
+   * is considered loaded when every account has at least that many entries.
+   */
+  enabledNetworksCountByAccount: Record<string, number>
   enabledNetworksMap: Networks
   enabledChainIds: number[]
   isDeveloperMode: boolean
@@ -40,7 +45,7 @@ const WalletBalanceComponent = ({
   isRefreshing,
   walletBalancesData,
   isBalancesError,
-  enabledNetworksCount,
+  enabledNetworksCountByAccount,
   enabledNetworksMap,
   enabledChainIds,
   isDeveloperMode,
@@ -55,14 +60,14 @@ const WalletBalanceComponent = ({
   const { formatCurrency } = useFormatCurrency()
 
   const { isLoading, balanceTotalInCurrency } = useMemo(() => {
-    const accountEntries = Object.values(walletBalancesData)
+    const accountEntries = Object.entries(walletBalancesData)
 
     let loading = accountEntries.length === 0
     let total = 0
-    for (const accountBalances of accountEntries) {
+    for (const [accountId, accountBalances] of accountEntries) {
       const result = computeAccountBalance({
         accountBalances: accountBalances ?? emptyAccountBalances,
-        enabledNetworksCount,
+        enabledNetworksCount: enabledNetworksCountByAccount[accountId] ?? 0,
         enabledNetworksMap,
         enabledChainIds,
         isDeveloperMode,
@@ -76,7 +81,7 @@ const WalletBalanceComponent = ({
     return { isLoading: loading, balanceTotalInCurrency: total }
   }, [
     walletBalancesData,
-    enabledNetworksCount,
+    enabledNetworksCountByAccount,
     enabledNetworksMap,
     enabledChainIds,
     isDeveloperMode,


### PR DESCRIPTION
## Description

**Ticket: [CP-14303]**

- Introduces `getEnabledNetworksForAccount`, a pure utility that filters the globally-enabled network list down to only the networks a given account can actually produce balance data for (i.e. has a non-empty address for that VM type).
- Replaces the global `enabledNetworks.length` loading threshold in `WalletCard`, `WalletBalance`, and `SelectAccounts` with a per-account count derived from the new utility.
- Fixes `computeAccountBalance` so that `enabledNetworksCount === 0` (account supports no enabled networks) correctly resolves to "loaded at $0" instead of triggering an indefinite loading state.

## Screenshots/Videos
<img width="320" alt="Screenshot 2026-05-20 at 12 39 49 PM" src="https://github.com/user-attachments/assets/aa638cf8-5d0b-4b99-bb08-38e77dd8922b" />


## Testing
iOS: 8590
Android: 8591

**Dev Testing**

1. Connect a Keystone hardware.
2. Navigate to the "My Wallets" screen.
3. Confirm the Keystone account balance loads and displays a dollar amount — previously it would spin indefinitely.

**QA Testing**
- Verify Keystone wallet balance displays correctly on the My Wallets screen without an infinite spinner.
- Verify that standard (non-hardware) wallet balances are unaffected.
- Verify the account picker in WalletConnect sessions shows correct loading states for all wallet types.

---

## Checklist
- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14303]: https://ava-labs.atlassian.net/browse/CP-14303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ