### PR TITLE
CP-14309: Track adopts PriceChart on token detail

### DIFF
--- a/packages/core-mobile/app/new/common/components/chart/TokenPriceChart.tsx
+++ b/packages/core-mobile/app/new/common/components/chart/TokenPriceChart.tsx
@@ -14,6 +14,7 @@ import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import { useTokenChartCandles } from 'common/hooks/useTokenChartCandles'
 import { useMarketToken } from 'common/hooks/useMarketToken'
 import { useTokenPriceDisplay } from 'common/hooks/useTokenPriceDisplay'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { useWatchlist } from 'hooks/watchlist/useWatchlist'
 import React, {
   FC,
@@ -263,7 +264,9 @@ export const TokenPriceChart: FC<Props> = ({
           onPriceHeaderPress={onPriceHeaderPress}
           formatPrice={formatPrice}
           isLoading={effectiveState === 'loading'}
-          priceText={formattedPrice}
+          priceText={
+            formattedPrice === UNKNOWN_AMOUNT ? undefined : formattedPrice
+          }
         />
       )}
       <PriceChart

--- a/packages/core-mobile/app/new/common/components/chart/TokenPriceChart.tsx
+++ b/packages/core-mobile/app/new/common/components/chart/TokenPriceChart.tsx
@@ -37,34 +37,25 @@ import { selectSelectedCurrency } from 'store/settings/currency'
 import { MarketToken } from 'store/watchlist'
 
 type Props = {
-  /** Held token to render (Portfolio path). Resolves marketToken via
-   * `useMarketToken`. Ignored when `marketToken` is provided. */
   token?: LocalTokenWithBalance | undefined
-  /** Directly-supplied watchlist token (Track path). Takes precedence over
-   * `token` — callers that already have one can avoid the extra lookup. */
+  /** Takes precedence over `token` and skips the `useMarketToken` lookup. */
   marketToken?: MarketToken | undefined
   width: number
   height?: number
-  /** Initial range when range is uncontrolled. Ignored if `range` is set. */
+  /** Ignored when `range` is provided (controlled mode). */
   initialRange?: ChartRange
-  /** Controlled range value. Pair with `onRangeChange`. */
   range?: ChartRange
   onRangeChange?: (range: ChartRange) => void
   onPriceHeaderPress?: () => void
-  /** Skip rendering the built-in `ChartHeader` when the parent screen already
-   * shows its own token header (e.g. Track's `TokenHeader` with the rank
-   * badge). The chart's crosshair SharedValues are still exposed via the
-   * `external*` props so the parent can drive its own overlay. */
+  /** Skip the built-in `ChartHeader` when the parent renders its own. The
+   * external SharedValues below stay populated regardless. */
   hideHeader?: boolean
-  /** Crosshair state mirrored out for the parent (e.g. to fade an overlay
-   * indicator). If omitted, the chart manages its own SharedValues. */
   externalIsActive?: SharedValue<boolean>
   externalActiveIndex?: SharedValue<number | null>
   externalCrosshairX?: SharedValue<number>
-  /** Fires on the JS thread with the candle at the crosshair index — or
-   * `null` when the crosshair deactivates. Use this instead of looking up
-   * the active candle yourself, because the chart's candles are bucketed
-   * by `useTokenChartCandles` and won't match the raw source data. */
+  /** Resolves the active candle from the chart's own (bucketed) `candles`,
+   * so the consumer doesn't index into the wrong array. Fires on the JS
+   * thread; `null` when the crosshair deactivates. */
   onActiveCandleChange?: (candle: OhlcCandle | null) => void
 }
 
@@ -197,8 +188,6 @@ export const TokenPriceChart: FC<Props> = ({
     onRangeChange
   )
 
-  // Prefer the caller-supplied marketToken (Track has one directly); fall back
-  // to resolving from the held token.
   const resolvedMarketToken = useMarketToken({
     token: marketTokenProp ? undefined : token
   })
@@ -206,10 +195,8 @@ export const TokenPriceChart: FC<Props> = ({
   const coingeckoId = marketToken?.coingeckoId ?? undefined
   const symbol = marketTokenProp?.symbol ?? token?.symbol ?? ''
 
-  // Live current price for the big idle heading. The change indicator is
-  // *not* computed here — we let `ChartHeader` derive it range-relative from
-  // the candles in view so the percent + amount update whenever the user
-  // switches range (matches Track's behavior).
+  // Only the live price is computed here; `ChartHeader` derives the delta
+  // range-relative from its candles so it updates per range switch.
   const { formattedPrice } = useTokenPriceDisplay({
     currentPrice: token?.priceInCurrency ?? marketToken?.currentPrice,
     priceChange24h: token?.priceChanges?.value ?? marketToken?.priceChange24h,
@@ -240,12 +227,6 @@ export const TokenPriceChart: FC<Props> = ({
   const isActive = externalIsActive ?? internalIsActive
   const activeIndex = externalActiveIndex ?? internalActiveIndex
   const crosshairX = externalCrosshairX ?? internalCrosshairX
-
-  // Bridge the active-index SharedValue back to JS so the parent can show
-  // an overlay with the right candle. The lookup happens on the JS thread
-  // — `scheduleOnRN` serializes its args across threads, which would strip
-  // the candle's structure into a POJO; passing the index keeps things
-  // simple and lets the consumer's callback receive the real object.
   const handleActiveIndex = useCallback(
     (idx: number | null) => {
       if (!onActiveCandleChange) return
@@ -258,12 +239,15 @@ export const TokenPriceChart: FC<Props> = ({
     },
     [candles, onActiveCandleChange]
   )
+  const hasActiveCandleListener = onActiveCandleChange !== undefined
   useAnimatedReaction(
     () => activeIndex.value,
     (idx, prev) => {
-      if (idx === prev) return
+      // Skip the UI→JS hop when no one is listening.
+      if (!hasActiveCandleListener || idx === prev) return
       scheduleOnRN(handleActiveIndex, idx)
-    }
+    },
+    [hasActiveCandleListener]
   )
 
   return (

--- a/packages/core-mobile/app/new/common/components/chart/TokenPriceChart.tsx
+++ b/packages/core-mobile/app/new/common/components/chart/TokenPriceChart.tsx
@@ -3,6 +3,7 @@ import {
   ChartHeader,
   ChartRange,
   Icons,
+  OhlcCandle,
   PriceChart,
   SegmentedControl,
   useTheme,
@@ -23,13 +24,17 @@ import React, {
   useState
 } from 'react'
 import { Pressable } from 'react-native'
-import { useSharedValue } from 'react-native-reanimated'
+import {
+  SharedValue,
+  useAnimatedReaction,
+  useSharedValue
+} from 'react-native-reanimated'
+import { scheduleOnRN } from 'react-native-worklets'
 import { useDispatch, useSelector } from 'react-redux'
 import { LocalTokenWithBalance } from 'store/balance'
 import { selectChartType, setChartType } from 'store/chartPreferences/slice'
 import { selectSelectedCurrency } from 'store/settings/currency'
 import { MarketToken } from 'store/watchlist'
-import { SharedValue } from 'react-native-reanimated'
 
 type Props = {
   /** Held token to render (Portfolio path). Resolves marketToken via
@@ -56,6 +61,11 @@ type Props = {
   externalIsActive?: SharedValue<boolean>
   externalActiveIndex?: SharedValue<number | null>
   externalCrosshairX?: SharedValue<number>
+  /** Fires on the JS thread with the candle at the crosshair index — or
+   * `null` when the crosshair deactivates. Use this instead of looking up
+   * the active candle yourself, because the chart's candles are bucketed
+   * by `useTokenChartCandles` and won't match the raw source data. */
+  onActiveCandleChange?: (candle: OhlcCandle | null) => void
 }
 
 const TOGGLE_SIZE = 36
@@ -158,7 +168,8 @@ export const TokenPriceChart: FC<Props> = ({
   hideHeader = false,
   externalIsActive,
   externalActiveIndex,
-  externalCrosshairX
+  externalCrosshairX,
+  onActiveCandleChange
 }) => {
   const chartType = useSelector(selectChartType)
   const selectedCurrency = useSelector(selectSelectedCurrency)
@@ -229,6 +240,31 @@ export const TokenPriceChart: FC<Props> = ({
   const isActive = externalIsActive ?? internalIsActive
   const activeIndex = externalActiveIndex ?? internalActiveIndex
   const crosshairX = externalCrosshairX ?? internalCrosshairX
+
+  // Bridge the active-index SharedValue back to JS so the parent can show
+  // an overlay with the right candle. The lookup happens on the JS thread
+  // — `scheduleOnRN` serializes its args across threads, which would strip
+  // the candle's structure into a POJO; passing the index keeps things
+  // simple and lets the consumer's callback receive the real object.
+  const handleActiveIndex = useCallback(
+    (idx: number | null) => {
+      if (!onActiveCandleChange) return
+      if (idx === null) {
+        onActiveCandleChange(null)
+        return
+      }
+      const candle = candles[idx]
+      onActiveCandleChange(candle ?? null)
+    },
+    [candles, onActiveCandleChange]
+  )
+  useAnimatedReaction(
+    () => activeIndex.value,
+    (idx, prev) => {
+      if (idx === prev) return
+      scheduleOnRN(handleActiveIndex, idx)
+    }
+  )
 
   return (
     <View style={{ paddingBottom: 18, gap: 12 }}>

--- a/packages/core-mobile/app/new/common/components/chart/TokenPriceChart.tsx
+++ b/packages/core-mobile/app/new/common/components/chart/TokenPriceChart.tsx
@@ -248,7 +248,7 @@ export const TokenPriceChart: FC<Props> = ({
       if (!hasActiveCandleListener || idx === prev) return
       scheduleOnRN(handleActiveIndex, idx)
     },
-    [hasActiveCandleListener]
+    [hasActiveCandleListener, handleActiveIndex]
   )
 
   return (

--- a/packages/core-mobile/app/new/common/components/chart/TokenPriceChart.tsx
+++ b/packages/core-mobile/app/new/common/components/chart/TokenPriceChart.tsx
@@ -28,14 +28,34 @@ import { useDispatch, useSelector } from 'react-redux'
 import { LocalTokenWithBalance } from 'store/balance'
 import { selectChartType, setChartType } from 'store/chartPreferences/slice'
 import { selectSelectedCurrency } from 'store/settings/currency'
+import { MarketToken } from 'store/watchlist'
+import { SharedValue } from 'react-native-reanimated'
 
 type Props = {
-  /** The held token whose price + chart to render. */
-  token: LocalTokenWithBalance | undefined
+  /** Held token to render (Portfolio path). Resolves marketToken via
+   * `useMarketToken`. Ignored when `marketToken` is provided. */
+  token?: LocalTokenWithBalance | undefined
+  /** Directly-supplied watchlist token (Track path). Takes precedence over
+   * `token` — callers that already have one can avoid the extra lookup. */
+  marketToken?: MarketToken | undefined
   width: number
   height?: number
+  /** Initial range when range is uncontrolled. Ignored if `range` is set. */
   initialRange?: ChartRange
+  /** Controlled range value. Pair with `onRangeChange`. */
+  range?: ChartRange
+  onRangeChange?: (range: ChartRange) => void
   onPriceHeaderPress?: () => void
+  /** Skip rendering the built-in `ChartHeader` when the parent screen already
+   * shows its own token header (e.g. Track's `TokenHeader` with the rank
+   * badge). The chart's crosshair SharedValues are still exposed via the
+   * `external*` props so the parent can drive its own overlay. */
+  hideHeader?: boolean
+  /** Crosshair state mirrored out for the parent (e.g. to fade an overlay
+   * indicator). If omitted, the chart manages its own SharedValues. */
+  externalIsActive?: SharedValue<boolean>
+  externalActiveIndex?: SharedValue<number | null>
+  externalCrosshairX?: SharedValue<number>
 }
 
 const TOGGLE_SIZE = 36
@@ -108,12 +128,37 @@ const ChartRangeSelector: FC<{
   )
 })
 
+const useControlledRange = (
+  initialRange: ChartRange,
+  rangeProp: ChartRange | undefined,
+  onRangeChange?: (range: ChartRange) => void
+): [ChartRange, (next: ChartRange) => void] => {
+  const [internal, setInternal] = useState<ChartRange>(initialRange)
+  const isControlled = rangeProp !== undefined
+  const value = isControlled ? rangeProp : internal
+  const setValue = useCallback(
+    (next: ChartRange) => {
+      if (!isControlled) setInternal(next)
+      onRangeChange?.(next)
+    },
+    [isControlled, onRangeChange]
+  )
+  return [value, setValue]
+}
+
 export const TokenPriceChart: FC<Props> = ({
   token,
+  marketToken: marketTokenProp,
   width,
   height = 235,
   initialRange = '1D',
-  onPriceHeaderPress
+  range: rangeProp,
+  onRangeChange,
+  onPriceHeaderPress,
+  hideHeader = false,
+  externalIsActive,
+  externalActiveIndex,
+  externalCrosshairX
 }) => {
   const chartType = useSelector(selectChartType)
   const selectedCurrency = useSelector(selectSelectedCurrency)
@@ -135,18 +180,26 @@ export const TokenPriceChart: FC<Props> = ({
     [formatCurrency]
   )
 
-  const [range, setRange] = useState<ChartRange>(initialRange)
+  const [range, handleRangeChange] = useControlledRange(
+    initialRange,
+    rangeProp,
+    onRangeChange
+  )
 
-  const marketToken = useMarketToken({ token })
+  // Prefer the caller-supplied marketToken (Track has one directly); fall back
+  // to resolving from the held token.
+  const resolvedMarketToken = useMarketToken({
+    token: marketTokenProp ? undefined : token
+  })
+  const marketToken = marketTokenProp ?? resolvedMarketToken
   const coingeckoId = marketToken?.coingeckoId ?? undefined
-  const symbol = token?.symbol ?? ''
+  const symbol = marketTokenProp?.symbol ?? token?.symbol ?? ''
 
-  const {
-    formattedPrice,
-    formattedPriceChange,
-    formattedPercent,
-    status: priceChangeStatus
-  } = useTokenPriceDisplay({
+  // Live current price for the big idle heading. The change indicator is
+  // *not* computed here — we let `ChartHeader` derive it range-relative from
+  // the candles in view so the percent + amount update whenever the user
+  // switches range (matches Track's behavior).
+  const { formattedPrice } = useTokenPriceDisplay({
     currentPrice: token?.priceInCurrency ?? marketToken?.currentPrice,
     priceChange24h: token?.priceChanges?.value ?? marketToken?.priceChange24h,
     priceChangePercentage24h:
@@ -154,14 +207,6 @@ export const TokenPriceChart: FC<Props> = ({
       token?.change24 ??
       marketToken?.priceChangePercentage24h
   })
-  const headerPriceChange =
-    formattedPriceChange === undefined && formattedPercent === undefined
-      ? undefined
-      : {
-          status: priceChangeStatus,
-          formattedPrice: formattedPriceChange,
-          formattedPercent
-        }
 
   const { candles, state, isFetching } = useTokenChartCandles({
     coingeckoId,
@@ -178,25 +223,29 @@ export const TokenPriceChart: FC<Props> = ({
       ? ('loading' as const)
       : state
 
-  const isActive = useSharedValue(false)
-  const activeIndex = useSharedValue<number | null>(null)
-  const crosshairX = useSharedValue(0)
+  const internalIsActive = useSharedValue(false)
+  const internalActiveIndex = useSharedValue<number | null>(null)
+  const internalCrosshairX = useSharedValue(0)
+  const isActive = externalIsActive ?? internalIsActive
+  const activeIndex = externalActiveIndex ?? internalActiveIndex
+  const crosshairX = externalCrosshairX ?? internalCrosshairX
 
   return (
     <View style={{ paddingBottom: 18, gap: 12 }}>
-      <ChartHeader
-        candles={candles}
-        symbol={symbol}
-        activeIndex={activeIndex}
-        crosshairX={crosshairX}
-        isActive={isActive}
-        containerWidth={width}
-        onPriceHeaderPress={onPriceHeaderPress}
-        formatPrice={formatPrice}
-        isLoading={effectiveState === 'loading'}
-        priceText={formattedPrice}
-        priceChange={headerPriceChange}
-      />
+      {!hideHeader && (
+        <ChartHeader
+          candles={candles}
+          symbol={symbol}
+          activeIndex={activeIndex}
+          crosshairX={crosshairX}
+          isActive={isActive}
+          containerWidth={width}
+          onPriceHeaderPress={onPriceHeaderPress}
+          formatPrice={formatPrice}
+          isLoading={effectiveState === 'loading'}
+          priceText={formattedPrice}
+        />
+      )}
       <PriceChart
         candles={candles}
         width={width}
@@ -218,7 +267,7 @@ export const TokenPriceChart: FC<Props> = ({
           alignItems: 'center'
         }}>
         <View sx={{ flex: 1 }}>
-          <ChartRangeSelector value={range} onChange={setRange} />
+          <ChartRangeSelector value={range} onChange={handleRangeChange} />
         </View>
         <ChartTypeToggle />
       </View>

--- a/packages/core-mobile/app/new/common/components/chart/TokenPriceChart.tsx
+++ b/packages/core-mobile/app/new/common/components/chart/TokenPriceChart.tsx
@@ -58,6 +58,10 @@ type Props = {
    * so the consumer doesn't index into the wrong array. Fires on the JS
    * thread; `null` when the crosshair deactivates. */
   onActiveCandleChange?: (candle: OhlcCandle | null) => void
+  /** Open of the first candle in the current range — the baseline a
+   * sibling indicator should compare an active candle's price against
+   * (so both come from the same series). Fires when the candles change. */
+  onRangeBaselineChange?: (baselineOpen: number | null) => void
 }
 
 const TOGGLE_SIZE = 36
@@ -161,7 +165,8 @@ export const TokenPriceChart: FC<Props> = ({
   externalIsActive,
   externalActiveIndex,
   externalCrosshairX,
-  onActiveCandleChange
+  onActiveCandleChange,
+  onRangeBaselineChange
 }) => {
   const chartType = useSelector(selectChartType)
   const selectedCurrency = useSelector(selectSelectedCurrency)
@@ -250,6 +255,11 @@ export const TokenPriceChart: FC<Props> = ({
     },
     [hasActiveCandleListener, handleActiveIndex]
   )
+
+  const rangeBaseline = candles[0]?.open ?? null
+  useEffect(() => {
+    onRangeBaselineChange?.(rangeBaseline)
+  }, [rangeBaseline, onRangeBaselineChange])
 
   return (
     <View style={{ paddingBottom: 18, gap: 12 }}>

--- a/packages/core-mobile/app/new/common/hooks/useTokenChartCandles.test.ts
+++ b/packages/core-mobile/app/new/common/hooks/useTokenChartCandles.test.ts
@@ -128,8 +128,8 @@ describe('useTokenChartCandles', () => {
       ])
     })
 
-    it('produces 24 candles from 24 sub-points for the 1D range', () => {
-      const points = Array.from({ length: 24 }, (_, i) =>
+    it('produces 48 candles from 48 sub-points for the 1D range', () => {
+      const points = Array.from({ length: 48 }, (_, i) =>
         makePoint(i * 60_000, 100 + i)
       )
       setQueryResult({ data: { dataPoints: points, ranges: {} } })
@@ -142,7 +142,7 @@ describe('useTokenChartCandles', () => {
         })
       )
 
-      expect(result.current.candles.length).toBe(24)
+      expect(result.current.candles.length).toBe(48)
       const first = result.current.candles[0]
       expect(first).toEqual(
         expect.objectContaining({
@@ -156,8 +156,9 @@ describe('useTokenChartCandles', () => {
     })
 
     it('aggregates open/high/low/close per bucket correctly', () => {
+      // 96 source points bucketed into 48 candles (1D) = 2 points per bucket.
       const points: ReturnType<typeof makePoint>[] = []
-      for (let i = 0; i < 48; i++) {
+      for (let i = 0; i < 96; i++) {
         points.push(makePoint(i * 1000, i))
       }
       setQueryResult({ data: { dataPoints: points, ranges: {} } })
@@ -170,7 +171,7 @@ describe('useTokenChartCandles', () => {
         })
       )
 
-      expect(result.current.candles.length).toBe(24)
+      expect(result.current.candles.length).toBe(48)
       expect(result.current.candles[0]).toEqual(
         expect.objectContaining({
           open: 0,
@@ -179,12 +180,12 @@ describe('useTokenChartCandles', () => {
           low: 0
         })
       )
-      expect(result.current.candles[23]).toEqual(
+      expect(result.current.candles[47]).toEqual(
         expect.objectContaining({
-          open: 46,
-          close: 47,
-          high: 47,
-          low: 46
+          open: 94,
+          close: 95,
+          high: 95,
+          low: 94
         })
       )
     })
@@ -205,8 +206,10 @@ describe('useTokenChartCandles', () => {
     })
 
     it('sums per-bucket volumes when source points carry volume', () => {
+      // 96 source points bucketed into 48 candles (1D) = 2 points per bucket,
+      // each carrying volume 10 → per-bucket volume 20.
       const points: ReturnType<typeof makePoint>[] = []
-      for (let i = 0; i < 48; i++) {
+      for (let i = 0; i < 96; i++) {
         points.push(makePoint(i * 1000, i, 10))
       }
       setQueryResult({ data: { dataPoints: points, ranges: {} } })
@@ -219,7 +222,7 @@ describe('useTokenChartCandles', () => {
         })
       )
 
-      expect(result.current.candles.length).toBe(24)
+      expect(result.current.candles.length).toBe(48)
       expect(result.current.candles.every(c => c.volume === 20)).toBe(true)
     })
 

--- a/packages/core-mobile/app/new/common/hooks/useTokenChartCandles.ts
+++ b/packages/core-mobile/app/new/common/hooks/useTokenChartCandles.ts
@@ -5,11 +5,13 @@ import { useEffect, useMemo, useRef } from 'react'
 import { VsCurrencyType } from '@avalabs/core-coingecko-sdk'
 import TokenService from 'services/token/TokenService'
 
-// CoinGecko granularity by `days`: 1 → 5m, 2-90 → hourly, >90 → daily.
-// 1H uses the range endpoint (null here) to get 5-min data.
+// CoinGecko granularity by `days`: 2-90 → hourly, >90 → daily.
+// 1H and 1D use the range endpoint (null here) so we get 5-min data over a
+// fixed window (see RANGE_TO_WINDOW_SECONDS) — that's enough source points to
+// bucket into the target candle count without one-source-point-per-candle.
 const RANGE_TO_DAYS: Record<ChartRange, number | null> = {
   '1H': null,
-  '1D': 1,
+  '1D': null,
   '1W': 7,
   '1M': 30,
   '3M': 90,
@@ -18,14 +20,18 @@ const RANGE_TO_DAYS: Record<ChartRange, number | null> = {
 
 const RANGE_TO_CANDLE_COUNT: Record<ChartRange, number> = {
   '1H': 12,
-  '1D': 24,
+  '1D': 48,
   '1W': 48,
-  '1M': 30,
-  '3M': 48,
+  '1M': 60,
+  '3M': 60,
   '1Y': 52
 }
 
-const HOUR_RANGE_WINDOW_SECONDS = 2 * 60 * 60
+// Window passed to the range endpoint when `RANGE_TO_DAYS[range]` is null.
+const RANGE_TO_WINDOW_SECONDS: Partial<Record<ChartRange, number>> = {
+  '1H': 2 * 60 * 60,
+  '1D': 24 * 60 * 60
+}
 
 type PriceDataPoint = { date: Date; value: number; volume?: number | null }
 
@@ -105,7 +111,7 @@ export const useTokenChartCandles = ({
     queryFn: () => {
       if (days === null) {
         const toSec = Math.floor(Date.now() / 1000)
-        const fromSec = toSec - HOUR_RANGE_WINDOW_SECONDS
+        const fromSec = toSec - (RANGE_TO_WINDOW_SECONDS[range] ?? 0)
         return TokenService.getChartDataForCoinRange({
           coingeckoId: coingeckoId as string,
           from: fromSec,

--- a/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
+++ b/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
@@ -4,6 +4,7 @@ import {
   GroupList,
   GroupListItem,
   Icons,
+  OhlcCandle,
   SegmentedControl,
   showAlert,
   Text,
@@ -62,7 +63,11 @@ const DEFAULT_DEBOUNCE_MILLISECONDS = 500
 
 // Maps the chart's range labels to the day count `useTokenDetails` understands
 // so its computed `ranges` (which drives Track's header) stays in sync with
-// whatever range the chart is showing.
+// whatever range the chart is showing. Note: `1H` is in the `ChartRange` type
+// but isn't currently exposed in `CHART_RANGES`, so this entry is unreachable
+// today — kept for type completeness. If 1H is ever surfaced, the header
+// delta will need a range-specific calc instead (CoinGecko's smallest
+// "days" granularity is 1, which is 24h — not 1h).
 const CHART_RANGE_TO_DAYS: Record<ChartRange, number> = {
   '1H': 1,
   '1D': 1,
@@ -151,40 +156,27 @@ const TrackTokenDetailScreen = (): JSX.Element => {
     []
   )
 
-  // Crosshair SharedValues are lifted up so we can drive the
-  // SelectedChartDataIndicator overlay + the header fade in/out.
+  // Crosshair SharedValues are lifted up so we can drive the header fade
+  // in/out. The active candle itself comes back via `onActiveCandleChange`
+  // — that's the chart's own bucketed data (different length/order from
+  // `useTokenDetails`'s raw `chartData`), so reading it via the callback
+  // avoids index-misalignment bugs.
   const chartIsActive = useSharedValue(false)
-  const chartActiveIndex = useSharedValue<number | null>(null)
   const chartCrosshairX = useSharedValue(0)
 
-  // Look up the selected chart point on the JS thread — `scheduleOnRN`
-  // serializes its arguments across threads, which would strip the `Date`
-  // prototype from the point and break `SelectedChartDataIndicator`.
-  const updateSelectedData = useCallback(
-    (idx: number | null) => {
-      if (idx === null) {
-        setSelectedData(undefined)
-        return
-      }
-      const point = chartData?.[idx]
-      if (point) setSelectedData(point)
-    },
-    [chartData]
-  )
+  const handleActiveCandleChange = useCallback((candle: OhlcCandle | null) => {
+    if (!candle) {
+      setSelectedData(undefined)
+      return
+    }
+    setSelectedData({ value: candle.close, date: new Date(candle.ts) })
+  }, [])
 
   useAnimatedReaction(
     () => chartIsActive.value,
     (active, prev) => {
       if (active === prev) return
       scheduleOnRN(setIsChartInteracting, active)
-    }
-  )
-
-  useAnimatedReaction(
-    () => chartActiveIndex.value,
-    (idx, prev) => {
-      if (idx === prev) return
-      scheduleOnRN(updateSelectedData, idx)
     }
   )
 
@@ -567,8 +559,8 @@ const TrackTokenDetailScreen = (): JSX.Element => {
             range={chartRange}
             onRangeChange={handleChartRangeChange}
             externalIsActive={chartIsActive}
-            externalActiveIndex={chartActiveIndex}
             externalCrosshairX={chartCrosshairX}
+            onActiveCandleChange={handleActiveCandleChange}
           />
         </View>
       )}

--- a/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
+++ b/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
@@ -61,13 +61,9 @@ const MAX_VALUE_WIDTH = '80%'
 const DELAY = 200
 const DEFAULT_DEBOUNCE_MILLISECONDS = 500
 
-// Maps the chart's range labels to the day count `useTokenDetails` understands
-// so its computed `ranges` (which drives Track's header) stays in sync with
-// whatever range the chart is showing. Note: `1H` is in the `ChartRange` type
-// but isn't currently exposed in `CHART_RANGES`, so this entry is unreachable
-// today — kept for type completeness. If 1H is ever surfaced, the header
-// delta will need a range-specific calc instead (CoinGecko's smallest
-// "days" granularity is 1, which is 24h — not 1h).
+// `1H` is unreachable today (not exposed via `CHART_RANGES`) — kept for
+// type completeness. If 1H is ever surfaced, the header delta will need a
+// range-specific calc since CoinGecko's smallest `days` is 1 (= 24h).
 const CHART_RANGE_TO_DAYS: Record<ChartRange, number> = {
   '1H': 1,
   '1D': 1,
@@ -117,9 +113,8 @@ const TrackTokenDetailScreen = (): JSX.Element => {
   const { navigateToBuy } = useBuy()
   const isPriceChartBlocked = useSelector(selectIsPriceChartBlocked)
 
-  // Chart range state lifted up from TokenPriceChart so we can sync the
-  // legacy useTokenDetails fetch (whose `ranges` powers TokenHeader's
-  // range-relative price delta) with the chart's selected range.
+  // `chartRange` here keeps `useTokenDetails.ranges` (TokenHeader's delta
+  // source) in sync with the chart's selected range.
   const [chartRange, setChartRange] = useState<ChartRange>('1D')
   const handleChartRangeChange = useCallback(
     (next: ChartRange) => {
@@ -129,7 +124,6 @@ const TrackTokenDetailScreen = (): JSX.Element => {
     [changeChartDays]
   )
 
-  // Legacy chart fallback (flag OFF): old segmented-control range picker.
   const selectedSegmentIndex = useSharedValue(0)
   const debouncedHandleDataSelected = useDebouncedCallback(
     (index: number) =>
@@ -156,11 +150,6 @@ const TrackTokenDetailScreen = (): JSX.Element => {
     []
   )
 
-  // Crosshair SharedValues are lifted up so we can drive the header fade
-  // in/out. The active candle itself comes back via `onActiveCandleChange`
-  // — that's the chart's own bucketed data (different length/order from
-  // `useTokenDetails`'s raw `chartData`), so reading it via the callback
-  // avoids index-misalignment bugs.
   const chartIsActive = useSharedValue(false)
   const chartCrosshairX = useSharedValue(0)
 
@@ -605,7 +594,6 @@ const TrackTokenDetailScreen = (): JSX.Element => {
   )
 }
 
-// Legacy chart fallback: kept while the `price-chart` flag is OFF.
 const LEGACY_SEGMENT_INDEX_TO_DAYS: Record<number, number> = {
   0: 1, // 24H
   1: 7, // 1W

--- a/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
+++ b/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
@@ -152,6 +152,12 @@ const TrackTokenDetailScreen = (): JSX.Element => {
 
   const chartIsActive = useSharedValue(false)
   const chartCrosshairX = useSharedValue(0)
+  // Baseline for `SelectedChartDataIndicator`'s percent-change — sourced
+  // from the same candle series the indicator is reading the selected
+  // value from, so the math never mixes datasets.
+  const [chartRangeBaseline, setChartRangeBaseline] = useState<number | null>(
+    null
+  )
 
   const handleActiveCandleChange = useCallback((candle: OhlcCandle | null) => {
     if (!candle) {
@@ -455,7 +461,11 @@ const TrackTokenDetailScreen = (): JSX.Element => {
             ]}>
             <SelectedChartDataIndicator
               selectedData={selectedData}
-              currentPrice={chartData?.[0]?.value}
+              currentPrice={
+                isPriceChartBlocked
+                  ? chartData?.[0]?.value
+                  : chartRangeBaseline ?? undefined
+              }
             />
           </Animated.View>
         )}
@@ -473,6 +483,8 @@ const TrackTokenDetailScreen = (): JSX.Element => {
     selectedDataIndicatorOpacity,
     selectedData,
     chartData,
+    chartRangeBaseline,
+    isPriceChartBlocked,
     tokenInfo?.logoUri,
     tokenInfo?.name,
     tokenInfo?.symbol
@@ -550,6 +562,7 @@ const TrackTokenDetailScreen = (): JSX.Element => {
             externalIsActive={chartIsActive}
             externalCrosshairX={chartCrosshairX}
             onActiveCandleChange={handleActiveCandleChange}
+            onRangeBaselineChange={setChartRangeBaseline}
           />
         </View>
       )}

--- a/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
+++ b/packages/core-mobile/app/new/features/track/screens/TrackTokenDetailScreen.tsx
@@ -1,5 +1,6 @@
 import {
   Card,
+  ChartRange,
   GroupList,
   GroupListItem,
   Icons,
@@ -22,6 +23,7 @@ import { noop, truncateAddress } from '@avalabs/core-utils-sdk'
 import { FavoriteBarButton } from 'common/components/FavoriteBarButton'
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import { ShareBarButton } from 'common/components/ShareBarButton'
+import { TokenPriceChart } from 'common/components/chart/TokenPriceChart'
 import { tokenIds } from 'consts/tokenIds'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import { useTokenDetails } from 'common/hooks/useTokenDetails'
@@ -36,14 +38,18 @@ import { SelectedChartDataIndicator } from 'features/track/components/SelectedCh
 import { TokenDetailChart } from 'features/track/components/TokenDetailChart'
 import { TokenHeader } from 'features/track/components/TokenHeader'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { StyleSheet } from 'react-native'
+import { StyleSheet, useWindowDimensions } from 'react-native'
 import Animated, {
   FadeIn,
+  useAnimatedReaction,
   useDerivedValue,
   useSharedValue,
   withTiming
 } from 'react-native-reanimated'
+import { scheduleOnRN } from 'react-native-worklets'
 import { MarketType } from 'store/watchlist'
+import { selectIsPriceChartBlocked } from 'store/posthog'
+import { useSelector } from 'react-redux'
 import { useDebouncedCallback } from 'use-debounce'
 import { getDomainFromUrl } from 'utils/getDomainFromUrl/getDomainFromUrl'
 import { isPositiveNumber } from 'utils/isPositiveNumber/isPositiveNumber'
@@ -53,6 +59,18 @@ import { useTrackTokenActions } from '../hooks/useTrackTokenActions'
 const MAX_VALUE_WIDTH = '80%'
 const DELAY = 200
 const DEFAULT_DEBOUNCE_MILLISECONDS = 500
+
+// Maps the chart's range labels to the day count `useTokenDetails` understands
+// so its computed `ranges` (which drives Track's header) stays in sync with
+// whatever range the chart is showing.
+const CHART_RANGE_TO_DAYS: Record<ChartRange, number> = {
+  '1H': 1,
+  '1D': 1,
+  '1W': 7,
+  '1M': 30,
+  '3M': 90,
+  '1Y': 365
+}
 
 const TrackTokenDetailScreen = (): JSX.Element => {
   const { theme } = useTheme()
@@ -72,6 +90,7 @@ const TrackTokenDetailScreen = (): JSX.Element => {
   const selectedDataIndicatorOpacity = useDerivedValue(
     () => 1 - headerOpacity.value
   )
+  const { width: screenWidth } = useWindowDimensions()
   const [selectedData, setSelectedData] = useState<{
     value: number
     date: Date
@@ -91,8 +110,83 @@ const TrackTokenDetailScreen = (): JSX.Element => {
   } = useTokenDetails({ tokenId, marketType })
 
   const { navigateToBuy } = useBuy()
+  const isPriceChartBlocked = useSelector(selectIsPriceChartBlocked)
 
+  // Chart range state lifted up from TokenPriceChart so we can sync the
+  // legacy useTokenDetails fetch (whose `ranges` powers TokenHeader's
+  // range-relative price delta) with the chart's selected range.
+  const [chartRange, setChartRange] = useState<ChartRange>('1D')
+  const handleChartRangeChange = useCallback(
+    (next: ChartRange) => {
+      setChartRange(next)
+      changeChartDays(CHART_RANGE_TO_DAYS[next])
+    },
+    [changeChartDays]
+  )
+
+  // Legacy chart fallback (flag OFF): old segmented-control range picker.
   const selectedSegmentIndex = useSharedValue(0)
+  const debouncedHandleDataSelected = useDebouncedCallback(
+    (index: number) =>
+      changeChartDays(LEGACY_SEGMENT_INDEX_TO_DAYS[index] ?? 1),
+    DEFAULT_DEBOUNCE_MILLISECONDS
+  )
+  const handleSelectSegment = useCallback(
+    (index: number) => {
+      selectedSegmentIndex.value = index
+      debouncedHandleDataSelected(index)
+    },
+    [selectedSegmentIndex, debouncedHandleDataSelected]
+  )
+  const handleDataSelected = useCallback(
+    (point: { value: number; date: Date }) => setSelectedData(point),
+    []
+  )
+  const handleChartGestureStart = useCallback(
+    () => setIsChartInteracting(true),
+    []
+  )
+  const handleChartGestureEnd = useCallback(
+    () => setIsChartInteracting(false),
+    []
+  )
+
+  // Crosshair SharedValues are lifted up so we can drive the
+  // SelectedChartDataIndicator overlay + the header fade in/out.
+  const chartIsActive = useSharedValue(false)
+  const chartActiveIndex = useSharedValue<number | null>(null)
+  const chartCrosshairX = useSharedValue(0)
+
+  // Look up the selected chart point on the JS thread — `scheduleOnRN`
+  // serializes its arguments across threads, which would strip the `Date`
+  // prototype from the point and break `SelectedChartDataIndicator`.
+  const updateSelectedData = useCallback(
+    (idx: number | null) => {
+      if (idx === null) {
+        setSelectedData(undefined)
+        return
+      }
+      const point = chartData?.[idx]
+      if (point) setSelectedData(point)
+    },
+    [chartData]
+  )
+
+  useAnimatedReaction(
+    () => chartIsActive.value,
+    (active, prev) => {
+      if (active === prev) return
+      scheduleOnRN(setIsChartInteracting, active)
+    }
+  )
+
+  useAnimatedReaction(
+    () => chartActiveIndex.value,
+    (idx, prev) => {
+      if (idx === prev) return
+      scheduleOnRN(updateSelectedData, idx)
+    }
+  )
 
   const lastUpdatedDate = chartData?.[chartData.length - 1]?.date
 
@@ -134,37 +228,6 @@ const TrackTokenDetailScreen = (): JSX.Element => {
     },
     [formatCurrency]
   )
-
-  const handleDataSelected = useCallback(
-    (point: { value: number; date: Date }): void => {
-      setSelectedData(point)
-    },
-    []
-  )
-
-  const debouncedHandleDataSelected = useDebouncedCallback(
-    (index: number) =>
-      changeChartDays(
-        SEGMENT_INDEX_MAP[index] ?? 1 // default to 1 day if index is not found
-      ),
-    DEFAULT_DEBOUNCE_MILLISECONDS
-  )
-
-  const handleSelectSegment = useCallback(
-    (index: number) => {
-      selectedSegmentIndex.value = index
-      debouncedHandleDataSelected(index)
-    },
-    [selectedSegmentIndex, debouncedHandleDataSelected]
-  )
-
-  const handleChartGestureStart = useCallback((): void => {
-    setIsChartInteracting(true)
-  }, [])
-
-  const handleChartGestureEnd = useCallback((): void => {
-    setIsChartInteracting(false)
-  }, [])
 
   const handlePressAbout = useCallback((): void => {
     showAlert({
@@ -445,53 +508,69 @@ const TrackTokenDetailScreen = (): JSX.Element => {
       isModal
       renderHeader={renderHeader}
       renderHeaderRight={renderHeaderRight}>
-      <TokenDetailChart
-        ranges={ranges}
-        chartData={chartData}
-        negative={ranges.diffValue < 0}
-        onDataSelected={handleDataSelected}
-        onGestureStart={handleChartGestureStart}
-        onGestureEnd={handleChartGestureEnd}
-        isUpdatingChartData={isUpdatingChartData}
-      />
-
-      {lastUpdatedDate ? (
-        <View sx={styles.lastUpdatedContainer}>
-          <Animated.View
-            entering={FadeIn.delay(DELAY * 3)}
-            style={{
-              alignSelf: 'center',
-              position: 'absolute'
-            }}>
-            <Animated.View
-              style={{
-                opacity: headerOpacity
-              }}>
-              <Text
-                variant="caption"
-                sx={{
-                  color: '$textSecondary'
-                }}>
-                Last updated:{' '}
-                {format(lastUpdatedDate, 'E, MMM dd, yyyy, h:mm aa')}
-              </Text>
-            </Animated.View>
-          </Animated.View>
-        </View>
-      ) : (
-        <View sx={styles.lastUpdatedContainer} />
-      )}
-      {tokenInfo?.has24hChartDataOnly === false && (
-        <Animated.View entering={FadeIn.delay(DELAY * 3)}>
-          <SegmentedControl
-            type="thin"
-            dynamicItemWidth={false}
-            items={SEGMENT_ITEMS}
-            style={styles.segmentedControl}
-            selectedSegmentIndex={selectedSegmentIndex}
-            onSelectSegment={handleSelectSegment}
+      {isPriceChartBlocked ? (
+        <>
+          <TokenDetailChart
+            ranges={ranges}
+            chartData={chartData}
+            negative={ranges.diffValue < 0}
+            onDataSelected={handleDataSelected}
+            onGestureStart={handleChartGestureStart}
+            onGestureEnd={handleChartGestureEnd}
+            isUpdatingChartData={isUpdatingChartData}
           />
-        </Animated.View>
+          {lastUpdatedDate ? (
+            <View sx={styles.lastUpdatedContainer}>
+              <Animated.View
+                entering={FadeIn.delay(DELAY * 3)}
+                style={{
+                  alignSelf: 'center',
+                  position: 'absolute'
+                }}>
+                <Animated.View
+                  style={{
+                    opacity: headerOpacity
+                  }}>
+                  <Text
+                    variant="caption"
+                    sx={{
+                      color: '$textSecondary'
+                    }}>
+                    Last updated:{' '}
+                    {format(lastUpdatedDate, 'E, MMM dd, yyyy, h:mm aa')}
+                  </Text>
+                </Animated.View>
+              </Animated.View>
+            </View>
+          ) : (
+            <View sx={styles.lastUpdatedContainer} />
+          )}
+          {tokenInfo?.has24hChartDataOnly === false && (
+            <Animated.View entering={FadeIn.delay(DELAY * 3)}>
+              <SegmentedControl
+                type="thin"
+                dynamicItemWidth={false}
+                items={LEGACY_SEGMENT_ITEMS}
+                style={styles.segmentedControl}
+                selectedSegmentIndex={selectedSegmentIndex}
+                onSelectSegment={handleSelectSegment}
+              />
+            </Animated.View>
+          )}
+        </>
+      ) : (
+        <View sx={{ paddingTop: 12 }}>
+          <TokenPriceChart
+            marketToken={token}
+            width={screenWidth}
+            hideHeader
+            range={chartRange}
+            onRangeChange={handleChartRangeChange}
+            externalIsActive={chartIsActive}
+            externalActiveIndex={chartActiveIndex}
+            externalCrosshairX={chartCrosshairX}
+          />
+        </View>
       )}
       <View sx={styles.aboutContainer}>
         {tokenInfo?.description && (
@@ -534,15 +613,15 @@ const TrackTokenDetailScreen = (): JSX.Element => {
   )
 }
 
-const SEGMENT_INDEX_MAP: Record<number, number> = {
+// Legacy chart fallback: kept while the `price-chart` flag is OFF.
+const LEGACY_SEGMENT_INDEX_TO_DAYS: Record<number, number> = {
   0: 1, // 24H
   1: 7, // 1W
   2: 30, // 1M
   3: 90, // 3M
   4: 365 // 1Y
 }
-
-const SEGMENT_ITEMS = [
+const LEGACY_SEGMENT_ITEMS = [
   { title: '24H' },
   { title: '1W' },
   { title: '1M' },

--- a/packages/k2-alpine/src/components/Chart/PriceChart/ChartFooter.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/ChartFooter.tsx
@@ -1,9 +1,11 @@
-import React, { FC, useMemo } from 'react'
+import React, { FC, useEffect, useMemo } from 'react'
 import { View } from 'react-native'
 import Animated, {
   Easing,
   SharedValue,
+  useAnimatedReaction,
   useAnimatedStyle,
+  useSharedValue,
   withTiming
 } from 'react-native-reanimated'
 import { Text } from '../../Primitives'
@@ -52,26 +54,43 @@ export const ChartFooter: FC<Props> = ({
     return latest ? formatLastUpdate(latest.ts) : ''
   }, [candles])
 
-  // Smoothly cross-fade between "Last update: …" and the active-volume label
-  // when the crosshair toggles. In line/area mode (no volume), the idle text
-  // still fades out on crosshair-active so the chart stays uncluttered while
-  // the user is reading prices.
-  const idleStyle = useAnimatedStyle(() => ({
-    opacity: withTiming(isActive.value ? 0 : 1, {
+  // Opacity lives in its own SharedValue driven by reactions on `isActive` /
+  // `showVolume`, so the per-frame `translateX` in `activeStyle` doesn't
+  // restart the `withTiming` opacity animation every crosshair frame.
+  const idleOpacity = useSharedValue(1)
+  const activeOpacity = useSharedValue(0)
+  useAnimatedReaction(
+    () => isActive.value,
+    active => {
+      idleOpacity.value = withTiming(active ? 0 : 1, {
+        duration: FADE_DURATION,
+        easing: Easing.out(Easing.quad)
+      })
+      activeOpacity.value = withTiming(showVolume && active ? 1 : 0, {
+        duration: FADE_DURATION,
+        easing: Easing.out(Easing.quad)
+      })
+    },
+    [showVolume]
+  )
+  // `useAnimatedReaction` re-registers on dep change but doesn't auto-fire,
+  // so push `showVolume` flips through an effect.
+  useEffect(() => {
+    const active = isActive.value
+    activeOpacity.value = withTiming(showVolume && active ? 1 : 0, {
       duration: FADE_DURATION,
       easing: Easing.out(Easing.quad)
     })
-  }))
+  }, [showVolume, isActive, activeOpacity])
+
+  const idleStyle = useAnimatedStyle(() => ({ opacity: idleOpacity.value }))
   const activeStyle = useAnimatedStyle(() => {
     const target = x.value - VOLUME_WIDTH / 2
     const min = EDGE_PADDING
     const max = width - VOLUME_WIDTH - EDGE_PADDING
     const clamped = Math.max(min, Math.min(max, target))
     return {
-      opacity: withTiming(showVolume && isActive.value ? 1 : 0, {
-        duration: FADE_DURATION,
-        easing: Easing.out(Easing.quad)
-      }),
+      opacity: activeOpacity.value,
       transform: [{ translateX: clamped }]
     }
   })

--- a/packages/k2-alpine/src/components/Chart/PriceChart/ChartFooter.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/ChartFooter.tsx
@@ -1,8 +1,10 @@
 import React, { FC, useMemo } from 'react'
 import { View } from 'react-native'
 import Animated, {
+  Easing,
   SharedValue,
-  useAnimatedStyle
+  useAnimatedStyle,
+  withTiming
 } from 'react-native-reanimated'
 import { Text } from '../../Primitives'
 import {
@@ -27,6 +29,7 @@ type Props = {
 
 const VOLUME_WIDTH = 140
 const EDGE_PADDING = 8
+const FADE_DURATION = 180
 
 export const ChartFooter: FC<Props> = ({
   candles,
@@ -49,8 +52,15 @@ export const ChartFooter: FC<Props> = ({
     return latest ? formatLastUpdate(latest.ts) : ''
   }, [candles])
 
+  // Smoothly cross-fade between "Last update: …" and the active-volume label
+  // when the crosshair toggles. In line/area mode (no volume), the idle text
+  // still fades out on crosshair-active so the chart stays uncluttered while
+  // the user is reading prices.
   const idleStyle = useAnimatedStyle(() => ({
-    opacity: showVolume && isActive.value ? 0 : 1
+    opacity: withTiming(isActive.value ? 0 : 1, {
+      duration: FADE_DURATION,
+      easing: Easing.out(Easing.quad)
+    })
   }))
   const activeStyle = useAnimatedStyle(() => {
     const target = x.value - VOLUME_WIDTH / 2
@@ -58,7 +68,10 @@ export const ChartFooter: FC<Props> = ({
     const max = width - VOLUME_WIDTH - EDGE_PADDING
     const clamped = Math.max(min, Math.min(max, target))
     return {
-      opacity: showVolume && isActive.value ? 1 : 0,
+      opacity: withTiming(showVolume && isActive.value ? 1 : 0, {
+        duration: FADE_DURATION,
+        easing: Easing.out(Easing.quad)
+      }),
       transform: [{ translateX: clamped }]
     }
   })

--- a/packages/k2-alpine/src/components/Chart/PriceChart/ChartHeader.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/ChartHeader.tsx
@@ -161,7 +161,10 @@ type Props = {
 const defaultFormatPrice = (amount: number): string =>
   `$${(Number.isFinite(amount) ? amount : 0).toFixed(2)}`
 
-const UNKNOWN_PRICE_TEXT = '–'
+// Reuse `formatPrice` so the currency symbol matches the rest of the header
+// (e.g. "$–", "€–", "£–"). Strip digits, dots and commas, leave the symbol.
+const formatUnknownPrice = (formatPrice: (amount: number) => string): string =>
+  formatPrice(0).replace(/[\d.,]+/g, '–')
 
 const SKELETON_WIDTH = 160
 const SKELETON_HEIGHT = 62
@@ -225,7 +228,7 @@ export const ChartHeader: FC<Props> = memo(
       active?.priceText ??
       idlePriceText ??
       lastCandle?.priceText ??
-      UNKNOWN_PRICE_TEXT
+      formatUnknownPrice(formatPrice)
     const subtitleText = active ? active.timeText : `Current price of ${symbol}`
     const indicator = active
       ? {

--- a/packages/k2-alpine/src/components/Chart/PriceChart/ChartHeader.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/ChartHeader.tsx
@@ -304,6 +304,7 @@ export const ChartHeader: FC<Props> = memo(
                   textVariant="buttonSmall"
                   percentSx={{ fontSize: 14, lineHeight: 18 }}
                   priceSx={{ fontSize: 14, lineHeight: 18 }}
+                  animated={active === undefined}
                 />
               ) : (
                 <Text variant="buttonSmall" sx={{ color: '$textSecondary' }}>

--- a/packages/k2-alpine/src/components/Chart/PriceChart/PriceChart.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/PriceChart.tsx
@@ -71,9 +71,8 @@ const renderPlaceholderState = ({
   width: number
   height: number
 }): React.ReactElement | null => {
-  // 'loading' and 'empty' fall through so the gridlines stay mounted under
-  // the spinner / "no data" overlay — avoids a layout swap mid-fade and
-  // gives users something to look at while waiting.
+  // `loading` and `empty` fall through to keep gridlines mounted under
+  // the spinner / overlay; only `error` swaps the layout.
   if (state === 'error') {
     return (
       <View
@@ -118,8 +117,6 @@ export const PriceChart: FC<Props> = ({
   const chartInset = mode === 'line' ? 0 : CHART_INSET
   const innerWidth = Math.max(0, width - 2 * chartInset)
   const slotWidth = candles.length > 0 ? innerWidth / candles.length : 0
-  // Cap the body width so sparse data (e.g. only a handful of candles in
-  // view) doesn't render as fat blocks.
   const bodyWidth = Math.min(
     slotWidth * CANDLE_BODY_WIDTH_RATIO,
     CANDLE_BODY_MAX_WIDTH
@@ -158,13 +155,11 @@ export const PriceChart: FC<Props> = ({
   const touchStartY = useSharedValue(0)
   const hasDecided = useSharedValue(false)
 
-  const chartContentOpacity = useSharedValue(0)
+  const chartContentOpacity = useSharedValue(1)
   useEffect(() => {
-    // Loading + empty both keep the layout mounted at full opacity so the
-    // gridlines stay visible behind the spinner / "no data" overlay — gives
-    // the user something to anchor on while a fetch is in flight or there's
-    // no data to draw. isFetching dims to 0.4 during a placeholder refetch
-    // so the previous range's chart visibly stales.
+    // Stay at full opacity while loading/empty so the gridlines remain
+    // visible behind the spinner / "no data" overlay. `isFetching` dims to
+    // 0.4 to visibly stale the previous range during a placeholder refetch.
     let target: number
     if (isFetching) target = 0.4
     else target = 1
@@ -191,10 +186,8 @@ export const PriceChart: FC<Props> = ({
 
   const hasCandles = candles.length > 0
 
-  // Shared between the gridline path and the y-axis labels so each label
-  // stays locked to its dashed line (including the edge-clamping below).
-  // When there are no candles, fall back to evenly-spaced placeholder
-  // positions so the empty-state grid still has structure.
+  // When `candles` is empty, evenly-spaced placeholder positions keep the
+  // empty-state grid intact (real labels are gated behind `hasCandles`).
   const tickPositions = useMemo(() => {
     if (!hasCandles) {
       const count = 3

--- a/packages/k2-alpine/src/components/Chart/PriceChart/PriceChart.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/PriceChart.tsx
@@ -64,35 +64,25 @@ type Props = {
 
 const renderPlaceholderState = ({
   state,
-  candles,
   width,
   height
 }: {
   state: ChartState
-  candles: OhlcCandle[]
   width: number
   height: number
 }): React.ReactElement | null => {
-  const containerStyle = {
-    width,
-    height,
-    justifyContent: 'center' as const,
-    alignItems: 'center' as const
-  }
-  // 'loading' falls through so the main layout stays mounted under the
-  // spinner overlay — avoids a layout swap mid-fade.
-  if (state === 'empty' && candles.length === 0) {
-    return (
-      <View style={containerStyle}>
-        <Text variant="caption" sx={{ color: '$textSecondary' }}>
-          No data for this range
-        </Text>
-      </View>
-    )
-  }
+  // 'loading' and 'empty' fall through so the gridlines stay mounted under
+  // the spinner / "no data" overlay — avoids a layout swap mid-fade and
+  // gives users something to look at while waiting.
   if (state === 'error') {
     return (
-      <View style={containerStyle}>
+      <View
+        style={{
+          width,
+          height,
+          justifyContent: 'center',
+          alignItems: 'center'
+        }}>
         <Text variant="caption" sx={{ color: '$textSecondary' }}>
           Couldn't load chart data
         </Text>
@@ -170,15 +160,19 @@ export const PriceChart: FC<Props> = ({
 
   const chartContentOpacity = useSharedValue(0)
   useEffect(() => {
+    // Loading + empty both keep the layout mounted at full opacity so the
+    // gridlines stay visible behind the spinner / "no data" overlay — gives
+    // the user something to anchor on while a fetch is in flight or there's
+    // no data to draw. isFetching dims to 0.4 during a placeholder refetch
+    // so the previous range's chart visibly stales.
     let target: number
-    if (state !== 'loaded') target = 0
-    else if (isFetching) target = 0.4
+    if (isFetching) target = 0.4
     else target = 1
     chartContentOpacity.value = withTiming(target, {
-      duration: target === 0 ? 120 : 250,
+      duration: 250,
       easing: Easing.out(Easing.quad)
     })
-  }, [state, isFetching, chartContentOpacity])
+  }, [isFetching, chartContentOpacity])
   const chartContentStyle = useAnimatedStyle(() => ({
     opacity: chartContentOpacity.value
   }))
@@ -195,9 +189,21 @@ export const PriceChart: FC<Props> = ({
     opacity: spinnerOpacity.value
   }))
 
+  const hasCandles = candles.length > 0
+
   // Shared between the gridline path and the y-axis labels so each label
   // stays locked to its dashed line (including the edge-clamping below).
+  // When there are no candles, fall back to evenly-spaced placeholder
+  // positions so the empty-state grid still has structure.
   const tickPositions = useMemo(() => {
+    if (!hasCandles) {
+      const count = 3
+      return Array.from({ length: count + 1 }, (_, i) => {
+        const rawY = (i / count) * priceAreaH
+        const clamped = Math.max(2, Math.min(priceAreaH - 3, rawY))
+        return { price: 0, y: clamped + priceTopPadding }
+      })
+    }
     const prices = yAxisTicks(minPrice, maxPrice, 3)
     return prices.map(price => {
       const rawY = priceToY({
@@ -210,7 +216,7 @@ export const PriceChart: FC<Props> = ({
       const clamped = Math.max(2, Math.min(priceAreaH - 3, rawY))
       return { price, y: clamped + priceTopPadding }
     })
-  }, [priceAreaH, minPrice, maxPrice, priceTopPadding])
+  }, [hasCandles, priceAreaH, minPrice, maxPrice, priceTopPadding])
 
   const gridPath = useMemo(() => {
     const p = Skia.Path.Make()
@@ -432,11 +438,12 @@ export const PriceChart: FC<Props> = ({
 
   const placeholder = renderPlaceholderState({
     state,
-    candles,
     width,
     height
   })
   if (placeholder) return placeholder
+
+  const isEmpty = state === 'empty' && !hasCandles
 
   return (
     <GestureDetector gesture={gesture}>
@@ -475,13 +482,15 @@ export const PriceChart: FC<Props> = ({
                   downColor={redColor}
                 />
               </Group>
-              <YAxisLabels
-                isActive={isActive}
-                ticks={tickPositions}
-                font={labelFont}
-                color={theme.colors.$textPrimary ?? '#000'}
-                formatPrice={formatPrice}
-              />
+              {hasCandles && (
+                <YAxisLabels
+                  isActive={isActive}
+                  ticks={tickPositions}
+                  font={labelFont}
+                  color={theme.colors.$textPrimary ?? '#000'}
+                  formatPrice={formatPrice}
+                />
+              )}
             </Canvas>
           </View>
           {showVolume && (
@@ -539,6 +548,23 @@ export const PriceChart: FC<Props> = ({
           ]}>
           <ActivityIndicator />
         </Animated.View>
+        {isEmpty && (
+          <View
+            pointerEvents="none"
+            style={{
+              position: 'absolute',
+              top: priceTopPadding,
+              left: 0,
+              right: 0,
+              height: priceAreaH,
+              justifyContent: 'center',
+              alignItems: 'center'
+            }}>
+            <Text variant="caption" sx={{ color: '$textSecondary' }}>
+              No data for this range
+            </Text>
+          </View>
+        )}
       </View>
     </GestureDetector>
   )

--- a/packages/k2-alpine/src/components/Chart/PriceChart/PriceChart.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/PriceChart.tsx
@@ -530,10 +530,10 @@ export const PriceChart: FC<Props> = ({
           style={[
             {
               position: 'absolute',
-              top: 0,
+              top: priceTopPadding,
               left: 0,
               right: 0,
-              bottom: 0,
+              height: priceAreaH,
               justifyContent: 'center',
               alignItems: 'center'
             },

--- a/packages/k2-alpine/src/components/Chart/PriceChart/PriceChart.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/PriceChart.tsx
@@ -22,6 +22,7 @@ import { colors as baseColors } from '../../../theme/tokens/colors'
 import { Text } from '../../Primitives'
 import { ChartFooter } from './ChartFooter'
 import {
+  CANDLE_BODY_MAX_WIDTH,
   CANDLE_BODY_WIDTH_RATIO,
   CHART_FOOTER_HEIGHT,
   CHART_INSET,
@@ -127,7 +128,12 @@ export const PriceChart: FC<Props> = ({
   const chartInset = mode === 'line' ? 0 : CHART_INSET
   const innerWidth = Math.max(0, width - 2 * chartInset)
   const slotWidth = candles.length > 0 ? innerWidth / candles.length : 0
-  const bodyWidth = slotWidth * CANDLE_BODY_WIDTH_RATIO
+  // Cap the body width so sparse data (e.g. only a handful of candles in
+  // view) doesn't render as fat blocks.
+  const bodyWidth = Math.min(
+    slotWidth * CANDLE_BODY_WIDTH_RATIO,
+    CANDLE_BODY_MAX_WIDTH
+  )
 
   const hasVolumeData = useMemo(
     () => candles.some(c => c.volume != null),

--- a/packages/k2-alpine/src/components/Chart/PriceChart/constants.ts
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/constants.ts
@@ -8,6 +8,7 @@ export const CHART_FOOTER_HEIGHT = 24
 export const PRICE_TOP_PADDING = 14
 
 export const CANDLE_BODY_WIDTH_RATIO = 0.6
+export const CANDLE_BODY_MAX_WIDTH = 8
 
 export const DURATIONS = {
   headerPress: 200,

--- a/packages/k2-alpine/src/components/PriceChangeIndicator/PriceChangeIndicator.tsx
+++ b/packages/k2-alpine/src/components/PriceChangeIndicator/PriceChangeIndicator.tsx
@@ -131,9 +131,11 @@ const AnimatedComponent = ({
       )}
       <View style={styles.innerWrapper}>
         {showArrow && (
-          <AnimateFadeScale>
-            <Arrow sx={arrowSx} status={status} size={arrowSize} />
-          </AnimateFadeScale>
+          <View style={styles.arrow}>
+            <AnimateFadeScale>
+              <Arrow sx={arrowSx} status={status} size={arrowSize} />
+            </AnimateFadeScale>
+          </View>
         )}
         {formattedPercent !== undefined && (
           <AnimatedText

--- a/packages/k2-alpine/src/components/PriceChangeIndicator/PriceChangeIndicator.tsx
+++ b/packages/k2-alpine/src/components/PriceChangeIndicator/PriceChangeIndicator.tsx
@@ -61,7 +61,7 @@ export const PriceChangeIndicator = ({
     ? `${signIndicator ?? signIndicatorText}${formattedPrice}`
     : undefined
 
-  const arrowSx = getArrowMargin(textVariant, status, formattedPercent)
+  const arrowSx = getArrowMargin(textVariant, formattedPercent)
 
   const arrowSize = textVariant === 'priceChangeIndicatorLarge' ? 20 : ICON_SIZE
 
@@ -259,19 +259,12 @@ const styles = StyleSheet.create({
 
 type TextVariants = 'buttonMedium' | 'buttonSmall' | 'priceChangeIndicatorLarge'
 
-function getArrowMarginBottom(
-  textVariant: TextVariants,
-  status: PriceChangeStatus
-): number {
-  if (textVariant === 'priceChangeIndicatorLarge') {
-    return 4
-  }
-
-  return textVariant === 'buttonMedium'
-    ? status === PriceChangeStatus.Up
-      ? 3
-      : 5
-    : 1
+function getArrowMarginBottom(textVariant: TextVariants): number {
+  // The `buttonMedium` / `buttonSmall` margins were a flex-end hack for an
+  // earlier layout; now that the arrow's wrapper uses `alignSelf: 'center'`,
+  // it lines up with the text glyphs on its own. The large variant still
+  // needs a small nudge to sit on its own baseline.
+  return textVariant === 'priceChangeIndicatorLarge' ? 4 : 0
 }
 
 function getArrowMarginLeft(
@@ -291,11 +284,10 @@ function getArrowMarginRight(textVariant: TextVariants): number {
 
 function getArrowMargin(
   textVariant: TextVariants,
-  status: PriceChangeStatus,
   formattedPercent: string | undefined
 ): SxProp {
   return {
-    marginBottom: getArrowMarginBottom(textVariant, status),
+    marginBottom: getArrowMarginBottom(textVariant),
     marginLeft: getArrowMarginLeft(textVariant, formattedPercent),
     marginRight: getArrowMarginRight(textVariant)
   }


### PR DESCRIPTION
## Description

**Ticket: [CP-14309](https://ava-labs.atlassian.net/browse/CP-14309)**

Track's token detail screen adopts the new `TokenPriceChart` (built in CP-14265) behind the `PRICE_CHART` PostHog flag. Flag OFF keeps the legacy `TokenDetailChart` + `SegmentedControl`. Track's existing `TokenHeader` is preserved (rank badge, range-relative delta) and the chart runs in headless mode beneath it — the chart's crosshair `SharedValue`s are lifted up to the screen so the existing `SelectedChartDataIndicator` cross-fade keeps working.

While I was in the chart code I also addressed a few polish items that came up during testing:

- **Portfolio chart indicator now updates per range** instead of always showing 24h. `ChartHeader` falls back to the candle-derived range-relative delta when `priceChange` isn't passed in — matches Track's behavior.
- **Indicator animates on range change** via `PriceChangeIndicator`'s `animated` mode (per-character `AnimatedText`). Gated on idle (`active === undefined`) so high-frequency crosshair scrubbing stays snappy with the plain renderer.
- **Fixed arrow vertical alignment** in `PriceChangeIndicator`'s animated branch — the plain branch wrapped the arrow in `<View style={{alignSelf:'center'}}>` but the animated branch didn't, so the arrow dropped to baseline. Animated now mirrors plain.
- **1D switched to CoinGecko range endpoint** (5-min granularity, 24h window) → 48 candles. 1M / 3M bumped to 60 candles.
- **Cap candle body width at 8px** so ranges with sparse data don't render as fat blocks.
- **Footer "Last update" / volume label cross-fade** softened with `withTiming` (180ms ease-out-quad). Idle text now also fades out on crosshair-active in line/area mode (not just candle mode).

No dependencies introduced. No breaking changes — Portfolio's range-relative delta is contained to the chart's own header; the 24h flows via `useTokenPriceDisplay` (used by `MarketListItem`, `TrendingTokenListItem`, etc.) are untouched.

## Screenshots/Videos

https://github.com/user-attachments/assets/803117ba-ee1f-4d99-a245-8a47c53391f5


## Testing

iOS - 8609
Android - [8610](https://app.bitrise.io/app/7d7ca5af7066e290/installable-artifacts/54067a5f93152023/public-install-page/1bc7402609c9960924bff7281751a639)

**Dev Testing**

- Track → tap any token → switch through 1D / 1W / 1M / 3M / 1Y. `TokenHeader`'s delta and the chart update per range. Scrub the chart → `SelectedChartDataIndicator` overlays, header fades out and back.
- Portfolio → tap any token with a balance → same range sweep. The indicator under the price should animate per character on range change. Scrub → indicator switches to the candle at the crosshair (plain, instant).
- Toggle `PRICE_CHART` flag OFF in PostHog → Track falls back to legacy `TokenDetailChart` + `SegmentedControl`. Toggle ON → new chart returns.

**QA Testing**

- Verify the chart indicator on Portfolio token detail updates whenever the user picks a different range (1D / 1W / 1M / 3M / 1Y) and animates smoothly.
- Verify the same range-relative update on Track token detail's `TokenHeader`.
- Verify the indicator's up/down arrow is vertically centered with the price/percent text on both screens.
- Verify crosshair scrubbing on both screens shows the right per-candle values and doesn't lag.
- Verify the legacy chart shows correctly when `PRICE_CHART` flag is OFF on Track.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14309]: https://ava-labs.atlassian.net/browse/CP-14309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ