### PR TITLE
CP-13856, CP-13858: align notification date column and allow 2-line subtitle

### DIFF
--- a/packages/core-mobile/app/new/features/notifications/components/NotificationListItem.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/NotificationListItem.tsx
@@ -77,7 +77,7 @@ const NotificationListItem: FC<NotificationListItemProps> = ({
                 sx={{
                   color: colors.$textSecondary
                 }}
-                numberOfLines={1}
+                numberOfLines={2}
                 ellipsizeMode="tail">
                 {subtitle}
               </Text>
@@ -104,8 +104,12 @@ const NotificationListItem: FC<NotificationListItemProps> = ({
                 : getDayString(timestamp, 'short')}
             </Text>
           )}
-          {accessoryType === 'chevron' && (
+          {accessoryType === 'chevron' ? (
             <Icons.Navigation.ChevronRightV2 color={colors.$textPrimary} />
+          ) : (
+            // Reserve chevron's 6px slot so the timestamp column aligns
+            // whether the row has a chevron or not.
+            <View style={{ width: 6 }} />
           )}
         </View>
       </View>


### PR DESCRIPTION
## Bitrise
iOS: 8641
Android: 8642

## Description

**Ticket: [CP-13856]** **Ticket: [CP-13858]**

Please provide:

- Reserve the chevron's 6px slot when accessoryType is 'none' so the timestamp column stays in the same horizontal position across rows that do and don't navigate (CP-13856).
- Allow the string subtitle to wrap to 2 lines so longer Core self-promo notification bodies are legible instead of truncating mid-thought (CP-13858).

## Screenshots/Videos
<img width="1320" height="2868" alt="IMG_2423" src="https://github.com/user-attachments/assets/bfb9451d-c6f0-4d6b-a9e6-cd076a974b60" />


## Testing

**Dev Testing (if applicable)**

- Provide steps to test the happy path of your feature
- Provide steps to test edge cases and error states
- Trigger a build on bitrise and reference it here
- Move the ticket into the "Testing" column on Jira

**QA Testing (if applicable)**

- Provide instructions for QA to test this feature thoroughly
- State expected behavior / acceptance criteria

## Checklist

Please check all that apply (if applicable)

- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-13856]: https://ava-labs.atlassian.net/browse/CP-13856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-13858]: https://ava-labs.atlassian.net/browse/CP-13858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ