### PR TITLE
CP-14184: add stake v2 search modal

### DIFF
--- a/packages/core-mobile/app/new/features/stake/v2/components/StakeCardList.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/components/StakeCardList.tsx
@@ -15,7 +15,6 @@ import {
   getListItemExitingAnimation
 } from 'common/utils/animations'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
-import { format, fromUnixTime } from 'date-fns'
 import { useRouter } from 'expo-router'
 import { useAvaxPrice } from 'features/portfolio/hooks/useAvaxPrice'
 import { useStakes } from 'hooks/earn/useStakes'
@@ -38,6 +37,7 @@ import { truncateNodeId } from 'utils/Utils'
 import { useAddStake } from '../../hooks/useAddStake'
 import { useStakeFilterAndSort } from '../../hooks/useStakeFilterAndSort'
 import { getActiveStakeProgress, getStakedAmount } from '../../utils'
+import { ensureCurrencySuffix, formatEndDate } from '../utils/cardFormat'
 import { getStakeTitle } from '../utils'
 import { BASE_CARD_HEIGHT, StakeCard } from './StakeCard'
 
@@ -294,18 +294,3 @@ enum StaticCard {
 }
 type StakeCardType = StaticCard | PChainTransaction
 const CARD_WIDTH = Math.floor((SCREEN_WIDTH - 16 * 2 - GRID_GAP) / 2)
-
-/**
- * `formatTokenInCurrency` only emits a trailing currency code for currencies
- * whose symbol equals the ISO code (e.g. CHF, NOK). For currencies like USD
- * the result is just "$327.64" with no suffix. The V2 stake card design wants
- * an explicit suffix in every case ("$327.64 USD"), so append the code unless
- * it's already there to avoid duplicates like "327.64 CHF CHF".
- */
-const ensureCurrencySuffix = (formatted: string, currency: string): string =>
-  formatted.endsWith(currency) ? formatted : `${formatted} ${currency}`
-
-const formatEndDate = (endTimestamp?: number): string => {
-  if (!endTimestamp) return '—'
-  return format(fromUnixTime(endTimestamp), 'MM/dd/yyyy')
-}

--- a/packages/core-mobile/app/new/features/stake/v2/components/StakeCardList.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/components/StakeCardList.tsx
@@ -9,14 +9,11 @@ import {
 import { useIsFocused } from '@react-navigation/native'
 import { FlashList, ListRenderItemInfo } from '@shopify/flash-list'
 import { LoadingState } from 'common/components/LoadingState'
-import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import {
   getListItemEnteringAnimation,
   getListItemExitingAnimation
 } from 'common/utils/animations'
-import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { useRouter } from 'expo-router'
-import { useAvaxPrice } from 'features/portfolio/hooks/useAvaxPrice'
 import { useStakes } from 'hooks/earn/useStakes'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
@@ -28,18 +25,10 @@ import {
   ViewStyle
 } from 'react-native'
 import Animated from 'react-native-reanimated'
-import { useSelector } from 'react-redux'
-import NetworkService from 'services/network/NetworkService'
-import { selectIsDeveloperMode } from 'store/settings/advanced'
-import { selectSelectedCurrency } from 'store/settings/currency'
-import { isCompleted, isOnGoing } from 'utils/earn/status'
-import { truncateNodeId } from 'utils/Utils'
 import { useAddStake } from '../../hooks/useAddStake'
 import { useStakeFilterAndSort } from '../../hooks/useStakeFilterAndSort'
-import { getActiveStakeProgress, getStakedAmount } from '../../utils'
-import { ensureCurrencySuffix, formatEndDate } from '../utils/cardFormat'
-import { getStakeTitle } from '../utils'
-import { BASE_CARD_HEIGHT, StakeCard } from './StakeCard'
+import { useStakeCardRenderer } from '../hooks/useStakeCardRenderer'
+import { BASE_CARD_HEIGHT } from './StakeCard'
 
 export interface StakeCardListHeaderProps {
   isEmpty: boolean
@@ -79,13 +68,6 @@ export const StakeCardList = ({
   } = useStakes(selectedSort)
   const stakes = useMemo(() => _data ?? [], [_data])
   const { theme } = useTheme()
-  const isDevMode = useSelector(selectIsDeveloperMode)
-  const { networkToken: pChainNetworkToken } =
-    NetworkService.getAvalancheNetworkP(isDevMode)
-
-  const avaxPrice = useAvaxPrice()
-  const { formatTokenInCurrency } = useFormatCurrency()
-  const selectedCurrency = useSelector(selectSelectedCurrency)
 
   const isEmpty = stakes.length === 0
 
@@ -112,64 +94,17 @@ export const StakeCardList = ({
     [navigate]
   )
 
-  const renderStake = useCallback(
-    (stake: PChainTransaction): JSX.Element | null => {
-      const now = new Date()
-      const stakeIsCompleted = isCompleted(stake, now)
-      const stakeIsActive = isOnGoing(stake, now)
+  // Single time snapshot shared across all cards in this render. We don't
+  // tick this live — users typically don't keep the home screen open long
+  // enough for the small drift in "Locked until" / progress to matter.
+  const now = useMemo(() => new Date(), [])
 
-      if (!stakeIsCompleted && !stakeIsActive) {
-        return null
-      }
-
-      const stakedTokenUnit = getStakedAmount(stake, pChainNetworkToken)
-      const stakedAmount = stakedTokenUnit
-        ? `${stakedTokenUnit.toDisplay({ fixedDp: 2 })} AVAX`
-        : `${UNKNOWN_AMOUNT} AVAX`
-      const stakedUsdValue = stakedTokenUnit
-        ? ensureCurrencySuffix(
-            formatTokenInCurrency({
-              amount: stakedTokenUnit
-                .mul(avaxPrice)
-                .toDisplay({ asNumber: true })
-            }),
-            selectedCurrency
-          )
-        : UNKNOWN_AMOUNT
-
-      return (
-        <StakeCard
-          variant={stakeIsCompleted ? 'completed' : 'active'}
-          title={getStakeTitle({
-            stake,
-            pChainNetworkToken,
-            isActive: stakeIsActive
-          })}
-          stakedAmount={stakedAmount}
-          stakedUsdValue={stakedUsdValue}
-          nodeId={truncateNodeId(stake.nodeId ?? '')}
-          endDate={formatEndDate(stake.endTimestamp)}
-          progress={
-            stakeIsActive ? getActiveStakeProgress(stake, now) : undefined
-          }
-          motion={motion}
-          // 'delegating' and 'validating' badges will be added as follow-up
-          // work; for now every active stake is surfaced as a fast stake.
-          badge={stakeIsActive ? 'fastStake' : undefined}
-          width={CARD_WIDTH}
-          onPress={() => handlePressStake(stake.txHash)}
-        />
-      )
-    },
-    [
-      pChainNetworkToken,
-      avaxPrice,
-      formatTokenInCurrency,
-      handlePressStake,
-      selectedCurrency,
-      motion
-    ]
-  )
+  const renderStake = useStakeCardRenderer({
+    now,
+    motion,
+    width: CARD_WIDTH,
+    onPressStake: handlePressStake
+  })
 
   const renderItem = useCallback(
     ({

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useStakeCardRenderer.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useStakeCardRenderer.tsx
@@ -1,0 +1,112 @@
+import { PChainTransaction } from '@avalabs/glacier-sdk'
+import { Motion } from '@avalabs/k2-alpine'
+import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
+import { useAvaxPrice } from 'features/portfolio/hooks/useAvaxPrice'
+import React, { useCallback, useMemo } from 'react'
+import { useSelector } from 'react-redux'
+import NetworkService from 'services/network/NetworkService'
+import { selectIsDeveloperMode } from 'store/settings/advanced'
+import { selectSelectedCurrency } from 'store/settings/currency'
+import { isCompleted, isOnGoing } from 'utils/earn/status'
+import { truncateNodeId } from 'utils/Utils'
+import { getActiveStakeProgress, getStakedAmount } from '../../utils'
+import { StakeCard } from '../components/StakeCard'
+import { ensureCurrencySuffix, formatEndDate } from '../utils/cardFormat'
+import { getStakeTitle } from '../utils'
+
+export interface UseStakeCardRendererArgs {
+  /** Time snapshot used for status detection and progress calculation. */
+  now: Date
+  /** Optional accelerometer-driven motion for the wave animation. */
+  motion?: Motion
+  /** Pixel width of each card cell. */
+  width: number
+  /** Callback fired when a card is tapped. */
+  onPressStake: (txHash: string) => void
+}
+
+/**
+ * Returns a memoised `(stake) => JSX.Element | null` that renders a single V2
+ * `StakeCard`. Returns `null` for stakes that are neither currently active nor
+ * completed (e.g. pending), so callers should still guard / pre-filter when
+ * the surrounding list (FlashList masonry) needs the cell count to match the
+ * rendered count.
+ *
+ * Shared by the V2 stake home screen (`StakeCardList`) and the stake search
+ * screen (`StakeSearchScreen`) — both surfaces render the same card cell with
+ * the same currency / motion / status plumbing.
+ */
+export const useStakeCardRenderer = ({
+  now,
+  motion,
+  width,
+  onPressStake
+}: UseStakeCardRendererArgs): ((
+  stake: PChainTransaction
+) => JSX.Element | null) => {
+  const isDevMode = useSelector(selectIsDeveloperMode)
+  const pChainNetwork = useMemo(
+    () => NetworkService.getAvalancheNetworkP(isDevMode),
+    [isDevMode]
+  )
+  const { networkToken: pChainNetworkToken } = pChainNetwork
+  const avaxPrice = useAvaxPrice()
+  const { formatTokenInCurrency } = useFormatCurrency()
+  const selectedCurrency = useSelector(selectSelectedCurrency)
+
+  return useCallback(
+    (stake: PChainTransaction): JSX.Element | null => {
+      const stakeIsCompleted = isCompleted(stake, now)
+      const stakeIsActive = isOnGoing(stake, now)
+      if (!stakeIsCompleted && !stakeIsActive) return null
+
+      const stakedTokenUnit = getStakedAmount(stake, pChainNetworkToken)
+      const stakedAmount = stakedTokenUnit
+        ? `${stakedTokenUnit.toDisplay({ fixedDp: 2 })} AVAX`
+        : `${UNKNOWN_AMOUNT} AVAX`
+      const stakedUsdValue = stakedTokenUnit
+        ? ensureCurrencySuffix(
+            formatTokenInCurrency({
+              amount: stakedTokenUnit
+                .mul(avaxPrice)
+                .toDisplay({ asNumber: true })
+            }),
+            selectedCurrency
+          )
+        : UNKNOWN_AMOUNT
+
+      return (
+        <StakeCard
+          variant={stakeIsActive ? 'active' : 'completed'}
+          title={getStakeTitle({
+            stake,
+            pChainNetworkToken,
+            isActive: stakeIsActive
+          })}
+          stakedAmount={stakedAmount}
+          stakedUsdValue={stakedUsdValue}
+          nodeId={truncateNodeId(stake.nodeId ?? '')}
+          endDate={formatEndDate(stake.endTimestamp)}
+          progress={
+            stakeIsActive ? getActiveStakeProgress(stake, now) : undefined
+          }
+          motion={motion}
+          badge={stakeIsActive ? 'fastStake' : undefined}
+          width={width}
+          onPress={() => onPressStake(stake.txHash)}
+        />
+      )
+    },
+    [
+      now,
+      pChainNetworkToken,
+      avaxPrice,
+      formatTokenInCurrency,
+      selectedCurrency,
+      motion,
+      width,
+      onPressStake
+    ]
+  )
+}

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeHomeScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeHomeScreen.tsx
@@ -1,5 +1,7 @@
 import {
+  AnimatedPressable,
   Chip,
+  Icons,
   NavigationTitleHeader,
   ScrollView,
   Text,
@@ -9,6 +11,7 @@ import {
 import { useEffectiveHeaderHeight } from 'common/hooks/useEffectiveHeaderHeight'
 import BlurredBarsContentLayout from 'common/components/BlurredBarsContentLayout'
 import { useFadingHeaderNavigation } from 'common/hooks/useFadingHeaderNavigation'
+import { useRouter } from 'expo-router'
 import React, { useCallback, useMemo, useState } from 'react'
 import { LayoutChangeEvent, LayoutRectangle } from 'react-native'
 import Animated, { useAnimatedStyle } from 'react-native-reanimated'
@@ -25,6 +28,7 @@ export const StakeHomeScreen = (): JSX.Element => {
   const headerHeight = useEffectiveHeaderHeight()
   const tabBarHeight = useBottomTabBarHeight()
   const { theme } = useTheme()
+  const { navigate } = useRouter()
 
   const [headerLayout, setHeaderLayout] = useState<
     LayoutRectangle | undefined
@@ -58,6 +62,10 @@ export const StakeHomeScreen = (): JSX.Element => {
     }
   }, [tabBarHeight, tabHeight])
 
+  const handleSearchPress = useCallback(() => {
+    navigate({ pathname: '/stakeSearch' })
+  }, [navigate])
+
   const renderHeader = useCallback(
     ({ isEmpty, filter }: StakeCardListHeaderProps): JSX.Element => {
       return (
@@ -86,31 +94,75 @@ export const StakeHomeScreen = (): JSX.Element => {
           </Animated.View>
           <Banner />
           {!isEmpty && (
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              sx={{ marginTop: 20 }}
-              contentContainerStyle={{
+            <View
+              sx={{
                 flexDirection: 'row',
-                gap: 8,
-                paddingHorizontal: 16
+                alignItems: 'center',
+                marginTop: 20,
+                paddingRight: 16,
+                gap: 8
               }}>
-              {filter.data[0]?.items.map(item => (
-                <Chip
-                  key={item.id}
-                  size="large"
-                  isSelected={item.id === filter.selected}
-                  onPress={() => filter.onSelected(item.id)}
-                  style={{ minWidth: 40 }}>
-                  {item.title}
-                </Chip>
-              ))}
-            </ScrollView>
+              <View sx={{ flex: 1 }}>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerStyle={{
+                    flexDirection: 'row',
+                    gap: 8,
+                    paddingLeft: 16,
+                    paddingRight: 8
+                  }}>
+                  {filter.data[0]?.items.map(item => (
+                    <Chip
+                      key={item.id}
+                      size="large"
+                      isSelected={item.id === filter.selected}
+                      onPress={() => filter.onSelected(item.id)}
+                      style={{ minWidth: 40 }}>
+                      {item.title}
+                    </Chip>
+                  ))}
+                </ScrollView>
+              </View>
+              <AnimatedPressable
+                onPress={handleSearchPress}
+                accessibilityRole="button"
+                accessibilityLabel="Search stakes"
+                style={{
+                  backgroundColor: theme.colors.$surfaceSecondary,
+                  borderRadius: 1000,
+                  height: 27,
+                  flexDirection: 'row',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  gap: 6,
+                  paddingHorizontal: 12
+                }}>
+                <Icons.Custom.Search
+                  color={theme.colors.$textPrimary}
+                  width={14}
+                  height={14}
+                />
+                <Text
+                  variant="buttonSmall"
+                  sx={{ color: theme.colors.$textSecondary }}>
+                  Search
+                </Text>
+              </AnimatedPressable>
+            </View>
           )}
         </View>
       )
     },
-    [theme.colors.$surfacePrimary, handleHeaderLayout, animatedHeaderStyle]
+    [
+      theme.colors.$surfacePrimary,
+      theme.colors.$surfaceSecondary,
+      theme.colors.$textPrimary,
+      theme.colors.$textSecondary,
+      handleHeaderLayout,
+      animatedHeaderStyle,
+      handleSearchPress
+    ]
   )
 
   return (

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeHomeScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeHomeScreen.tsx
@@ -1,4 +1,5 @@
 import {
+  alpha,
   AnimatedPressable,
   Chip,
   Icons,
@@ -11,6 +12,7 @@ import {
 import { useEffectiveHeaderHeight } from 'common/hooks/useEffectiveHeaderHeight'
 import BlurredBarsContentLayout from 'common/components/BlurredBarsContentLayout'
 import { useFadingHeaderNavigation } from 'common/hooks/useFadingHeaderNavigation'
+import { LinearGradient } from 'expo-linear-gradient'
 import { useRouter } from 'expo-router'
 import React, { useCallback, useMemo, useState } from 'react'
 import { LayoutChangeEvent, LayoutRectangle } from 'react-native'
@@ -22,6 +24,11 @@ import {
   StakeCardListHeaderProps
 } from '../components/StakeCardList'
 import { Banner } from '../components/Banner'
+
+// Width of the right-edge fade overlay on the chip scroll. Matches the
+// pattern used by TradeFilters so trailing chips fade into the screen
+// background instead of butting up against the Search button.
+const CHIP_FADE_WIDTH = 42
 
 export const StakeHomeScreen = (): JSX.Element => {
   const frame = useSafeAreaFrame()
@@ -102,7 +109,7 @@ export const StakeHomeScreen = (): JSX.Element => {
                 paddingRight: 16,
                 gap: 8
               }}>
-              <View sx={{ flex: 1 }}>
+              <View sx={{ flex: 1, overflow: 'hidden' }}>
                 <ScrollView
                   horizontal
                   showsHorizontalScrollIndicator={false}
@@ -110,7 +117,7 @@ export const StakeHomeScreen = (): JSX.Element => {
                     flexDirection: 'row',
                     gap: 8,
                     paddingLeft: 16,
-                    paddingRight: 8
+                    paddingRight: CHIP_FADE_WIDTH
                   }}>
                   {filter.data[0]?.items.map(item => (
                     <Chip
@@ -123,6 +130,22 @@ export const StakeHomeScreen = (): JSX.Element => {
                     </Chip>
                   ))}
                 </ScrollView>
+                <LinearGradient
+                  pointerEvents="none"
+                  style={{
+                    position: 'absolute',
+                    right: 0,
+                    top: 0,
+                    bottom: 0,
+                    width: CHIP_FADE_WIDTH
+                  }}
+                  colors={[
+                    alpha(theme.colors.$surfacePrimary, 0),
+                    theme.colors.$surfacePrimary
+                  ]}
+                  start={{ x: 0, y: 0 }}
+                  end={{ x: 1, y: 0 }}
+                />
               </View>
               <AnimatedPressable
                 onPress={handleSearchPress}

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
@@ -21,11 +21,16 @@ import {
   getListItemExitingAnimation
 } from 'common/utils/animations'
 import { UNKNOWN_AMOUNT } from 'consts/amount'
-import { format, fromUnixTime } from 'date-fns'
 import { useRouter } from 'expo-router'
 import { useAvaxPrice } from 'features/portfolio/hooks/useAvaxPrice'
 import { useStakes } from 'hooks/earn/useStakes'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState
+} from 'react'
 import { AppState, Platform } from 'react-native'
 import Animated from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -38,10 +43,10 @@ import { truncateNodeId } from 'utils/Utils'
 import { STAKE_SORTS } from '../../hooks/useStakeFilterAndSort'
 import { getActiveStakeProgress, getStakedAmount } from '../../utils'
 import { StakeCard } from '../components/StakeCard'
+import { ensureCurrencySuffix, formatEndDate } from '../utils/cardFormat'
 import { getStakeTitle } from '../utils'
-
-const magnifyingGlassIcon = require('../../../../assets/icons/magnifying_glass.png')
-const cactusIcon = require('../../../../assets/icons/cactus.png')
+import magnifyingGlassIcon from '../../../../assets/icons/magnifying_glass.png'
+import cactusIcon from '../../../../assets/icons/cactus.png'
 
 // Match the home screen card width: outer screen padding (16) on each side,
 // minus the GRID_GAP between the two columns, divided by 2.
@@ -63,6 +68,10 @@ export const StakeSearchScreen = (): JSX.Element => {
   const isFocused = useIsFocused()
 
   const [searchText, setSearchText] = useState('')
+  // Defer the filter input so keystrokes feel snappy even when the stake list
+  // is large — React renders the SearchBar with the latest text, then catches
+  // up on `filteredStakes` once the main thread is free.
+  const deferredSearchText = useDeferredValue(searchText)
   const [selectedSort, setSelectedSort] = useState<SortOrder>(SortOrder.DESC)
   const [appState, setAppState] = useState(AppState.currentState)
 
@@ -73,8 +82,11 @@ export const StakeSearchScreen = (): JSX.Element => {
   const motion = useMotion(isMotionActive)
 
   const isDevMode = useSelector(selectIsDeveloperMode)
-  const { networkToken: pChainNetworkToken } =
-    NetworkService.getAvalancheNetworkP(isDevMode)
+  const pChainNetwork = useMemo(
+    () => NetworkService.getAvalancheNetworkP(isDevMode),
+    [isDevMode]
+  )
+  const { networkToken: pChainNetworkToken } = pChainNetwork
   const avaxPrice = useAvaxPrice()
   const { formatTokenInCurrency } = useFormatCurrency()
   const selectedCurrency = useSelector(selectSelectedCurrency)
@@ -82,13 +94,24 @@ export const StakeSearchScreen = (): JSX.Element => {
   const { data: _data } = useStakes(selectedSort)
   const stakes = useMemo(() => _data ?? [], [_data])
 
-  const trimmedQuery = searchText.trim()
+  // Single time snapshot — search results don't need to tick live and FlashList
+  // recycles cells, so reusing one `now` avoids constructing a new Date per
+  // visible card per render.
+  const now = useMemo(() => new Date(), [])
+
+  const trimmedQuery = deferredSearchText.trim()
   const hasQuery = trimmedQuery.length > 0
 
   const filteredStakes = useMemo(() => {
     if (!hasQuery) return []
     const q = trimmedQuery.toLowerCase()
     return stakes.filter(stake => {
+      // Drop stakes that aren't either currently active or completed — the
+      // card renderer can't display them anyway. Filtering here keeps the
+      // FlashList cell count aligned with the rendered count (important for
+      // `masonry` layout).
+      if (!isOnGoing(stake, now) && !isCompleted(stake, now)) return false
+
       const fullNodeId = (stake.nodeId ?? '').toLowerCase()
       const truncated = truncateNodeId(stake.nodeId ?? '').toLowerCase()
       const endDate = formatEndDate(stake.endTimestamp).toLowerCase()
@@ -96,7 +119,7 @@ export const StakeSearchScreen = (): JSX.Element => {
         fullNodeId.includes(q) || truncated.includes(q) || endDate.includes(q)
       )
     })
-  }, [stakes, trimmedQuery, hasQuery])
+  }, [stakes, trimmedQuery, hasQuery, now])
 
   const sortData = useMemo(() => {
     return STAKE_SORTS.map(s => ({
@@ -121,12 +144,10 @@ export const StakeSearchScreen = (): JSX.Element => {
   )
 
   const renderStakeCard = useCallback(
-    (stake: PChainTransaction): JSX.Element | null => {
-      const now = new Date()
-      const stakeIsCompleted = isCompleted(stake, now)
+    (stake: PChainTransaction): JSX.Element => {
+      // `filteredStakes` has already guaranteed every stake here is either
+      // active or completed, so we can branch on `isOnGoing` directly.
       const stakeIsActive = isOnGoing(stake, now)
-
-      if (!stakeIsCompleted && !stakeIsActive) return null
 
       const stakedTokenUnit = getStakedAmount(stake, pChainNetworkToken)
       const stakedAmount = stakedTokenUnit
@@ -145,7 +166,7 @@ export const StakeSearchScreen = (): JSX.Element => {
 
       return (
         <StakeCard
-          variant={stakeIsCompleted ? 'completed' : 'active'}
+          variant={stakeIsActive ? 'active' : 'completed'}
           title={getStakeTitle({
             stake,
             pChainNetworkToken,
@@ -166,6 +187,7 @@ export const StakeSearchScreen = (): JSX.Element => {
       )
     },
     [
+      now,
       pChainNetworkToken,
       avaxPrice,
       formatTokenInCurrency,
@@ -176,12 +198,7 @@ export const StakeSearchScreen = (): JSX.Element => {
   )
 
   const renderItem = useCallback(
-    ({
-      item,
-      index
-    }: ListRenderItemInfo<PChainTransaction>): JSX.Element | null => {
-      const content = renderStakeCard(item)
-      if (!content) return null
+    ({ item, index }: ListRenderItemInfo<PChainTransaction>): JSX.Element => {
       return (
         <Animated.View
           style={{
@@ -190,7 +207,7 @@ export const StakeSearchScreen = (): JSX.Element => {
           }}
           entering={getListItemEnteringAnimation(index)}
           exiting={getListItemExitingAnimation(index)}>
-          {content}
+          {renderStakeCard(item)}
         </Animated.View>
       )
     },
@@ -258,7 +275,6 @@ export const StakeSearchScreen = (): JSX.Element => {
             />
           }
           title={'Find stakes\nby date or node ID'}
-          description=""
         />
       )}
 
@@ -271,7 +287,6 @@ export const StakeSearchScreen = (): JSX.Element => {
           }}
           icon={<Image source={cactusIcon} sx={{ width: 42, height: 42 }} />}
           title="No results found"
-          description=""
         />
       )}
 
@@ -316,12 +331,4 @@ export const StakeSearchScreen = (): JSX.Element => {
       )}
     </View>
   )
-}
-
-const ensureCurrencySuffix = (formatted: string, currency: string): string =>
-  formatted.endsWith(currency) ? formatted : `${formatted} ${currency}`
-
-const formatEndDate = (endTimestamp?: number): string => {
-  if (!endTimestamp) return '—'
-  return format(fromUnixTime(endTimestamp), 'MM/dd/yyyy')
 }

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
@@ -75,10 +75,16 @@ export const StakeSearchScreen = (): JSX.Element => {
 
   const { data: _data } = useStakes(selectedSort)
   const stakes = useMemo(() => _data ?? [], [_data])
+  // Distinguish "no stakes received yet" from "received an empty list" so we
+  // don't flash the cactus "No results found" panel during the initial fetch
+  // or while react-query refetches after a sort change.
+  const hasLoadedStakes = _data !== undefined
 
   // Single time snapshot — search results don't need to tick live and FlashList
   // recycles cells, so reusing one `now` avoids constructing a new Date per
-  // visible card per render.
+  // visible card per render. The trade-off is that a stake whose endTimestamp
+  // elapses while the modal is open keeps its mount-time active/completed
+  // classification; acceptable here because the modal is short-lived.
   const now = useMemo(() => new Date(), [])
 
   const trimmedQuery = deferredSearchText.trim()
@@ -160,9 +166,13 @@ export const StakeSearchScreen = (): JSX.Element => {
     }
   }, [])
 
-  const showZeroState = !hasQuery
-  const showResults = hasQuery && filteredStakes.length > 0
-  const showNoResults = hasQuery && !showResults
+  // While stakes haven't arrived yet keep the zero-state visible — the
+  // "Find stakes by date or node ID" prompt is a benign fallback that avoids
+  // misleading users with "No results found" before any real data is compared.
+  const showZeroState = !hasQuery || !hasLoadedStakes
+  const showResults = hasQuery && hasLoadedStakes && filteredStakes.length > 0
+  const showNoResults =
+    hasQuery && hasLoadedStakes && filteredStakes.length === 0
 
   return (
     <View

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
@@ -1,0 +1,327 @@
+import { PChainTransaction, SortOrder } from '@avalabs/glacier-sdk'
+import {
+  AnimatedPressable,
+  Chip,
+  GRID_GAP,
+  Image,
+  SCREEN_WIDTH,
+  SearchBar,
+  Text,
+  useMotion,
+  useTheme,
+  View
+} from '@avalabs/k2-alpine'
+import { useIsFocused } from '@react-navigation/native'
+import { FlashList, ListRenderItemInfo } from '@shopify/flash-list'
+import { DropdownMenu } from 'common/components/DropdownMenu'
+import { ErrorState } from 'common/components/ErrorState'
+import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
+import {
+  getListItemEnteringAnimation,
+  getListItemExitingAnimation
+} from 'common/utils/animations'
+import { UNKNOWN_AMOUNT } from 'consts/amount'
+import { format, fromUnixTime } from 'date-fns'
+import { useRouter } from 'expo-router'
+import { useAvaxPrice } from 'features/portfolio/hooks/useAvaxPrice'
+import { useStakes } from 'hooks/earn/useStakes'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { AppState, Platform } from 'react-native'
+import Animated from 'react-native-reanimated'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useSelector } from 'react-redux'
+import NetworkService from 'services/network/NetworkService'
+import { selectIsDeveloperMode } from 'store/settings/advanced'
+import { selectSelectedCurrency } from 'store/settings/currency'
+import { isCompleted, isOnGoing } from 'utils/earn/status'
+import { truncateNodeId } from 'utils/Utils'
+import { STAKE_SORTS } from '../../hooks/useStakeFilterAndSort'
+import { getActiveStakeProgress, getStakedAmount } from '../../utils'
+import { StakeCard } from '../components/StakeCard'
+import { getStakeTitle } from '../utils'
+
+const magnifyingGlassIcon = require('../../../../assets/icons/magnifying_glass.png')
+const cactusIcon = require('../../../../assets/icons/cactus.png')
+
+// Match the home screen card width: outer screen padding (16) on each side,
+// minus the GRID_GAP between the two columns, divided by 2.
+const CARD_WIDTH = Math.floor((SCREEN_WIDTH - 16 * 2 - GRID_GAP) / 2)
+
+/**
+ * Modal search screen for stakes. Filters stakes by node ID (full or
+ * truncated form) or by their formatted end date (MM/dd/yyyy). The
+ * filter/sort/render logic intentionally does not reuse the home's
+ * `StakeCardList` because that component bakes in the `AddCard` slot
+ * and the chip filter row, which the search experience does not want.
+ * The card-rendering math is duplicated as a contained block; if it
+ * grows we should hoist it into a shared hook.
+ */
+export const StakeSearchScreen = (): JSX.Element => {
+  const { back, canGoBack, navigate } = useRouter()
+  const { theme } = useTheme()
+  const insets = useSafeAreaInsets()
+  const isFocused = useIsFocused()
+
+  const [searchText, setSearchText] = useState('')
+  const [selectedSort, setSelectedSort] = useState<SortOrder>(SortOrder.DESC)
+  const [appState, setAppState] = useState(AppState.currentState)
+
+  const isMotionActive = useMemo(
+    () => appState === 'active' && isFocused && Platform.OS === 'ios',
+    [appState, isFocused]
+  )
+  const motion = useMotion(isMotionActive)
+
+  const isDevMode = useSelector(selectIsDeveloperMode)
+  const { networkToken: pChainNetworkToken } =
+    NetworkService.getAvalancheNetworkP(isDevMode)
+  const avaxPrice = useAvaxPrice()
+  const { formatTokenInCurrency } = useFormatCurrency()
+  const selectedCurrency = useSelector(selectSelectedCurrency)
+
+  const { data: _data } = useStakes(selectedSort)
+  const stakes = useMemo(() => _data ?? [], [_data])
+
+  const trimmedQuery = searchText.trim()
+  const hasQuery = trimmedQuery.length > 0
+
+  const filteredStakes = useMemo(() => {
+    if (!hasQuery) return []
+    const q = trimmedQuery.toLowerCase()
+    return stakes.filter(stake => {
+      const fullNodeId = (stake.nodeId ?? '').toLowerCase()
+      const truncated = truncateNodeId(stake.nodeId ?? '').toLowerCase()
+      const endDate = formatEndDate(stake.endTimestamp).toLowerCase()
+      return (
+        fullNodeId.includes(q) || truncated.includes(q) || endDate.includes(q)
+      )
+    })
+  }, [stakes, trimmedQuery, hasQuery])
+
+  const sortData = useMemo(() => {
+    return STAKE_SORTS.map(s => ({
+      key: s.key,
+      items: s.items.map(i => ({
+        id: i.id,
+        title: i.title,
+        selected: i.id === selectedSort
+      }))
+    }))
+  }, [selectedSort])
+
+  const handleCancel = useCallback(() => {
+    if (canGoBack()) back()
+  }, [back, canGoBack])
+
+  const handlePressStake = useCallback(
+    (txHash: string) => {
+      navigate({ pathname: '/stakeDetail', params: { txHash } })
+    },
+    [navigate]
+  )
+
+  const renderStakeCard = useCallback(
+    (stake: PChainTransaction): JSX.Element | null => {
+      const now = new Date()
+      const stakeIsCompleted = isCompleted(stake, now)
+      const stakeIsActive = isOnGoing(stake, now)
+
+      if (!stakeIsCompleted && !stakeIsActive) return null
+
+      const stakedTokenUnit = getStakedAmount(stake, pChainNetworkToken)
+      const stakedAmount = stakedTokenUnit
+        ? `${stakedTokenUnit.toDisplay({ fixedDp: 2 })} AVAX`
+        : `${UNKNOWN_AMOUNT} AVAX`
+      const stakedUsdValue = stakedTokenUnit
+        ? ensureCurrencySuffix(
+            formatTokenInCurrency({
+              amount: stakedTokenUnit
+                .mul(avaxPrice)
+                .toDisplay({ asNumber: true })
+            }),
+            selectedCurrency
+          )
+        : UNKNOWN_AMOUNT
+
+      return (
+        <StakeCard
+          variant={stakeIsCompleted ? 'completed' : 'active'}
+          title={getStakeTitle({
+            stake,
+            pChainNetworkToken,
+            isActive: stakeIsActive
+          })}
+          stakedAmount={stakedAmount}
+          stakedUsdValue={stakedUsdValue}
+          nodeId={truncateNodeId(stake.nodeId ?? '')}
+          endDate={formatEndDate(stake.endTimestamp)}
+          progress={
+            stakeIsActive ? getActiveStakeProgress(stake, now) : undefined
+          }
+          motion={motion}
+          badge={stakeIsActive ? 'fastStake' : undefined}
+          width={CARD_WIDTH}
+          onPress={() => handlePressStake(stake.txHash)}
+        />
+      )
+    },
+    [
+      pChainNetworkToken,
+      avaxPrice,
+      formatTokenInCurrency,
+      selectedCurrency,
+      motion,
+      handlePressStake
+    ]
+  )
+
+  const renderItem = useCallback(
+    ({
+      item,
+      index
+    }: ListRenderItemInfo<PChainTransaction>): JSX.Element | null => {
+      const content = renderStakeCard(item)
+      if (!content) return null
+      return (
+        <Animated.View
+          style={{
+            marginBottom: 14,
+            marginHorizontal: GRID_GAP / 2
+          }}
+          entering={getListItemEnteringAnimation(index)}
+          exiting={getListItemExitingAnimation(index)}>
+          {content}
+        </Animated.View>
+      )
+    },
+    [renderStakeCard]
+  )
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', nextAppState => {
+      setAppState(nextAppState)
+    })
+    return () => {
+      subscription.remove()
+    }
+  }, [])
+
+  const showZeroState = !hasQuery
+  const showResults = hasQuery && filteredStakes.length > 0
+  const showNoResults = hasQuery && !showResults
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: theme.colors.$surfacePrimary
+      }}>
+      <View
+        sx={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: 16,
+          paddingHorizontal: 16,
+          paddingTop: 16,
+          paddingBottom: 12
+        }}>
+        <View sx={{ flex: 1 }}>
+          <SearchBar
+            searchText={searchText}
+            onTextChanged={setSearchText}
+            placeholder="Search"
+            autoFocus
+          />
+        </View>
+        <AnimatedPressable
+          accessibilityRole="button"
+          accessibilityLabel="Cancel search"
+          onPress={handleCancel}
+          hitSlop={8}>
+          <Text variant="body1" sx={{ color: '$textPrimary' }}>
+            Cancel
+          </Text>
+        </AnimatedPressable>
+      </View>
+
+      {showZeroState && (
+        <ErrorState
+          sx={{
+            flex: 1,
+            justifyContent: 'flex-start',
+            paddingTop: 96
+          }}
+          icon={
+            <Image
+              source={magnifyingGlassIcon}
+              sx={{ width: 42, height: 42 }}
+            />
+          }
+          title={'Find stakes\nby date or node ID'}
+          description=""
+        />
+      )}
+
+      {showNoResults && (
+        <ErrorState
+          sx={{
+            flex: 1,
+            justifyContent: 'flex-start',
+            paddingTop: 96
+          }}
+          icon={<Image source={cactusIcon} sx={{ width: 42, height: 42 }} />}
+          title="No results found"
+          description=""
+        />
+      )}
+
+      {showResults && (
+        <FlashList
+          data={filteredStakes}
+          numColumns={2}
+          masonry
+          renderItem={renderItem}
+          ListHeaderComponent={
+            <View
+              sx={{
+                paddingHorizontal: GRID_GAP / 2,
+                paddingBottom: 12
+              }}>
+              <DropdownMenu
+                groups={sortData}
+                onPressAction={(event: { nativeEvent: { event: string } }) =>
+                  setSelectedSort(event.nativeEvent.event as SortOrder)
+                }>
+                <Chip
+                  size="large"
+                  hitSlop={8}
+                  rightIcon="expandMore"
+                  style={{ alignSelf: 'flex-start' }}>
+                  Sort
+                </Chip>
+              </DropdownMenu>
+            </View>
+          }
+          showsVerticalScrollIndicator={false}
+          keyExtractor={(item, index) => item.txHash ?? index.toString()}
+          removeClippedSubviews={true}
+          extraData={{ isDark: theme.isDark, motion }}
+          contentContainerStyle={{
+            paddingHorizontal: 16 - GRID_GAP / 2,
+            paddingBottom: insets.bottom + 16
+          }}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
+        />
+      )}
+    </View>
+  )
+}
+
+const ensureCurrencySuffix = (formatted: string, currency: string): string =>
+  formatted.endsWith(currency) ? formatted : `${formatted} ${currency}`
+
+const formatEndDate = (endTimestamp?: number): string => {
+  if (!endTimestamp) return '—'
+  return format(fromUnixTime(endTimestamp), 'MM/dd/yyyy')
+}

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
@@ -45,12 +45,13 @@ const CARD_WIDTH = Math.floor((SCREEN_WIDTH - 16 * 2 - GRID_GAP) / 2)
 
 /**
  * Modal search screen for stakes. Filters stakes by node ID (full or
- * truncated form) or by their formatted end date (MM/dd/yyyy). The
- * filter/sort/render logic intentionally does not reuse the home's
- * `StakeCardList` because that component bakes in the `AddCard` slot
- * and the chip filter row, which the search experience does not want.
- * The card-rendering math is duplicated as a contained block; if it
- * grows we should hoist it into a shared hook.
+ * truncated form) or by their formatted end date (MM/dd/yyyy).
+ *
+ * The screen intentionally doesn't reuse the home's `StakeCardList` — the
+ * search experience has no AddCard slot and no chip filter row — but the
+ * card cell itself is rendered through the shared `useStakeCardRenderer`
+ * hook, so any card-level changes (formatting, motion, status badge, etc.)
+ * automatically propagate to both surfaces.
  */
 export const StakeSearchScreen = (): JSX.Element => {
   const { back, canGoBack, navigate } = useRouter()

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
@@ -15,6 +15,7 @@ import { useIsFocused } from '@react-navigation/native'
 import { FlashList, ListRenderItemInfo } from '@shopify/flash-list'
 import { DropdownMenu } from 'common/components/DropdownMenu'
 import { ErrorState } from 'common/components/ErrorState'
+import Grabber from 'common/components/Grabber'
 import {
   getListItemEnteringAnimation,
   getListItemExitingAnimation
@@ -186,7 +187,14 @@ export const StakeSearchScreen = (): JSX.Element => {
           alignItems: 'center',
           gap: 16,
           paddingHorizontal: 16,
-          paddingTop: 16,
+          // On Android, compensate for the parent modal layout's
+          // `marginTop: -insets.top + 8` (see useModalScreensOptions). Without
+          // this the SearchBar renders above the visible viewport even though
+          // it still accepts input. iOS doesn't apply the negative marginTop
+          // and the pageSheet already insets from the status bar.
+          // Extra +12 leaves a visible gap below the Grabber (which sits at
+          // top: 9 on iOS / top: insets.top - 2 on Android, height 5).
+          paddingTop: Platform.OS === 'android' ? insets.top + 18 : 28,
           paddingBottom: 12
         }}>
         <View sx={{ flex: 1 }}>
@@ -222,6 +230,7 @@ export const StakeSearchScreen = (): JSX.Element => {
             />
           }
           title={'Find stakes\nby date or node ID'}
+          description=""
         />
       )}
 
@@ -234,8 +243,20 @@ export const StakeSearchScreen = (): JSX.Element => {
           }}
           icon={<Image source={cactusIcon} sx={{ width: 42, height: 42 }} />}
           title="No results found"
+          description=""
         />
       )}
+
+      <View
+        style={{
+          position: 'absolute',
+          top: Platform.OS === 'android' ? insets.top - 2 : 9,
+          left: 0,
+          right: 0,
+          zIndex: 1000
+        }}>
+        <Grabber />
+      </View>
 
       {showResults && (
         <FlashList

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
@@ -15,14 +15,11 @@ import { useIsFocused } from '@react-navigation/native'
 import { FlashList, ListRenderItemInfo } from '@shopify/flash-list'
 import { DropdownMenu } from 'common/components/DropdownMenu'
 import { ErrorState } from 'common/components/ErrorState'
-import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import {
   getListItemEnteringAnimation,
   getListItemExitingAnimation
 } from 'common/utils/animations'
-import { UNKNOWN_AMOUNT } from 'consts/amount'
 import { useRouter } from 'expo-router'
-import { useAvaxPrice } from 'features/portfolio/hooks/useAvaxPrice'
 import { useStakes } from 'hooks/earn/useStakes'
 import React, {
   useCallback,
@@ -34,17 +31,11 @@ import React, {
 import { AppState, Platform } from 'react-native'
 import Animated from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { useSelector } from 'react-redux'
-import NetworkService from 'services/network/NetworkService'
-import { selectIsDeveloperMode } from 'store/settings/advanced'
-import { selectSelectedCurrency } from 'store/settings/currency'
 import { isCompleted, isOnGoing } from 'utils/earn/status'
 import { truncateNodeId } from 'utils/Utils'
 import { STAKE_SORTS } from '../../hooks/useStakeFilterAndSort'
-import { getActiveStakeProgress, getStakedAmount } from '../../utils'
-import { StakeCard } from '../components/StakeCard'
-import { ensureCurrencySuffix, formatEndDate } from '../utils/cardFormat'
-import { getStakeTitle } from '../utils'
+import { useStakeCardRenderer } from '../hooks/useStakeCardRenderer'
+import { formatEndDate } from '../utils/cardFormat'
 import magnifyingGlassIcon from '../../../../assets/icons/magnifying_glass.png'
 import cactusIcon from '../../../../assets/icons/cactus.png'
 
@@ -80,16 +71,6 @@ export const StakeSearchScreen = (): JSX.Element => {
     [appState, isFocused]
   )
   const motion = useMotion(isMotionActive)
-
-  const isDevMode = useSelector(selectIsDeveloperMode)
-  const pChainNetwork = useMemo(
-    () => NetworkService.getAvalancheNetworkP(isDevMode),
-    [isDevMode]
-  )
-  const { networkToken: pChainNetworkToken } = pChainNetwork
-  const avaxPrice = useAvaxPrice()
-  const { formatTokenInCurrency } = useFormatCurrency()
-  const selectedCurrency = useSelector(selectSelectedCurrency)
 
   const { data: _data } = useStakes(selectedSort)
   const stakes = useMemo(() => _data ?? [], [_data])
@@ -143,62 +124,17 @@ export const StakeSearchScreen = (): JSX.Element => {
     [navigate]
   )
 
-  const renderStakeCard = useCallback(
-    (stake: PChainTransaction): JSX.Element => {
-      // `filteredStakes` has already guaranteed every stake here is either
-      // active or completed, so we can branch on `isOnGoing` directly.
-      const stakeIsActive = isOnGoing(stake, now)
-
-      const stakedTokenUnit = getStakedAmount(stake, pChainNetworkToken)
-      const stakedAmount = stakedTokenUnit
-        ? `${stakedTokenUnit.toDisplay({ fixedDp: 2 })} AVAX`
-        : `${UNKNOWN_AMOUNT} AVAX`
-      const stakedUsdValue = stakedTokenUnit
-        ? ensureCurrencySuffix(
-            formatTokenInCurrency({
-              amount: stakedTokenUnit
-                .mul(avaxPrice)
-                .toDisplay({ asNumber: true })
-            }),
-            selectedCurrency
-          )
-        : UNKNOWN_AMOUNT
-
-      return (
-        <StakeCard
-          variant={stakeIsActive ? 'active' : 'completed'}
-          title={getStakeTitle({
-            stake,
-            pChainNetworkToken,
-            isActive: stakeIsActive
-          })}
-          stakedAmount={stakedAmount}
-          stakedUsdValue={stakedUsdValue}
-          nodeId={truncateNodeId(stake.nodeId ?? '')}
-          endDate={formatEndDate(stake.endTimestamp)}
-          progress={
-            stakeIsActive ? getActiveStakeProgress(stake, now) : undefined
-          }
-          motion={motion}
-          badge={stakeIsActive ? 'fastStake' : undefined}
-          width={CARD_WIDTH}
-          onPress={() => handlePressStake(stake.txHash)}
-        />
-      )
-    },
-    [
-      now,
-      pChainNetworkToken,
-      avaxPrice,
-      formatTokenInCurrency,
-      selectedCurrency,
-      motion,
-      handlePressStake
-    ]
-  )
+  const renderStakeCard = useStakeCardRenderer({
+    now,
+    motion,
+    width: CARD_WIDTH,
+    onPressStake: handlePressStake
+  })
 
   const renderItem = useCallback(
     ({ item, index }: ListRenderItemInfo<PChainTransaction>): JSX.Element => {
+      // `filteredStakes` has pre-filtered to active/completed only, so the
+      // renderer is guaranteed to return a JSX element (never null) here.
       return (
         <Animated.View
           style={{

--- a/packages/core-mobile/app/new/features/stake/v2/utils/cardFormat.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/utils/cardFormat.ts
@@ -1,0 +1,26 @@
+import { format, fromUnixTime } from 'date-fns'
+
+/**
+ * Append the currency code to a formatted token amount unless it's already
+ * present.
+ *
+ * `formatTokenInCurrency` only emits a trailing currency code for currencies
+ * whose symbol equals the ISO code (e.g. CHF, NOK). For currencies like USD
+ * the result is just "$327.64" with no suffix. The V2 stake card design wants
+ * an explicit suffix in every case ("$327.64 USD"), so append the code unless
+ * it's already there to avoid duplicates like "327.64 CHF CHF".
+ */
+export const ensureCurrencySuffix = (
+  formatted: string,
+  currency: string
+): string =>
+  formatted.endsWith(currency) ? formatted : `${formatted} ${currency}`
+
+/**
+ * Format a stake's `endTimestamp` (Unix seconds) as `MM/dd/yyyy`, or return an
+ * em-dash placeholder when the timestamp is missing.
+ */
+export const formatEndDate = (endTimestamp?: number): string => {
+  if (!endTimestamp) return '—'
+  return format(fromUnixTime(endTimestamp), 'MM/dd/yyyy')
+}

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/stakeSearch/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/stakeSearch/_layout.tsx
@@ -1,0 +1,19 @@
+import { Stack } from 'common/components/Stack'
+import {
+  modalFirstScreenOptions,
+  modalStackNavigatorScreenOptions
+} from 'common/consts/screenOptions'
+import React from 'react'
+
+export default function StakeSearchLayout(): JSX.Element {
+  return (
+    <Stack screenOptions={modalStackNavigatorScreenOptions}>
+      <Stack.Screen
+        name="index"
+        // The screen owns its own SearchBar + Cancel button, so we hide
+        // the native stack header entirely.
+        options={{ ...modalFirstScreenOptions, headerShown: false }}
+      />
+    </Stack>
+  )
+}

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/stakeSearch/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/stakeSearch/index.tsx
@@ -1,0 +1,3 @@
+import { StakeSearchScreen } from 'features/stake/v2/screens/StakeSearchScreen'
+
+export { StakeSearchScreen as default }

--- a/packages/core-mobile/app/new/routes/(signedIn)/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/_layout.tsx
@@ -162,6 +162,10 @@ export default function WalletLayout(): JSX.Element {
             options={stackNavigatorScreenOptions}
           />
           <Stack.Screen
+            name="(modals)/stakeSearch"
+            options={secondaryModalScreensOptions}
+          />
+          <Stack.Screen
             name="(modals)/claimStakeReward"
             options={modalScreensOptions}
           />


### PR DESCRIPTION
## Description

**Ticket: [CP-14184]**

- New stake search modal accessible from the V2 stake home screen. Entry point is a "Search" pill rendered next to the chip filter row (with a fade gradient that masks trailing chips so they don't collide with the button). The modal opens its own screen with a `SearchBar`, a sortable masonry `FlashList` of matching stakes, and dedicated zero-state ("Find stakes by date or node ID") and no-results ("No results found") panels.
- Search matches against three values per stake — the full node ID, the truncated `NodeID...xxxxx` form, and the formatted `MM/dd/yyyy` end date — case-insensitive, with `useDeferredValue` to keep keystrokes snappy when the dataset is large.
- New shared building blocks under `features/stake/v2/`:
  - `hooks/useStakeCardRenderer.tsx` — returns a memoised `(stake) => JSX.Element | null` that handles the currency / motion / status plumbing. Used by both the home screen's `StakeCardList` and the new search screen. The card rendering math previously duplicated between the two surfaces is now defined once.

## Screenshots/Videos
<img width="320" alt="IMG_1554" src="https://github.com/user-attachments/assets/1ffc1c48-10fc-4bcd-ba94-884ddeb30f2a" />

## Testing
iOS: 8649
Android: 8650

1. Enable both `fast-stake-enabled` and `everything` feature flags in PostHog (V2 stake home screen must be active).
2. Go to the **Stake** tab. Verify the new **Search** pill renders to the right of the chip filter row.
3. With stakes present, scroll the chip row horizontally and verify the right edge fades smoothly into the screen background.
4. Tap **Search** — modal should slide in with the SearchBar autofocused (keyboard up).
5. With the SearchBar empty, verify the zero-state ("Find stakes by date or node ID") with the magnifying glass icon is shown.
6. Type a few characters of a known node ID — results should appear in a 2-column masonry layout.
7. Type a partial end date in `MM/dd/yyyy` format (e.g. `2026`, `01/06`) — date-matching stakes should appear.
8. Type a string that matches nothing — verify the no-results panel with the cactus icon is shown.
9. Tap the **Sort** chip and pick a different order — verify the underlying `useStakes` call refetches with the new sort.
10. Tap a result card — should navigate to the V2 stake detail screen with the correct `txHash`.
11. Tap **Cancel** — modal dismisses back to the home screen.
12. Disable `fast-stake-enabled`, navigate to Stake — verify the V1 screen is shown (Search pill should not appear).

## Checklist

- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [X] I have included screenshots / videos of android and ios
- [X] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14184]: https://ava-labs.atlassian.net/browse/CP-14184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ