### PR TITLE
CP-14058: disable Nest Egg feature

### DIFF
--- a/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
+++ b/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
@@ -25,9 +25,10 @@ import {
   selectFusionTransferGasMarginBps
 } from 'store/posthog'
 import { audioFeedback, Audios } from 'utils/AudioFeedback'
-import { swapCompleted } from 'store/nestEgg'
+// Nest Egg disabled (CP-14058) — see swapCompleted dispatch below
+// import { swapCompleted } from 'store/nestEgg'
 import { ServiceType, type GasSettings } from '@avalabs/fusion-sdk'
-import { bigintToBig } from '@avalabs/core-utils-sdk'
+// import { bigintToBig } from '@avalabs/core-utils-sdk' // Nest Egg disabled (CP-14058)
 import type { Quote, Transfer } from '../types'
 import {
   useSwapSelectedFromToken,
@@ -352,36 +353,40 @@ export const SwapContextProvider = ({
         })
       )
 
+      // Nest Egg disabled (CP-14058): feature unused and linked to a blank,
+      // un-dismissable modal on iOS. Commented out (not removed) so it can be
+      // re-enabled later.
+      //
       // Dispatch swapCompleted for Nest Egg qualification tracking.
       // Computed from `transfer.amountIn` (what actually swapped) not
       // the live `amount` state, so if the user changed the input
       // between submit and completion the analytics still reflect
       // reality. bigintToBig preserves precision that Number() would
       // lose on large amounts.
-      const swapTxHash = transfer.source?.txHash
-      if (
-        swapTxHash &&
-        transfer.amountIn &&
-        fromTokenData.priceInCurrency !== undefined &&
-        'decimals' in fromTokenData
-      ) {
-        const fromAmountUsd = bigintToBig(
-          BigInt(transfer.amountIn),
-          fromTokenData.decimals
-        )
-          .times(fromTokenData.priceInCurrency)
-          .toNumber()
-        dispatch(
-          swapCompleted({
-            txHash: swapTxHash,
-            chainId: Number(quote.sourceChain.chainId.split(':')[1]),
-            fromTokenSymbol: fromTokenData.symbol,
-            toTokenSymbol: toTokenData.symbol,
-            fromAmountUsd,
-            toAmountUsd: fromAmountUsd
-          })
-        )
-      }
+      // const swapTxHash = transfer.source?.txHash
+      // if (
+      //   swapTxHash &&
+      //   transfer.amountIn &&
+      //   fromTokenData.priceInCurrency !== undefined &&
+      //   'decimals' in fromTokenData
+      // ) {
+      //   const fromAmountUsd = bigintToBig(
+      //     BigInt(transfer.amountIn),
+      //     fromTokenData.decimals
+      //   )
+      //     .times(fromTokenData.priceInCurrency)
+      //     .toNumber()
+      //   dispatch(
+      //     swapCompleted({
+      //       txHash: swapTxHash,
+      //       chainId: Number(quote.sourceChain.chainId.split(':')[1]),
+      //       fromTokenSymbol: fromTokenData.symbol,
+      //       toTokenSymbol: toTokenData.symbol,
+      //       fromAmountUsd,
+      //       toAmountUsd: fromAmountUsd
+      //     })
+      //   )
+      // }
     },
     [dispatch, setTransfers, isQuickSwapsActive, feeSetting, maxBuy]
   )

--- a/packages/core-mobile/app/new/routes/(signedIn)/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/_layout.tsx
@@ -237,10 +237,13 @@ export default function WalletLayout(): JSX.Element {
             name="(modals)/solanaLaunch"
             options={modalScreensOptions}
           />
-          <Stack.Screen
+          {/* Nest Egg disabled (CP-14058): feature unused and linked to a
+              blank, un-dismissable modal on iOS. Commented out (not removed)
+              so it can be re-enabled later. */}
+          {/* <Stack.Screen
             name="(modals)/nestEggCampaign"
             options={modalScreensOptions}
-          />
+          /> */}
           <Stack.Screen
             name="(modals)/appUpdate"
             options={modalScreensOptions}

--- a/packages/core-mobile/app/store/middleware/listener.ts
+++ b/packages/core-mobile/app/store/middleware/listener.ts
@@ -17,7 +17,8 @@ import { AppAddListener, AppStartListening } from 'store/types'
 import { addCurrencyListeners } from 'store/settings/currency/listeners'
 import { addMeldListeners } from 'store/meld/listeners'
 import { addBranchListeners } from 'store/branch/listener'
-import { addNestEggListeners } from 'store/nestEgg/listeners'
+// Nest Egg disabled (CP-14058) — see addNestEggListeners call below
+// import { addNestEggListeners } from 'store/nestEgg/listeners'
 import { addFusionListeners } from 'new/features/swap/store/listeners'
 
 const listener = createListenerMiddleware({
@@ -61,7 +62,10 @@ addMeldListeners(startListening)
 
 addBranchListeners(startListening)
 
-addNestEggListeners(startListening)
+// Nest Egg disabled (CP-14058): feature unused and linked to a blank,
+// un-dismissable modal on iOS. Commented out (not removed) so it can be
+// re-enabled later.
+// addNestEggListeners(startListening)
 
 addFusionListeners(startListening)
 

--- a/packages/core-mobile/app/store/notifications/listeners/handleAfterLoginFlows.ts
+++ b/packages/core-mobile/app/store/notifications/listeners/handleAfterLoginFlows.ts
@@ -8,17 +8,19 @@ import Config from 'react-native-config'
 import AnalyticsService from 'services/analytics/AnalyticsService'
 import { AppUpdateService } from 'services/AppUpdateService/AppUpdateService'
 import NotificationsService from 'services/notifications/NotificationsService'
-import {
-  selectHasAcknowledgedNestEggQualification,
-  selectHasQualifiedForNestEgg,
-  selectIsUserEligibleForNestEggModal
-} from 'store/nestEgg'
-import { selectIsNewSeedlessUserEligibleForNestEggModal } from 'store/nestEgg/slice'
+// Nest Egg disabled (CP-14058) — see promptNestEggCampaignModalIfNeeded below
+// import {
+//   selectHasAcknowledgedNestEggQualification,
+//   selectHasQualifiedForNestEgg,
+//   selectIsUserEligibleForNestEggModal
+// } from 'store/nestEgg'
+// import { selectIsNewSeedlessUserEligibleForNestEggModal } from 'store/nestEgg/slice'
 import {
   selectIsEnableNotificationPromptBlocked,
-  selectIsNestEggCampaignBlocked,
-  selectIsNestEggEligible,
-  selectIsNestEggNewSeedlessOnly,
+  // Nest Egg disabled (CP-14058)
+  // selectIsNestEggCampaignBlocked,
+  // selectIsNestEggEligible,
+  // selectIsNestEggNewSeedlessOnly,
   selectIsSolanaLaunchModalBlocked,
   selectIsSolanaSupportBlocked
 } from 'store/posthog'
@@ -37,7 +39,10 @@ export const handleAfterLoginFlows = async (
   await promptAppUpdateScreenIfNeeded()
   await promptEnableNotificationsIfNeeded(listenerApi)
   await promptSolanaLaunchModalIfNeeded(listenerApi)
-  await promptNestEggCampaignModalIfNeeded(listenerApi)
+  // Nest Egg disabled (CP-14058): feature unused and linked to a blank,
+  // un-dismissable modal on iOS. Commented out (not removed) so it can be
+  // re-enabled later.
+  // await promptNestEggCampaignModalIfNeeded(listenerApi)
 }
 
 const promptAppUpdateScreenIfNeeded = async (): Promise<void> => {
@@ -169,67 +174,71 @@ const promptSolanaLaunchModalIfNeeded = async (
   }
 }
 
-/**
- * Show Nest Egg campaign modal
- * Only applies to seedless wallets (not mnemonic or keystone)
- *
- * Flag behavior (independent flags):
- * - nest-egg-campaign ON: All seedless users see the modal
- * - nest-egg-new-seedless-only ON: Only new seedless users see the modal
- */
-const promptNestEggCampaignModalIfNeeded = async (
-  listenerApi: AppListenerEffectAPI
-): Promise<void> => {
-  const { getState } = listenerApi
-  const state = getState()
-
-  // Check if campaign is blocked (neither flag is enabled)
-  const isCampaignBlocked = selectIsNestEggCampaignBlocked(state)
-  if (isCampaignBlocked) {
-    return
-  }
-
-  // Only seedless wallets are eligible for the campaign
-  const isEligible = selectIsNestEggEligible(state)
-  if (!isEligible) {
-    return
-  }
-
-  // Check if user has already qualified (completed a swap)
-  const hasQualified = selectHasQualifiedForNestEgg(state)
-  // Check if user has acknowledged qualification
-  const hasAcknowledged = selectHasAcknowledgedNestEggQualification(state)
-
-  // First, check if user qualified but hasn't acknowledged yet
-  // This handles the case where user qualified, app closed, and now opening again
-  if (hasQualified && !hasAcknowledged) {
-    await waitForInteractions()
-
-    await navigateWithPromise('/nestEggCampaign/success')
-    return
-  }
-
-  // Check which flag is enabled (they work independently)
-  const isNewSeedlessOnly = selectIsNestEggNewSeedlessOnly(state)
-
-  if (isNewSeedlessOnly) {
-    // nest-egg-new-seedless-only is ON: only NEW seedless users see the modal
-    const isNewUserEligible =
-      selectIsNewSeedlessUserEligibleForNestEggModal(state)
-
-    if (isNewUserEligible) {
-      await waitForInteractions()
-
-      await navigateWithPromise('/nestEggCampaign')
-    }
-  } else {
-    // nest-egg-campaign is ON: ALL seedless users can see the modal
-    const isUserEligible = selectIsUserEligibleForNestEggModal(state)
-
-    if (isUserEligible) {
-      await waitForInteractions()
-
-      await navigateWithPromise('/nestEggCampaign')
-    }
-  }
-}
+// Nest Egg disabled (CP-14058): feature unused and linked to a blank,
+// un-dismissable modal on iOS. Commented out (not removed) so it can be
+// re-enabled later.
+//
+// /**
+//  * Show Nest Egg campaign modal
+//  * Only applies to seedless wallets (not mnemonic or keystone)
+//  *
+//  * Flag behavior (independent flags):
+//  * - nest-egg-campaign ON: All seedless users see the modal
+//  * - nest-egg-new-seedless-only ON: Only new seedless users see the modal
+//  */
+// const promptNestEggCampaignModalIfNeeded = async (
+//   listenerApi: AppListenerEffectAPI
+// ): Promise<void> => {
+//   const { getState } = listenerApi
+//   const state = getState()
+//
+//   // Check if campaign is blocked (neither flag is enabled)
+//   const isCampaignBlocked = selectIsNestEggCampaignBlocked(state)
+//   if (isCampaignBlocked) {
+//     return
+//   }
+//
+//   // Only seedless wallets are eligible for the campaign
+//   const isEligible = selectIsNestEggEligible(state)
+//   if (!isEligible) {
+//     return
+//   }
+//
+//   // Check if user has already qualified (completed a swap)
+//   const hasQualified = selectHasQualifiedForNestEgg(state)
+//   // Check if user has acknowledged qualification
+//   const hasAcknowledged = selectHasAcknowledgedNestEggQualification(state)
+//
+//   // First, check if user qualified but hasn't acknowledged yet
+//   // This handles the case where user qualified, app closed, and now opening again
+//   if (hasQualified && !hasAcknowledged) {
+//     await waitForInteractions()
+//
+//     await navigateWithPromise('/nestEggCampaign/success')
+//     return
+//   }
+//
+//   // Check which flag is enabled (they work independently)
+//   const isNewSeedlessOnly = selectIsNestEggNewSeedlessOnly(state)
+//
+//   if (isNewSeedlessOnly) {
+//     // nest-egg-new-seedless-only is ON: only NEW seedless users see the modal
+//     const isNewUserEligible =
+//       selectIsNewSeedlessUserEligibleForNestEggModal(state)
+//
+//     if (isNewUserEligible) {
+//       await waitForInteractions()
+//
+//       await navigateWithPromise('/nestEggCampaign')
+//     }
+//   } else {
+//     // nest-egg-campaign is ON: ALL seedless users can see the modal
+//     const isUserEligible = selectIsUserEligibleForNestEggModal(state)
+//
+//     if (isUserEligible) {
+//       await waitForInteractions()
+//
+//       await navigateWithPromise('/nestEggCampaign')
+//     }
+//   }
+// }


### PR DESCRIPTION
## Description

**Ticket: [CP-14058](https://ava-labs.atlassian.net/browse/CP-14058)**

Users have reported a blank, un-dismissable modal on iOS that survives force-quit and phone restart, and the Nest Egg campaign modal is the prime suspect. Since the campaign is over and the feature is unused, this disables the Nest Egg wiring to stop the modal from being triggered. The code is commented out (not deleted) so it can be re-enabled if the campaign returns, while we continue investigating why it renders blank.

## What's disabled

- The `nestEggCampaign` modal screen registration (`(signedIn)/_layout.tsx`)
- The Nest Egg swap listener (`addNestEggListeners`)
- The after-login modal trigger (`promptNestEggCampaignModalIfNeeded`)
- The `swapCompleted` dispatch in `SwapContext`

Because `tsconfig` enforces `noUnusedLocals`, the now-orphaned imports and helper function are commented out alongside the call sites (otherwise type-check fails). Nothing is removed.

## Testing

**Dev Testing**

- With a seedless wallet and the `nest-egg-campaign` / `nest-egg-new-seedless-only` flags toggled ON in PostHog: log in and confirm the Nest Egg campaign modal **no longer appears** after login.
- Complete a qualifying C-Chain swap ($10+) and confirm the Nest Egg success modal **no longer appears** (the `swapCompleted` dispatch is disabled).
- Confirm normal after-login flows still work: app-update prompt, push-notification prompt, and the Solana launch modal are unaffected.
- Confirm swaps still complete successfully end-to-end (only the Nest Egg analytics dispatch was removed from the swap flow).

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14058]: https://ava-labs.atlassian.net/browse/CP-14058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ