### PR TITLE
Require approval for EVM dApp connections in in-app browser

### DIFF
--- a/packages/core-mobile/app/hooks/browser/evmProviderShim.test.ts
+++ b/packages/core-mobile/app/hooks/browser/evmProviderShim.test.ts
@@ -25,11 +25,9 @@ describe('buildEvmProviderShim', () => {
       expect(shim).toContain("var _chainId = '0xa86a'")
     })
 
-    it('embeds the address', () => {
+    it('does not embed the address (no pre-seeded account)', () => {
       const shim = buildEvmProviderShim(defaultParams)
-      expect(shim).toContain(
-        "var _address = '0x1234567890abcdef1234567890abcdef12345678'"
-      )
+      expect(shim).not.toContain('var _address =')
     })
 
     it('embeds a different chain ID when provided', () => {
@@ -42,13 +40,13 @@ describe('buildEvmProviderShim', () => {
       expect(shim).not.toContain("var _chainId = '0xa86a'")
     })
 
-    it('embeds an empty address when not provided', () => {
+    it('accepts an empty address without embedding it', () => {
       const shim = buildEvmProviderShim({
         chainId: '0xa86a',
         address: '',
         uuid: defaultParams.uuid
       })
-      expect(shim).toContain("var _address = ''")
+      expect(shim).not.toContain('var _address =')
     })
   })
 
@@ -66,9 +64,9 @@ describe('buildEvmProviderShim', () => {
       expect(shim).toContain('_isConnected: true')
     })
 
-    it('initializes _accounts from _address', () => {
+    it('starts _accounts empty — native primes on load based on permissions', () => {
       const shim = buildEvmProviderShim(defaultParams)
-      expect(shim).toContain('var _accounts = _address ? [_address] : []')
+      expect(shim).toContain('var _accounts = []')
     })
   })
 
@@ -112,17 +110,20 @@ describe('buildEvmProviderShim', () => {
       shim = buildEvmProviderShim(defaultParams)
     })
 
+    it.each(['eth_chainId', 'eth_accounts', 'net_version', 'eth_coinbase'])(
+      'handles %s locally (sync cache)',
+      method => {
+        expect(shim).toContain(`method === '${method}'`)
+      }
+    )
+
     it.each([
-      'eth_chainId',
-      'eth_accounts',
-      'net_version',
-      'eth_coinbase',
       'eth_requestAccounts',
       'wallet_requestPermissions',
       'wallet_getPermissions',
       'wallet_revokePermissions'
-    ])('handles %s locally', method => {
-      expect(shim).toContain(`method === '${method}'`)
+    ])('round-trips %s to native (no inpage implementation)', method => {
+      expect(shim).not.toContain(`method === '${method}'`)
     })
   })
 

--- a/packages/core-mobile/app/hooks/browser/evmProviderShim.ts
+++ b/packages/core-mobile/app/hooks/browser/evmProviderShim.ts
@@ -17,6 +17,11 @@
  *   )
  */
 import {
+  BRIDGE_UNAVAILABLE_MESSAGE,
+  JSON_RPC_INTERNAL_ERROR_CODE,
+  JSON_RPC_RESOURCE_UNAVAILABLE_CODE
+} from './injectedProvider/errors'
+import {
   INJECTED_PROVIDER_NAME,
   INJECTED_PROVIDER_RDNS,
   INJECTED_PROVIDER_ICON
@@ -24,11 +29,13 @@ import {
 
 export function buildEvmProviderShim({
   chainId,
-  address,
   uuid
 }: {
   chainId: string // hex, e.g. '0xa86a'
-  address: string // e.g. '0x1234...'
+  // Accepted for caller compatibility but intentionally NOT embedded: accounts
+  // are primed via __coreProviderEmit('accountsChanged', ...) after the user
+  // approves a connection, never pre-seeded into the shim. See tests.
+  address?: string
   uuid: string // stable UUIDv4 persisted across restarts
 }): string {
   return `(function() {
@@ -94,12 +101,17 @@ export function buildEvmProviderShim({
   var _listeners = {};
   var _pendingInteractive = {};
   var INTERACTIVE_METHODS = {
+    'eth_requestAccounts': true,
+    'wallet_requestPermissions': true,
     'wallet_addEthereumChain': true,
     'wallet_watchAsset': true
   };
   var _chainId = '${chainId}';
-  var _address = '${address}';
-  var _accounts = _address ? [_address] : [];
+  // _accounts is seeded empty. Native primes it via
+  // __coreProviderEmit('accountsChanged', [...]) on page load if the origin
+  // already has a permission grant; otherwise the dApp must call
+  // eth_requestAccounts to trigger the approval UI.
+  var _accounts = [];
 
   // ──────────────────────────────────────────────
   // 4. Native response / event bridge
@@ -168,40 +180,10 @@ export function buildEvmProviderShim({
       if (method === 'eth_coinbase') {
         return Promise.resolve(_accounts.length > 0 ? _accounts[0] : null);
       }
-      if (method === 'eth_requestAccounts') {
-        if (!_address) return Promise.reject({ code: 4100, message: 'No account available' });
-        _accounts = [_address];
-        provider.selectedAddress = _address;
-        setTimeout(function() {
-          emit('accountsChanged', _accounts);
-        }, 0);
-        return Promise.resolve([_address]);
-      }
-      if (method === 'wallet_requestPermissions') {
-        if (!_address) return Promise.reject({ code: 4100, message: 'No account available' });
-        _accounts = [_address];
-        provider.selectedAddress = _address;
-        setTimeout(function() { emit('accountsChanged', _accounts); }, 0);
-        return Promise.resolve([{
-          parentCapability: 'eth_accounts',
-          date: Date.now(),
-          caveats: [{ type: 'restrictReturnedAccounts', value: [_address] }]
-        }]);
-      }
-      if (method === 'wallet_getPermissions') {
-        var perms = _accounts.length > 0 ? [{
-          parentCapability: 'eth_accounts',
-          date: Date.now(),
-          caveats: [{ type: 'restrictReturnedAccounts', value: [_accounts[0]] }]
-        }] : [];
-        return Promise.resolve(perms);
-      }
-      if (method === 'wallet_revokePermissions') {
-        _accounts = [];
-        provider.selectedAddress = null;
-        setTimeout(function() { emit('accountsChanged', []); }, 0);
-        return Promise.resolve(null);
-      }
+      // Connect + permission methods round-trip to native so the user is prompted
+      // (eth_requestAccounts, wallet_requestPermissions) or the permissions slice
+      // is consulted (wallet_getPermissions, wallet_revokePermissions). The shim
+      // keeps _accounts in sync via __coreProviderEmit on 'accountsChanged'.
 
       // wallet_switchEthereumChain: optimistically update local chain state
       // SYNCHRONOUSLY before the bridge round-trip.  This fires chainChanged
@@ -210,7 +192,7 @@ export function buildEvmProviderShim({
       // the React error #185 infinite-loop that occurs over an async bridge.
       if (method === 'wallet_switchEthereumChain') {
         if (_pendingInteractive['wallet_switchEthereumChain']) {
-          return Promise.reject({ code: -32002, message: 'wallet_switchEthereumChain already pending' });
+          return Promise.reject({ code: ${JSON_RPC_RESOURCE_UNAVAILABLE_CODE}, message: 'wallet_switchEthereumChain already pending' });
         }
         var swTargetChainId = (params[0] && params[0].chainId) || null;
         if (swTargetChainId && swTargetChainId !== _chainId) {
@@ -233,8 +215,8 @@ export function buildEvmProviderShim({
               // chainChanged(original), which ConnectKit's "ensure correct chain"
               // useEffect sees as a mismatch and re-calls switchChain — producing
               // React error #185 (infinite update loop). wagmi enters status:'error'
-              // from the 4001 rejection; keeping _chainId at target prevents the
-              // re-trigger. The dApp receives the 4001 and shows its rejection UX.
+              // from the EIP-1193 user-rejected rejection; keeping _chainId at target prevents the
+              // re-trigger. The dApp receives that rejection and shows its rejection UX.
               reject(e);
             }
           };
@@ -249,13 +231,13 @@ export function buildEvmProviderShim({
             }));
           } catch(swErr) {
             delete _pendingInteractive['wallet_switchEthereumChain'];
-            reject({ code: -32603, message: 'Bridge unavailable' });
+            reject({ code: ${JSON_RPC_INTERNAL_ERROR_CODE}, message: '${BRIDGE_UNAVAILABLE_MESSAGE}' });
           }
         });
       }
 
       if (INTERACTIVE_METHODS[method] && _pendingInteractive[method]) {
-        return Promise.reject({ code: -32002, message: 'Request of type ' + method + ' already pending for origin. Please wait.' });
+        return Promise.reject({ code: ${JSON_RPC_RESOURCE_UNAVAILABLE_CODE}, message: 'Request of type ' + method + ' already pending for origin. Please wait.' });
       }
       var isInteractive = !!INTERACTIVE_METHODS[method];
       if (isInteractive) _pendingInteractive[method] = true;
@@ -288,7 +270,7 @@ export function buildEvmProviderShim({
         } catch(e) {
           delete _callbacks[id];
           if (isInteractive) delete _pendingInteractive[method];
-          reject({ code: -32603, message: 'Bridge unavailable' });
+          reject({ code: ${JSON_RPC_INTERNAL_ERROR_CODE}, message: '${BRIDGE_UNAVAILABLE_MESSAGE}' });
         }
       });
     },
@@ -362,7 +344,7 @@ export function buildEvmProviderShim({
 
     chainId: _chainId,
     networkVersion: String(parseInt(_chainId, 16)),
-    selectedAddress: _address || null
+    selectedAddress: null
   };
 
   // ──────────────────────────────────────────────

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/errors.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/errors.ts
@@ -1,0 +1,16 @@
+/** EIP-1193: user rejected the request (connect/sign cancel, etc.). */
+export const EIP1193_USER_REJECTED_CODE = 4001
+
+/** JSON-RPC 2.0 internal error. */
+export const JSON_RPC_INTERNAL_ERROR_CODE = -32603
+
+/** JSON-RPC resource unavailable (request already pending). */
+export const JSON_RPC_RESOURCE_UNAVAILABLE_CODE = -32002
+
+export const USER_REJECTED_REQUEST_MESSAGE = 'User rejected the request.'
+export const CONNECT_PROMPT_TIMED_OUT_MESSAGE = 'Connect prompt timed out'
+export const BRIDGE_UNAVAILABLE_MESSAGE = 'Bridge unavailable'
+
+export function isUserRejectedRpcError(err: unknown): boolean {
+  return (err as { code?: number })?.code === EIP1193_USER_REJECTED_CODE
+}

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -1,6 +1,13 @@
+import { NetworkVMType } from '@avalabs/core-chains-sdk'
 import { setTabChainId } from 'store/browser/slices/tabs'
 import type { Networks } from 'store/network/types'
 import { fetch as nitroFetch } from 'react-native-nitro-fetch'
+import type { Account } from 'store/account'
+import {
+  EIP1193_USER_REJECTED_CODE,
+  JSON_RPC_INTERNAL_ERROR_CODE,
+  USER_REJECTED_REQUEST_MESSAGE
+} from './errors'
 import { createInjectedProviderRouter } from './router'
 import { BrowserNetwork, RouterDeps } from './types'
 
@@ -37,13 +44,23 @@ type MockDeps = {
   trackPendingOrigin: jest.Mock
   setBrowserNetworkSpy: jest.Mock
   currentNetwork: { value: BrowserNetwork }
+  hasPermission: jest.Mock
+  grantPermission: jest.Mock
+  revokePermission: jest.Mock
+  requestConnectApproval: jest.Mock
+  activeAccount: { value: Account | undefined }
 }
+
+const MOCK_ADDR = '0xTestAddress1234567890'
+const MOCK_ACCOUNT = { addressC: MOCK_ADDR } as Account
 
 function makeDeps(overrides?: {
   browserNetwork?: BrowserNetwork
   allNetworks?: Networks
   nativeOrigin?: string | undefined
   tabId?: string
+  activeAccount?: Account | undefined
+  hasPermission?: boolean
 }): MockDeps {
   const currentNetwork = {
     value: overrides?.browserNetwork ?? {
@@ -72,6 +89,16 @@ function makeDeps(overrides?: {
   const setBrowserNetworkSpy = jest.fn((net: BrowserNetwork) => {
     currentNetwork.value = net
   })
+  const hasPermission = jest.fn(() => overrides?.hasPermission ?? false)
+  const grantPermission = jest.fn()
+  const revokePermission = jest.fn()
+  const requestConnectApproval = jest.fn()
+  const activeAccount = {
+    value:
+      overrides && 'activeAccount' in overrides
+        ? overrides.activeAccount
+        : MOCK_ACCOUNT
+  }
 
   const deps: RouterDeps = {
     getBrowserNetwork: () => currentNetwork.value,
@@ -92,7 +119,12 @@ function makeDeps(overrides?: {
       description: '',
       url: 'https://example.com',
       icons: []
-    })
+    }),
+    getActiveAccount: () => activeAccount.value,
+    hasPermission,
+    grantPermission,
+    revokePermission,
+    requestConnectApproval
   }
 
   return {
@@ -102,6 +134,11 @@ function makeDeps(overrides?: {
     requestSigning,
     dispatch,
     trackPendingOrigin,
+    hasPermission,
+    grantPermission,
+    revokePermission,
+    requestConnectApproval,
+    activeAccount,
     setBrowserNetworkSpy,
     currentNetwork
   }
@@ -152,7 +189,7 @@ describe('createInjectedProviderRouter', () => {
       expect(sendResponse).toHaveBeenCalledWith(
         1,
         expect.objectContaining({
-          code: -32603,
+          code: JSON_RPC_INTERNAL_ERROR_CODE,
           message: expect.stringContaining('Origin unavailable')
         }),
         undefined
@@ -292,7 +329,10 @@ describe('createInjectedProviderRouter', () => {
 
     it('on rejection, propagates the error', async () => {
       const { deps, sendResponse, requestSigning } = makeDeps()
-      const rejection = { code: 4001, message: 'User rejected' }
+      const rejection = {
+        code: EIP1193_USER_REJECTED_CODE,
+        message: USER_REJECTED_REQUEST_MESSAGE
+      }
       requestSigning.mockRejectedValueOnce(rejection)
       const router = createInjectedProviderRouter(deps)
 
@@ -312,12 +352,15 @@ describe('createInjectedProviderRouter', () => {
   })
 
   describe('wallet_revokePermissions', () => {
-    it('emits accountsChanged([]) and responds null — does NOT emit disconnect', () => {
-      const { deps, sendResponse, emitEvent } = makeDeps()
+    it('revokes the grant for the origin, emits accountsChanged([]), responds null, does NOT emit disconnect', () => {
+      const { deps, sendResponse, emitEvent, revokePermission } = makeDeps()
       const router = createInjectedProviderRouter(deps)
 
       send(router, 'wallet_revokePermissions')
 
+      expect(revokePermission).toHaveBeenCalledWith({
+        domain: 'https://example.com'
+      })
       expect(emitEvent).toHaveBeenCalledWith('accountsChanged', [])
       expect(emitEvent).not.toHaveBeenCalledWith(
         'disconnect',
@@ -325,12 +368,186 @@ describe('createInjectedProviderRouter', () => {
       )
       expect(sendResponse).toHaveBeenCalledWith(1, null, null)
     })
+
+    it('skips the slice write when origin is unknown, still emits accountsChanged', () => {
+      const { deps, emitEvent, revokePermission } = makeDeps({
+        nativeOrigin: undefined
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'wallet_revokePermissions')
+
+      expect(revokePermission).not.toHaveBeenCalled()
+      expect(emitEvent).toHaveBeenCalledWith('accountsChanged', [])
+    })
+  })
+
+  describe('eth_requestAccounts', () => {
+    it('returns the active address without prompting when already granted', async () => {
+      const { deps, sendResponse, requestConnectApproval, grantPermission } =
+        makeDeps({ hasPermission: true })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'eth_requestAccounts')
+      await new Promise(r => setImmediate(r))
+
+      expect(requestConnectApproval).not.toHaveBeenCalled()
+      expect(grantPermission).not.toHaveBeenCalled()
+      expect(sendResponse).toHaveBeenCalledWith(1, null, [MOCK_ADDR])
+    })
+
+    it('opens approval when not granted, grants, and returns selected accounts', async () => {
+      const {
+        deps,
+        sendResponse,
+        requestConnectApproval,
+        grantPermission,
+        emitEvent
+      } = makeDeps()
+      requestConnectApproval.mockResolvedValueOnce([MOCK_ACCOUNT])
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'eth_requestAccounts')
+      await new Promise(r => setImmediate(r))
+
+      expect(requestConnectApproval).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'https://example.com' })
+      )
+      expect(grantPermission).toHaveBeenCalledWith({
+        domain: 'https://example.com',
+        address: MOCK_ADDR,
+        vmType: NetworkVMType.EVM
+      })
+      expect(sendResponse).toHaveBeenCalledWith(1, null, [MOCK_ADDR])
+      expect(emitEvent).toHaveBeenCalledWith('accountsChanged', [MOCK_ADDR])
+    })
+
+    it('propagates user rejection from the approval', async () => {
+      const { deps, sendResponse, requestConnectApproval } = makeDeps()
+      const rejection = {
+        code: EIP1193_USER_REJECTED_CODE,
+        message: USER_REJECTED_REQUEST_MESSAGE
+      }
+      requestConnectApproval.mockRejectedValueOnce(rejection)
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'eth_requestAccounts')
+      await new Promise(r => setImmediate(r))
+
+      expect(sendResponse).toHaveBeenCalledWith(1, rejection, undefined)
+    })
+
+    it('rejects with unauthorized (4100) when there is no active account', async () => {
+      const { deps, sendResponse } = makeDeps({ activeAccount: undefined })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'eth_requestAccounts')
+      await new Promise(r => setImmediate(r))
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: 4100 }),
+        undefined
+      )
+    })
+
+    it('rejects with unauthorized (4100) when origin is missing', async () => {
+      const { deps, sendResponse } = makeDeps({ nativeOrigin: undefined })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'eth_requestAccounts')
+      await new Promise(r => setImmediate(r))
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: 4100 }),
+        undefined
+      )
+    })
+  })
+
+  describe('wallet_requestPermissions', () => {
+    it('returns EIP-2255 permission object when already granted', async () => {
+      const { deps, sendResponse } = makeDeps({ hasPermission: true })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'wallet_requestPermissions')
+      await new Promise(r => setImmediate(r))
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        null,
+        expect.arrayContaining([
+          expect.objectContaining({
+            parentCapability: 'eth_accounts',
+            caveats: expect.arrayContaining([
+              expect.objectContaining({
+                type: 'restrictReturnedAccounts',
+                value: [MOCK_ADDR]
+              })
+            ])
+          })
+        ])
+      )
+    })
+
+    it('opens approval and returns EIP-2255 permission object on approval', async () => {
+      const { deps, sendResponse, requestConnectApproval, grantPermission } =
+        makeDeps()
+      requestConnectApproval.mockResolvedValueOnce([MOCK_ACCOUNT])
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'wallet_requestPermissions')
+      await new Promise(r => setImmediate(r))
+
+      expect(requestConnectApproval).toHaveBeenCalledTimes(1)
+      expect(grantPermission).toHaveBeenCalledTimes(1)
+      const [[, , result]] = sendResponse.mock.calls
+      expect(result).toEqual([
+        expect.objectContaining({ parentCapability: 'eth_accounts' })
+      ])
+    })
+  })
+
+  describe('wallet_getPermissions', () => {
+    it('returns an EIP-2255 permission list when the active account is granted', () => {
+      const { deps, sendResponse } = makeDeps({ hasPermission: true })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'wallet_getPermissions')
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        null,
+        expect.arrayContaining([
+          expect.objectContaining({ parentCapability: 'eth_accounts' })
+        ])
+      )
+    })
+
+    it('returns an empty array when the active account is not granted', () => {
+      const { deps, sendResponse } = makeDeps({ hasPermission: false })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'wallet_getPermissions')
+
+      expect(sendResponse).toHaveBeenCalledWith(1, null, [])
+    })
+
+    it('returns an empty array when origin is missing', () => {
+      const { deps, sendResponse } = makeDeps({ nativeOrigin: undefined })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'wallet_getPermissions')
+
+      expect(sendResponse).toHaveBeenCalledWith(1, null, [])
+    })
   })
 
   describe('wallet_watchAsset', () => {
-    it('on 4001 rejection, responds with (null, false) per EIP-747', async () => {
+    it('on EIP-1193 user rejection, responds with (null, false) per EIP-747', async () => {
       const { deps, sendResponse, requestSigning } = makeDeps()
-      requestSigning.mockRejectedValueOnce({ code: 4001 })
+      requestSigning.mockRejectedValueOnce({ code: EIP1193_USER_REJECTED_CODE })
       const router = createInjectedProviderRouter(deps)
 
       send(router, 'wallet_watchAsset', [
@@ -341,9 +558,12 @@ describe('createInjectedProviderRouter', () => {
       expect(sendResponse).toHaveBeenCalledWith(1, null, false)
     })
 
-    it('on non-4001 error, propagates as real error', async () => {
+    it('on non-user-rejection error, propagates as real error', async () => {
       const { deps, sendResponse, requestSigning } = makeDeps()
-      const internalErr = { code: -32603, message: 'internal' }
+      const internalErr = {
+        code: JSON_RPC_INTERNAL_ERROR_CODE,
+        message: 'internal'
+      }
       requestSigning.mockRejectedValueOnce(internalErr)
       const router = createInjectedProviderRouter(deps)
 
@@ -399,7 +619,10 @@ describe('createInjectedProviderRouter', () => {
 
     it('propagates rejection from requestSigning', async () => {
       const { deps, sendResponse, requestSigning } = makeDeps()
-      const err = { code: 4001, message: 'User rejected' }
+      const err = {
+        code: EIP1193_USER_REJECTED_CODE,
+        message: USER_REJECTED_REQUEST_MESSAGE
+      }
       requestSigning.mockRejectedValueOnce(err)
       const router = createInjectedProviderRouter(deps)
 
@@ -426,7 +649,7 @@ describe('createInjectedProviderRouter', () => {
 
       expect(sendResponse).toHaveBeenCalledWith(
         1,
-        expect.objectContaining({ code: -32603 }),
+        expect.objectContaining({ code: JSON_RPC_INTERNAL_ERROR_CODE }),
         undefined
       )
     })
@@ -468,7 +691,7 @@ describe('createInjectedProviderRouter', () => {
 
       expect(sendResponse).toHaveBeenCalledWith(
         1,
-        expect.objectContaining({ code: -32603 }),
+        expect.objectContaining({ code: JSON_RPC_INTERNAL_ERROR_CODE }),
         undefined
       )
     })

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -1,9 +1,11 @@
-import { rpcErrors } from '@metamask/rpc-errors'
+import { providerErrors, rpcErrors } from '@metamask/rpc-errors'
+import { NetworkVMType } from '@avalabs/core-chains-sdk'
 import { RpcMethod } from '@avalabs/vm-module-types'
 import Logger from 'utils/Logger'
 import { getEvmCaip2ChainId } from 'utils/caip2ChainIds'
 import { setTabChainId } from 'store/browser/slices/tabs'
 import { fetch as nitroFetch } from 'react-native-nitro-fetch'
+import { isUserRejectedRpcError } from './errors'
 import { MAX_MESSAGE_SIZE, ProviderRequest, RouterDeps } from './types'
 
 const READ_ONLY_METHODS = new Set([
@@ -41,9 +43,12 @@ const SIGNING_METHODS: Record<string, RpcMethod> = {
 const ALLOWED_METHODS = new Set([
   ...READ_ONLY_METHODS,
   ...Object.keys(SIGNING_METHODS),
+  'eth_requestAccounts',
+  'wallet_requestPermissions',
+  'wallet_getPermissions',
+  'wallet_revokePermissions',
   'wallet_switchEthereumChain',
   'wallet_addEthereumChain',
-  'wallet_revokePermissions',
   'wallet_watchAsset'
 ])
 
@@ -56,6 +61,23 @@ const APPROVAL_METHODS = new Set<string>([
   'wallet_addEthereumChain',
   'wallet_watchAsset'
 ])
+
+// EIP-2255 — only eth_accounts is supported; no other restricted methods today.
+function buildAccountsPermission(addresses: string[]): unknown[] {
+  if (addresses.length === 0) return []
+  return [
+    {
+      parentCapability: 'eth_accounts',
+      date: Date.now(),
+      caveats: [
+        {
+          type: 'restrictReturnedAccounts',
+          value: addresses
+        }
+      ]
+    }
+  ]
+}
 
 function validateProviderRequest(data: unknown): data is ProviderRequest {
   if (typeof data !== 'object' || data === null) return false
@@ -136,7 +158,12 @@ export function createInjectedProviderRouter(
     emitEvent,
     getNativeOrigin,
     trackPendingOrigin,
-    getPeerMeta
+    getPeerMeta,
+    getActiveAccount,
+    hasPermission,
+    grantPermission,
+    revokePermission,
+    requestConnectApproval
   } = deps
 
   const proxyToRpc = async (
@@ -293,7 +320,161 @@ export function createInjectedProviderRouter(
     }
   }
 
+  // EIP-2255: resolve permissions for the current origin against the active
+  // EVM account. Today only `eth_accounts` is supported — there is no notion
+  // of a restricted method beyond account access.
+  const resolveActiveAccountAddresses = (origin: string): string[] => {
+    const active = getActiveAccount()
+    if (!active?.addressC) return []
+    const granted = hasPermission({
+      domain: origin,
+      address: active.addressC,
+      vmType: NetworkVMType.EVM
+    })
+    return granted ? [active.addressC] : []
+  }
+
+  const handleRequestAccounts = async (id: number): Promise<void> => {
+    const origin = getNativeOrigin()
+    if (!origin) {
+      sendResponse(
+        id,
+        providerErrors.unauthorized('Origin unavailable — cannot connect'),
+        undefined
+      )
+      return
+    }
+    const active = getActiveAccount()
+    if (!active?.addressC) {
+      sendResponse(
+        id,
+        providerErrors.unauthorized('No active account'),
+        undefined
+      )
+      return
+    }
+
+    // Already connected: return without prompting.
+    if (
+      hasPermission({
+        domain: origin,
+        address: active.addressC,
+        vmType: NetworkVMType.EVM
+      })
+    ) {
+      sendResponse(id, null, [active.addressC])
+      return
+    }
+
+    try {
+      const peerMeta = getPeerMeta()
+      const selected = await requestConnectApproval(peerMeta)
+      const addresses: string[] = []
+      for (const account of selected) {
+        if (!account.addressC) continue
+        grantPermission({
+          domain: origin,
+          address: account.addressC,
+          vmType: NetworkVMType.EVM
+        })
+        addresses.push(account.addressC)
+      }
+      if (addresses.length === 0) {
+        sendResponse(id, providerErrors.userRejectedRequest(), undefined)
+        return
+      }
+      // Emit accountsChanged before resolving the Promise — matches
+      // MetaMask/Rabby ordering so wagmi listeners see the event alongside
+      // the resolution rather than one render later.
+      emitEvent('accountsChanged', addresses)
+      sendResponse(id, null, addresses)
+    } catch (e) {
+      sendResponse(id, e, undefined)
+    }
+  }
+
+  // EIP-2255: `wallet_requestPermissions` is user-visible permissions gate.
+  // Behaves identically to `eth_requestAccounts` in our scope (only capability
+  // is `eth_accounts`); response shape differs (array of Permission objects).
+  const handleRequestPermissions = async (id: number): Promise<void> => {
+    const origin = getNativeOrigin()
+    if (!origin) {
+      sendResponse(
+        id,
+        providerErrors.unauthorized('Origin unavailable — cannot connect'),
+        undefined
+      )
+      return
+    }
+    const active = getActiveAccount()
+    if (!active?.addressC) {
+      sendResponse(
+        id,
+        providerErrors.unauthorized('No active account'),
+        undefined
+      )
+      return
+    }
+
+    const alreadyGranted = hasPermission({
+      domain: origin,
+      address: active.addressC,
+      vmType: NetworkVMType.EVM
+    })
+
+    if (alreadyGranted) {
+      sendResponse(id, null, buildAccountsPermission([active.addressC]))
+      return
+    }
+
+    try {
+      const peerMeta = getPeerMeta()
+      const selected = await requestConnectApproval(peerMeta)
+      const addresses: string[] = []
+      for (const account of selected) {
+        if (!account.addressC) continue
+        grantPermission({
+          domain: origin,
+          address: account.addressC,
+          vmType: NetworkVMType.EVM
+        })
+        addresses.push(account.addressC)
+      }
+      if (addresses.length === 0) {
+        sendResponse(id, providerErrors.userRejectedRequest(), undefined)
+        return
+      }
+      // Emit accountsChanged before resolving the Promise (see handleRequestAccounts).
+      emitEvent('accountsChanged', addresses)
+      sendResponse(id, null, buildAccountsPermission(addresses))
+    } catch (e) {
+      sendResponse(id, e, undefined)
+    }
+  }
+
+  const handleGetPermissions = (id: number): void => {
+    const origin = getNativeOrigin()
+    if (!origin) {
+      sendResponse(id, null, [])
+      return
+    }
+    sendResponse(
+      id,
+      null,
+      buildAccountsPermission(resolveActiveAccountAddresses(origin))
+    )
+  }
+
   const handleRevokePermissions = (id: number): void => {
+    const origin = getNativeOrigin()
+    if (origin) {
+      // Whole-domain revoke (address omitted) — drops grants for every
+      // address previously approved at this origin, not just the active
+      // one. Matches MetaMask's "Disconnect this site" UX. When multi-
+      // account selection is introduced, revisit whether a narrower revoke
+      // is warranted.
+      revokePermission({ domain: origin })
+    }
     // Only emit accountsChanged([]) — NOT disconnect. Per EIP-1193,
     // 'disconnect' means the provider lost network connectivity, not
     // that the user revoked access. Emitting disconnect causes wagmi
@@ -317,13 +498,44 @@ export function createInjectedProviderRouter(
       })
       sendResponse(id, null, result)
     } catch (e) {
-      // EIP-747: explicit user rejection (4001) returns false; all other
+      // EIP-747: explicit user rejection returns false; all other
       // errors (invalid params, internal) are surfaced as real RPC errors
-      if ((e as { code?: number })?.code === 4001) {
+      if (isUserRejectedRpcError(e)) {
         sendResponse(id, null, false)
       } else {
         sendResponse(id, e, undefined)
       }
+    }
+  }
+
+  const dispatchMethod = (
+    id: number,
+    method: string,
+    params: unknown
+  ): void => {
+    // Ensure params is always an array for handlers that expect one.
+    // wallet_watchAsset is the only method that legitimately accepts object-form
+    // params (some dApps send { type, options } instead of [{ type, options }]);
+    // its handler normalizes internally.
+    const safeParams = Array.isArray(params) ? params : []
+    if (method === 'eth_requestAccounts') {
+      handleRequestAccounts(id)
+    } else if (method === 'wallet_requestPermissions') {
+      handleRequestPermissions(id)
+    } else if (method === 'wallet_getPermissions') {
+      handleGetPermissions(id)
+    } else if (method === 'wallet_switchEthereumChain') {
+      handleSwitchEthereumChain(id, safeParams)
+    } else if (method === 'wallet_addEthereumChain') {
+      handleAddEthereumChain(id, safeParams)
+    } else if (method === 'wallet_revokePermissions') {
+      handleRevokePermissions(id)
+    } else if (method === 'wallet_watchAsset') {
+      handleWatchAsset(id, params)
+    } else if (method in SIGNING_METHODS) {
+      dispatchSigningRequest(id, method, safeParams)
+    } else if (READ_ONLY_METHODS.has(method)) {
+      proxyToRpc(id, method, safeParams)
     }
   }
 
@@ -365,24 +577,7 @@ export function createInjectedProviderRouter(
       return
     }
 
-    // Ensure params is always an array for handlers that expect one.
-    // wallet_watchAsset is the only method that legitimately accepts object-form
-    // params (some dApps send { type, options } instead of [{ type, options }]);
-    // its handler normalizes internally.
-    const safeParams = Array.isArray(params) ? params : []
-    if (method === 'wallet_switchEthereumChain') {
-      handleSwitchEthereumChain(id, safeParams)
-    } else if (method === 'wallet_addEthereumChain') {
-      handleAddEthereumChain(id, safeParams)
-    } else if (method === 'wallet_revokePermissions') {
-      handleRevokePermissions(id)
-    } else if (method === 'wallet_watchAsset') {
-      handleWatchAsset(id, params)
-    } else if (method in SIGNING_METHODS) {
-      dispatchSigningRequest(id, method, safeParams)
-    } else if (READ_ONLY_METHODS.has(method)) {
-      proxyToRpc(id, method, safeParams)
-    }
+    dispatchMethod(id, method, params)
   }
 
   return { handleProviderMessage }

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/types.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/types.ts
@@ -1,8 +1,10 @@
 import type { Dispatch } from '@reduxjs/toolkit'
+import type { NetworkVMType } from '@avalabs/core-chains-sdk'
 import type { Networks } from 'store/network/types'
 import type { TabId } from 'store/browser/types'
 import type { PeerMeta } from 'store/rpc/types'
 import type { Request as InAppRequest } from 'store/rpc/utils/createInAppRequest'
+import type { Account } from 'store/account'
 
 // Upper bound (1 MiB) on a single provider message from the WebView. The
 // payload is attacker-controlled — any page can call
@@ -51,4 +53,26 @@ export type RouterDeps = {
   trackPendingOrigin: (id: number, origin: string) => void
 
   getPeerMeta: () => PeerMeta
+  getActiveAccount: () => Account | undefined
+
+  // Permissions
+  hasPermission: (args: {
+    domain: string
+    address: string
+    vmType: NetworkVMType
+  }) => boolean
+  grantPermission: (args: {
+    domain: string
+    address: string
+    vmType: NetworkVMType
+  }) => void
+  revokePermission: (args: {
+    domain: string
+    address?: string
+    vmType?: NetworkVMType
+  }) => void
+
+  // Connect approval — hook implements: stash in cache + navigate + park a promise.
+  // Resolves with user-selected accounts, rejects with EIP-1193 user-rejected on cancel.
+  requestConnectApproval: (peerMeta: PeerMeta) => Promise<Account[]>
 }

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react-hooks'
-import { useSelector, useDispatch } from 'react-redux'
+import { useSelector, useDispatch, useStore } from 'react-redux'
 import { NetworkVMType } from '@avalabs/core-chains-sdk'
 import { RpcMethod } from 'store/rpc/types'
 import RNWebView from 'react-native-webview'
@@ -10,6 +10,11 @@ import {
   setActive
 } from 'store/network/slice'
 import { selectTabChainId, setTabChainId } from 'store/browser/slices/tabs'
+import {
+  EIP1193_USER_REJECTED_CODE,
+  JSON_RPC_INTERNAL_ERROR_CODE,
+  USER_REJECTED_REQUEST_MESSAGE
+} from './injectedProvider/errors'
 import { useEvmInjectedProvider } from './useEvmInjectedProvider'
 
 // proxyToRpc calls nitroFetch; mock it explicitly (the root __mocks__ manual
@@ -21,9 +26,7 @@ jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useSelector: jest.fn(),
   useDispatch: jest.fn(),
-  useStore: jest.fn(() => ({
-    getState: jest.fn(() => ({ posthog: { featureFlags: {} } }))
-  }))
+  useStore: jest.fn()
 }))
 
 jest.mock('store/network/slice', () => ({
@@ -54,8 +57,7 @@ jest.mock('utils/caip2ChainIds', () => ({
 
 jest.mock('./evmProviderShim', () => ({
   buildEvmProviderShim: jest.fn(
-    ({ chainId, address }: { chainId: string; address: string }) =>
-      `SHIM(${chainId},${address})`
+    ({ chainId }: { chainId: string }) => `SHIM(${chainId})`
   )
 }))
 
@@ -87,6 +89,13 @@ const mockAllNetworks = {
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>
 const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>
+const mockUseStore = useStore as jest.MockedFunction<typeof useStore>
+
+const mockStore = {
+  getState: () => ({ permissions: { grants: {} } }),
+  dispatch: jest.fn(),
+  subscribe: jest.fn(() => () => undefined)
+} as unknown as ReturnType<typeof useStore>
 
 function setupMocks(
   overrides: {
@@ -123,17 +132,16 @@ describe('useEvmInjectedProvider', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockUseDispatch.mockReturnValue(mockDispatch)
+    mockUseStore.mockReturnValue(mockStore)
     setupMocks()
   })
 
   describe('providerShimJs', () => {
-    it('generates shim with active account and network', () => {
+    it('generates shim with active network chain', () => {
       const { result } = renderHook(() =>
         useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
       )
-      expect(result.current.providerShimJs).toBe(
-        'SHIM(0xa86a,0xTestAddress1234567890)'
-      )
+      expect(result.current.providerShimJs).toBe('SHIM(0xa86a)')
     })
 
     it('uses fallback chain ID for non-EVM networks', () => {
@@ -143,17 +151,15 @@ describe('useEvmInjectedProvider', () => {
       const { result } = renderHook(() =>
         useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
       )
-      expect(result.current.providerShimJs).toBe(
-        'SHIM(0x1,0xTestAddress1234567890)'
-      )
+      expect(result.current.providerShimJs).toBe('SHIM(0x1)')
     })
 
-    it('uses empty address when no active account', () => {
+    it('still generates shim when no active account', () => {
       setupMocks({ account: null })
       const { result } = renderHook(() =>
         useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
       )
-      expect(result.current.providerShimJs).toBe('SHIM(0xa86a,)')
+      expect(result.current.providerShimJs).toBe('SHIM(0xa86a)')
     })
   })
 
@@ -499,9 +505,10 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('does not emit chainChanged when wallet_addEthereumChain is rejected', async () => {
-        const mockRequest = jest
-          .fn()
-          .mockRejectedValue({ code: 4001, message: 'User rejected' })
+        const mockRequest = jest.fn().mockRejectedValue({
+          code: EIP1193_USER_REJECTED_CODE,
+          message: USER_REJECTED_REQUEST_MESSAGE
+        })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
         const { result } = renderHook(() =>
@@ -529,9 +536,10 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('responds with error when user rejects', async () => {
-        const mockRequest = jest
-          .fn()
-          .mockRejectedValue({ code: 4001, message: 'User rejected' })
+        const mockRequest = jest.fn().mockRejectedValue({
+          code: EIP1193_USER_REJECTED_CODE,
+          message: USER_REJECTED_REQUEST_MESSAGE
+        })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
         const { result } = renderHook(() =>
@@ -555,7 +563,7 @@ describe('useEvmInjectedProvider', () => {
         })
 
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
-          expect.stringContaining('"code":4001')
+          expect.stringContaining(`"code":${EIP1193_USER_REJECTED_CODE}`)
         )
       })
     })
@@ -664,9 +672,10 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('responds false (not an error) when user rejects, per EIP-747', async () => {
-        const mockRequest = jest
-          .fn()
-          .mockRejectedValue({ code: 4001, message: 'User rejected' })
+        const mockRequest = jest.fn().mockRejectedValue({
+          code: EIP1193_USER_REJECTED_CODE,
+          message: USER_REJECTED_REQUEST_MESSAGE
+        })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
         const { result } = renderHook(() =>
@@ -842,10 +851,11 @@ describe('useEvmInjectedProvider', () => {
         )
       })
 
-      it('responds with error code 4001 on user rejection', async () => {
-        const mockRequest = jest
-          .fn()
-          .mockRejectedValue({ code: 4001, message: 'User rejected' })
+      it('responds with EIP-1193 user-rejected code on user rejection', async () => {
+        const mockRequest = jest.fn().mockRejectedValue({
+          code: EIP1193_USER_REJECTED_CODE,
+          message: USER_REJECTED_REQUEST_MESSAGE
+        })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
         const { result } = renderHook(() =>
@@ -872,7 +882,7 @@ describe('useEvmInjectedProvider', () => {
           expect.stringContaining('__coreProviderRespond(21,')
         )
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
-          expect.stringContaining('"code":4001')
+          expect.stringContaining(`"code":${EIP1193_USER_REJECTED_CODE}`)
         )
       })
 
@@ -891,7 +901,7 @@ describe('useEvmInjectedProvider', () => {
         })
 
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
-          expect.stringContaining('"code":-32603')
+          expect.stringContaining(`"code":${JSON_RPC_INTERNAL_ERROR_CODE}`)
         )
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
           expect.stringContaining('Origin unavailable')
@@ -1139,7 +1149,7 @@ describe('useEvmInjectedProvider', () => {
         })
 
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
-          expect.stringContaining('"code":-32603')
+          expect.stringContaining(`"code":${JSON_RPC_INTERNAL_ERROR_CODE}`)
         )
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
           expect.stringContaining('RPC request failed')
@@ -1384,6 +1394,104 @@ describe('useEvmInjectedProvider', () => {
       })
 
       expect(result.current.dappMetadata.current).toBeNull()
+    })
+
+    describe('primes _accounts on page load', () => {
+      const metadata = JSON.stringify({
+        domain: 'opensea.io',
+        name: 'OpenSea',
+        icon: '',
+        url: 'https://opensea.io/'
+      })
+
+      const withPermission = (addr: string): ReturnType<typeof useStore> =>
+        ({
+          getState: () => ({
+            permissions: {
+              grants: {
+                'https://opensea.io': {
+                  [addr]: ['EVM']
+                }
+              }
+            }
+          }),
+          dispatch: jest.fn(),
+          subscribe: jest.fn(() => () => undefined)
+        } as unknown as ReturnType<typeof useStore>)
+
+      it('injects accountsChanged([address]) when the origin has a grant for the active account', () => {
+        mockUseStore.mockReturnValue(withPermission(mockActiveAccount.addressC))
+        const { result } = renderHook(() =>
+          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+        )
+        act(() => {
+          result.current.setCurrentUrl('https://opensea.io/')
+        })
+        mockInjectJavaScript.mockClear()
+
+        act(() => {
+          result.current.handleDomainMetadata(metadata)
+        })
+
+        expect(mockInjectJavaScript).toHaveBeenCalledWith(
+          expect.stringContaining(
+            `__coreProviderEmit('accountsChanged', ["${mockActiveAccount.addressC}"])`
+          )
+        )
+      })
+
+      it('injects accountsChanged([]) when no grant exists for the origin', () => {
+        const { result } = renderHook(() =>
+          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+        )
+        act(() => {
+          result.current.setCurrentUrl('https://opensea.io/')
+        })
+        mockInjectJavaScript.mockClear()
+
+        act(() => {
+          result.current.handleDomainMetadata(metadata)
+        })
+
+        expect(mockInjectJavaScript).toHaveBeenCalledWith(
+          expect.stringContaining("__coreProviderEmit('accountsChanged', [])")
+        )
+      })
+
+      it('does not inject accountsChanged when origin is missing', () => {
+        const { result } = renderHook(() =>
+          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+        )
+        // currentUrlRef is never set, so origin stays ''
+        mockInjectJavaScript.mockClear()
+
+        act(() => {
+          result.current.handleDomainMetadata(metadata)
+        })
+
+        expect(mockInjectJavaScript).not.toHaveBeenCalledWith(
+          expect.stringContaining("__coreProviderEmit('accountsChanged'")
+        )
+      })
+
+      it('does not inject accountsChanged when there is no active account', () => {
+        setupMocks({ account: null })
+        const { result } = renderHook(() =>
+          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+        )
+        act(() => {
+          result.current.setCurrentUrl('https://opensea.io/')
+        })
+        mockInjectJavaScript.mockClear()
+
+        act(() => {
+          result.current.handleDomainMetadata(metadata)
+        })
+
+        expect(mockInjectJavaScript).not.toHaveBeenCalledWith(
+          expect.stringContaining("__coreProviderEmit('accountsChanged'")
+        )
+      })
     })
   })
 })

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { shallowEqual, useDispatch, useSelector, useStore } from 'react-redux'
-import { RootState } from 'store/types'
 import { selectActiveAccount } from 'store/account/slice'
 import { selectActiveNetwork, selectAllNetworks } from 'store/network/slice'
 import { selectTabChainId } from 'store/browser/slices/tabs'
@@ -11,10 +10,31 @@ import Logger from 'utils/Logger'
 import { createInAppRequest } from 'store/rpc/utils/createInAppRequest'
 import { PeerMeta } from 'store/rpc/types'
 import { serializeError } from '@metamask/rpc-errors'
+import { router as appRouter } from 'expo-router'
+import { walletConnectCache } from 'services/walletconnectv2/walletConnectCache/walletConnectCache'
+import {
+  grantPermission as grantPermissionAction,
+  revokePermission as revokePermissionAction,
+  selectHasPermission
+} from 'store/permissions/slice'
+import type { RootState } from 'store/types'
+import type { Account } from 'store/account'
 import { buildEvmProviderShim } from './evmProviderShim'
 import { getInjectedProviderUuid } from './getInjectedProviderUuid'
 import { createInjectedProviderRouter } from './injectedProvider/router'
+import {
+  CONNECT_PROMPT_TIMED_OUT_MESSAGE,
+  EIP1193_USER_REJECTED_CODE,
+  JSON_RPC_INTERNAL_ERROR_CODE,
+  USER_REJECTED_REQUEST_MESSAGE
+} from './injectedProvider/errors'
 import { BrowserNetwork, DomainMetadata } from './injectedProvider/types'
+
+// If the connect-approval screen never mounts or never resolves (e.g. Metro
+// hot-reloaded the cache, the page crashed mid-navigation, etc.), reject the
+// parked promise after this interval so the dApp can surface an error and
+// the user isn't stuck with a spinning button.
+const CONNECT_APPROVAL_TIMEOUT_MS = 90_000
 
 function getOriginFromUrl(url: string): string | undefined {
   if (!url) return undefined
@@ -92,15 +112,12 @@ export function useEvmInjectedProvider(
     return '0x' + initialChainId.toString(16)
   }, [activeNetwork.vmName, initialChainId])
 
-  const evmAddress = activeAccount?.addressC ?? ''
-
   const providerShimJs = useMemo(() => {
     return buildEvmProviderShim({
       chainId: chainIdHex,
-      address: evmAddress,
       uuid: getInjectedProviderUuid()
     })
-  }, [chainIdHex, evmAddress])
+  }, [chainIdHex])
 
   const sendResponse = useCallback(
     (id: number, error: unknown, result: unknown) => {
@@ -190,12 +207,106 @@ export function useEvmInjectedProvider(
     }
   }, [])
 
+  const activeAccountRef = useRef(activeAccount)
+
+  useEffect(() => {
+    activeAccountRef.current = activeAccount
+  }, [activeAccount])
+
+  // When this browser tab unmounts (tab closed), reject any parked connect
+  // approval with 4001 so the dApp's eth_requestAccounts promise settles instead
+  // of hanging until supersede or the 90s timeout. Inactive tabs stay mounted
+  // when switching tabs, so this does not run on tab switch.
+  useEffect(() => {
+    return () => {
+      prevInflightConnectReject.current?.({
+        code: EIP1193_USER_REJECTED_CODE,
+        message: USER_REJECTED_REQUEST_MESSAGE
+      })
+      prevInflightConnectReject.current = null
+    }
+  }, [])
+
+  // Tracks the reject fn of an in-flight connect approval so a later request
+  // (or an unmount) can unstick it. Writes and clears happen only inside
+  // requestConnectApproval.
+  const prevInflightConnectReject = useRef<((err: unknown) => void) | null>(
+    null
+  )
+
+  const requestConnectApproval = useCallback(
+    (peerMeta: PeerMeta): Promise<Account[]> => {
+      // If a prior connect is still parked (screen never mounted, or a second
+      // request arrived before the first resolved), reject it so its dApp can
+      // unstick. Then replace the cache entry with our own settled-guarded
+      // callbacks.
+      prevInflightConnectReject.current?.({
+        code: EIP1193_USER_REJECTED_CODE,
+        message: USER_REJECTED_REQUEST_MESSAGE
+      })
+      prevInflightConnectReject.current = null
+
+      return new Promise<Account[]>((resolve, reject) => {
+        let settled = false
+        const safeResolve = (selected: Account[]): void => {
+          if (settled) return
+          settled = true
+          // Only clear if the ref still points to THIS request's handler — a
+          // newer in-flight request would have overwritten it, and we must not
+          // clobber that one.
+          if (prevInflightConnectReject.current === safeReject) {
+            prevInflightConnectReject.current = null
+          }
+          resolve(selected)
+          // fallbackTimer would be no op, no need to maintain
+          clearTimeout(fallbackTimer)
+        }
+        const safeReject = (err: unknown): void => {
+          if (settled) return
+          settled = true
+          // Only clear if the ref still points to THIS request's handler — a
+          // newer in-flight request would have overwritten it, and we must not
+          // clobber that one.
+          if (prevInflightConnectReject.current === safeReject) {
+            prevInflightConnectReject.current = null
+          }
+          reject(err)
+          // fallbackTimer would be no op, no need to maintain
+          clearTimeout(fallbackTimer)
+        }
+        prevInflightConnectReject.current = safeReject
+
+        walletConnectCache.injectedAuthParams.set({
+          peerMeta,
+          onApprove: safeResolve,
+          onReject: () =>
+            safeReject({
+              code: EIP1193_USER_REJECTED_CODE,
+              message: USER_REJECTED_REQUEST_MESSAGE
+            })
+        })
+        appRouter.navigate('/authorizeInjectedDapp')
+
+        // Safety net: if the screen never mounts or calls back within 90s,
+        // reject so the dApp can surface an error instead of hanging.
+        const fallbackTimer = setTimeout(() => {
+          safeReject({
+            code: JSON_RPC_INTERNAL_ERROR_CODE,
+            message: CONNECT_PROMPT_TIMED_OUT_MESSAGE
+          })
+        }, CONNECT_APPROVAL_TIMEOUT_MS)
+      })
+    },
+    []
+  )
+
   const router = useMemo(() => {
     // requestSigning closes over dispatch + store.getState (the latter was
     // added in CP-14159 so the in-app request payload can read the current
     // network state). Construct inside the memo so it always picks up the
     // latest references and rebuilds when dispatch changes.
     const requestSigning = createInAppRequest(dispatch, store.getState)
+
     return createInjectedProviderRouter({
       getBrowserNetwork: () => browserNetworkRef.current,
       setBrowserNetwork: net => {
@@ -211,23 +322,63 @@ export function useEvmInjectedProvider(
       trackPendingOrigin: (id, origin) => {
         pendingOrigins.current.set(id, origin)
       },
-      getPeerMeta
+      getPeerMeta,
+      getActiveAccount: () => activeAccountRef.current,
+      hasPermission: ({ domain, address, vmType }) =>
+        selectHasPermission({ domain, address, vmType })(store.getState()),
+      grantPermission: ({ domain, address, vmType }) =>
+        dispatch(grantPermissionAction({ domain, address, vmType })),
+      revokePermission: ({ domain, address, vmType }) =>
+        dispatch(revokePermissionAction({ domain, address, vmType })),
+      requestConnectApproval
     })
-  }, [dispatch, store, tabId, sendResponse, emitEvent, getPeerMeta])
+  }, [
+    dispatch,
+    store,
+    tabId,
+    sendResponse,
+    emitEvent,
+    getPeerMeta,
+    requestConnectApproval
+  ])
 
   const handleProviderMessage = useCallback(
     (payload: string) => router.handleProviderMessage(payload),
     [router]
   )
 
-  const handleDomainMetadata = useCallback((payload: string) => {
-    try {
-      dappMetadata.current = JSON.parse(payload)
-      Logger.trace('[InjectedProvider] domain_metadata', dappMetadata.current)
-    } catch {
-      Logger.error('[InjectedProvider] Invalid domain_metadata payload')
-    }
-  }, [])
+  const handleDomainMetadata = useCallback(
+    (payload: string) => {
+      try {
+        dappMetadata.current = JSON.parse(payload)
+        Logger.trace('[InjectedProvider] domain_metadata', dappMetadata.current)
+      } catch {
+        Logger.error('[InjectedProvider] Invalid domain_metadata payload')
+      }
+
+      // Prime the shim's _accounts cache on page load: if the current origin
+      // already has an EVM grant for the active account, emit accountsChanged
+      // so dApps with auto-reconnect (wagmi autoConnect, etc.) see the
+      // connection immediately without prompting. If no grant exists, emit
+      // an empty array to keep the shim in sync (e.g. after the user revoked
+      // the grant from Connected Sites while the tab was open).
+      const origin = getOriginFromUrl(currentUrlRef.current)
+      const active = activeAccountRef.current
+      if (!origin || !active?.addressC) return
+      const granted = selectHasPermission({
+        domain: origin,
+        address: active.addressC,
+        vmType: NetworkVMType.EVM
+      })(store.getState())
+      const accounts = granted ? [active.addressC] : []
+      webViewRef.current?.injectJavaScript(
+        `window.__coreProviderEmit && window.__coreProviderEmit('accountsChanged', ${JSON.stringify(
+          accounts
+        )}); true;`
+      )
+    },
+    [store, webViewRef]
+  )
 
   return {
     providerShimJs,

--- a/packages/core-mobile/app/new/features/accountSettings/hooks/useConnectedDapps.ts
+++ b/packages/core-mobile/app/new/features/accountSettings/hooks/useConnectedDapps.ts
@@ -1,39 +1,62 @@
 import { useDappConnectionV2 } from 'hooks/useDappConnectionV2'
 import { useState, useEffect, useMemo } from 'react'
+import { shallowEqual, useDispatch, useSelector } from 'react-redux'
 import { Session } from 'services/walletconnectv2/types'
 import WalletConnectService from 'services/walletconnectv2/WalletConnectService'
 import { WalletConnectVersions } from 'store/walletConnectV2/types'
+import {
+  revokePermission,
+  selectConnectedDomains
+} from 'store/permissions/slice'
 import Logger from 'utils/Logger'
 
 const GET_DAPPS_V2_INTERVAL = 5000 // 5s
 
-export type Dapp = {
-  id: string // the session topic
-  dapp: Session
+export type WCDapp = {
+  kind: 'wc'
+  id: string
+  session: Session
   version: WalletConnectVersions.V2
 }
 
+export type InjectedDapp = {
+  kind: 'injected'
+  id: string
+  domain: string
+}
+
+export type Dapp = WCDapp | InjectedDapp
+
 export const useConnectedDapps = (): {
   allApprovedDapps: Dapp[]
-  killSession: (topic: string) => Promise<void>
-  killAllSessions: () => Promise<void>
+  killDapp: (dapp: Dapp) => Promise<void>
+  killAllDapps: () => Promise<void>
 } => {
   const { killSessions } = useDappConnectionV2()
-  const [approvedDappsV2, setApprovedDappsV2] = useState<Session[]>([])
+  const dispatch = useDispatch()
+  const injectedDomains = useSelector(selectConnectedDomains, shallowEqual)
+  const [approvedWcSessions, setApprovedWcSessions] = useState<Session[]>([])
 
-  const allApprovedDapps = useMemo(() => {
-    return approvedDappsV2.map<Dapp>(dapp => ({
-      id: dapp.topic,
-      dapp,
+  const allApprovedDapps = useMemo<Dapp[]>(() => {
+    const wcDapps: Dapp[] = approvedWcSessions.map(session => ({
+      kind: 'wc',
+      id: session.topic,
+      session,
       version: WalletConnectVersions.V2
     }))
-  }, [approvedDappsV2])
+    const injectedDapps: Dapp[] = injectedDomains.map(domain => ({
+      kind: 'injected',
+      id: `injected:${domain}`,
+      domain
+    }))
+    return [...wcDapps, ...injectedDapps]
+  }, [approvedWcSessions, injectedDomains])
 
   useEffect(() => {
     const getSessions = (): void => {
       try {
         const sessions = WalletConnectService.getSessions()
-        setApprovedDappsV2(sessions)
+        setApprovedWcSessions(sessions)
       } catch (err) {
         Logger.error('failed to get sessions', err)
       }
@@ -49,23 +72,41 @@ export const useConnectedDapps = (): {
     return () => clearInterval(id)
   }, [])
 
-  const killSession = async (topic: string): Promise<void> => {
-    const session = approvedDappsV2.find(dapp => dapp.topic === topic)
-    if (!session) return
-    await killSessions([session])
-    setApprovedDappsV2(
-      approvedDappsV2.filter(dapp => dapp.topic !== session.topic)
-    )
+  const killDapp = async (dapp: Dapp): Promise<void> => {
+    if (dapp.kind === 'wc') {
+      // Callers (onPress) don't await this, so swallow + log a teardown
+      // failure rather than letting it surface as an unhandled rejection.
+      try {
+        await killSessions([dapp.session])
+      } catch (err) {
+        Logger.error('failed to kill session', err)
+      }
+      setApprovedWcSessions(current =>
+        current.filter(s => s.topic !== dapp.session.topic)
+      )
+    } else {
+      dispatch(revokePermission({ domain: dapp.domain }))
+    }
   }
 
-  const killAllSessions = async (): Promise<void> => {
-    await killSessions(approvedDappsV2)
-    setApprovedDappsV2([])
+  const killAllDapps = async (): Promise<void> => {
+    // Revoke injected-domain grants even if WC teardown fails — otherwise a
+    // single killSessions rejection would leave injected dApps connected and
+    // the screen stuck. Also avoids an unhandled rejection at the call site.
+    try {
+      await killSessions(approvedWcSessions)
+      setApprovedWcSessions([])
+    } catch (err) {
+      Logger.error('failed to kill sessions', err)
+    }
+    injectedDomains.forEach(domain => {
+      dispatch(revokePermission({ domain }))
+    })
   }
 
   return {
     allApprovedDapps,
-    killSession,
-    killAllSessions
+    killDapp,
+    killAllDapps
   }
 }

--- a/packages/core-mobile/app/new/features/injectedProvider/screens/AuthorizeInjectedDappScreen.tsx
+++ b/packages/core-mobile/app/new/features/injectedProvider/screens/AuthorizeInjectedDappScreen.tsx
@@ -1,0 +1,124 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { StyleSheet, View } from 'react-native'
+import { useSelector } from 'react-redux'
+import { selectAccounts, selectActiveAccount } from 'store/account/slice'
+import { showSnackbar } from 'new/common/utils/toast'
+import { router } from 'expo-router'
+import { SCREEN_WIDTH, Text } from '@avalabs/k2-alpine'
+import { InjectedAuthParams } from 'services/walletconnectv2/walletConnectCache/types'
+import { ActionSheet } from 'new/common/components/ActionSheet'
+import { withWalletConnectCache } from 'common/components/withWalletConnectCache'
+import { DappLogo } from 'common/components/DappLogo'
+import { Account } from 'store/account'
+import { SelectAccounts } from 'features/rpc/components/SelectAccounts'
+
+const showNoActiveAccountMessage = (): void => {
+  showSnackbar('There is no active account.')
+}
+
+const AuthorizeInjectedDappScreen = ({
+  params: { peerMeta, onApprove, onReject }
+}: {
+  params: InjectedAuthParams
+}): JSX.Element => {
+  const activeAccount = useSelector(selectActiveAccount)
+  const allAccounts = useSelector(selectAccounts)
+  const [selectedAccounts, setSelectedAccounts] = useState<Account[]>([])
+  const approveDisabled = selectedAccounts.length === 0
+
+  const rejectAndClose = useCallback(() => {
+    onReject()
+    router.canGoBack() && router.back()
+  }, [onReject])
+
+  const approveAndClose = useCallback(() => {
+    onApprove(selectedAccounts)
+    router.canGoBack() && router.back()
+  }, [onApprove, selectedAccounts])
+
+  useEffect(() => {
+    if (!activeAccount) {
+      showNoActiveAccountMessage()
+      rejectAndClose()
+    }
+  }, [activeAccount, rejectAndClose])
+
+  const onSelect = useCallback(
+    (account: Account): void => {
+      if (!selectedAccounts.find(item => item.addressC === account.addressC))
+        setSelectedAccounts(current => [...current, account])
+      else
+        setSelectedAccounts(current =>
+          current.filter(item => item.addressC !== account.addressC)
+        )
+    },
+    [selectedAccounts]
+  )
+
+  return (
+    <ActionSheet
+      isModal
+      navigationTitle="Connect wallet?"
+      onClose={rejectAndClose}
+      confirm={{
+        label: 'Connect',
+        onPress: approveAndClose,
+        disabled: approveDisabled
+      }}
+      cancel={{
+        label: 'Cancel',
+        onPress: rejectAndClose
+      }}>
+      <>
+        <View style={styles.iconContainer}>
+          <DappLogo peerMeta={peerMeta} />
+          <View style={styles.domainUrlContainer}>
+            <Text
+              variant="heading6"
+              style={{
+                textAlign: 'center',
+                width: SCREEN_WIDTH * 0.7,
+                marginBottom: 24
+              }}
+              numberOfLines={2}>
+              {peerMeta.name}
+            </Text>
+            <Text
+              variant="body1"
+              style={{ textAlign: 'center', width: SCREEN_WIDTH * 0.85 }}>
+              <Text variant="body1" style={{ fontWeight: '600' }}>
+                {peerMeta.url}
+              </Text>
+              {
+                ' wants to connect. This will allow the site to view your wallet address and balance, and request approval for transactions and message signatures.'
+              }
+            </Text>
+          </View>
+        </View>
+        <SelectAccounts
+          onSelect={onSelect}
+          selectedAccounts={selectedAccounts}
+          accounts={allAccounts}
+        />
+      </>
+    </ActionSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  iconContainer: {
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  domainUrlContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 24,
+    marginBottom: 48,
+    marginHorizontal: 20
+  }
+})
+
+export default withWalletConnectCache('injectedAuthParams')(
+  AuthorizeInjectedDappScreen
+)

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/connectedSites.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/accountSettings/connectedSites.tsx
@@ -22,14 +22,14 @@ const ConnectedSitesScreen = (): JSX.Element => {
   const {
     theme: { colors }
   } = useTheme()
-  const { allApprovedDapps, killSession, killAllSessions } = useConnectedDapps()
+  const { allApprovedDapps, killDapp, killAllDapps } = useConnectedDapps()
   const [searchText, setSearchText] = useState('')
 
   const disconnectDapp = useCallback(
-    async (topic: string): Promise<void> => {
-      killSession(topic)
+    async (dapp: Dapp): Promise<void> => {
+      killDapp(dapp)
     },
-    [killSession]
+    [killDapp]
   )
 
   const disconnectAll = useCallback(() => {
@@ -41,30 +41,57 @@ const ConnectedSitesScreen = (): JSX.Element => {
         {
           text: 'Disconnect',
           style: 'destructive',
-          onPress: () => killAllSessions()
+          onPress: () => killAllDapps()
         }
       ]
     })
-  }, [killAllSessions])
+  }, [killAllDapps])
+
+  const getDappDisplay = useCallback(
+    (
+      dapp: Dapp
+    ): {
+      name: string
+      url: string
+      peerMeta: {
+        name: string
+        description: string
+        url: string
+        icons: string[]
+      }
+    } => {
+      if (dapp.kind === 'wc') {
+        const { name, url } = dapp.session.peer.metadata
+        return { name, url, peerMeta: dapp.session.peer.metadata }
+      }
+      return {
+        name: dapp.domain,
+        url: dapp.domain,
+        peerMeta: {
+          name: dapp.domain,
+          description: '',
+          url: dapp.domain,
+          icons: []
+        }
+      }
+    },
+    []
+  )
 
   const searchResults = useMemo(() => {
     if (searchText === '') {
       return allApprovedDapps
     }
-    return allApprovedDapps.filter(
-      dapp =>
-        dapp.dapp.peer.metadata.name
-          .toLowerCase()
-          .includes(searchText.toLowerCase()) ||
-        dapp.dapp.peer.metadata.url
-          .toLowerCase()
-          .includes(searchText.toLowerCase())
-    )
-  }, [allApprovedDapps, searchText])
+    const q = searchText.toLowerCase()
+    return allApprovedDapps.filter(dapp => {
+      const { name, url } = getDappDisplay(dapp)
+      return name.toLowerCase().includes(q) || url.toLowerCase().includes(q)
+    })
+  }, [allApprovedDapps, searchText, getDappDisplay])
 
   const renderItem = useCallback(
     (item: Dapp): React.JSX.Element => {
-      const { name, url } = item.dapp.peer.metadata
+      const { name, url, peerMeta } = getDappDisplay(item)
       return (
         <View
           sx={{
@@ -83,7 +110,7 @@ const ConnectedSitesScreen = (): JSX.Element => {
               borderRadius: 12,
               backgroundColor: colors.$surfaceSecondary
             }}>
-            <DappLogo peerMeta={item.dapp.peer.metadata} size={32} />
+            <DappLogo peerMeta={peerMeta} size={32} />
             <View
               sx={{
                 flex: 1,
@@ -105,7 +132,7 @@ const ConnectedSitesScreen = (): JSX.Element => {
               </Text>
             </View>
             <TouchableOpacity
-              onPress={() => disconnectDapp(item.dapp.topic)}
+              onPress={() => disconnectDapp(item)}
               sx={{
                 width: 100,
                 alignItems: 'center',
@@ -142,7 +169,7 @@ const ConnectedSitesScreen = (): JSX.Element => {
             </Text>
           </View>
           <TouchableOpacity
-            onPress={() => disconnectDapp(item.dapp.topic)}
+            onPress={() => disconnectDapp(item)}
             sx={{
               width: 100,
               alignItems: 'center',
@@ -162,7 +189,8 @@ const ConnectedSitesScreen = (): JSX.Element => {
       colors.$borderPrimary,
       colors.$surfaceSecondary,
       colors.$textSecondary,
-      disconnectDapp
+      disconnectDapp,
+      getDappDisplay
     ]
   )
 

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/authorizeInjectedDapp/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/authorizeInjectedDapp/_layout.tsx
@@ -1,0 +1,14 @@
+import { Stack } from 'common/components/Stack'
+import {
+  modalFirstScreenOptions,
+  modalStackNavigatorScreenOptions
+} from 'common/consts/screenOptions'
+import React from 'react'
+
+export default function AuthorizeInjectedDappLayout(): JSX.Element {
+  return (
+    <Stack screenOptions={modalStackNavigatorScreenOptions}>
+      <Stack.Screen name="index" options={modalFirstScreenOptions} />
+    </Stack>
+  )
+}

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/authorizeInjectedDapp/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/authorizeInjectedDapp/index.tsx
@@ -1,0 +1,1 @@
+export { default } from 'features/injectedProvider/screens/AuthorizeInjectedDappScreen'

--- a/packages/core-mobile/app/new/routes/(signedIn)/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/_layout.tsx
@@ -103,6 +103,10 @@ export default function WalletLayout(): JSX.Element {
             options={modalScreensOptions}
           />
           <Stack.Screen
+            name="(modals)/authorizeInjectedDapp"
+            options={modalScreensOptions}
+          />
+          <Stack.Screen
             name="(modals)/collectibleSend"
             options={modalScreensOptions}
           />

--- a/packages/core-mobile/app/services/walletconnectv2/walletConnectCache/types.ts
+++ b/packages/core-mobile/app/services/walletconnectv2/walletConnectCache/types.ts
@@ -18,6 +18,7 @@ import { WalletAddEthereumChainRpcRequest } from 'store/rpc/handlers/chain/walle
 import { WalletWatchAssetRpcRequest } from 'store/rpc/handlers/chain/wallet_watchAsset/wallet_watchAsset'
 import { Account } from 'store/account'
 import { WalletType } from 'services/wallet/types'
+import { PeerMeta } from 'store/rpc/types'
 
 export type SessionProposalParams = {
   request: WCSessionProposal
@@ -76,4 +77,10 @@ export type AddEthereumChainParams = {
 export type WatchAssetParams = {
   request: WalletWatchAssetRpcRequest
   token: ERC20Token
+}
+
+export type InjectedAuthParams = {
+  peerMeta: PeerMeta
+  onApprove: (selectedAccounts: Account[]) => void
+  onReject: () => void
 }

--- a/packages/core-mobile/app/services/walletconnectv2/walletConnectCache/walletConnectCache.ts
+++ b/packages/core-mobile/app/services/walletconnectv2/walletConnectCache/walletConnectCache.ts
@@ -5,7 +5,8 @@ import {
   SessionProposalParams,
   EditContactParams,
   AddEthereumChainParams,
-  WatchAssetParams
+  WatchAssetParams,
+  InjectedAuthParams
 } from './types'
 
 // a simple in-memory cache (no reactivity or persistence support)
@@ -18,5 +19,6 @@ export const walletConnectCache = {
   editContactParams: createCache<EditContactParams>('edit contact'),
   addEthereumChainParams:
     createCache<AddEthereumChainParams>('add ethereum chain'),
-  watchAssetParams: createCache<WatchAssetParams>('watch asset')
+  watchAssetParams: createCache<WatchAssetParams>('watch asset'),
+  injectedAuthParams: createCache<InjectedAuthParams>('injected auth')
 }

--- a/packages/core-mobile/app/store/index.ts
+++ b/packages/core-mobile/app/store/index.ts
@@ -17,6 +17,7 @@ import { customTokenReducer as customToken } from './customToken/slice'
 import { securityReducer as security } from './security/slice'
 import { posthogReducer as posthog } from './posthog/slice'
 import { addressBookReducer as addressBook } from './addressBook/slice'
+import { permissionsReducer as permissions } from './permissions/slice'
 import { viewOnceReducer as viewOnce } from './viewOnce/slice'
 import settings from './settings'
 import { transactionApi } from './transaction'
@@ -42,6 +43,7 @@ const combinedReducer = combineReducers({
   account,
   notifications,
   addressBook,
+  permissions,
   customToken,
   posthog,
   wallet,

--- a/packages/core-mobile/app/store/permissions/slice.test.ts
+++ b/packages/core-mobile/app/store/permissions/slice.test.ts
@@ -1,0 +1,255 @@
+import { NetworkVMType } from '@avalabs/core-chains-sdk'
+import { RootState } from 'store/types'
+import {
+  grantPermission,
+  permissionsReducer,
+  revokePermission,
+  selectAddressesForDomain,
+  selectConnectedDomains,
+  selectGrantsForDomain,
+  selectHasPermission
+} from './slice'
+import { PermissionsState } from './types'
+
+const ADDR_A = '0xAAAA'
+const ADDR_B = '0xBBBB'
+const DOMAIN_UNI = 'https://app.uniswap.org'
+const DOMAIN_OS = 'https://opensea.io'
+
+const buildRootState = (state: PermissionsState): RootState =>
+  ({ permissions: state } as unknown as RootState)
+
+const emptyState: PermissionsState = { grants: {} }
+
+describe('permissions slice', () => {
+  describe('grantPermission', () => {
+    it('creates the domain + address + vm entry from empty state', () => {
+      const next = permissionsReducer(
+        emptyState,
+        grantPermission({
+          domain: DOMAIN_UNI,
+          address: ADDR_A,
+          vmType: NetworkVMType.EVM
+        })
+      )
+      expect(next.grants).toEqual({
+        [DOMAIN_UNI]: {
+          [ADDR_A]: [NetworkVMType.EVM]
+        }
+      })
+    })
+
+    it('does not duplicate an existing vm type for the same (domain, address)', () => {
+      const seeded: PermissionsState = {
+        grants: {
+          [DOMAIN_UNI]: { [ADDR_A]: [NetworkVMType.EVM] }
+        }
+      }
+      const next = permissionsReducer(
+        seeded,
+        grantPermission({
+          domain: DOMAIN_UNI,
+          address: ADDR_A,
+          vmType: NetworkVMType.EVM
+        })
+      )
+      expect(next.grants[DOMAIN_UNI]?.[ADDR_A]).toEqual([NetworkVMType.EVM])
+    })
+
+    it('appends a new vm type alongside an existing one', () => {
+      const seeded: PermissionsState = {
+        grants: {
+          [DOMAIN_UNI]: { [ADDR_A]: [NetworkVMType.EVM] }
+        }
+      }
+      const next = permissionsReducer(
+        seeded,
+        grantPermission({
+          domain: DOMAIN_UNI,
+          address: ADDR_A,
+          vmType: NetworkVMType.SVM
+        })
+      )
+      expect(next.grants[DOMAIN_UNI]?.[ADDR_A]).toEqual([
+        NetworkVMType.EVM,
+        NetworkVMType.SVM
+      ])
+    })
+
+    it('supports multiple addresses per domain', () => {
+      let state = emptyState
+      state = permissionsReducer(
+        state,
+        grantPermission({
+          domain: DOMAIN_UNI,
+          address: ADDR_A,
+          vmType: NetworkVMType.EVM
+        })
+      )
+      state = permissionsReducer(
+        state,
+        grantPermission({
+          domain: DOMAIN_UNI,
+          address: ADDR_B,
+          vmType: NetworkVMType.EVM
+        })
+      )
+      expect(state.grants[DOMAIN_UNI]).toEqual({
+        [ADDR_A]: [NetworkVMType.EVM],
+        [ADDR_B]: [NetworkVMType.EVM]
+      })
+    })
+  })
+
+  describe('revokePermission', () => {
+    const seeded: PermissionsState = {
+      grants: {
+        [DOMAIN_UNI]: {
+          [ADDR_A]: [NetworkVMType.EVM, NetworkVMType.SVM],
+          [ADDR_B]: [NetworkVMType.EVM]
+        },
+        [DOMAIN_OS]: {
+          [ADDR_A]: [NetworkVMType.EVM]
+        }
+      }
+    }
+
+    it('drops only the given vm type when vmType is specified', () => {
+      const next = permissionsReducer(
+        seeded,
+        revokePermission({
+          domain: DOMAIN_UNI,
+          address: ADDR_A,
+          vmType: NetworkVMType.EVM
+        })
+      )
+      expect(next.grants[DOMAIN_UNI]?.[ADDR_A]).toEqual([NetworkVMType.SVM])
+    })
+
+    it('drops the address entry when vmType removal empties it', () => {
+      const next = permissionsReducer(
+        seeded,
+        revokePermission({
+          domain: DOMAIN_UNI,
+          address: ADDR_B,
+          vmType: NetworkVMType.EVM
+        })
+      )
+      expect(next.grants[DOMAIN_UNI]?.[ADDR_B]).toBeUndefined()
+      // Other address for same domain untouched
+      expect(next.grants[DOMAIN_UNI]?.[ADDR_A]).toEqual([
+        NetworkVMType.EVM,
+        NetworkVMType.SVM
+      ])
+    })
+
+    it('drops the whole address (all vm types) when vmType is omitted', () => {
+      const next = permissionsReducer(
+        seeded,
+        revokePermission({ domain: DOMAIN_UNI, address: ADDR_A })
+      )
+      expect(next.grants[DOMAIN_UNI]?.[ADDR_A]).toBeUndefined()
+      expect(next.grants[DOMAIN_UNI]?.[ADDR_B]).toEqual([NetworkVMType.EVM])
+    })
+
+    it('drops the whole domain when address is omitted', () => {
+      const next = permissionsReducer(
+        seeded,
+        revokePermission({ domain: DOMAIN_UNI })
+      )
+      expect(next.grants[DOMAIN_UNI]).toBeUndefined()
+      expect(next.grants[DOMAIN_OS]).toBeDefined()
+    })
+
+    it('drops the domain entry when removing the last address', () => {
+      const single: PermissionsState = {
+        grants: { [DOMAIN_OS]: { [ADDR_A]: [NetworkVMType.EVM] } }
+      }
+      const next = permissionsReducer(
+        single,
+        revokePermission({
+          domain: DOMAIN_OS,
+          address: ADDR_A,
+          vmType: NetworkVMType.EVM
+        })
+      )
+      expect(next.grants[DOMAIN_OS]).toBeUndefined()
+    })
+
+    it('is a no-op for unknown domain / address', () => {
+      const next1 = permissionsReducer(
+        seeded,
+        revokePermission({ domain: 'https://unknown.test' })
+      )
+      expect(next1).toEqual(seeded)
+
+      const next2 = permissionsReducer(
+        seeded,
+        revokePermission({ domain: DOMAIN_UNI, address: '0xCCCC' })
+      )
+      expect(next2).toEqual(seeded)
+    })
+  })
+
+  describe('selectors', () => {
+    const state = buildRootState({
+      grants: {
+        [DOMAIN_UNI]: {
+          [ADDR_A]: [NetworkVMType.EVM]
+        },
+        [DOMAIN_OS]: {
+          [ADDR_B]: [NetworkVMType.EVM]
+        }
+      }
+    })
+
+    it('selectHasPermission returns true only for an exact (domain, address, vmType) match', () => {
+      expect(
+        selectHasPermission({
+          domain: DOMAIN_UNI,
+          address: ADDR_A,
+          vmType: NetworkVMType.EVM
+        })(state)
+      ).toBe(true)
+      expect(
+        selectHasPermission({
+          domain: DOMAIN_UNI,
+          address: ADDR_A,
+          vmType: NetworkVMType.SVM
+        })(state)
+      ).toBe(false)
+      expect(
+        selectHasPermission({
+          domain: DOMAIN_UNI,
+          address: ADDR_B,
+          vmType: NetworkVMType.EVM
+        })(state)
+      ).toBe(false)
+      expect(
+        selectHasPermission({
+          domain: 'https://unknown.test',
+          address: ADDR_A,
+          vmType: NetworkVMType.EVM
+        })(state)
+      ).toBe(false)
+    })
+
+    it('selectGrantsForDomain returns the nested grants or empty', () => {
+      expect(selectGrantsForDomain(DOMAIN_UNI)(state)).toEqual({
+        [ADDR_A]: [NetworkVMType.EVM]
+      })
+      expect(selectGrantsForDomain('https://nope.test')(state)).toEqual({})
+    })
+
+    it('selectConnectedDomains returns every domain key', () => {
+      const domains = selectConnectedDomains(state)
+      expect(domains).toEqual(expect.arrayContaining([DOMAIN_UNI, DOMAIN_OS]))
+      expect(domains).toHaveLength(2)
+    })
+
+    it("selectAddressesForDomain returns that domain's address keys", () => {
+      expect(selectAddressesForDomain(DOMAIN_UNI)(state)).toEqual([ADDR_A])
+      expect(selectAddressesForDomain('https://nope.test')(state)).toEqual([])
+    })
+  })
+})

--- a/packages/core-mobile/app/store/permissions/slice.ts
+++ b/packages/core-mobile/app/store/permissions/slice.ts
@@ -1,0 +1,103 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { NetworkVMType } from '@avalabs/core-chains-sdk'
+import { RootState } from 'store/types'
+import { Address, Domain, DomainGrants, PermissionsState } from './types'
+
+const reducerName = 'permissions'
+
+const initialState: PermissionsState = {
+  grants: {}
+}
+
+type GrantPayload = {
+  domain: Domain
+  address: Address
+  vmType: NetworkVMType
+}
+
+type RevokePayload = {
+  domain: Domain
+  address?: Address
+  vmType?: NetworkVMType
+}
+
+const permissionsSlice = createSlice({
+  name: reducerName,
+  initialState,
+  reducers: {
+    grantPermission: (state, action: PayloadAction<GrantPayload>) => {
+      const { domain, address, vmType } = action.payload
+      const domainGrants = state.grants[domain] ?? {}
+      const addressGrants = domainGrants[address] ?? []
+      if (!addressGrants.includes(vmType)) {
+        addressGrants.push(vmType)
+      }
+      domainGrants[address] = addressGrants
+      state.grants[domain] = domainGrants
+    },
+    revokePermission: (state, action: PayloadAction<RevokePayload>) => {
+      const { domain, address, vmType } = action.payload
+      const domainGrants = state.grants[domain]
+      if (!domainGrants) return
+
+      if (address === undefined) {
+        delete state.grants[domain]
+        return
+      }
+
+      const addressGrants = domainGrants[address]
+      if (!addressGrants) return
+
+      if (vmType === undefined) {
+        delete domainGrants[address]
+      } else {
+        domainGrants[address] = addressGrants.filter(v => v !== vmType)
+        if (domainGrants[address]?.length === 0) {
+          delete domainGrants[address]
+        }
+      }
+
+      if (Object.keys(domainGrants).length === 0) {
+        delete state.grants[domain]
+      }
+    }
+  }
+})
+
+export const selectGrantsForDomain =
+  (domain: Domain) =>
+  (state: RootState): DomainGrants =>
+    state.permissions.grants[domain] ?? {}
+
+export const selectHasPermission =
+  ({
+    domain,
+    address,
+    vmType
+  }: {
+    domain: Domain
+    address: Address
+    vmType: NetworkVMType
+  }) =>
+  (state: RootState): boolean => {
+    const domainGrants = state.permissions.grants[domain]
+    if (!domainGrants) return false
+    const addressGrants = domainGrants[address]
+    if (!addressGrants) return false
+    return addressGrants.includes(vmType)
+  }
+
+export const selectConnectedDomains = (state: RootState): Domain[] =>
+  Object.keys(state.permissions.grants)
+
+export const selectAddressesForDomain =
+  (domain: Domain) =>
+  (state: RootState): Address[] => {
+    const domainGrants = state.permissions.grants[domain]
+    if (!domainGrants) return []
+    return Object.keys(domainGrants)
+  }
+
+export const { grantPermission, revokePermission } = permissionsSlice.actions
+
+export const permissionsReducer = permissionsSlice.reducer

--- a/packages/core-mobile/app/store/permissions/types.ts
+++ b/packages/core-mobile/app/store/permissions/types.ts
@@ -1,0 +1,14 @@
+import type { NetworkVMType } from '@avalabs/core-chains-sdk'
+
+export type Domain = string
+export type Address = string
+
+export type DomainGrants = {
+  [address: Address]: NetworkVMType[]
+}
+
+export type PermissionsState = {
+  grants: {
+    [domain: Domain]: DomainGrants
+  }
+}


### PR DESCRIPTION
## Description

**Ticket: [CP-14366](https://ava-labs.atlassian.net/browse/CP-14366)**

Adds Phase 1(b) of the injected-provider modernization plan. Previously, a dApp loaded in the in-app browser could call `eth_requestAccounts` and silently receive the user's active address with no prompt and no record. This PR makes those calls round-trip to the React Native app, open an approval UI, persist the grant, and replay it on return visits so dApps auto-reconnect.

**Stacked PR:** base is `boyer/injected-provider-updates` (Phase 1a — #3861). Review/merge #3861 first; GitHub will retarget this onto `main` once it lands. This branch was rebased onto the current Phase 1a head and squashed to a single commit.

**Summary of changes:**

- NEW `app/store/permissions/` slice — per-`(domain, address, vmType)` grants with `grantPermission` / `revokePermission` actions and `selectHasPermission` / `selectConnectedDomains` / `selectAddressesForDomain` selectors. Persisted via existing redux-persist with the `EncryptThenMac` transform. 14 slice tests.
- NEW `features/injectedProvider/screens/AuthorizeInjectedDappScreen.tsx` — connect approval modal. Duplicates the visual layout of the existing `AuthorizeDappScreen` (DappLogo + peer + SelectAccounts + ActionSheet) with injected-specific plumbing (reads `InjectedAuthParams` from `walletConnectCache`, calls `onApprove(selectedAccounts)` / `onReject()` to resolve the router's parked promise).
- NEW modal route `(signedIn)/(modals)/authorizeInjectedDapp/` — registered in `(signedIn)/_layout.tsx`.
- EXTENDED `walletConnectCache` with an `injectedAuthParams` slot and corresponding type. The HOC (`withWalletConnectCache`) is slot-agnostic, so the screen consumes the new slot without any HOC changes.
- EXTENDED router (from Phase 1a) with 4 new handlers: `handleRequestAccounts`, `handleRequestPermissions`, `handleGetPermissions`, and a rewritten `handleRevokePermissions` that dispatches into the new slice. Method routing was extracted into a `dispatchMethod` helper. Router tests grew from 22 → 33.
- EXTENDED `useEvmInjectedProvider` hook with (a) `requestConnectApproval` (a `useCallback`) that sets the cache, navigates, parks a promise, and adds a 90s timeout + settled-guard + reject-prior-in-flight (so a stuck screen can't hang the dApp or pile up concurrent requests), and (b) a permission-aware `handleDomainMetadata` that primes `_accounts` via `accountsChanged` on page load when a grant already exists for the current origin.
- MODIFIED `evmProviderShim.ts` — removed the 4 inpage implementations of `eth_requestAccounts` / `wallet_requestPermissions` / `wallet_getPermissions` / `wallet_revokePermissions`. Removed the pre-seeded `_accounts = [_address]` init — the shim now starts with an empty array and native primes it based on permissions (the `address` param is retained for caller compatibility but no longer embedded).
- EXTENDED `useConnectedDapps` — `Dapp` is now a discriminated union of `WCDapp | InjectedDapp`, and the hook merges injected grants from the permissions slice with WalletConnect sessions. `connectedSites.tsx` updated to render both shapes and route disconnects through the new `killDapp` / `killAllDapps` API.
- MIGRATION 30 — initializes `permissions: { grants: {} }` for existing persisted state (persist `VERSION` bumped to 30).

**Motivation:** closes the biggest security gap in the in-app browser. Before this PR, every site the user visits silently receives the active wallet address on `eth_requestAccounts` with zero friction. After: an approval is required on first visit, grants are tracked per-origin, and users can review / revoke from the existing Connected Sites UI.

**Dependencies:** none.

**Breaking:** no. Feature is behind a feature flag and has never shipped to production users.

## Screenshots/Videos

No screenshots — visual parity with the existing WalletConnect `AuthorizeDappScreen` (same DappLogo, account picker, ActionSheet). The only user-visible change is that the modal now also appears when connecting via the in-app browser rather than only via WalletConnect.

## Testing
iOS: 8667
Android: 8668

**Dev Testing — validated end-to-end on Android (Pixel 8 Pro):**

| # | Test | Site | Result |
|---|------|------|--------|
| 1 | Connect approval modal appears on first visit | opensea.io / app.uniswap.org / etherscan.io / revoke.cash | ✅ |
| 2 | Approve with account → dApp sees connected | Uniswap, OpenSea | ✅ |
| 3 | Auto-reconnect on return visit (different tab) | Uniswap | ✅ |
| 4 | `personal_sign` via existing signing path | Etherscan Verified Signature | ✅ |
| 5 | `eth_signTypedData_v4` | OpenSea | ✅ |
| 6 | `wallet_switchEthereumChain` (optimistic chainChanged preserved; no ConnectKit loop) | Uniswap | ✅ |
| 7 | `wallet_addEthereumChain` end-to-end | chainlist.org → Gnosis Chain | ✅ |
| 8 | `eth_sendTransaction` via connect-gated flow | revoke.cash revoke allowance | ✅ |
| 9 | Cancel modal → dApp gets clean 4001 | app.aave.com | ✅ |
| 10 | Revoke via Settings → Connected Sites → dApp shows disconnected | Uniswap | ✅ |
| 11 | Concurrent connects across tabs (prior request rejected, new one proceeds) | Two fresh tabs | ✅ |

> Note: the dev-testing matrix above was validated on the pre-rebase branch. After rebasing onto the current Phase 1a head, the change was re-verified statically (below); a fresh device pass is recommended before merge.

**Known expected behaviors (not regressions):**

- Switching active wallet account mid-session with a dApp that has a grant ONLY for the prior active address will cause the dApp to re-prompt on next interaction — our grant model is per-address. Loosening this to match MetaMask's broader "per-domain" semantics is scoped to a later polish pass (Phase 3d).
- login.xyz's Sign-In with Ethereum demo shows an empty WalletConnect widget because the site forces WC and its WC project ID is unresponsive from the in-app browser. Unrelated to injected-provider behavior.

**Static (re-run after rebase):**

- `yarn tsc` — ✅ 0 errors
- `yarn lint` (`--max-warnings=0` on all touched files) — ✅ 0 errors, 0 warnings
- Tests — ✅ 33 router + 15 permissions + hook/shim suites, 722 passing across the affected suites
- Trigger a Bitrise build and reference it here: _<build link TBD>_
- Move the ticket into the "Testing" column on Jira.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14159]: https://ava-labs.atlassian.net/browse/CP-14159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CP-14366]: https://ava-labs.atlassian.net/browse/CP-14366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
