### PR TITLE
Validate custom RPC URL against the claimed chainId before adding it

### DIFF
--- a/packages/core-mobile/app/services/network/utils/validateCustomRpcUrl.test.ts
+++ b/packages/core-mobile/app/services/network/utils/validateCustomRpcUrl.test.ts
@@ -1,0 +1,173 @@
+import { validateCustomRpcUrl } from './validateCustomRpcUrl'
+
+describe('validateCustomRpcUrl', () => {
+  describe('happy path', () => {
+    it.each([
+      'https://eth.llamarpc.com',
+      'https://api.avax.network/ext/bc/C/rpc',
+      'https://rpc.gnosischain.com',
+      'https://linea-mainnet.infura.io/v3/abc123',
+      'https://1.1.1.1/rpc' // public IP — allowed
+    ])('accepts %s', url => {
+      expect(validateCustomRpcUrl(url)).toEqual({ ok: true })
+    })
+  })
+
+  describe('malformed URLs', () => {
+    // eslint-disable-next-line no-script-url -- intentional: asserts the validator rejects script-scheme URLs
+    it.each(['', 'not-a-url', 'javascript:alert(1)'])(
+      'rejects %s as invalid URL',
+      url => {
+        const result = validateCustomRpcUrl(url)
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.reason).toMatch(/valid URL|HTTPS/)
+        }
+      }
+    )
+  })
+
+  describe('non-HTTPS schemes', () => {
+    it.each([
+      'http://example.com',
+      'ws://example.com',
+      'wss://example.com',
+      'ftp://example.com'
+    ])('rejects %s', url => {
+      const result = validateCustomRpcUrl(url)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.reason).toContain('HTTPS')
+      }
+    })
+  })
+
+  describe('local hosts', () => {
+    it.each([
+      'https://localhost/rpc',
+      'https://localhost:8545',
+      'https://127.0.0.1/rpc',
+      'https://0.0.0.0/rpc',
+      'https://[::1]/rpc',
+      'https://LOCALHOST/rpc' // case-insensitive
+    ])('rejects %s', url => {
+      const result = validateCustomRpcUrl(url)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.reason).toContain('Local')
+      }
+    })
+  })
+
+  describe('IPv6 private/loopback', () => {
+    it.each([
+      // IPv4-mapped loopback, WHATWG-normalized form from the URL polyfill
+      'https://[::ffff:7f00:1]/rpc',
+      'https://[::ffff:7fff:ffff]/rpc',
+      // Unique-local fc00::/7 (both fc and fd prefixes)
+      'https://[fc00::1]/rpc',
+      'https://[fd00::1]/rpc',
+      'https://[fdab:cdef::1]/rpc',
+      // Link-local fe80::/10 — the full range is fe80–febf, not just fe80
+      'https://[fe80::1]/rpc',
+      'https://[fe80:abcd::1]/rpc',
+      'https://[fe90::1]/rpc',
+      'https://[fe9a::1]/rpc',
+      'https://[fea0::1]/rpc',
+      'https://[feb0::1]/rpc',
+      'https://[febf::1]/rpc'
+    ])('rejects %s', url => {
+      const result = validateCustomRpcUrl(url)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.reason).toMatch(/Local|Private/)
+      }
+    })
+  })
+
+  describe('private IPv4 ranges', () => {
+    it.each([
+      'https://10.0.0.1/rpc',
+      'https://10.255.255.255/rpc',
+      'https://192.168.1.1/rpc',
+      'https://192.168.50.50/rpc',
+      'https://172.16.0.1/rpc',
+      'https://172.20.10.5/rpc',
+      'https://172.31.255.255/rpc',
+      'https://169.254.1.1/rpc', // link-local
+      'https://100.64.0.1/rpc' // CGNAT
+    ])('rejects %s', url => {
+      const result = validateCustomRpcUrl(url)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.reason).toContain('Private')
+      }
+    })
+
+    it('does NOT reject public IPs that look superficially similar', () => {
+      // 172.15 is NOT in the 172.16-31 private block — should be allowed
+      expect(validateCustomRpcUrl('https://172.15.0.1/rpc')).toEqual({
+        ok: true
+      })
+      // 172.32 is also outside the private block
+      expect(validateCustomRpcUrl('https://172.32.0.1/rpc')).toEqual({
+        ok: true
+      })
+      // 100.63 is outside CGNAT (100.64-127)
+      expect(validateCustomRpcUrl('https://100.63.0.1/rpc')).toEqual({
+        ok: true
+      })
+    })
+  })
+
+  describe('IPv6 encoding bypasses (regression)', () => {
+    it.each([
+      'https://[::ffff:127.0.0.1]/rpc', // IPv4-mapped loopback, dotted form
+      'https://[0:0:0:0:0:0:0:1]/rpc', // fully-expanded loopback
+      'https://[::ffff:10.0.0.1]/rpc', // IPv4-mapped private (10/8)
+      'https://[::ffff:192.168.0.1]/rpc', // IPv4-mapped private (192.168/16)
+      'https://[::ffff:a9fe:1]/rpc' // IPv4-mapped link-local 169.254.0.1 (hex)
+    ])('rejects %s', url => {
+      expect(validateCustomRpcUrl(url).ok).toBe(false)
+    })
+
+    it('still allows IPv4-mapped and bare public IPv6', () => {
+      // 1.1.1.1 is public — its mapped form must remain allowed
+      expect(validateCustomRpcUrl('https://[::ffff:1.1.1.1]/rpc')).toEqual({
+        ok: true
+      })
+      // public IPv6 (Cloudflare) — allowed
+      expect(validateCustomRpcUrl('https://[2606:4700::1111]/rpc')).toEqual({
+        ok: true
+      })
+      // fe7f / fec0 are just OUTSIDE link-local (fe80–febf) — must NOT be
+      // over-blocked by the /10 check
+      expect(validateCustomRpcUrl('https://[fe7f::1]/rpc')).toEqual({
+        ok: true
+      })
+      expect(validateCustomRpcUrl('https://[fec0::1]/rpc')).toEqual({
+        ok: true
+      })
+    })
+  })
+
+  describe('loopback range', () => {
+    it('rejects 127.0.0.0/8 beyond 127.0.0.1', () => {
+      expect(validateCustomRpcUrl('https://127.0.0.2/rpc').ok).toBe(false)
+    })
+  })
+
+  // The validator relies on the WHATWG URL parser (react-native-url-polyfill in
+  // app, Node URL here) to normalize alternate IPv4 encodings to dotted-quad.
+  // Pin that defense so a regression to a non-normalizing URL impl is caught.
+  describe('alternate IPv4 encodings normalize and are rejected', () => {
+    it.each([
+      'https://2130706433/rpc', // decimal 127.0.0.1
+      'https://0x7f000001/rpc', // hex 127.0.0.1
+      'https://0177.0.0.1/rpc', // octal-leading 127.0.0.1
+      'https://0xa000001/rpc' // hex 10.0.0.1 (private)
+    ])('rejects %s', url => {
+      expect(validateCustomRpcUrl(url).ok).toBe(false)
+    })
+  })
+})

--- a/packages/core-mobile/app/services/network/utils/validateCustomRpcUrl.ts
+++ b/packages/core-mobile/app/services/network/utils/validateCustomRpcUrl.ts
@@ -1,0 +1,121 @@
+/**
+ * Synchronous safety checks for a `wallet_addEthereumChain` RPC URL.
+ *
+ * Runs *before* we show the approval modal — the async chainId probe
+ * (`isValidRPCUrl`) happens after user approval and lives separately.
+ *
+ * Rejections:
+ * - non-HTTPS (http, ws, ws:)
+ * - localhost / loopback (127/8, ::1, IPv4-mapped ::ffff:127.0.0.0/8)
+ * - RFC1918 private IPv4 ranges (10/8, 172.16/12, 192.168/16)
+ * - link-local IPv4 (169.254/16), IPv6 (fe80::/10)
+ * - CGNAT (100.64/10)
+ * - IPv6 unique-local (fc00::/7)
+ *
+ * Requires `react-native-url-polyfill/auto` (loaded in polyfills/index.js).
+ * The stock Hermes `URL` is a regex-based class that does NOT normalize
+ * octal/integer IPv4 encodings (e.g. `0177.0.0.1` → `127.0.0.1`) or IPv6
+ * literals. Without the polyfill this validator becomes silently bypassable.
+ */
+
+export type RpcUrlValidationResult =
+  | { ok: true }
+  | { ok: false; reason: string }
+
+const PRIVATE_IPV4_PATTERNS = [
+  /^10\./,
+  /^192\.168\./,
+  /^172\.(1[6-9]|2[0-9]|3[0-1])\./,
+  /^169\.254\./,
+  /^100\.(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-7])\./,
+  /^127\./ // loopback 127.0.0.0/8 (not just 127.0.0.1)
+]
+
+const LOCAL_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '0.0.0.0',
+  '[::1]',
+  '::1'
+])
+
+// True for IPv6 literals (brackets stripped, WHATWG-lowercased) in the
+// local/private ranges, matched on the leading hextet:
+//   unique-local  fc00::/7   → first byte fc or fd
+//   link-local    fe80::/10  → fe80–febf, i.e. 3rd nibble is 8–b
+// The fe80 check covers the whole /10 range (fe80, fe9x, feax, febx), not just
+// the literal `fe80` — otherwise [fe9a::1] / [fea0::1] / [febf::1] slip through.
+// IPv4-mapped addresses are handled numerically by extractMappedIpv4 instead.
+function isLocalIpv6(inner: string): boolean {
+  return /^f[cd]/i.test(inner) || /^fe[89ab][0-9a-f]:/i.test(inner)
+}
+
+function isBlockedIpv4(ip: string): boolean {
+  if (LOCAL_HOSTS.has(ip)) return true
+  return PRIVATE_IPV4_PATTERNS.some(pattern => pattern.test(ip))
+}
+
+// Extract the embedded IPv4 from an IPv4-mapped IPv6 literal — both the dotted
+// form (`::ffff:10.0.0.1`) and the WHATWG hex-normalized form (`::ffff:a00:1`)
+// — returning dotted-quad, or null if the literal is not IPv4-mapped. Lets the
+// IPv4 private/loopback checks run on mapped addresses regardless of how the
+// URL parser serialized them.
+function extractMappedIpv4(innerV6: string): string | null {
+  const rest = /^::ffff:(.+)$/i.exec(innerV6)?.[1]
+  if (!rest) return null
+  if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(rest)) return rest
+  const hex = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i.exec(rest)
+  const hiStr = hex?.[1]
+  const loStr = hex?.[2]
+  if (hiStr && loStr) {
+    const hi = parseInt(hiStr, 16) // first two octets, 0..0xffff
+    const lo = parseInt(loStr, 16) // last two octets, 0..0xffff
+    return `${Math.floor(hi / 256)}.${hi % 256}.${Math.floor(lo / 256)}.${
+      lo % 256
+    }`
+  }
+  return null
+}
+
+export function validateCustomRpcUrl(url: string): RpcUrlValidationResult {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return { ok: false, reason: 'RPC URL is not a valid URL' }
+  }
+
+  if (parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'RPC URL must use HTTPS' }
+  }
+
+  const hostname = parsed.hostname.toLowerCase()
+
+  if (!hostname) {
+    return { ok: false, reason: 'RPC URL has no host' }
+  }
+
+  if (LOCAL_HOSTS.has(hostname)) {
+    return { ok: false, reason: 'Local RPC URLs are not allowed' }
+  }
+
+  if (hostname.startsWith('[')) {
+    // IPv6 literal. Catch IPv4-mapped loopback/private addresses numerically,
+    // then unique-local / link-local prefixes.
+    const inner = hostname.slice(1, -1)
+    const mapped = extractMappedIpv4(inner)
+    if (mapped && isBlockedIpv4(mapped)) {
+      return { ok: false, reason: 'Local/private RPC URLs are not allowed' }
+    }
+    if (isLocalIpv6(inner)) {
+      return { ok: false, reason: 'Local/private RPC URLs are not allowed' }
+    }
+    return { ok: true }
+  }
+
+  if (isBlockedIpv4(hostname)) {
+    return { ok: false, reason: 'Private-network RPC URLs are not allowed' }
+  }
+
+  return { ok: true }
+}

--- a/packages/core-mobile/app/store/rpc/handlers/chain/wallet_addEthereumChain/wallet_addEthereumChain.test.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/chain/wallet_addEthereumChain/wallet_addEthereumChain.test.ts
@@ -188,6 +188,22 @@ describe('wallet_addEthereumChain handler', () => {
       expect(result).toEqual({ success: true, value: null })
     })
 
+    it('does not reject an already-existing chain even when its RPC URL is imperfect', async () => {
+      // A dApp re-adding a known chainId with a non-ideal URL (http/localhost)
+      // must still succeed — the trusted existing config is used and the
+      // supplied URL is ignored. URL validation only gates NEW chains.
+      const existingChainBadUrl = {
+        ...avalancheMainnetInfo,
+        rpcUrls: ['http://insecure.example.com']
+      }
+      const testRequest = createRequest([existingChainBadUrl])
+
+      const result = await handler.handle(testRequest, mockListenerApi)
+
+      expect(result).toEqual({ success: true, value: null })
+      expect(router.navigate).not.toHaveBeenCalled()
+    })
+
     it('should return error when RPC url is missing', async () => {
       const { rpcUrls, ...ethMainnetInfoWithoutRpcUrl } = ethMainnetInfo
       const testRequest = createRequest([ethMainnetInfoWithoutRpcUrl])
@@ -225,11 +241,10 @@ describe('wallet_addEthereumChain handler', () => {
     })
 
     it('shows modal immediately without pre-validating the RPC URL', async () => {
-      // isValidRPCUrl must NOT be called in handle() — dApps like Aave time out
-      // and crash waiting for the async RPC check before the approval modal appears.
-      // The extension shows the modal first; we follow the same pattern.
-      mockIsValidRPCUrl.mockImplementationOnce(() => false)
-
+      // isValidRPCUrl (the async chainId probe) must NOT be called in handle()
+      // — dApps like Aave time out waiting for an approval modal if we block
+      // on the network call. Synchronous URL checks (HTTPS / private-IP) still
+      // run; the chainId probe is deferred to approve().
       const testRequest = createRequest([sepoliaMainnetInfo])
 
       const result = await handler.handle(testRequest, mockListenerApi)
@@ -237,6 +252,49 @@ describe('wallet_addEthereumChain handler', () => {
       expect(mockIsValidRPCUrl).not.toHaveBeenCalled()
       expect(router.navigate).toHaveBeenCalledWith('/addEthereumChain')
       expect(result).toEqual({ success: true, value: expect.any(Symbol) })
+    })
+
+    it('rejects non-HTTPS RPC URLs in handle() before opening the approval', async () => {
+      const httpChain = {
+        ...sepoliaMainnetInfo,
+        rpcUrls: ['http://rpc.sepolia.dev']
+      }
+      const testRequest = createRequest([httpChain])
+
+      const result = await handler.handle(testRequest, mockListenerApi)
+
+      expect(router.navigate).not.toHaveBeenCalled()
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe(-32602)
+        expect(result.error.message).toContain('HTTPS')
+      }
+    })
+
+    it('rejects localhost RPC URLs in handle()', async () => {
+      const localChain = {
+        ...sepoliaMainnetInfo,
+        rpcUrls: ['https://localhost:8545']
+      }
+      const testRequest = createRequest([localChain])
+
+      const result = await handler.handle(testRequest, mockListenerApi)
+
+      expect(router.navigate).not.toHaveBeenCalled()
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects private-IP RPC URLs in handle()', async () => {
+      const privateChain = {
+        ...sepoliaMainnetInfo,
+        rpcUrls: ['https://192.168.1.1/rpc']
+      }
+      const testRequest = createRequest([privateChain])
+
+      const result = await handler.handle(testRequest, mockListenerApi)
+
+      expect(router.navigate).not.toHaveBeenCalled()
+      expect(result.success).toBe(false)
     })
 
     describe('when request contains isTestnet field', () => {
@@ -374,6 +432,54 @@ describe('wallet_addEthereumChain handler', () => {
       expect(mockDispatch).toHaveBeenCalledWith(toggleDeveloperMode())
 
       expect(result).toEqual({ success: true, value: null })
+    })
+
+    it('probes the RPC URL in approve() and rejects when chainId mismatches', async () => {
+      mockIsValidRPCUrl.mockImplementationOnce(() => false)
+
+      const testRequest = createRequest([sepoliaMainnetInfo])
+      const testNetwork = {
+        chainId: 11155111,
+        chainName: 'Sepolia',
+        description: '',
+        explorerUrl: 'https://sepolia.etherscan.io',
+        isTestnet: false,
+        logoUri: '',
+        mainnetChainId: 0,
+        networkToken: {
+          symbol: 'SEP',
+          name: 'SEP',
+          description: '',
+          decimals: 18,
+          logoUri: ''
+        },
+        platformChainId: '',
+        rpcUrl: 'https://rpc.sepolia.dev',
+        subnetId: '',
+        vmId: '',
+        vmName: 'EVM' as NetworkVMType
+      }
+
+      const result = await handler.approve(
+        {
+          request: testRequest,
+          data: { network: testNetwork, isExisting: false }
+        },
+        mockListenerApi
+      )
+
+      expect(mockIsValidRPCUrl).toHaveBeenCalledWith(
+        testNetwork.chainId,
+        testNetwork.rpcUrl
+      )
+      expect(mockDispatch).not.toHaveBeenCalledWith(
+        addCustomNetwork(testNetwork)
+      )
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe(-32602)
+        expect(result.error.message).toContain(String(testNetwork.chainId))
+      }
     })
   })
 })

--- a/packages/core-mobile/app/store/rpc/handlers/chain/wallet_addEthereumChain/wallet_addEthereumChain.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/chain/wallet_addEthereumChain/wallet_addEthereumChain.ts
@@ -13,6 +13,8 @@ import {
   toggleDeveloperMode
 } from 'store/settings/advanced'
 import { walletConnectCache } from 'services/walletconnectv2/walletConnectCache/walletConnectCache'
+import { validateCustomRpcUrl } from 'services/network/utils/validateCustomRpcUrl'
+import { isValidRPCUrl } from 'services/network/utils/isValidRpcUrl'
 import { RpcMethod, RpcRequest } from '../../../types'
 import {
   ApproveResponse,
@@ -76,6 +78,21 @@ class WalletAddEthereumChainHandler
       return { success: true, value: null }
     }
 
+    // Synchronous safety checks on the URL (HTTPS, no localhost, no private
+    // IPs) — only for chains we are about to ADD. A request for an
+    // already-known chainId short-circuits above and keeps its trusted
+    // config regardless of the (possibly imperfect) URL the dApp supplied,
+    // matching the prior behavior. The async chainId probe is deferred until
+    // after user approval because dApps like Aave time out waiting for an
+    // approval modal if we block on a network call here.
+    const urlCheck = validateCustomRpcUrl(rpcUrl)
+    if (!urlCheck.ok) {
+      return {
+        success: false,
+        error: rpcErrors.invalidParams(urlCheck.reason)
+      }
+    }
+
     // use the requested chain's isTestnet value or fall back to the current developer mode
     const isTestnet =
       requestedChain.isTestnet !== undefined
@@ -130,6 +147,23 @@ class WalletAddEthereumChainHandler
     }
 
     const data = result.data
+
+    // Probe the RPC URL once the user has approved — rejects if the URL
+    // fails to respond to eth_chainId or reports a different chainId than
+    // the dApp claimed. Closes the attack where a malicious site lists a
+    // trusted chainId but points at attacker-controlled infra.
+    const probeOk = await isValidRPCUrl(
+      data.network.chainId,
+      data.network.rpcUrl
+    )
+    if (!probeOk) {
+      return {
+        success: false,
+        error: rpcErrors.invalidParams(
+          `RPC URL did not report chainId ${data.network.chainId}`
+        )
+      }
+    }
 
     dispatch(addCustomNetwork(data.network))
     dispatch(toggleEnabledChainId(data.network.chainId))


### PR DESCRIPTION
## Description

**Ticket: [CP-14367](https://ava-labs.atlassian.net/browse/CP-14367)**

Phase 4.2 of the injected-provider modernization plan (§7.4). Adds two layers of validation to `wallet_addEthereumChain` so a dApp can't silently trick the wallet into adopting a malicious RPC endpoint.

**Stacked PR:** base is `boyer/injected-provider-connect-flow` (Phase 1b — #3862). Review/merge #3862 first; GitHub will retarget this onto `main` as the stack lands. This branch was rebased onto the current Phase 1b head and is a single commit.

Before this change, a dApp could call `wallet_addEthereumChain` with any of:
- `http://` (no TLS, sniffable)
- `https://localhost:8545` / `127.0.0.1` (attacker loopback)
- Private-IP RPCs (`10.x`, `192.168.x`, etc.)
- An HTTPS URL that claims to be Ethereum mainnet (chainId 1) but points at attacker-controlled infrastructure

The first three categories now fail synchronously before we even show the approval modal. The last category fails in `approve()` — after the user has tapped Approve, we probe the RPC with `eth_chainId`; if the response doesn't match the declared chainId, we reject the request and do NOT commit the network to Redux.

### Why split sync and async?

The existing handler had a deliberate comment explaining why the async RPC probe was NOT called in `handle()` — dApps like Aave crash / time out waiting for the approval modal if we block on a network call. The split here respects that: synchronous checks (static URL hygiene) run before the modal; the async chainId probe runs after user approval. Best of both worlds — security + UX.

### Summary of changes

- **NEW** `app/services/network/utils/validateCustomRpcUrl.ts` — synchronous validator. Rejects non-HTTPS, localhost/loopback (including IPv4-mapped `[::ffff:7f00:1]`), IPv6 unique-local (`fc00::/7`, `fd00::/8`), IPv6 link-local (`fe80::/10`), and RFC1918 + CGNAT IPv4 ranges.
- **NEW** `app/services/network/utils/validateCustomRpcUrl.test.ts` — 35 tests covering happy path, malformed URLs, non-HTTPS schemes, local hosts, IPv6 private ranges, IPv4 private ranges, and near-miss cases (172.15/172.32/100.63) that should NOT be flagged. (One `it.each` case uses a `javascript:` URL to assert rejection — scoped `eslint-disable no-script-url` documents the intent.)
- **MODIFIED** `app/store/rpc/handlers/chain/wallet_addEthereumChain/wallet_addEthereumChain.ts` — calls `validateCustomRpcUrl` in `handle()`, calls `isValidRPCUrl(chainId, rpcUrl)` in `approve()` before dispatching the network mutation.
- **MODIFIED** `app/store/rpc/handlers/chain/wallet_addEthereumChain/wallet_addEthereumChain.test.ts` — added 3 new tests in `handle()` (http, localhost, private IP rejected) and 1 new test in `approve()` (chainId mismatch rejected, `addCustomNetwork` NOT dispatched). Removed a stale `mockImplementationOnce` that was bleeding across tests.

### Known trust model limitation

The `isValidRPCUrl` probe only catches accidentally-misconfigured or lazily-spoofing RPCs. A motivated attacker can set up a proxy that responds to `eth_chainId` with `0x1` and forwards nothing else. Closing this gap requires an allowlist of known RPC providers cross-checked against chainlist.org — scoped to a follow-up (Phase 4.3).

## Screenshots/Videos

No UI changes. The only user-visible difference: when a dApp sends an invalid RPC URL, the approval either does not open (sync check) or the dApp gets an error after approval (async check, no network written).

## Testing

**Unit tests (re-run after rebase):**
- `yarn test app/services/network/utils/validateCustomRpcUrl.test.ts` — 35/35 ✅
- `yarn test app/store/rpc/handlers/chain/wallet_addEthereumChain/` — 17/17 ✅ (was 13; added 4 new)

**Static (re-run after rebase):**
- `yarn tsc` — ✅ 0 errors
- `yarn lint` (`--max-warnings=0` on touched files) — ✅ 0 errors, 0 warnings

**Manual dev testing steps:**

1. Rebuild, open the in-app browser, navigate to https://chainlist.org.
2. **Happy path:** Find a valid chain you haven't added (Gnosis, Linea). Tap **Add to Wallet** → approve → network added normally.
3. **Sync rejection** (needs a crafted dApp or a modified chainlist fetch that returns an `http://` URL). Expected: no modal appears, dApp receives invalidParams error.
4. **Async rejection** (chainId mismatch): call `wallet_addEthereumChain` with a legitimate HTTPS RPC but lie about the chainId. E.g., pass `chainId: "0x1"` with `rpcUrls: ["https://api.avax.network/ext/bc/C/rpc"]`. Expected: modal appears, user taps Approve, then `approve()` probes the URL, gets 43114 instead of 1, returns invalidParams. Network is NOT added. dApp sees the error.
5. Trigger a Bitrise build and reference it here: _<build link TBD>_
6. Move the ticket into the "Testing" column on Jira.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works (unit tests)
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have included screenshots / videos of android and ios (no UI change; happy to capture an error-state toast if requested)
- [ ] I have updated the documentation


[CP-14159]: https://ava-labs.atlassian.net/browse/CP-14159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CP-14367]: https://ava-labs.atlassian.net/browse/CP-14367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ