### PR TITLE
CP-14316: Show network logos in token-select filter chips

### DIFF
--- a/packages/core-mobile/app/new/common/components/NetworkFilterChips.tsx
+++ b/packages/core-mobile/app/new/common/components/NetworkFilterChips.tsx
@@ -1,0 +1,71 @@
+import { ChainId, Network } from '@avalabs/core-chains-sdk'
+import { Chip, useTheme, View } from '@avalabs/k2-alpine'
+import { NetworkLogoWithChain } from 'common/components/NetworkLogoWithChain'
+import React from 'react'
+import { ScrollView } from 'react-native'
+
+const getNetworkDisplayName = (network: Network): string => {
+  switch (network.chainId) {
+    case ChainId.AVALANCHE_MAINNET_ID:
+      return 'Avalanche (C-Chain)'
+    case ChainId.AVALANCHE_TESTNET_ID:
+      return 'Avalanche (C-Chain Testnet)'
+    case ChainId.SOLANA_MAINNET_ID:
+      return 'Solana'
+    default:
+      return network.chainName
+  }
+}
+
+export const NetworkFilterChips = ({
+  networks,
+  selectedNetwork,
+  onSelectNetwork
+}: {
+  networks: Network[] | undefined
+  selectedNetwork: Network | undefined
+  onSelectNetwork: (network: Network) => void
+}): JSX.Element | null => {
+  const { theme } = useTheme()
+
+  if (!networks || networks.length <= 1) return null
+
+  return (
+    <ScrollView
+      testID="network_selector_scroll"
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={{ gap: 8 }}>
+      {networks.map(network => {
+        const isSelected = network.chainId === selectedNetwork?.chainId
+        return (
+          // Wrap in View to host the testID — Chip's ChipProps doesn't declare
+          // testID even though TouchableOpacity would accept it via ...rest.
+          <View
+            key={network.chainId}
+            testID={`network_selector__${network.chainName}`}>
+            <Chip
+              size="large"
+              isSelected={isSelected}
+              onPress={() => onSelectNetwork(network)}
+              renderLeft={() => (
+                <NetworkLogoWithChain
+                  network={network}
+                  networkSize={18}
+                  showChainLogo={false}
+                  outerBorderColor={theme.colors.$surfaceSecondary}
+                />
+              )}
+              style={{
+                paddingLeft: 6,
+                paddingRight: 10,
+                gap: 4
+              }}>
+              {getNetworkDisplayName(network)}
+            </Chip>
+          </View>
+        )
+      })}
+    </ScrollView>
+  )
+}

--- a/packages/core-mobile/app/new/common/components/NetworkFilterChips.tsx
+++ b/packages/core-mobile/app/new/common/components/NetworkFilterChips.tsx
@@ -49,17 +49,19 @@ export const NetworkFilterChips = ({
               isSelected={isSelected}
               onPress={() => onSelectNetwork(network)}
               renderLeft={() => (
-                <NetworkLogoWithChain
-                  network={network}
-                  networkSize={18}
-                  showChainLogo={false}
-                  outerBorderColor={theme.colors.$surfaceSecondary}
-                />
+                <View sx={{ marginTop: 4, marginLeft: 4, marginBottom: 4 }}>
+                  <NetworkLogoWithChain
+                    network={network}
+                    networkSize={19}
+                    showChainLogo={false}
+                    outerBorderColor={theme.colors.$surfaceSecondary}
+                  />
+                </View>
               )}
               style={{
-                paddingLeft: 6,
+                paddingLeft: 0,
                 paddingRight: 10,
-                gap: 4
+                gap: 5
               }}>
               {getNetworkDisplayName(network)}
             </Chip>

--- a/packages/core-mobile/app/new/common/components/NetworkFilterChips.tsx
+++ b/packages/core-mobile/app/new/common/components/NetworkFilterChips.tsx
@@ -57,6 +57,7 @@ export const NetworkFilterChips = ({
                 />
               )}
               style={{
+                minHeight: 32,
                 paddingLeft: 4,
                 paddingRight: 10,
                 gap: 5

--- a/packages/core-mobile/app/new/common/components/NetworkFilterChips.tsx
+++ b/packages/core-mobile/app/new/common/components/NetworkFilterChips.tsx
@@ -49,17 +49,15 @@ export const NetworkFilterChips = ({
               isSelected={isSelected}
               onPress={() => onSelectNetwork(network)}
               renderLeft={() => (
-                <View sx={{ marginTop: 4, marginLeft: 4, marginBottom: 4 }}>
-                  <NetworkLogoWithChain
-                    network={network}
-                    networkSize={19}
-                    showChainLogo={false}
-                    outerBorderColor={theme.colors.$surfaceSecondary}
-                  />
-                </View>
+                <NetworkLogoWithChain
+                  network={network}
+                  networkSize={19}
+                  showChainLogo={false}
+                  outerBorderColor={theme.colors.$surfaceSecondary}
+                />
               )}
               style={{
-                paddingLeft: 0,
+                paddingLeft: 4,
                 paddingRight: 10,
                 gap: 5
               }}>

--- a/packages/core-mobile/app/new/features/swap/screens/SelectFromSwapTokenScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SelectFromSwapTokenScreen.tsx
@@ -1,9 +1,7 @@
 import React, { useMemo, useState, useCallback, useEffect } from 'react'
-import { ScrollView } from 'react-native'
-import { ChainId, Network } from '@avalabs/core-chains-sdk'
+import { Network } from '@avalabs/core-chains-sdk'
 import {
   ActivityIndicator,
-  Button,
   Icons,
   SCREEN_WIDTH,
   SearchBar,
@@ -15,6 +13,7 @@ import {
 } from '@avalabs/k2-alpine'
 import { ErrorState } from 'common/components/ErrorState'
 import { ListScreenV2 } from 'common/components/ListScreenV2'
+import { NetworkFilterChips } from 'common/components/NetworkFilterChips'
 import { useRouter } from 'expo-router'
 import { LogoWithNetwork } from 'features/portfolio/assets/components/LogoWithNetwork'
 import { useTokensWithBalanceByNetworkForAccount } from 'features/portfolio/hooks/useTokensWithBalanceByNetworkForAccount'
@@ -106,39 +105,16 @@ export const SelectFromSwapTokenScreen = ({
     [setSelectedToken, canGoBack, back]
   )
 
-  const renderNetworkSelector = useCallback(() => {
-    if (!networks || networks.length <= 1) return null
-
-    return (
-      <ScrollView
-        testID="network_selector_scroll"
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerStyle={{ gap: 8 }}>
-        {networks.map(network => (
-          <Button
-            key={network.chainId}
-            testID={`network_selector__${network.chainName}`}
-            size="small"
-            type={
-              network.chainId === selectedNetwork?.chainId
-                ? 'primary'
-                : 'secondary'
-            }
-            onPress={() => setSelectedNetwork(network)}
-            style={{ flexShrink: 0, alignSelf: 'flex-start' }}>
-            {network.chainId === ChainId.AVALANCHE_MAINNET_ID
-              ? 'Avalanche (C-Chain)'
-              : network.chainId === ChainId.AVALANCHE_TESTNET_ID
-              ? 'Avalanche (C-Chain Testnet)'
-              : network.chainId === ChainId.SOLANA_MAINNET_ID
-              ? 'Solana '
-              : network.chainName}
-          </Button>
-        ))}
-      </ScrollView>
-    )
-  }, [networks, selectedNetwork])
+  const renderNetworkSelector = useCallback(
+    () => (
+      <NetworkFilterChips
+        networks={networks}
+        selectedNetwork={selectedNetwork}
+        onSelectNetwork={setSelectedNetwork}
+      />
+    ),
+    [networks, selectedNetwork]
+  )
 
   const renderItem: ListRenderItem<LocalTokenWithBalance> = useCallback(
     ({ item, index }) => {

--- a/packages/core-mobile/app/new/features/swap/screens/SelectToSwapTokenScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SelectToSwapTokenScreen.tsx
@@ -1,9 +1,8 @@
 import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react'
-import { LayoutChangeEvent, ScrollView } from 'react-native'
-import { ChainId, Network } from '@avalabs/core-chains-sdk'
+import { LayoutChangeEvent } from 'react-native'
+import { Network } from '@avalabs/core-chains-sdk'
 import {
   ActivityIndicator,
-  Button,
   Icons,
   SCREEN_WIDTH,
   SearchBar,
@@ -15,6 +14,7 @@ import {
 } from '@avalabs/k2-alpine'
 import { ErrorState } from 'common/components/ErrorState'
 import { ListScreenRef, ListScreenV2 } from 'common/components/ListScreenV2'
+import { NetworkFilterChips } from 'common/components/NetworkFilterChips'
 import { useRouter } from 'expo-router'
 import { LogoWithNetwork } from 'features/portfolio/assets/components/LogoWithNetwork'
 import { ListRenderItem } from '@shopify/flash-list'
@@ -270,39 +270,16 @@ export const SelectToSwapTokenScreen = ({
   }, [isFetchingNextPage])
 
   // Render network tabs
-  const renderNetworkSelector = useCallback(() => {
-    if (!networks || networks.length <= 1) return null
-
-    return (
-      <ScrollView
-        testID="network_selector_scroll"
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerStyle={{ gap: 8 }}>
-        {networks.map(network => (
-          <Button
-            key={network.chainId}
-            testID={`network_selector__${network.chainName}`}
-            size="small"
-            type={
-              network.chainId === selectedNetwork?.chainId
-                ? 'primary'
-                : 'secondary'
-            }
-            onPress={() => setSelectedNetwork(network)}
-            style={{ flexShrink: 0, alignSelf: 'flex-start' }}>
-            {network.chainId === ChainId.AVALANCHE_MAINNET_ID
-              ? 'Avalanche (C-Chain)'
-              : network.chainId === ChainId.AVALANCHE_TESTNET_ID
-              ? 'Avalanche (C-Chain Testnet)'
-              : network.chainId === ChainId.SOLANA_MAINNET_ID
-              ? 'Solana '
-              : network.chainName}
-          </Button>
-        ))}
-      </ScrollView>
-    )
-  }, [networks, selectedNetwork])
+  const renderNetworkSelector = useCallback(
+    () => (
+      <NetworkFilterChips
+        networks={networks}
+        selectedNetwork={selectedNetwork}
+        onSelectNetwork={setSelectedNetwork}
+      />
+    ),
+    [networks, selectedNetwork]
+  )
 
   // Render token item
   const renderItem: ListRenderItem<SwapTokenListItem> = useCallback(


### PR DESCRIPTION
iOS: 8672
Android: 8673
## Description

**Ticket: [CP-14316]**

- Extract the network filter row from `SelectFromSwapTokenScreen` and `SelectToSwapTokenScreen` into a shared `NetworkFilterChips` component (`app/new/common/components/`).
- The chips now use k2-alpine's `Chip` + `NetworkLogoWithChain` (same pattern as `NetworkFilterDropdown` and `TradeFilters`), displaying the network logo on the left of each chip name.
- Per-chip layout: logo 19px with 4px top/left/bottom margins; chip `paddingLeft: 0`, `paddingRight: 10`, `gap: 5`; vertical text margin (~6px) emerges from the chip's `minHeight: 32` + centered alignment.

## Screenshots/Videos

<img width="1320" height="2868" alt="IMG_2451" src="https://github.com/user-attachments/assets/b95b6efa-d67f-4f5e-8660-6a14e75a5b95" />


## Testing

## Dev-testing
- [ ] Open swap → select source token → confirm each network chip displays its logo on the left
- [ ] Same in swap → select destination token
- [ ] Tap each chip → confirm the selected chip turns black (selected state) and the unselected chips stay light gray
- [ ] Confirm the network filtering still works (selected network's tokens are shown)
- [ ] Switch testnet mode on → confirm Avalanche (C-Chain Testnet) chip name renders correctly

**QA Testing (if applicable)**

- Provide instructions for QA to test this feature thoroughly
- State expected behavior / acceptance criteria

## Checklist

Please check all that apply (if applicable)

- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14316]: https://ava-labs.atlassian.net/browse/CP-14316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ