### PR TITLE
CP-14184: nest stake detail in search modal and fix transitions

### DIFF
--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
@@ -238,7 +238,7 @@ export const StakeSearchScreen = (): JSX.Element => {
               sx={{ width: 42, height: 42 }}
             />
           }
-          title={'Find stakes\nby date or node ID'}
+          title={'Find stakes by date\n(mm/dd/yyyy) or node ID'}
           description=""
         />
       )}

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
@@ -20,6 +20,11 @@ import {
   getListItemEnteringAnimation,
   getListItemExitingAnimation
 } from 'common/utils/animations'
+import {
+  FORM_SHEET_FOCUS_BUFFER_MS,
+  useAfterScreenEnterTransition
+} from 'common/hooks/useAfterScreenEnterTransition'
+import { dismissKeyboardIfNeeded } from 'common/utils/dismissKeyboardIfNeeded'
 import { useRouter } from 'expo-router'
 import { useStakes } from 'hooks/earn/useStakes'
 import React, {
@@ -27,9 +32,10 @@ import React, {
   useDeferredValue,
   useEffect,
   useMemo,
+  useRef,
   useState
 } from 'react'
-import { AppState, Platform } from 'react-native'
+import { AppState, Platform, TextInput } from 'react-native'
 import Animated from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { isCompleted, isOnGoing } from 'utils/earn/status'
@@ -60,6 +66,7 @@ export const StakeSearchScreen = (): JSX.Element => {
   const insets = useSafeAreaInsets()
   const isFocused = useIsFocused()
 
+  const searchBarRef = useRef<TextInput>(null)
   const [searchText, setSearchText] = useState('')
   // Defer the filter input so keystrokes feel snappy even when the stake list
   // is large — React renders the SearchBar with the latest text, then catches
@@ -126,7 +133,11 @@ export const StakeSearchScreen = (): JSX.Element => {
   }, [back, canGoBack])
 
   const handlePressStake = useCallback(
-    (txHash: string) => {
+    async (txHash: string) => {
+      // Dismiss the keyboard before navigating so it doesn't linger over (or
+      // fight the layout of) the pushed detail screen. On Android this waits
+      // for the keyboard to actually hide; on iOS it resolves immediately.
+      await dismissKeyboardIfNeeded()
       // Push the detail onto this search modal's own stack (slides in over the
       // results) rather than opening the global /stakeDetail modal.
       navigate({ pathname: '/stakeSearch/stakeDetail', params: { txHash } })
@@ -166,6 +177,14 @@ export const StakeSearchScreen = (): JSX.Element => {
     },
     [renderStakeCard]
   )
+
+  // Focus the SearchBar imperatively once the modal's enter transition has
+  // settled instead of relying on the native `autoFocus` prop. On iOS form
+  // sheets, autoFocus races the transition/keyboard and can drop focus or make
+  // the keyboard bounce; the buffer lets layout settle first.
+  useAfterScreenEnterTransition(() => searchBarRef.current?.focus(), {
+    layoutBufferMs: FORM_SHEET_FOCUS_BUFFER_MS
+  })
 
   useEffect(() => {
     const subscription = AppState.addEventListener('change', nextAppState => {
@@ -208,10 +227,10 @@ export const StakeSearchScreen = (): JSX.Element => {
         }}>
         <View sx={{ flex: 1 }}>
           <SearchBar
+            ref={searchBarRef}
             searchText={searchText}
             onTextChanged={setSearchText}
             placeholder="Search"
-            autoFocus
           />
         </View>
         <AnimatedPressable

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
@@ -127,7 +127,9 @@ export const StakeSearchScreen = (): JSX.Element => {
 
   const handlePressStake = useCallback(
     (txHash: string) => {
-      navigate({ pathname: '/stakeDetail', params: { txHash } })
+      // Push the detail onto this search modal's own stack (slides in over the
+      // results) rather than opening the global /stakeDetail modal.
+      navigate({ pathname: '/stakeSearch/stakeDetail', params: { txHash } })
     },
     [navigate]
   )

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
@@ -140,9 +140,16 @@ export const StakeSearchScreen = (): JSX.Element => {
   })
 
   const renderItem = useCallback(
-    ({ item, index }: ListRenderItemInfo<PChainTransaction>): JSX.Element => {
-      // `filteredStakes` has pre-filtered to active/completed only, so the
-      // renderer is guaranteed to return a JSX element (never null) here.
+    ({
+      item,
+      index
+    }: ListRenderItemInfo<PChainTransaction>): JSX.Element | null => {
+      // FlashList's `masonry` layout can briefly invoke `renderItem` with an
+      // `undefined` item when `data` shrinks between renders (e.g. while
+      // typing into the SearchBar narrows `filteredStakes`). Guard so we
+      // don't dereference an undefined stake before the next layout pass
+      // catches up.
+      if (!item) return null
       return (
         <Animated.View
           style={{
@@ -260,6 +267,13 @@ export const StakeSearchScreen = (): JSX.Element => {
 
       {showResults && (
         <FlashList
+          // Remount the list on every query change. FlashList's masonry layout
+          // manager retains stale column heights across an in-place `data`
+          // swap, so the top rows stay unpainted until a scroll forces a
+          // layout recompute. Keying by the query gives each result set a
+          // fresh layout (and resets scroll to the top, which is the desired
+          // search UX).
+          key={trimmedQuery}
           data={filteredStakes}
           numColumns={2}
           masonry
@@ -267,8 +281,9 @@ export const StakeSearchScreen = (): JSX.Element => {
           ListHeaderComponent={
             <View
               sx={{
+                paddingTop: 4,
                 paddingHorizontal: GRID_GAP / 2,
-                paddingBottom: 12
+                paddingBottom: 16
               }}>
               <DropdownMenu
                 groups={sortData}

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/stakeSearch/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/stakeSearch/_layout.tsx
@@ -11,9 +11,12 @@ export default function StakeSearchLayout(): JSX.Element {
     <Stack screenOptions={modalStackNavigatorScreenOptions}>
       <Stack.Screen
         name="index"
-        // The screen owns its own SearchBar + Cancel button, so we hide
-        // the native stack header entirely.
-        options={{ ...modalFirstScreenOptions, headerShown: false }}
+        // The screen owns its own SearchBar + Cancel button, so the header is
+        // kept empty (no back button, no title) but NOT hidden. Keeping a
+        // (transparent) header here means that when `stakeDetail` is pushed on
+        // top, iOS has a header to interpolate from — without it the detail's
+        // header pops in mid-transition (visible "clunk").
+        options={modalFirstScreenOptions}
       />
       {/* Pushed on top of the search results when a stake is tapped, so the
           detail stays within the search modal stack instead of opening the

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/stakeSearch/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/stakeSearch/_layout.tsx
@@ -1,7 +1,8 @@
 import { Stack } from 'common/components/Stack'
 import {
   modalFirstScreenOptions,
-  modalStackNavigatorScreenOptions
+  modalStackNavigatorScreenOptions,
+  stackScreensOptions
 } from 'common/consts/screenOptions'
 import React from 'react'
 
@@ -14,6 +15,10 @@ export default function StakeSearchLayout(): JSX.Element {
         // the native stack header entirely.
         options={{ ...modalFirstScreenOptions, headerShown: false }}
       />
+      {/* Pushed on top of the search results when a stake is tapped, so the
+          detail stays within the search modal stack instead of opening the
+          global /stakeDetail modal. */}
+      <Stack.Screen name="stakeDetail" options={stackScreensOptions} />
     </Stack>
   )
 }

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/stakeSearch/stakeDetail.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/stakeSearch/stakeDetail.tsx
@@ -1,0 +1,18 @@
+import { StakeDetailScreen } from 'features/stake/screens/StakeDetailScreen'
+import { StakeDetailScreen as StakeDetailScreenV2 } from 'features/stake/v2/screens/StakeDetailScreen'
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { selectIsFastStakeBlocked } from 'store/posthog'
+
+const StakeDetailRoute = (): React.JSX.Element => {
+  const isFastStakeBlocked = useSelector(selectIsFastStakeBlocked)
+
+  // fast-stake-enabled flag on: show the new V2 detail screen
+  if (!isFastStakeBlocked) {
+    return <StakeDetailScreenV2 />
+  }
+
+  return <StakeDetailScreen />
+}
+
+export default StakeDetailRoute

--- a/packages/k2-alpine/src/components/SearchBar/SearchBar.tsx
+++ b/packages/k2-alpine/src/components/SearchBar/SearchBar.tsx
@@ -1,5 +1,11 @@
 import debounce from 'lodash.debounce'
-import React, { FC, useCallback, useEffect, useRef, useState } from 'react'
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 import { TextInput, TextInputProps, ViewStyle } from 'react-native'
 import { useTheme } from '../../hooks'
 import { Icons } from '../../theme/tokens/Icons'
@@ -41,19 +47,22 @@ const HEIGHT = 40
  * @constructor
  */
 
-export const SearchBar: FC<Props> = ({
-  onTextChanged,
-  searchText,
-  placeholder = 'Search',
-  useDebounce = false,
-  debounceMillis = DEFAULT_DEBOUNCE_MILLISECONDS,
-  textColor,
-  setSearchBarFocused,
-  containerStyle,
-  rightComponent,
-  useCancel,
-  ...rest
-}) => {
+export const SearchBar = forwardRef<TextInput, Props>(function SearchBar(
+  {
+    onTextChanged,
+    searchText,
+    placeholder = 'Search',
+    useDebounce = false,
+    debounceMillis = DEFAULT_DEBOUNCE_MILLISECONDS,
+    textColor,
+    setSearchBarFocused,
+    containerStyle,
+    rightComponent,
+    useCancel,
+    ...rest
+  },
+  ref
+) {
   const textInputRef = useRef<TextInput>(null)
   const {
     theme: { colors, isDark }
@@ -159,7 +168,17 @@ export const SearchBar: FC<Props> = ({
             autoCorrect={false}
             autoComplete="off"
             autoCapitalize="none"
-            ref={textInputRef}
+            ref={node => {
+              // Keep the internal ref (used by clear/blur) working while also
+              // exposing the underlying TextInput to callers via forwardRef
+              // (e.g. for imperative focus after a screen-enter transition).
+              textInputRef.current = node
+              if (typeof ref === 'function') {
+                ref(node)
+              } else if (ref) {
+                ref.current = node
+              }
+            }}
             style={{
               height: '100%',
               lineHeight: 16,
@@ -203,4 +222,4 @@ export const SearchBar: FC<Props> = ({
       )}
     </View>
   )
-}
+})


### PR DESCRIPTION
## Description

**Ticket: [CP-14184]**

- Stake detail now opens **within** the search modal's own navigation stack (`/stakeSearch/stakeDetail`) instead of the global `/stakeDetail` modal. This makes the back gesture flow naturally: detail → search results → home. The nested route reuses the same V1/V2 flag-based branching as the global detail route.
- Fixes a FlashList masonry bug where the stale column-height cache left the top rows unpainted after the result set changed — the list is now keyed by the search query, giving each result set a fresh layout (and resetting scroll to the top, which is the desired search UX). Added a guard against FlashList briefly invoking `renderItem` with an `undefined` item during shrinking-data transitions.
- Smooths the search → detail header transition by keeping a (transparent) header on the search screen so iOS has a header to interpolate from, eliminating a visible "clunk" mid-transition.
- Fixes keyboard timing on iOS form sheets: replaced the `autoFocus` prop (which races the enter transition and causes the keyboard to bounce / drop focus) with imperative focus after the enter transition settles, and dismisses the keyboard before navigating to the detail screen so it doesn't linger. Converted the k2-alpine `SearchBar` to `forwardRef` to support imperative focus while preserving its internal clear/blur ref.

## Screenshots/Videos
https://github.com/user-attachments/assets/c98274d6-e14e-49a7-8669-f4b597d7076e

## Testing
iOS: 8668
Android: 8669

1. Enable `fast-stake-enabled`. Go to Stake → tap Search.
2. Type a query that narrows results progressively — confirm the masonry grid's top rows paint immediately on each keystroke (previously stayed blank until scrolled).
3. Tap a result card — verify the keyboard dismisses, then the detail screen slides in within the same modal (header transition is smooth).
4. Press back — verify you return to the search results (not directly to home), then back again returns to the stake home.

## Checklist
- [X] I have performed a self-review of my code
- [X] I have verified the code works
- [X] I have included screenshots / videos of android and ios
- [X] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14184]: https://ava-labs.atlassian.net/browse/CP-14184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ