### PR TITLE
Require verified origin for every injected provider request

### DIFF
--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -180,7 +180,7 @@ describe('createInjectedProviderRouter', () => {
       expect(trackPendingOrigin).toHaveBeenCalledWith(1, 'https://example.com')
     })
 
-    it('rejects signing methods when native origin is unavailable', () => {
+    it('rejects any method with unauthorized when native origin is unavailable', () => {
       const { deps, sendResponse } = makeDeps({ nativeOrigin: undefined })
       const router = createInjectedProviderRouter(deps)
 
@@ -189,8 +189,43 @@ describe('createInjectedProviderRouter', () => {
       expect(sendResponse).toHaveBeenCalledWith(
         1,
         expect.objectContaining({
-          code: JSON_RPC_INTERNAL_ERROR_CODE,
+          code: 4100,
           message: expect.stringContaining('Origin unavailable')
+        }),
+        undefined
+      )
+    })
+
+    it('rejects non-signing read-only methods when native origin is unavailable', () => {
+      const { deps, sendResponse } = makeDeps({ nativeOrigin: undefined })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'eth_blockNumber')
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: 4100 }),
+        undefined
+      )
+    })
+
+    it('rejects with invalidRequest when shim-reported origin differs from native origin', () => {
+      const { deps, sendResponse } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      router.handleProviderMessage(
+        JSON.stringify({
+          id: 1,
+          origin: 'https://evil.example',
+          request: { method: 'eth_blockNumber', params: [] }
+        })
+      )
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          code: -32600,
+          message: expect.stringContaining('Origin mismatch')
         }),
         undefined
       )
@@ -369,8 +404,12 @@ describe('createInjectedProviderRouter', () => {
       expect(sendResponse).toHaveBeenCalledWith(1, null, null)
     })
 
-    it('skips the slice write when origin is unknown, still emits accountsChanged', () => {
-      const { deps, emitEvent, revokePermission } = makeDeps({
+    it('rejects wallet_revokePermissions outright when origin is unknown', () => {
+      // Post-origin-hardening: no method proceeds without a verified native
+      // origin, including revoke. Returning 4100 makes the ambiguity explicit
+      // rather than silently emitting accountsChanged for an origin we can't
+      // identify.
+      const { deps, sendResponse, emitEvent, revokePermission } = makeDeps({
         nativeOrigin: undefined
       })
       const router = createInjectedProviderRouter(deps)
@@ -378,7 +417,15 @@ describe('createInjectedProviderRouter', () => {
       send(router, 'wallet_revokePermissions')
 
       expect(revokePermission).not.toHaveBeenCalled()
-      expect(emitEvent).toHaveBeenCalledWith('accountsChanged', [])
+      expect(emitEvent).not.toHaveBeenCalledWith(
+        'accountsChanged',
+        expect.anything()
+      )
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: 4100 }),
+        undefined
+      )
     })
   })
 
@@ -534,13 +581,22 @@ describe('createInjectedProviderRouter', () => {
       expect(sendResponse).toHaveBeenCalledWith(1, null, [])
     })
 
-    it('returns an empty array when origin is missing', () => {
+    it('rejects wallet_getPermissions with unauthorized when origin is missing', () => {
+      // The prior behavior of returning [] for unknown origin would let a
+      // page with no verified origin (e.g. about:blank, pre-navigation race)
+      // make the request and get a clean empty response. Post-hardening every
+      // method requires a native origin; this call is rejected upstream of
+      // the handler.
       const { deps, sendResponse } = makeDeps({ nativeOrigin: undefined })
       const router = createInjectedProviderRouter(deps)
 
       send(router, 'wallet_getPermissions')
 
-      expect(sendResponse).toHaveBeenCalledWith(1, null, [])
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: 4100 }),
+        undefined
+      )
     })
   })
 

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -52,16 +52,6 @@ const ALLOWED_METHODS = new Set([
   'wallet_watchAsset'
 ])
 
-// CP-14159: methods that surface an approval modal require a verified native
-// origin. Without one, the downstream generateInAppRequestPayload falls back
-// to CORE_MOBILE_META and misattributes the request to core.app — the exact
-// spoofing class CP-14159 exists to prevent.
-const APPROVAL_METHODS = new Set<string>([
-  ...Object.keys(SIGNING_METHODS),
-  'wallet_addEthereumChain',
-  'wallet_watchAsset'
-])
-
 // EIP-2255 — only eth_accounts is supported; no other restricted methods today.
 function buildAccountsPermission(addresses: string[]): unknown[] {
   if (addresses.length === 0) return []
@@ -550,10 +540,24 @@ export function createInjectedProviderRouter(
     const { method, params } = rpc
 
     const nativeOrigin = getNativeOrigin()
+
+    // Origin mismatch — the shim-reported origin disagrees with the origin
+    // tracked by the WebView's navigation state. Either a race during
+    // cross-origin navigation (rare) or a sign the page is trying to spoof
+    // its origin (hostile). Either way, refuse the request.
+    //
+    // Note: if the shim provides `pageOrigin` but `nativeOrigin` is missing
+    // (e.g., first RPC arrives before onNavigationStateChange has fired),
+    // we deliberately fall through to the `!nativeOrigin` gate below. We
+    // can't verify the shim's claim without a native anchor, so 4100
+    // "unauthorized" is the right response — not "invalidRequest," since
+    // the payload itself is well-formed.
     if (pageOrigin && nativeOrigin && pageOrigin !== nativeOrigin) {
       Logger.warn(
-        `[InjectedProvider] Origin mismatch: page=${pageOrigin} native=${nativeOrigin}`
+        `[InjectedProvider] Origin mismatch rejected: page=${pageOrigin} native=${nativeOrigin}`
       )
+      sendResponse(id, rpcErrors.invalidRequest('Origin mismatch'), undefined)
+      return
     }
 
     Logger.trace(`[InjectedProvider] ${method}`, params)
@@ -567,15 +571,20 @@ export function createInjectedProviderRouter(
       return
     }
 
-    if (nativeOrigin) {
-      trackPendingOrigin(id, nativeOrigin)
-    } else if (APPROVAL_METHODS.has(method)) {
-      // Any approval-class method (signing + addEthereumChain + watchAsset)
-      // requires a verified page origin — see CP-14159. Reject without one
-      // rather than letting peerMeta fall through to CORE_MOBILE_META.
-      sendResponse(id, rpcErrors.internal('Origin unavailable'), undefined)
+    // Every method requires a known native origin. Requests that arrive
+    // before the WebView has reported its first URL, or from an iframe or
+    // about:blank context, have no authoritative origin to gate on — reject
+    // rather than silently treat them as unscoped.
+    if (!nativeOrigin) {
+      sendResponse(
+        id,
+        providerErrors.unauthorized('Origin unavailable'),
+        undefined
+      )
       return
     }
+
+    trackPendingOrigin(id, nativeOrigin)
 
     dispatchMethod(id, method, params)
   }

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -128,6 +128,20 @@ function setupMocks(
   )
 }
 
+// Wraps renderHook and seeds a native origin by default. Tests that explicitly
+// want the no-origin path pass an empty string: `renderProvider('')`.
+function renderProvider(url = 'https://example.com') {
+  const hookReturn = renderHook(() =>
+    useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+  )
+  if (url) {
+    act(() => {
+      hookReturn.result.current.setCurrentUrl(url)
+    })
+  }
+  return hookReturn
+}
+
 describe('useEvmInjectedProvider', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -138,9 +152,7 @@ describe('useEvmInjectedProvider', () => {
 
   describe('providerShimJs', () => {
     it('generates shim with active network chain', () => {
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
       expect(result.current.providerShimJs).toBe('SHIM(0xa86a)')
     })
 
@@ -148,26 +160,20 @@ describe('useEvmInjectedProvider', () => {
       setupMocks({
         network: { ...mockActiveNetwork, vmName: NetworkVMType.BITCOIN }
       })
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
       expect(result.current.providerShimJs).toBe('SHIM(0x1)')
     })
 
     it('still generates shim when no active account', () => {
       setupMocks({ account: null })
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
       expect(result.current.providerShimJs).toBe('SHIM(0xa86a)')
     })
   })
 
   describe('sendResponse', () => {
     it('injects __coreProviderRespond with result', () => {
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
 
       act(() => {
         result.current.emitEvent('chainChanged', '0x1')
@@ -181,9 +187,7 @@ describe('useEvmInjectedProvider', () => {
 
   describe('emitEvent', () => {
     it('injects __coreProviderEmit with event name and data', () => {
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
 
       act(() => {
         result.current.emitEvent('chainChanged', '0x1')
@@ -195,9 +199,7 @@ describe('useEvmInjectedProvider', () => {
     })
 
     it('injects accountsChanged with array data', () => {
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
 
       act(() => {
         result.current.emitEvent('accountsChanged', ['0xNewAddr'])
@@ -211,9 +213,7 @@ describe('useEvmInjectedProvider', () => {
 
   describe('handleProviderMessage', () => {
     it('ignores invalid JSON payload', () => {
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
 
       act(() => {
         result.current.handleProviderMessage('not-json')
@@ -224,9 +224,7 @@ describe('useEvmInjectedProvider', () => {
 
     describe('wallet_switchEthereumChain', () => {
       it('auto-approves, dispatches setTabChainId for the tab, and responds null', async () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -260,9 +258,7 @@ describe('useEvmInjectedProvider', () => {
         const mockSignFn = jest.fn().mockResolvedValue('0xSig')
         mockCreateInAppRequest.mockReturnValue(mockSignFn)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -314,9 +310,7 @@ describe('useEvmInjectedProvider', () => {
           }
         })
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         // Switch browser to chain 1 (auto-approved)
         await act(async () => {
@@ -348,9 +342,7 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('returns null immediately when requested chain is already active', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         // 43114 is the active chain
         const payload = JSON.stringify({
@@ -369,14 +361,12 @@ describe('useEvmInjectedProvider', () => {
           setTabChainId({ tabId: 'test-tab-id', chainId: 43114 })
         )
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
-          'window.__coreProviderRespond(2, null, null); true;'
+          expect.stringContaining('__coreProviderRespond(2, null, null)')
         )
       })
 
       it('returns error 4902 when chain is not in wallet (shim no-rollback prevents wagmi re-trigger loop)', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 3,
@@ -399,9 +389,7 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('returns error when chainId param is missing', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 4,
@@ -426,9 +414,7 @@ describe('useEvmInjectedProvider', () => {
         const mockRequest = jest.fn().mockResolvedValue(null)
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -483,9 +469,7 @@ describe('useEvmInjectedProvider', () => {
         })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         await act(async () => {
           result.current.handleProviderMessage(
@@ -511,9 +495,7 @@ describe('useEvmInjectedProvider', () => {
         })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         await act(async () => {
           result.current.handleProviderMessage(
@@ -542,9 +524,7 @@ describe('useEvmInjectedProvider', () => {
         })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -570,9 +550,7 @@ describe('useEvmInjectedProvider', () => {
 
     describe('wallet_revokePermissions', () => {
       it('emits accountsChanged (not disconnect) then responds null', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 7,
@@ -612,9 +590,7 @@ describe('useEvmInjectedProvider', () => {
         const mockRequest = jest.fn().mockResolvedValue(true)
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -650,9 +626,7 @@ describe('useEvmInjectedProvider', () => {
         const mockRequest = jest.fn().mockResolvedValue(true)
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -678,9 +652,7 @@ describe('useEvmInjectedProvider', () => {
         })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -739,9 +711,7 @@ describe('useEvmInjectedProvider', () => {
           const mockRequest = jest.fn().mockResolvedValue('0xSignature')
           mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-          const { result } = renderHook(() =>
-            useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-          )
+          const { result } = renderProvider()
 
           act(() => {
             result.current.setCurrentUrl('https://example.com')
@@ -826,9 +796,7 @@ describe('useEvmInjectedProvider', () => {
         const mockRequest = jest.fn().mockResolvedValue('0xSignatureResult')
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -858,9 +826,7 @@ describe('useEvmInjectedProvider', () => {
         })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -887,9 +853,7 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('rejects signing when origin is unavailable', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider('')
 
         const payload = JSON.stringify({
           id: 22,
@@ -901,7 +865,7 @@ describe('useEvmInjectedProvider', () => {
         })
 
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
-          expect.stringContaining(`"code":${JSON_RPC_INTERNAL_ERROR_CODE}`)
+          expect.stringContaining('"code":4100')
         )
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
           expect.stringContaining('Origin unavailable')
@@ -968,9 +932,7 @@ describe('useEvmInjectedProvider', () => {
           .mockRejectedValue({ code: 4902, message: 'Unrecognized chain ID' })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -999,9 +961,7 @@ describe('useEvmInjectedProvider', () => {
           .mockRejectedValue({ message: 'Something went wrong' })
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -1055,9 +1015,7 @@ describe('useEvmInjectedProvider', () => {
         }
         mockNitroFetch.mockResolvedValue(mockResponse as unknown as Response)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 100,
@@ -1085,9 +1043,7 @@ describe('useEvmInjectedProvider', () => {
         }
         mockNitroFetch.mockResolvedValue(mockResponse as unknown as Response)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 101,
@@ -1102,7 +1058,9 @@ describe('useEvmInjectedProvider', () => {
         })
 
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
-          'window.__coreProviderRespond(101, null, "0xBalanceValue"); true;'
+          expect.stringContaining(
+            '__coreProviderRespond(101, null, "0xBalanceValue")'
+          )
         )
       })
 
@@ -1114,9 +1072,7 @@ describe('useEvmInjectedProvider', () => {
         }
         mockNitroFetch.mockResolvedValue(mockResponse as unknown as Response)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 102,
@@ -1135,9 +1091,7 @@ describe('useEvmInjectedProvider', () => {
       it('handles fetch failure gracefully', async () => {
         mockNitroFetch.mockRejectedValue(new Error('Network error'))
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 103,
@@ -1166,9 +1120,7 @@ describe('useEvmInjectedProvider', () => {
           }
         })
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 104,
@@ -1188,9 +1140,7 @@ describe('useEvmInjectedProvider', () => {
 
     describe('unsupported methods', () => {
       it('returns error -32601 for unknown methods', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 200,
@@ -1215,9 +1165,7 @@ describe('useEvmInjectedProvider', () => {
         const mockRequest = jest.fn().mockResolvedValue('0xResult')
         mockCreateInAppRequest.mockReturnValue(mockRequest)
 
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         act(() => {
           result.current.setCurrentUrl('https://example.com')
@@ -1240,9 +1188,7 @@ describe('useEvmInjectedProvider', () => {
 
     describe('validation and security', () => {
       it('rejects malformed payloads with -32600', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 400,
@@ -1259,9 +1205,7 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('rejects unknown methods with -32601', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         const payload = JSON.stringify({
           id: 401,
@@ -1278,9 +1222,7 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('exposes setCurrentUrl', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
 
         expect(typeof result.current.setCurrentUrl).toBe('function')
       })
@@ -1366,9 +1308,7 @@ describe('useEvmInjectedProvider', () => {
 
   describe('handleDomainMetadata', () => {
     it('stores valid domain metadata', () => {
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
 
       const metadata = {
         domain: 'opensea.io',
@@ -1385,9 +1325,7 @@ describe('useEvmInjectedProvider', () => {
     })
 
     it('handles invalid JSON gracefully', () => {
-      const { result } = renderHook(() =>
-        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-      )
+      const { result } = renderProvider()
 
       act(() => {
         result.current.handleDomainMetadata('invalid-json')
@@ -1421,9 +1359,7 @@ describe('useEvmInjectedProvider', () => {
 
       it('injects accountsChanged([address]) when the origin has a grant for the active account', () => {
         mockUseStore.mockReturnValue(withPermission(mockActiveAccount.addressC))
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
         act(() => {
           result.current.setCurrentUrl('https://opensea.io/')
         })
@@ -1441,9 +1377,7 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('injects accountsChanged([]) when no grant exists for the origin', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
         act(() => {
           result.current.setCurrentUrl('https://opensea.io/')
         })
@@ -1459,9 +1393,7 @@ describe('useEvmInjectedProvider', () => {
       })
 
       it('does not inject accountsChanged when origin is missing', () => {
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider('')
         // currentUrlRef is never set, so origin stays ''
         mockInjectJavaScript.mockClear()
 
@@ -1476,9 +1408,7 @@ describe('useEvmInjectedProvider', () => {
 
       it('does not inject accountsChanged when there is no active account', () => {
         setupMocks({ account: null })
-        const { result } = renderHook(() =>
-          useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
-        )
+        const { result } = renderProvider()
         act(() => {
           result.current.setCurrentUrl('https://opensea.io/')
         })


### PR DESCRIPTION
## Description

**Ticket: [CP-14368](https://ava-labs.atlassian.net/browse/CP-14368)**

Phase 3a of the injected-provider modernization plan. Closes two origin-trust gaps in the router:

1. **Non-signing methods could proceed without a verified native origin.** Only signing methods were rejected when `nativeOrigin` was missing; read-only (`eth_blockNumber`, `eth_call`, …), `wallet_revokePermissions`, `wallet_addEthereumChain`, `wallet_watchAsset` all passed through. A page with no verifiable origin (pre-nav race, `about:blank`, iframe) could call any of them.
2. **Origin mismatch was logged but not rejected.** When the shim-reported `pageOrigin` differed from the WebView-tracked `nativeOrigin`, we emitted `Logger.warn` and continued serving the request. That's the hostile-page-spoofing-origin path as far as we can detect it in-band.

Directly hardens the CP-14159 origin-spoofing class.

**Stacked PR:** base is `boyer/injected-provider-rpc-validation` (Phase 4.2 — #3863). Review/merge that first; GitHub will retarget this as the stack lands. Rebased onto the current head; single commit.

## Change

In `router.ts:handleProviderMessage`:
- Mismatch (`pageOrigin && nativeOrigin && pageOrigin !== nativeOrigin`) now rejects with `rpcErrors.invalidRequest('Origin mismatch')` instead of warn-and-pass.
- After the `ALLOWED_METHODS` check, any request with `!nativeOrigin` is rejected with `providerErrors.unauthorized('Origin unavailable')` (code 4100) — all methods, not just signing.
- The previous approval-methods-only origin gate (`APPROVAL_METHODS`) is removed, now subsumed by the universal check.

## Summary of changes

- **MODIFIED** `app/hooks/browser/injectedProvider/router.ts` — reshaped the origin gate in `handleProviderMessage` (universal native-origin requirement + mismatch rejection). Removed the now-redundant `APPROVAL_METHODS` set. Method routing still goes through the `dispatchMethod` helper introduced in the rpc-validation/connect-flow stack.
- **MODIFIED** `app/hooks/browser/injectedProvider/router.test.ts` — signing error code on missing origin is now 4100; revoke / getPermissions rejected outright without origin; added read-only-rejection and origin-mismatch tests. Router tests: 35.
- **MODIFIED** `app/hooks/browser/useEvmInjectedProvider.test.ts` — added a `renderProvider(url = 'https://example.com')` helper that seeds `setCurrentUrl` by default (tests exercising the no-origin path pass `''`); migrated the hook tests to it. Hook tests: 73.

## Trust model notes

- Error code 4100 ("unauthorized") is the least-wrong EIP-1193 code here. `-32603 internal` would be inaccurate (well-formed request), `-32600 invalidRequest` implies a malformed envelope. 4100 matches the existing "Origin unavailable" branches in `handleRequestAccounts` / `handleRequestPermissions`.
- The mismatch path requires BOTH `pageOrigin` and `nativeOrigin` to be set. When the shim claims an origin but the native side hasn't tracked one yet, we fall through to the generic "no origin" 4100 gate — can't verify the claim, so no authorization.

## Screenshots/Videos

No UI changes. User-visible difference: if the first RPC call from a brand-new tab arrives before the WebView's first `onNavigationStateChange`, it now receives a 4100 rejection. Realistic dApps retry after `window.ethereum` emits `connect` or after `window.load`, so the race window is narrow.

## Testing

**Unit tests (re-run after rebase):**
- `yarn test app/hooks/browser/injectedProvider/router.test.ts` — 35/35 ✅
- `yarn test app/hooks/browser/useEvmInjectedProvider.test.ts` — 73/73 ✅

**Static (re-run after rebase):**
- `yarn tsc` — ✅ 0 errors
- `yarn lint` (`--max-warnings=0` on touched files) — ✅ 0 errors, 0 warnings

**Manual dev testing:**
iOS: 8716
Android: 8717

1. Fresh tab → Uniswap → Connect Wallet → approval modal appears → approve → dApp shows connected (validates the path where `onNavigationStateChange` fired before `eth_requestAccounts`).
2. Signing request from a granted origin → approval screen appears with correct chain + peer info.
3. Revoke from Settings → Connected Sites → dApp shows disconnected on next refresh.
4. Hostile/tampered page posting a `provider_request` with a mismatched `origin` field → rejected with `invalidRequest('Origin mismatch')` (covered by the new router unit test).
5. Trigger a Bitrise build and reference it here: _<build link TBD>_
6. Move the ticket into the "Testing" column on Jira.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works (unit tests)
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have included screenshots / videos of android and ios (no UI change)
- [ ] I have updated the documentation


[CP-14368]: https://ava-labs.atlassian.net/browse/CP-14368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ