### PR TITLE
Cancel in-flight injected provider requests on cross-origin navigation

### DIFF
--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -154,6 +154,21 @@ function send(
   )
 }
 
+// Like `send` but with an explicit request id — needed by tests that track
+// multiple concurrent in-flight requests (the router keys its abort map by id).
+function sendWithId(
+  router: ReturnType<typeof createInjectedProviderRouter>,
+  id: number,
+  request: { method: string; params?: unknown[] }
+): void {
+  router.handleProviderMessage(
+    JSON.stringify({
+      id,
+      request: { method: request.method, params: request.params ?? [] }
+    })
+  )
+}
+
 describe('createInjectedProviderRouter', () => {
   beforeEach(() => jest.clearAllMocks())
 
@@ -664,12 +679,15 @@ describe('createInjectedProviderRouter', () => {
       send(router, 'personal_sign', ['0xMsg', '0xAddr'])
       await new Promise(r => setImmediate(r))
 
-      expect(requestSigning).toHaveBeenCalledWith({
-        method: 'personal_sign',
-        params: ['0xMsg', '0xAddr'],
-        chainId: 'eip155:43114',
-        peerMeta: expect.objectContaining({ name: 'example' })
-      })
+      expect(requestSigning).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'personal_sign',
+          params: ['0xMsg', '0xAddr'],
+          chainId: 'eip155:43114',
+          peerMeta: expect.objectContaining({ name: 'example' }),
+          signal: expect.any(AbortSignal)
+        })
+      )
       expect(sendResponse).toHaveBeenCalledWith(1, null, '0xSig')
     })
 
@@ -750,6 +768,88 @@ describe('createInjectedProviderRouter', () => {
         expect.objectContaining({ code: JSON_RPC_INTERNAL_ERROR_CODE }),
         undefined
       )
+    })
+  })
+
+  describe('cancelByOrigin', () => {
+    it('aborts in-flight signing requests whose origin does not match the new origin', async () => {
+      const { deps, requestSigning } = makeDeps()
+      // Never resolves — simulates a signing request sitting on an approval
+      // screen while the user navigates away.
+      let capturedSignal: AbortSignal | undefined
+      requestSigning.mockImplementationOnce(args => {
+        capturedSignal = args.signal
+        return new Promise(() => undefined)
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      sendWithId(router, 42, {
+        method: 'personal_sign',
+        params: ['0xMsg', '0xAddr']
+      })
+      await new Promise(r => setImmediate(r))
+
+      expect(capturedSignal?.aborted).toBe(false)
+
+      router.cancelByOrigin('https://other.example')
+
+      expect(capturedSignal?.aborted).toBe(true)
+    })
+
+    it('does not abort requests whose origin matches the new origin', async () => {
+      const { deps, requestSigning } = makeDeps()
+      let capturedSignal: AbortSignal | undefined
+      requestSigning.mockImplementationOnce(args => {
+        capturedSignal = args.signal
+        return new Promise(() => undefined)
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      sendWithId(router, 42, {
+        method: 'personal_sign',
+        params: ['0xMsg', '0xAddr']
+      })
+      await new Promise(r => setImmediate(r))
+
+      // Same origin as makeDeps default — should NOT abort
+      router.cancelByOrigin('https://example.com')
+
+      expect(capturedSignal?.aborted).toBe(false)
+    })
+
+    it('is a no-op when there are no in-flight requests', () => {
+      const { deps } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      // Does not throw, does not emit anything
+      expect(() =>
+        router.cancelByOrigin('https://anywhere.example')
+      ).not.toThrow()
+    })
+
+    it('cleans up in-flight tracking after abort', async () => {
+      const { deps, requestSigning } = makeDeps()
+      const signals: AbortSignal[] = []
+      requestSigning.mockImplementation(args => {
+        if (args.signal) signals.push(args.signal)
+        return new Promise(() => undefined)
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      sendWithId(router, 1, { method: 'personal_sign', params: ['a', 'b'] })
+      await new Promise(r => setImmediate(r))
+
+      router.cancelByOrigin('https://other.example')
+      expect(signals[0]?.aborted).toBe(true)
+
+      // A second cancel round should not re-abort the same controller.
+      // (If it did, reading .aborted still returns true, but the important
+      // thing is the entry was removed from the map.) Fire another request
+      // and confirm it gets its own independent signal.
+      sendWithId(router, 2, { method: 'personal_sign', params: ['c', 'd'] })
+      await new Promise(r => setImmediate(r))
+      expect(signals[1]).toBeDefined()
+      expect(signals[1]?.aborted).toBe(false)
     })
   })
 })

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -245,6 +245,31 @@ describe('createInjectedProviderRouter', () => {
         undefined
       )
     })
+
+    it('does not treat a non-string origin as a mismatch', () => {
+      // `origin` is not type-checked by validateProviderRequest. A truthy
+      // non-string value must not trip the mismatch branch — it's ignored and
+      // the request proceeds gated on the trusted nativeOrigin.
+      const { deps, sendResponse, trackPendingOrigin } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      router.handleProviderMessage(
+        JSON.stringify({
+          id: 1,
+          origin: { not: 'a string' },
+          request: { method: 'eth_blockNumber', params: [] }
+        })
+      )
+
+      expect(sendResponse).not.toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          message: expect.stringContaining('Origin mismatch')
+        }),
+        undefined
+      )
+      expect(trackPendingOrigin).toHaveBeenCalledWith(1, 'https://example.com')
+    })
   })
 
   describe('payload parsing', () => {

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -176,8 +176,14 @@ export function createInjectedProviderRouter(
     return controller
   }
 
-  const clearInFlight = (id: number): void => {
-    inFlightRequests.delete(id)
+  const clearInFlight = (id: number, controller: AbortController): void => {
+    // Only delete if the entry still belongs to THIS request. If a later
+    // request reused the same JSON-RPC id (overwriting the entry), deleting
+    // unconditionally would drop the newer request's controller and break its
+    // cancellation/cleanup.
+    if (inFlightRequests.get(id)?.controller === controller) {
+      inFlightRequests.delete(id)
+    }
   }
 
   const proxyToRpc = async (
@@ -249,7 +255,7 @@ export function createInjectedProviderRouter(
     } catch (e) {
       sendResponse(id, e, undefined)
     } finally {
-      clearInFlight(id)
+      clearInFlight(id, controller)
     }
   }
 
@@ -340,7 +346,7 @@ export function createInjectedProviderRouter(
     } catch (e) {
       sendResponse(id, e, undefined)
     } finally {
-      clearInFlight(id)
+      clearInFlight(id, controller)
     }
   }
 
@@ -533,7 +539,7 @@ export function createInjectedProviderRouter(
         sendResponse(id, e, undefined)
       }
     } finally {
-      clearInFlight(id)
+      clearInFlight(id, controller)
     }
   }
 

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -240,7 +240,10 @@ export function createInjectedProviderRouter(
     }
 
     const caip2ChainId = getEvmCaip2ChainId(getBrowserNetwork().chainId)
-    const origin = getNativeOrigin() ?? ''
+    const origin = getNativeOrigin()
+    // gated by handleProviderMessage (rejects 4100 when absent); never register
+    // a synthetic '' so cancelByOrigin comparisons stay meaningful.
+    if (!origin) return
     const controller = registerInFlight(id, origin)
 
     try {
@@ -319,7 +322,10 @@ export function createInjectedProviderRouter(
       | undefined
     const addHexChainId = addParam?.chainId
     const addRpcUrl = addParam?.rpcUrls?.[0]
-    const origin = getNativeOrigin() ?? ''
+    const origin = getNativeOrigin()
+    // gated by handleProviderMessage (rejects 4100 when absent); never register
+    // a synthetic '' so cancelByOrigin comparisons stay meaningful.
+    if (!origin) return
     const controller = registerInFlight(id, origin)
     try {
       await requestSigning({
@@ -519,7 +525,10 @@ export function createInjectedProviderRouter(
   ): Promise<void> => {
     // Normalize: some dApps send object form { type, options } instead of array
     const normalizedParams = Array.isArray(params) ? params : [params]
-    const origin = getNativeOrigin() ?? ''
+    const origin = getNativeOrigin()
+    // gated by handleProviderMessage (rejects 4100 when absent); never register
+    // a synthetic '' so cancelByOrigin comparisons stay meaningful.
+    if (!origin) return
     const controller = registerInFlight(id, origin)
     try {
       const result = await requestSigning({

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -132,6 +132,18 @@ function parseProviderPayload(
 
 export type InjectedProviderRouter = {
   handleProviderMessage: (payload: string) => void
+  /**
+   * Aborts every in-flight abortable request whose origin does not match
+   * `currentOrigin`. Call when the WebView navigates to a new origin so stale
+   * signing / add-chain / watch-asset flows tied to the prior page cannot
+   * complete or broadcast.
+   */
+  cancelByOrigin: (currentOrigin: string | undefined) => void
+}
+
+type InFlightRequest = {
+  origin: string
+  controller: AbortController
 }
 
 export function createInjectedProviderRouter(
@@ -155,6 +167,18 @@ export function createInjectedProviderRouter(
     revokePermission,
     requestConnectApproval
   } = deps
+
+  const inFlightRequests = new Map<number, InFlightRequest>()
+
+  const registerInFlight = (id: number, origin: string): AbortController => {
+    const controller = new AbortController()
+    inFlightRequests.set(id, { origin, controller })
+    return controller
+  }
+
+  const clearInFlight = (id: number): void => {
+    inFlightRequests.delete(id)
+  }
 
   const proxyToRpc = async (
     id: number,
@@ -210,17 +234,22 @@ export function createInjectedProviderRouter(
     }
 
     const caip2ChainId = getEvmCaip2ChainId(getBrowserNetwork().chainId)
+    const origin = getNativeOrigin() ?? ''
+    const controller = registerInFlight(id, origin)
 
     try {
       const result = await requestSigning({
         method: rpcMethod,
         params,
         chainId: caip2ChainId,
-        peerMeta: getPeerMeta()
+        peerMeta: getPeerMeta(),
+        signal: controller.signal
       })
       sendResponse(id, null, result)
     } catch (e) {
       sendResponse(id, e, undefined)
+    } finally {
+      clearInFlight(id)
     }
   }
 
@@ -284,12 +313,15 @@ export function createInjectedProviderRouter(
       | undefined
     const addHexChainId = addParam?.chainId
     const addRpcUrl = addParam?.rpcUrls?.[0]
+    const origin = getNativeOrigin() ?? ''
+    const controller = registerInFlight(id, origin)
     try {
       await requestSigning({
         method: 'wallet_addEthereumChain' as unknown as RpcMethod,
         params,
         chainId: getEvmCaip2ChainId(getBrowserNetwork().chainId),
-        peerMeta: getPeerMeta()
+        peerMeta: getPeerMeta(),
+        signal: controller.signal
       })
       // User approved — switch browser chain to the new network and notify dApp
       if (addHexChainId) {
@@ -307,6 +339,8 @@ export function createInjectedProviderRouter(
       sendResponse(id, null, null)
     } catch (e) {
       sendResponse(id, e, undefined)
+    } finally {
+      clearInFlight(id)
     }
   }
 
@@ -479,12 +513,15 @@ export function createInjectedProviderRouter(
   ): Promise<void> => {
     // Normalize: some dApps send object form { type, options } instead of array
     const normalizedParams = Array.isArray(params) ? params : [params]
+    const origin = getNativeOrigin() ?? ''
+    const controller = registerInFlight(id, origin)
     try {
       const result = await requestSigning({
         method: 'wallet_watchAsset' as unknown as RpcMethod,
         params: normalizedParams,
         chainId: getEvmCaip2ChainId(getBrowserNetwork().chainId),
-        peerMeta: getPeerMeta()
+        peerMeta: getPeerMeta(),
+        signal: controller.signal
       })
       sendResponse(id, null, result)
     } catch (e) {
@@ -495,6 +532,8 @@ export function createInjectedProviderRouter(
       } else {
         sendResponse(id, e, undefined)
       }
+    } finally {
+      clearInFlight(id)
     }
   }
 
@@ -589,5 +628,15 @@ export function createInjectedProviderRouter(
     dispatchMethod(id, method, params)
   }
 
-  return { handleProviderMessage }
+  const cancelByOrigin = (currentOrigin: string | undefined): void => {
+    if (inFlightRequests.size === 0) return
+    for (const [id, entry] of inFlightRequests.entries()) {
+      if (entry.origin !== currentOrigin) {
+        entry.controller.abort()
+        inFlightRequests.delete(id)
+      }
+    }
+  }
+
+  return { handleProviderMessage, cancelByOrigin }
 }

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -597,7 +597,18 @@ export function createInjectedProviderRouter(
     // can't verify the shim's claim without a native anchor, so 4100
     // "unauthorized" is the right response — not "invalidRequest," since
     // the payload itself is well-formed.
-    if (pageOrigin && nativeOrigin && pageOrigin !== nativeOrigin) {
+    //
+    // `origin` isn't type-checked by validateProviderRequest, so require a
+    // string here: a truthy non-string would otherwise always be `!==` the
+    // native origin and trip this branch with noisy logs / bogus rejections.
+    // A non-string origin is treated like an absent one — the request still
+    // gates on the trusted nativeOrigin below (the real anchor; pageOrigin is
+    // only the extra spoof-detection layer).
+    if (
+      typeof pageOrigin === 'string' &&
+      nativeOrigin &&
+      pageOrigin !== nativeOrigin
+    ) {
       Logger.warn(
         `[InjectedProvider] Origin mismatch rejected: page=${pageOrigin} native=${nativeOrigin}`
       )

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -61,6 +61,20 @@ jest.mock('./evmProviderShim', () => ({
   )
 }))
 
+jest.mock('expo-router', () => ({
+  router: {
+    canGoBack: jest.fn(() => false),
+    back: jest.fn(),
+    navigate: jest.fn()
+  }
+}))
+
+jest.mock('vmModule/ApprovalController/ApprovalController', () => ({
+  approvalController: {
+    handleGoBackIfNeeded: jest.fn()
+  }
+}))
+
 jest.mock('./getInjectedProviderUuid', () => ({
   getInjectedProviderUuid: () => 'test-uuid-1234'
 }))
@@ -733,14 +747,17 @@ describe('useEvmInjectedProvider', () => {
             mockDispatch,
             expect.any(Function)
           )
-          expect(mockRequest).toHaveBeenCalledWith({
-            method: rpcMethod,
-            params: ['param1', 'param2'],
-            chainId: 'eip155:43114',
-            peerMeta: expect.objectContaining({
-              url: 'https://example.com'
+          expect(mockRequest).toHaveBeenCalledWith(
+            expect.objectContaining({
+              method: rpcMethod,
+              params: ['param1', 'param2'],
+              chainId: 'eip155:43114',
+              peerMeta: expect.objectContaining({
+                url: 'https://example.com'
+              }),
+              signal: expect.any(AbortSignal)
             })
-          })
+          )
         }
       )
 
@@ -1303,6 +1320,69 @@ describe('useEvmInjectedProvider', () => {
         call[0].includes("__coreProviderEmit('chainChanged'")
       )
       expect(chainChangedCalls).toHaveLength(0)
+    })
+  })
+
+  describe('setCurrentUrl origin-change cleanup', () => {
+    it('aborts in-flight signing request when navigating cross-origin', async () => {
+      const { approvalController: mockApprovalController } = jest.requireMock(
+        'vmModule/ApprovalController/ApprovalController'
+      )
+      ;(mockApprovalController.handleGoBackIfNeeded as jest.Mock).mockClear()
+
+      let capturedSignal: AbortSignal | undefined
+      const mockRequest = jest.fn(args => {
+        capturedSignal = args.signal
+        return new Promise(() => undefined)
+      })
+      mockCreateInAppRequest.mockReturnValue(mockRequest)
+
+      const { result } = renderProvider('https://uniswap.org')
+
+      await act(async () => {
+        result.current.handleProviderMessage(
+          JSON.stringify({
+            id: 99,
+            request: { method: 'personal_sign', params: ['0xMsg', '0xAddr'] }
+          })
+        )
+      })
+
+      expect(capturedSignal?.aborted).toBe(false)
+
+      act(() => {
+        result.current.setCurrentUrl('https://opensea.io')
+      })
+
+      expect(capturedSignal?.aborted).toBe(true)
+      expect(mockApprovalController.handleGoBackIfNeeded).toHaveBeenCalled()
+    })
+
+    it('does NOT abort in-flight request on same-origin navigation (SPA route change)', async () => {
+      let capturedSignal: AbortSignal | undefined
+      const mockRequest = jest.fn(args => {
+        capturedSignal = args.signal
+        return new Promise(() => undefined)
+      })
+      mockCreateInAppRequest.mockReturnValue(mockRequest)
+
+      const { result } = renderProvider('https://uniswap.org/swap')
+
+      await act(async () => {
+        result.current.handleProviderMessage(
+          JSON.stringify({
+            id: 99,
+            request: { method: 'personal_sign', params: ['0xMsg', '0xAddr'] }
+          })
+        )
+      })
+
+      act(() => {
+        // Same origin, different path — mimics a SPA nav_change message
+        result.current.setCurrentUrl('https://uniswap.org/pool')
+      })
+
+      expect(capturedSignal?.aborted).toBe(false)
     })
   })
 

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import { shallowEqual, useDispatch, useSelector, useStore } from 'react-redux'
 import { selectActiveAccount } from 'store/account/slice'
 import { selectActiveNetwork, selectAllNetworks } from 'store/network/slice'
@@ -365,9 +365,12 @@ export function useEvmInjectedProvider(
     requestConnectApproval
   ])
 
-  // Publish the router to the ref so setCurrentUrl (defined above, fires
-  // on nav events) can call cancelByOrigin without restructuring the memo.
-  useEffect(() => {
+  // Publish the router to the ref so setCurrentUrl (defined above, fires on nav
+  // events) can call cancelByOrigin. useLayoutEffect (not useEffect) so the ref
+  // is populated synchronously on commit, before any WebView navigation event
+  // can fire — otherwise an early cross-origin nav could run setCurrentUrl with
+  // a null ref and silently skip the security-sensitive cancellation.
+  useLayoutEffect(() => {
     routerRef.current = router
   }, [router])
 

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -12,6 +12,7 @@ import { PeerMeta } from 'store/rpc/types'
 import { serializeError } from '@metamask/rpc-errors'
 import { router as appRouter } from 'expo-router'
 import { walletConnectCache } from 'services/walletconnectv2/walletConnectCache/walletConnectCache'
+import { approvalController } from 'vmModule/ApprovalController/ApprovalController'
 import {
   grantPermission as grantPermissionAction,
   revokePermission as revokePermissionAction,
@@ -21,7 +22,10 @@ import type { RootState } from 'store/types'
 import type { Account } from 'store/account'
 import { buildEvmProviderShim } from './evmProviderShim'
 import { getInjectedProviderUuid } from './getInjectedProviderUuid'
-import { createInjectedProviderRouter } from './injectedProvider/router'
+import {
+  createInjectedProviderRouter,
+  InjectedProviderRouter
+} from './injectedProvider/router'
 import {
   CONNECT_PROMPT_TIMED_OUT_MESSAGE,
   EIP1193_USER_REJECTED_CODE,
@@ -103,8 +107,34 @@ export function useEvmInjectedProvider(
     )
   }, [activeNetwork, tabChainId, webViewRef])
 
+  // Router is assigned below (after useMemo). setCurrentUrl may fire before
+  // the router is constructed on first render, so we route through a ref.
+  const routerRef = useRef<InjectedProviderRouter | null>(null)
+
+  // Tracks the reject fn of an in-flight connect approval so a later request
+  // or an origin change can unstick it. Also used by requestConnectApproval
+  // in the memo below.
+  const prevInflightConnectReject = useRef<((err: unknown) => void) | null>(
+    null
+  )
+
   const setCurrentUrl = useCallback((url: string) => {
+    const prevOrigin = getOriginFromUrl(currentUrlRef.current)
     currentUrlRef.current = url
+    const newOrigin = getOriginFromUrl(url)
+
+    // Only cancel on actual origin change — within-origin SPA nav (nav_change
+    // messages firing on pushState/replaceState) keeps the tab connected to
+    // the same dApp, so stale approvals remain legitimate.
+    if (prevOrigin && prevOrigin !== newOrigin) {
+      routerRef.current?.cancelByOrigin(newOrigin)
+      prevInflightConnectReject.current?.({
+        code: EIP1193_USER_REJECTED_CODE,
+        message: USER_REJECTED_REQUEST_MESSAGE
+      })
+      prevInflightConnectReject.current = null
+      approvalController.handleGoBackIfNeeded()
+    }
   }, [])
 
   const chainIdHex = useMemo(() => {
@@ -227,13 +257,6 @@ export function useEvmInjectedProvider(
     }
   }, [])
 
-  // Tracks the reject fn of an in-flight connect approval so a later request
-  // (or an unmount) can unstick it. Writes and clears happen only inside
-  // requestConnectApproval.
-  const prevInflightConnectReject = useRef<((err: unknown) => void) | null>(
-    null
-  )
-
   const requestConnectApproval = useCallback(
     (peerMeta: PeerMeta): Promise<Account[]> => {
       // If a prior connect is still parked (screen never mounted, or a second
@@ -341,6 +364,10 @@ export function useEvmInjectedProvider(
     getPeerMeta,
     requestConnectApproval
   ])
+
+  // Publish the router to the ref so setCurrentUrl (defined above, fires
+  // on nav events) can call cancelByOrigin without restructuring the memo.
+  routerRef.current = router
 
   const handleProviderMessage = useCallback(
     (payload: string) => router.handleProviderMessage(payload),

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -367,7 +367,9 @@ export function useEvmInjectedProvider(
 
   // Publish the router to the ref so setCurrentUrl (defined above, fires
   // on nav events) can call cancelByOrigin without restructuring the memo.
-  routerRef.current = router
+  useEffect(() => {
+    routerRef.current = router
+  }, [router])
 
   const handleProviderMessage = useCallback(
     (payload: string) => router.handleProviderMessage(payload),

--- a/packages/core-mobile/app/store/rpc/utils/createInAppRequest.test.ts
+++ b/packages/core-mobile/app/store/rpc/utils/createInAppRequest.test.ts
@@ -1,4 +1,7 @@
-import { RpcMethod as VmModuleRpcMethod } from '@avalabs/vm-module-types'
+import {
+  RpcError,
+  RpcMethod as VmModuleRpcMethod
+} from '@avalabs/vm-module-types'
 import { FeatureVars } from 'services/posthog/types'
 import { RootState } from 'store/types'
 import {
@@ -282,7 +285,10 @@ describe('createInAppRequest', () => {
         params: []
       })
 
-      const err = { code: 4001, message: 'user rejected' }
+      const err = {
+        code: 4001,
+        message: 'user rejected'
+      } as unknown as RpcError
       mockListenerEffects.forEach(effect =>
         effect(
           onInAppRequestFailed({ requestId: FIXED_REQUEST_ID, error: err })

--- a/packages/core-mobile/app/store/rpc/utils/createInAppRequest.test.ts
+++ b/packages/core-mobile/app/store/rpc/utils/createInAppRequest.test.ts
@@ -1,30 +1,33 @@
-import { Dispatch } from '@reduxjs/toolkit'
 import { RpcMethod as VmModuleRpcMethod } from '@avalabs/vm-module-types'
 import { FeatureVars } from 'services/posthog/types'
 import { RootState } from 'store/types'
+import {
+  onInAppRequestFailed,
+  onInAppRequestSucceeded,
+  onRequest,
+  onRequestRejected
+} from '../slice'
 import { RequestContext } from '../types'
 import { createInAppRequest } from './createInAppRequest'
-import { generateInAppRequestPayload } from './generateInAppRequestPayload'
+import * as generatePayload from './generateInAppRequestPayload'
+
+const FIXED_REQUEST_ID = 9999
+
+let mockListenerEffects: Array<(action: unknown) => void> = []
 
 jest.mock('store/middleware/listener', () => ({
-  addAppListener: jest.fn(() => ({ type: 'addListener' }))
+  addAppListener: (opts: { effect: (action: unknown) => void }) => {
+    return () => {
+      // Our mock tracks the effect directly so tests can drive it.
+      mockListenerEffects.push(opts.effect)
+      return () => {
+        mockListenerEffects = mockListenerEffects.filter(
+          fn => fn !== opts.effect
+        )
+      }
+    }
+  }
 }))
-
-jest.mock('../slice', () => ({
-  onRequest: jest.fn(payload => ({ type: 'rpc/onRequest', payload })),
-  onInAppRequestSucceeded: { match: jest.fn(() => false) },
-  onInAppRequestFailed: { match: jest.fn(() => false) }
-}))
-
-jest.mock('./generateInAppRequestPayload', () => ({
-  generateInAppRequestPayload: jest.fn(() => ({
-    type: 'rpc/onRequest',
-    payload: { requestId: 'req-1' },
-    data: { id: 'req-1' }
-  }))
-}))
-
-const mockGenerateInAppRequestPayload = generateInAppRequestPayload as jest.Mock
 
 const makeState = (saeOverride?: string): RootState =>
   ({
@@ -35,69 +38,258 @@ const makeState = (saeOverride?: string): RootState =>
     }
   } as unknown as RootState)
 
+const defaultGetState = (): RootState => makeState(undefined)
+
 describe('createInAppRequest', () => {
-  let dispatch: jest.MockedFunction<Dispatch>
+  let dispatch: jest.Mock
+  let payloadSpy: jest.SpyInstance
 
   beforeEach(() => {
-    jest.clearAllMocks()
-    dispatch = jest.fn() as unknown as jest.MockedFunction<Dispatch>
-  })
-
-  it('snapshots the sae-override flag into request.context when set', () => {
-    const getState = (): RootState => makeState('enabled')
-    const request = createInAppRequest(dispatch, getState)
-
-    request({
-      method: VmModuleRpcMethod.ETH_SEND_TRANSACTION,
-      params: [],
-      chainId: 'eip155:43114',
-      context: { existing: 'value' }
+    mockListenerEffects = []
+    dispatch = jest.fn(action => {
+      // The listener middleware action is a thunk that registers the listener
+      // and returns an unsubscribe; plain actions are returned as-is.
+      if (typeof action === 'function') return action()
+      return action
     })
 
-    expect(mockGenerateInAppRequestPayload).toHaveBeenCalledWith(
-      expect.objectContaining({
-        context: {
-          existing: 'value',
-          [RequestContext.SAE_OVERRIDE]: 'enabled'
-        }
-      })
-    )
+    // Deterministic request id so we can reference it in onRequestRejected
+    // assertions below.
+    payloadSpy = jest
+      .spyOn(generatePayload, 'generateInAppRequestPayload')
+      .mockImplementation(
+        ({ method, params, chainId, peerMeta }) =>
+          ({
+            provider: 'core-mobile' as unknown as never,
+            method,
+
+            data: {
+              id: FIXED_REQUEST_ID,
+              topic: 'core-mobile-test',
+              params: { request: { method, params }, chainId: chainId ?? '' }
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any,
+            peerMeta
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any)
+      )
   })
 
-  it("defaults the sae-override key to 'auto' when the flag is unset", () => {
-    const getState = (): RootState => makeState(undefined)
-    const request = createInAppRequest(dispatch, getState)
-
-    request({
-      method: VmModuleRpcMethod.ETH_SEND_TRANSACTION,
-      params: [],
-      chainId: 'eip155:43114'
-    })
-
-    expect(mockGenerateInAppRequestPayload).toHaveBeenCalledWith(
-      expect.objectContaining({
-        context: { [RequestContext.SAE_OVERRIDE]: 'auto' }
-      })
-    )
+  afterEach(() => {
+    payloadSpy.mockRestore()
   })
 
-  it('reads the flag at request creation time, not at module load time', () => {
-    let currentOverride: string | undefined = 'disabled'
-    const getState = (): RootState => makeState(currentOverride)
-    const request = createInAppRequest(dispatch, getState)
+  describe('sae-override context', () => {
+    it('snapshots the sae-override flag into request.context when set', () => {
+      const request = createInAppRequest(dispatch, () => makeState('enabled'))
 
-    currentOverride = 'enabled'
+      request({
+        method: VmModuleRpcMethod.ETH_SEND_TRANSACTION,
+        params: [],
+        chainId: 'eip155:43114',
+        context: { existing: 'value' }
+      })
 
-    request({
-      method: VmModuleRpcMethod.ETH_SEND_TRANSACTION,
-      params: [],
-      chainId: 'eip155:43114'
+      expect(payloadSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: {
+            existing: 'value',
+            [RequestContext.SAE_OVERRIDE]: 'enabled'
+          }
+        })
+      )
     })
 
-    expect(mockGenerateInAppRequestPayload).toHaveBeenCalledWith(
-      expect.objectContaining({
-        context: { [RequestContext.SAE_OVERRIDE]: 'enabled' }
+    it("defaults the sae-override key to 'auto' when the flag is unset", () => {
+      const request = createInAppRequest(dispatch, () => makeState(undefined))
+
+      request({
+        method: VmModuleRpcMethod.ETH_SEND_TRANSACTION,
+        params: [],
+        chainId: 'eip155:43114'
       })
-    )
+
+      expect(payloadSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: { [RequestContext.SAE_OVERRIDE]: 'auto' }
+        })
+      )
+    })
+
+    it('reads the flag at request creation time, not at module load time', () => {
+      let currentOverride: string | undefined = 'disabled'
+      const request = createInAppRequest(dispatch, () =>
+        makeState(currentOverride)
+      )
+
+      currentOverride = 'enabled'
+
+      request({
+        method: VmModuleRpcMethod.ETH_SEND_TRANSACTION,
+        params: [],
+        chainId: 'eip155:43114'
+      })
+
+      expect(payloadSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: { [RequestContext.SAE_OVERRIDE]: 'enabled' }
+        })
+      )
+    })
+  })
+
+  describe('abort / cancellation', () => {
+    it('rejects synchronously without dispatching onRequest when signal is already aborted', async () => {
+      const controller = new AbortController()
+      controller.abort()
+
+      const request = createInAppRequest(dispatch, defaultGetState)
+
+      await expect(
+        request({
+          method: VmModuleRpcMethod.PERSONAL_SIGN,
+          params: [],
+          signal: controller.signal
+        })
+      ).rejects.toEqual(expect.objectContaining({ code: 4001 }))
+
+      expect(dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: onRequest.type })
+      )
+    })
+
+    it('dispatches onRequestRejected when the signal aborts mid-flight', async () => {
+      const controller = new AbortController()
+      const request = createInAppRequest(dispatch, defaultGetState)
+
+      const promise = request({
+        method: VmModuleRpcMethod.PERSONAL_SIGN,
+        params: ['0xMsg', '0xAddr'],
+        signal: controller.signal
+      })
+
+      // onRequest should have been dispatched once
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: onRequest.type })
+      )
+
+      controller.abort()
+
+      await expect(promise).rejects.toEqual(
+        expect.objectContaining({ code: 4001 })
+      )
+
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: onRequestRejected.type,
+          payload: expect.objectContaining({
+            request: expect.objectContaining({
+              data: expect.objectContaining({ id: FIXED_REQUEST_ID })
+            })
+          })
+        })
+      )
+    })
+
+    it('ignores a later success event after abort has settled the promise', async () => {
+      const controller = new AbortController()
+      const request = createInAppRequest(dispatch, defaultGetState)
+
+      const promise = request({
+        method: VmModuleRpcMethod.PERSONAL_SIGN,
+        params: [],
+        signal: controller.signal
+      })
+
+      controller.abort()
+
+      // Fire a spurious success after abort — promise should already have
+      // settled to reject and must not flip to resolve.
+      mockListenerEffects.forEach(effect =>
+        effect(
+          onInAppRequestSucceeded({
+            requestId: FIXED_REQUEST_ID,
+            txHash: '0xDEADBEEF'
+          })
+        )
+      )
+
+      await expect(promise).rejects.toEqual(
+        expect.objectContaining({ code: 4001 })
+      )
+    })
+
+    it('does NOT dispatch onRequestRejected when the listener settles first (normal success)', async () => {
+      const controller = new AbortController()
+      const request = createInAppRequest(dispatch, defaultGetState)
+
+      const promise = request({
+        method: VmModuleRpcMethod.PERSONAL_SIGN,
+        params: [],
+        signal: controller.signal
+      })
+
+      // Simulate the handler dispatching onInAppRequestSucceeded.
+      mockListenerEffects.forEach(effect =>
+        effect(
+          onInAppRequestSucceeded({
+            requestId: FIXED_REQUEST_ID,
+            txHash: '0xABC'
+          })
+        )
+      )
+
+      await expect(promise).resolves.toBe('0xABC')
+
+      // A subsequent abort should be a no-op: no onRequestRejected dispatched.
+      dispatch.mockClear()
+      controller.abort()
+
+      expect(dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: onRequestRejected.type })
+      )
+    })
+
+    it('detaches the abort listener when the request settles, so it is not retained', async () => {
+      const controller = new AbortController()
+      const removeSpy = jest.spyOn(controller.signal, 'removeEventListener')
+      const request = createInAppRequest(dispatch, defaultGetState)
+
+      const promise = request({
+        method: VmModuleRpcMethod.PERSONAL_SIGN,
+        params: [],
+        signal: controller.signal
+      })
+
+      mockListenerEffects.forEach(effect =>
+        effect(
+          onInAppRequestSucceeded({
+            requestId: FIXED_REQUEST_ID,
+            txHash: '0xABC'
+          })
+        )
+      )
+      await expect(promise).resolves.toBe('0xABC')
+
+      expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function))
+    })
+
+    it('rejects when the listener settles with onInAppRequestFailed (no abort involved)', async () => {
+      const request = createInAppRequest(dispatch, defaultGetState)
+
+      const promise = request({
+        method: VmModuleRpcMethod.PERSONAL_SIGN,
+        params: []
+      })
+
+      const err = { code: 4001, message: 'user rejected' }
+      mockListenerEffects.forEach(effect =>
+        effect(
+          onInAppRequestFailed({ requestId: FIXED_REQUEST_ID, error: err })
+        )
+      )
+
+      await expect(promise).rejects.toEqual(err)
+    })
   })
 })

--- a/packages/core-mobile/app/store/rpc/utils/createInAppRequest.ts
+++ b/packages/core-mobile/app/store/rpc/utils/createInAppRequest.ts
@@ -1,4 +1,5 @@
 import { Dispatch, isAnyOf } from '@reduxjs/toolkit'
+import { providerErrors } from '@metamask/rpc-errors'
 import { addAppListener } from 'store/middleware/listener'
 import { RpcMethod as VmModuleRpcMethod } from '@avalabs/vm-module-types'
 import { selectSaeOverride } from 'store/posthog/slice'
@@ -6,7 +7,8 @@ import { RootState } from 'store/types'
 import {
   onInAppRequestFailed,
   onInAppRequestSucceeded,
-  onRequest
+  onRequest,
+  onRequestRejected
 } from '../slice'
 import { PeerMeta, RequestContext, RpcMethod } from '../types'
 import { generateInAppRequestPayload } from './generateInAppRequestPayload'
@@ -21,13 +23,22 @@ export type Request = ({
   params,
   chainId,
   context,
-  peerMeta
+  peerMeta,
+  signal
 }: {
   method: VmModuleRpcMethod
   params: unknown
   chainId?: string
   context?: Record<string, unknown>
   peerMeta?: PeerMeta
+  /**
+   * Optional AbortSignal. Aborting cancels the in-flight request by
+   * dispatching `onRequestRejected` (so any open handler — including
+   * `eth_sendTransaction` sitting on an approval screen — sees the rejection
+   * before it broadcasts) and rejects the returned Promise with
+   * `userRejectedRequest`.
+   */
+  signal?: AbortSignal
 }) => Promise<string>
 
 /**
@@ -61,7 +72,7 @@ export const createInAppRequest = (
   dispatch: Dispatch,
   getState: () => RootState
 ): Request => {
-  return ({ method, params, chainId, context, peerMeta }) => {
+  return ({ method, params, chainId, context, peerMeta, signal }) => {
     return new Promise((resolve, reject) => {
       // Snapshot the SAE override flag into context so downstream consumers
       // (gate util, ApprovalController) don't need to reach into redux from
@@ -80,27 +91,77 @@ export const createInAppRequest = (
         context: enrichedContext,
         peerMeta
       })
+
+      if (signal?.aborted) {
+        reject(providerErrors.userRejectedRequest())
+        return
+      }
+
       dispatch(onRequest(inAppRequest))
+
+      let settled = false
+      // Abort listener, detached on settle so it doesn't keep this closure
+      // attached to a long-lived `signal` (pattern: LedgerService.ts). A no-op
+      // default lets the success/fail paths call removeEventListener
+      // unconditionally — it's replaced below when a `signal` is provided.
+      let onAbort: () => void = () => undefined
 
       // wait for the success/fail action and resolve/reject accordingly
       const unsubscribe = dispatch(
         addAppListener({
           matcher: EVENTS_TO_SUBSCRIBE,
           effect: action => {
-            if (action.payload.requestId === inAppRequest.data.id) {
-              if (onInAppRequestSucceeded.match(action)) {
-                // @ts-ignore unsubcribe is a valid function
-                unsubscribe()
-                resolve(action.payload.txHash)
-              } else if (onInAppRequestFailed.match(action)) {
-                // @ts-ignore unsubcribe is a valid function
-                unsubscribe()
-                reject(action.payload.error)
-              }
+            if (action.payload.requestId !== inAppRequest.data.id) return
+            if (onInAppRequestSucceeded.match(action)) {
+              settled = true
+              // @ts-ignore unsubscribe is a valid function
+              unsubscribe()
+              signal?.removeEventListener('abort', onAbort)
+              resolve(action.payload.txHash)
+            } else if (onInAppRequestFailed.match(action)) {
+              settled = true
+              // @ts-ignore unsubscribe is a valid function
+              unsubscribe()
+              signal?.removeEventListener('abort', onAbort)
+              reject(action.payload.error)
             }
           }
         })
       )
+
+      if (signal) {
+        onAbort = () => {
+          if (settled) return
+          settled = true
+          // @ts-ignore unsubscribe is a valid function
+          unsubscribe()
+          // Propagate a rejection so any handler currently sitting on the
+          // approval screen (e.g. eth_sendTransaction) short-circuits
+          // before broadcasting. The handler's machinery will dispatch
+          // onInAppRequestFailed, but the listener above is already
+          // `settled` so our reject() only fires once.
+          //
+          // Known race (Phase 3 Stage B): if the user has already tapped
+          // Approve and `handleRequestInternally` has matched the approval
+          // action, the handler's `approve(...)` path (which signs and
+          // broadcasts) is already running and this dispatch is dropped.
+          // Fully closing the window requires plumbing AbortSignal into
+          // WalletService.sign and the VM-module broadcast path — out of
+          // scope for this phase. The window we DO close: user opens an
+          // approval modal but has NOT yet tapped Approve when navigation
+          // happens.
+          dispatch(
+            onRequestRejected({
+              request: inAppRequest,
+              error: providerErrors.userRejectedRequest() as Parameters<
+                typeof onRequestRejected
+              >[0]['error']
+            })
+          )
+          reject(providerErrors.userRejectedRequest())
+        }
+        signal.addEventListener('abort', onAbort, { once: true })
+      }
     })
   }
 }

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -200,10 +200,14 @@ class ApprovalController implements VmModuleApprovalController {
 
   handleGoBackIfNeeded = (): void => {
     const currentRoute = currentRouteStore.getState().currentRoute
+    if (!router.canGoBack()) return
     if (
-      (currentRoute?.endsWith('ledgerReviewTransaction') ||
-        currentRoute?.endsWith('approval')) &&
-      router.canGoBack()
+      currentRoute?.endsWith('ledgerReviewTransaction') ||
+      currentRoute?.endsWith('approval') ||
+      currentRoute?.endsWith('addEthereumChain') ||
+      currentRoute?.endsWith('authorizeInjectedDapp') ||
+      currentRoute?.endsWith('authorizeDapp') ||
+      currentRoute?.endsWith('watchAsset')
     ) {
       router.back()
     }


### PR DESCRIPTION
## Description

**Ticket: [CP-14369](https://ava-labs.atlassian.net/browse/CP-14369)**

Phase 3b of the injected-provider modernization plan. Closes the stale-approval attack: user triggers a signing request on dApp A, navigates away without approving, returns later and taps Approve — transaction broadcasts.

After this PR, on cross-origin navigation:
1. In-flight handlers (`eth_sendTransaction`, `personal_sign`, `eth_signTypedData_*`, `wallet_addEthereumChain`, `wallet_watchAsset`) are aborted via an `AbortSignal` threaded through `createInAppRequest`. The abort dispatches `onRequestRejected` into the RPC slice, short-circuiting the handler before it broadcasts (assuming the user has NOT yet tapped Approve).
2. The in-flight connect approval (parked `eth_requestAccounts` / `wallet_requestPermissions` promise) is rejected.
3. `ApprovalController.handleGoBackIfNeeded` dismisses the stale approval screen across the relevant modal routes.

**Same-origin SPA nav (pushState/replaceState within `uniswap.org`) is preserved** — no cleanup fires. The gate is `prevOrigin && prevOrigin !== newOrigin`.

**Stacked PR:** base is `boyer/injected-provider-origin-hardening` (Phase 3a — #3866). Review/merge that first; GitHub will retarget this as the stack lands. Rebased onto the current head; single commit.

## Known race (documented inline)

If the user has already tapped Approve and `handleRequestInternally` has consumed the approval action, the VM module's sign + broadcast path is already running and this dispatch is dropped. Fully closing the window requires plumbing `AbortSignal` into `WalletService.sign` and the VM-module broadcast path — out of scope for this phase. The window we DO close: user opens an approval modal but has NOT yet tapped Approve when navigation happens. See the inline comment in `createInAppRequest.ts`.

## Summary of changes

- **MODIFIED `app/store/rpc/utils/createInAppRequest.ts`** — added optional `signal?: AbortSignal` to the `Request` type. On abort: unsubscribe listener, dispatch `onRequestRejected`, reject the Promise. A `settled` flag + `{ once: true }` listener prevent double-firing; a synchronous `signal.aborted` check at entry rejects immediately with no dispatch. (Merged with the existing `(dispatch, getState)` + SAE-override enrichment from the upstream stack.)
- **`app/store/rpc/utils/createInAppRequest.test.ts`** — covers pre-aborted signal, mid-flight abort, abort-then-success race (settled guard), normal success-then-abort, handler-dispatched failure, plus the SAE-override context cases. 8 tests.
- **MODIFIED `app/hooks/browser/injectedProvider/router.ts`** — tracks `Map<id, {origin, controller}>` for every async handler that awaits `requestSigning`; passes `controller.signal` into the signing call and cleans up in `finally`. New `cancelByOrigin(currentOrigin)` aborts all entries whose origin doesn't match.
- **`app/hooks/browser/injectedProvider/router.test.ts`** — added `cancelByOrigin` coverage (cross-origin aborts, same-origin preserves, empty-map no-op, cleanup correctness). 39 tests.
- **MODIFIED `app/hooks/browser/useEvmInjectedProvider.ts`** — `setCurrentUrl` detects origin change and calls `router.cancelByOrigin` + rejects the parked connect promise + `approvalController.handleGoBackIfNeeded`. Router is accessed via a `routerRef` since `setCurrentUrl` is defined before the router `useMemo`.
- **`app/hooks/browser/useEvmInjectedProvider.test.ts`** — added `expo-router` + `approvalController` mocks and origin-change cleanup tests. 75 tests.
- **MODIFIED `app/vmModule/ApprovalController/ApprovalController.ts`** — `handleGoBackIfNeeded` route list extended to also include `addEthereumChain`, `authorizeInjectedDapp`, `authorizeDapp`, `watchAsset`.

## Screenshots/Videos

No UI changes. User-visible difference: opening an approval modal on dApp A, then navigating to dApp B via the URL bar, now dismisses the modal automatically; dApp A's in-flight request receives a `4001` rejection.

## Testing

iOS: 8728
Android: 8729

**Unit tests (re-run after rebase):**
- `createInAppRequest.test.ts` — 8/8 ✅
- `router.test.ts` — 39/39 ✅
- `useEvmInjectedProvider.test.ts` — 75/75 ✅

**Static (re-run after rebase):**
- `yarn tsc` — ✅ 0 errors
- `yarn lint` (`--max-warnings=0` on touched files) — ✅ 0 errors (one pre-existing `no-shadow` warning in `ApprovalController.ts`, unrelated to this change and suppressed by CI's `--quiet`)

**Manual dev testing:**

1. Open the in-app browser → a dApp (e.g. opensea.io). Trigger a signing request → approval modal appears.
2. Without approving/cancelling, navigate to a different origin (e.g. app.uniswap.org) via the address bar.
3. ✅ Approval modal dismisses automatically; the opensea.io request receives `4001 user rejected`.
4. **Same-origin regression:** Uniswap → Swap → Pool (same origin, different route) — open modals persist (SPA soft-nav is not an origin change).
5. **Ledger flow:** trigger a signing request, open the Ledger review screen, navigate away → it dismisses.
6. Trigger a Bitrise build and reference it here: _<build link TBD>_
7. Move the ticket into the "Testing" column on Jira.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works (unit tests)
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have included screenshots / videos of android and ios (no UI change beyond modal dismissal)
- [ ] I have updated the documentation


[CP-14369]: https://ava-labs.atlassian.net/browse/CP-14369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ