### PR TITLE
CP-14389: fix modal grabber in ScrollScreen

### DIFF
--- a/packages/core-mobile/app/new/common/components/ListScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ListScreen.tsx
@@ -153,7 +153,6 @@ export const ListScreen = <T,>({
     {
       header: <NavigationTitleHeader title={navigationTitle ?? title ?? ''} />,
       targetLayout,
-      shouldHeaderHaveGrabber: isModal,
       hideHeaderBackground: shouldShowStickyHeader,
       hasSeparator: shouldShowStickyHeader
         ? renderHeader

--- a/packages/core-mobile/app/new/common/components/ListScreenV2.tsx
+++ b/packages/core-mobile/app/new/common/components/ListScreenV2.tsx
@@ -184,7 +184,6 @@ export const ListScreenV2 = <T,>({
     {
       header: <NavigationTitleHeader title={navigationTitle ?? title ?? ''} />,
       targetLayout,
-      shouldHeaderHaveGrabber: isModal,
       hideHeaderBackground: shouldShowStickyHeader,
       hasSeparator: shouldShowStickyHeader
         ? renderHeader

--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -194,7 +194,7 @@ export const ScrollScreen = ({
     targetLayout: headerLayout,
     shouldHeaderHaveGrabber: isModal,
     hasParent,
-    hideHeaderBackground,
+    hideHeaderBackground: isModal,
     renderHeaderRight,
     showNavigationHeaderTitle
   })
@@ -385,8 +385,6 @@ export const ScrollScreen = ({
   }, [insets.top, isModal])
 
   const renderHeaderBackground = useCallback(() => {
-    if (hideHeaderBackground) return null
-
     return (
       <View
         pointerEvents="none"
@@ -418,7 +416,7 @@ export const ScrollScreen = ({
       </View>
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [headerHeight, hideHeaderBackground])
+  }, [headerHeight])
 
   // 90% of our screens reuse this component but only some need keyboard avoiding
   // If you have an input on the screen, you need to enable this prop

--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -192,11 +192,7 @@ export const ScrollScreen = ({
   } = useFadingHeaderNavigation({
     header: <NavigationTitleHeader title={navigationTitle ?? title ?? ''} />,
     targetLayout: headerLayout,
-    shouldHeaderHaveGrabber: isModal,
     hasParent,
-    // Modals always need the transparent (Pressable) header background so the
-    // grabber can receive drag gestures; non-modal callers can still opt in
-    // explicitly via the `hideHeaderBackground` prop.
     hideHeaderBackground: hideHeaderBackground || isModal,
     renderHeaderRight,
     showNavigationHeaderTitle

--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -385,6 +385,7 @@ export const ScrollScreen = ({
   }, [insets.top, isModal])
 
   const renderHeaderBackground = useCallback(() => {
+    if (hideHeaderBackground) return null
     return (
       <View
         pointerEvents="none"

--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -194,7 +194,10 @@ export const ScrollScreen = ({
     targetLayout: headerLayout,
     shouldHeaderHaveGrabber: isModal,
     hasParent,
-    hideHeaderBackground: isModal,
+    // Modals always need the transparent (Pressable) header background so the
+    // grabber can receive drag gestures; non-modal callers can still opt in
+    // explicitly via the `hideHeaderBackground` prop.
+    hideHeaderBackground: hideHeaderBackground || isModal,
     renderHeaderRight,
     showNavigationHeaderTitle
   })
@@ -417,7 +420,7 @@ export const ScrollScreen = ({
       </View>
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [headerHeight])
+  }, [headerHeight, hideHeaderBackground])
 
   // 90% of our screens reuse this component but only some need keyboard avoiding
   // If you have an input on the screen, you need to enable this prop

--- a/packages/core-mobile/app/new/common/hooks/useFadingHeaderNavigation.tsx
+++ b/packages/core-mobile/app/new/common/hooks/useFadingHeaderNavigation.tsx
@@ -29,7 +29,6 @@ export const useFadingHeaderNavigation = ({
   header,
   targetLayout,
   backgroundColor,
-  shouldHeaderHaveGrabber = false,
   hideHeaderBackground = false,
   hasSeparator = true,
   shouldDelayBlurOniOS = false,
@@ -40,7 +39,6 @@ export const useFadingHeaderNavigation = ({
 }: {
   header?: React.ReactNode
   targetLayout?: LayoutRectangle
-  shouldHeaderHaveGrabber?: boolean
   hideHeaderBackground?: boolean
   hasSeparator?: boolean
   shouldDelayBlurOniOS?: boolean
@@ -174,7 +172,7 @@ export const useFadingHeaderNavigation = ({
       </View>
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldHeaderHaveGrabber, header, handleLayout])
+  }, [header, handleLayout])
 
   // Return a stable function reference that returns the memoized component
   const headerTitle = useCallback(() => {

--- a/packages/core-mobile/app/new/common/hooks/useSimpleFadingHeader.tsx
+++ b/packages/core-mobile/app/new/common/hooks/useSimpleFadingHeader.tsx
@@ -6,14 +6,12 @@ import { useFadingHeaderNavigation } from './useFadingHeaderNavigation'
 
 interface FadingHeaderOptions {
   title: string
-  shouldHeaderHaveGrabber?: boolean
 }
 
 // a wrapper around useFadingHeaderNavigation that provides a more convenient API
 // for the simple use case of a fading header on a scrollable modal screen
 export const useSimpleFadingHeader = ({
-  title,
-  shouldHeaderHaveGrabber = true
+  title
 }: FadingHeaderOptions): {
   animatedHeaderStyle: ViewStyle
   onScroll: ReturnType<typeof useFadingHeaderNavigation>['onScroll']
@@ -31,8 +29,7 @@ export const useSimpleFadingHeader = ({
 
   const { onScroll, targetHiddenProgress } = useFadingHeaderNavigation({
     header,
-    targetLayout: headerLayout,
-    shouldHeaderHaveGrabber
+    targetLayout: headerLayout
   })
 
   const animatedHeaderStyle = useAnimatedStyle(() => ({

--- a/packages/core-mobile/app/new/features/defiMarket/components/borrow/BorrowDetailContent.tsx
+++ b/packages/core-mobile/app/new/features/defiMarket/components/borrow/BorrowDetailContent.tsx
@@ -40,8 +40,7 @@ export function BorrowDetailContent({
 
   const { onScroll, animatedHeaderStyle, handleHeaderLayout } =
     useSimpleFadingHeader({
-      title: 'Borrow details',
-      shouldHeaderHaveGrabber: false
+      title: 'Borrow details'
     })
 
   const collateralDeposits = useMemo(() => {

--- a/packages/core-mobile/app/new/features/defiMarket/screens/DepositDetailScreen.tsx
+++ b/packages/core-mobile/app/new/features/defiMarket/screens/DepositDetailScreen.tsx
@@ -51,8 +51,7 @@ export function DepositDetailScreen(): JSX.Element {
 
   const { onScroll } = useFadingHeaderNavigation({
     header: navHeader,
-    targetLayout: headerLayout,
-    shouldHeaderHaveGrabber: false
+    targetLayout: headerLayout
   })
 
   const handleHeaderLayout = useCallback((event: LayoutChangeEvent): void => {


### PR DESCRIPTION
## Description

**Ticket: [CP-14389]**

Fixes the modal grabber rendering in `ScrollScreen` by tying `hideHeaderBackground` to `isModal` and always rendering the header background view. Previously the early `return null` in `renderHeaderBackground` short-circuited the layout used for the grabber on modal screens.

- Pass `hideHeaderBackground: isModal` to the header hook so modal screens get the correct header background behavior
- Remove the early `return null` in `renderHeaderBackground` and drop `hideHeaderBackground` from its deps so the background view is always mounted and the grabber renders correctly
- No new dependencies, no breaking changes

## Screenshots/Videos

**Before**

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-03 at 12 33 03" src="https://github.com/user-attachments/assets/7a4ecc92-d31c-40a4-8e24-6f859e33e962" />

**After**

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-03 at 12 32 45" src="https://github.com/user-attachments/assets/026d1a32-77e8-43a1-a71e-db997521d8ab" />


## Testing

iOS - 8711
Android - 8712

**Dev Testing**

- Open any screen that uses `ScrollScreen` as a modal (e.g. stake detail, search modals) and verify the grabber is visible at the top of the sheet
- Verify non-modal screens using `ScrollScreen` still render their header background correctly and that scroll-based header transitions are unaffected
- 
## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14389]: https://ava-labs.atlassian.net/browse/CP-14389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ