### PR TITLE
Route injected read-only RPC through module.onRpcRequest

### DIFF
--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -198,6 +198,29 @@ describe('createInjectedProviderRouter', () => {
       )
     })
 
+    it('routes prototype-chain method names to read-only, never signing', async () => {
+      // `method` is dApp-controlled; signing detection must be an own-property
+      // check so inherited Object keys can't hit the signing branch and call
+      // requestSigning with a non-RPC value.
+      const { deps, requestSigning, requestReadOnly } = makeDeps()
+      const router = createInjectedProviderRouter(deps)
+
+      for (const m of [
+        'toString',
+        'constructor',
+        '__proto__',
+        'hasOwnProperty'
+      ]) {
+        send(router, m)
+      }
+      await new Promise(r => setImmediate(r))
+
+      expect(requestSigning).not.toHaveBeenCalled()
+      expect(requestReadOnly).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'toString' })
+      )
+    })
+
     it('tracks native origin for allowed methods', () => {
       const { deps, trackPendingOrigin } = makeDeps()
       const router = createInjectedProviderRouter(deps)

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -1,4 +1,5 @@
 import { NetworkVMType } from '@avalabs/core-chains-sdk'
+import { RpcMethod } from '@avalabs/vm-module-types'
 import { setTabChainId } from 'store/browser/slices/tabs'
 import type { Networks } from 'store/network/types'
 import type { Account } from 'store/account'
@@ -7,7 +8,7 @@ import {
   JSON_RPC_INTERNAL_ERROR_CODE,
   USER_REJECTED_REQUEST_MESSAGE
 } from './errors'
-import { createInjectedProviderRouter } from './router'
+import { createInjectedProviderRouter, SIGNING_METHODS } from './router'
 import { BrowserNetwork, RouterDeps } from './types'
 
 jest.mock('store/browser/slices/tabs', () => ({
@@ -740,6 +741,35 @@ describe('createInjectedProviderRouter', () => {
       await new Promise(r => setImmediate(r))
 
       expect(sendResponse).toHaveBeenCalledWith(1, err, undefined)
+    })
+
+    it('routes eth_sendTransactionBatch through requestSigning, not the read-only path', async () => {
+      const { deps, requestSigning, requestReadOnly } = makeDeps()
+      requestSigning.mockResolvedValueOnce('0xBatch')
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'eth_sendTransactionBatch', [[{ to: '0x0' }]])
+      await new Promise(r => setImmediate(r))
+
+      expect(requestSigning).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'eth_sendTransactionBatch' })
+      )
+      expect(requestReadOnly).not.toHaveBeenCalled()
+    })
+
+    it('SIGNING_METHODS covers every EVM signing method in the RpcMethod enum (drift guard)', () => {
+      // Source of truth: the vm-module RpcMethod enum. Every eth_*/personal_*
+      // member is an EVM method that requires approval and must take the
+      // signing path; one missing here would silently fall through to the
+      // read-only branch (the drift hazard CP-14384 removed for the read-only
+      // list). If the enum gains a new EVM signing method, this fails until
+      // SIGNING_METHODS is updated.
+      const evmSigningMethods = Object.values(RpcMethod).filter(
+        m => m.startsWith('eth_') || m.startsWith('personal_')
+      )
+      expect(Object.keys(SIGNING_METHODS).sort()).toEqual(
+        [...evmSigningMethods].sort()
+      )
     })
   })
 

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -1,7 +1,6 @@
 import { NetworkVMType } from '@avalabs/core-chains-sdk'
 import { setTabChainId } from 'store/browser/slices/tabs'
 import type { Networks } from 'store/network/types'
-import { fetch as nitroFetch } from 'react-native-nitro-fetch'
 import type { Account } from 'store/account'
 import {
   EIP1193_USER_REJECTED_CODE,
@@ -10,10 +9,6 @@ import {
 } from './errors'
 import { createInjectedProviderRouter } from './router'
 import { BrowserNetwork, RouterDeps } from './types'
-
-jest.mock('react-native-nitro-fetch', () => ({ fetch: jest.fn() }))
-
-const mockNitroFetch = nitroFetch as jest.MockedFunction<typeof nitroFetch>
 
 jest.mock('store/browser/slices/tabs', () => ({
   setTabChainId: jest.fn((payload: { tabId: string; chainId: number }) => ({
@@ -40,6 +35,7 @@ type MockDeps = {
   sendResponse: jest.Mock
   emitEvent: jest.Mock
   requestSigning: jest.Mock
+  requestReadOnly: jest.Mock
   dispatch: jest.Mock
   trackPendingOrigin: jest.Mock
   setBrowserNetworkSpy: jest.Mock
@@ -84,6 +80,7 @@ function makeDeps(overrides?: {
   const sendResponse = jest.fn()
   const emitEvent = jest.fn()
   const requestSigning = jest.fn()
+  const requestReadOnly = jest.fn().mockResolvedValue('0xreadonly')
   const dispatch = jest.fn()
   const trackPendingOrigin = jest.fn()
   const setBrowserNetworkSpy = jest.fn((net: BrowserNetwork) => {
@@ -107,6 +104,7 @@ function makeDeps(overrides?: {
     tabId: overrides?.tabId ?? 'tab-1',
     dispatch,
     requestSigning,
+    requestReadOnly,
     sendResponse,
     emitEvent,
     getNativeOrigin: () =>
@@ -132,6 +130,7 @@ function makeDeps(overrides?: {
     sendResponse,
     emitEvent,
     requestSigning,
+    requestReadOnly,
     dispatch,
     trackPendingOrigin,
     hasPermission,
@@ -173,12 +172,24 @@ describe('createInjectedProviderRouter', () => {
   beforeEach(() => jest.clearAllMocks())
 
   describe('dispatch', () => {
-    it('rejects unknown methods with methodNotFound', () => {
-      const { deps, sendResponse } = makeDeps()
+    it('routes unknown/non-signing methods to requestReadOnly and propagates its error', async () => {
+      // Method classification is no longer a static allowlist: anything not
+      // injected-specific or signing is handed to requestReadOnly, which
+      // validates against the module manifest and rejects unsupported methods
+      // with methodNotFound (-32601). The router just propagates that.
+      const { deps, sendResponse, requestReadOnly } = makeDeps()
+      requestReadOnly.mockRejectedValueOnce({
+        code: -32601,
+        message: 'Unsupported method: totally_fake_method'
+      })
       const router = createInjectedProviderRouter(deps)
 
       send(router, 'totally_fake_method')
+      await new Promise(r => setImmediate(r))
 
+      expect(requestReadOnly).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'totally_fake_method' })
+      )
       expect(sendResponse).toHaveBeenCalledWith(
         1,
         expect.objectContaining({ code: -32601 }),
@@ -732,67 +743,36 @@ describe('createInjectedProviderRouter', () => {
     })
   })
 
-  describe('proxyToRpc', () => {
-    afterEach(() => {
-      mockNitroFetch.mockReset()
-    })
-
-    it('returns internal error when rpcUrl is empty', async () => {
-      const { deps, sendResponse } = makeDeps({
-        browserNetwork: { chainId: 1, rpcUrl: '' }
+  describe('read-only dispatch', () => {
+    it('delegates read-only methods to requestReadOnly with the per-tab chainId and resolves the result', async () => {
+      const { deps, sendResponse, requestReadOnly } = makeDeps({
+        browserNetwork: { chainId: 1, rpcUrl: 'https://eth.llamarpc.com' }
       })
+      requestReadOnly.mockResolvedValueOnce('0xabc')
       const router = createInjectedProviderRouter(deps)
 
-      send(router, 'eth_blockNumber')
+      send(router, 'eth_call', [{ to: '0x0' }])
       await new Promise(r => setImmediate(r))
 
-      expect(sendResponse).toHaveBeenCalledWith(
-        1,
-        expect.objectContaining({ code: JSON_RPC_INTERNAL_ERROR_CODE }),
-        undefined
-      )
-    })
-
-    it('proxies result on successful RPC fetch', async () => {
-      const { deps, sendResponse } = makeDeps()
-      mockNitroFetch.mockResolvedValue({
-        json: async () => ({ result: '0xabc' })
-      } as unknown as Response)
-      const router = createInjectedProviderRouter(deps)
-
-      send(router, 'eth_blockNumber')
-      await new Promise(r => setImmediate(r))
-
+      expect(requestReadOnly).toHaveBeenCalledWith({
+        id: 1,
+        method: 'eth_call',
+        params: [{ to: '0x0' }],
+        chainId: 1
+      })
       expect(sendResponse).toHaveBeenCalledWith(1, null, '0xabc')
     })
 
-    it('surfaces RPC error field', async () => {
-      const { deps, sendResponse } = makeDeps()
+    it('propagates an RpcError-shaped rejection from requestReadOnly', async () => {
+      const { deps, sendResponse, requestReadOnly } = makeDeps()
       const rpcErr = { code: -32000, message: 'node error' }
-      mockNitroFetch.mockResolvedValue({
-        json: async () => ({ error: rpcErr })
-      } as unknown as Response)
+      requestReadOnly.mockRejectedValueOnce(rpcErr)
       const router = createInjectedProviderRouter(deps)
 
       send(router, 'eth_blockNumber')
       await new Promise(r => setImmediate(r))
 
       expect(sendResponse).toHaveBeenCalledWith(1, rpcErr, undefined)
-    })
-
-    it('returns internal error on fetch failure', async () => {
-      const { deps, sendResponse } = makeDeps()
-      mockNitroFetch.mockRejectedValue(new Error('network down'))
-      const router = createInjectedProviderRouter(deps)
-
-      send(router, 'eth_blockNumber')
-      await new Promise(r => setImmediate(r))
-
-      expect(sendResponse).toHaveBeenCalledWith(
-        1,
-        expect.objectContaining({ code: JSON_RPC_INTERNAL_ERROR_CODE }),
-        undefined
-      )
     })
   })
 

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -4,32 +4,14 @@ import { RpcMethod } from '@avalabs/vm-module-types'
 import Logger from 'utils/Logger'
 import { getEvmCaip2ChainId } from 'utils/caip2ChainIds'
 import { setTabChainId } from 'store/browser/slices/tabs'
-import { fetch as nitroFetch } from 'react-native-nitro-fetch'
 import { isUserRejectedRpcError } from './errors'
 import { MAX_MESSAGE_SIZE, ProviderRequest, RouterDeps } from './types'
 
-const READ_ONLY_METHODS = new Set([
-  'eth_blockNumber',
-  'eth_call',
-  'eth_estimateGas',
-  'eth_gasPrice',
-  'eth_getBalance',
-  'eth_getBlockByHash',
-  'eth_getBlockByNumber',
-  'eth_getCode',
-  'eth_getLogs',
-  'eth_getStorageAt',
-  'eth_getTransactionByHash',
-  'eth_getTransactionCount',
-  'eth_getTransactionReceipt',
-  'eth_maxPriorityFeePerGas',
-  'eth_feeHistory',
-  'web3_clientVersion',
-  'web3_sha3',
-  'eth_getBlockTransactionCountByHash',
-  'eth_getBlockTransactionCountByNumber'
-])
-
+// Injected-specific methods (connect / EIP-2255 permissions / chain management)
+// are handled directly in `dispatchMethod`. Signing methods route through
+// `requestSigning`. Everything else is treated as read-only and dispatched to
+// the VM module, which validates it against its manifest — so the read-only
+// allowlist is no longer hand-maintained here (CP-14384).
 const SIGNING_METHODS: Record<string, RpcMethod> = {
   [RpcMethod.ETH_SEND_TRANSACTION]: RpcMethod.ETH_SEND_TRANSACTION,
   [RpcMethod.PERSONAL_SIGN]: RpcMethod.PERSONAL_SIGN,
@@ -39,18 +21,6 @@ const SIGNING_METHODS: Record<string, RpcMethod> = {
   [RpcMethod.SIGN_TYPED_DATA_V3]: RpcMethod.SIGN_TYPED_DATA_V3,
   [RpcMethod.SIGN_TYPED_DATA_V4]: RpcMethod.SIGN_TYPED_DATA_V4
 }
-
-const ALLOWED_METHODS = new Set([
-  ...READ_ONLY_METHODS,
-  ...Object.keys(SIGNING_METHODS),
-  'eth_requestAccounts',
-  'wallet_requestPermissions',
-  'wallet_getPermissions',
-  'wallet_revokePermissions',
-  'wallet_switchEthereumChain',
-  'wallet_addEthereumChain',
-  'wallet_watchAsset'
-])
 
 // EIP-2255 — only eth_accounts is supported; no other restricted methods today.
 function buildAccountsPermission(addresses: string[]): unknown[] {
@@ -156,6 +126,7 @@ export function createInjectedProviderRouter(
     tabId,
     dispatch,
     requestSigning,
+    requestReadOnly,
     sendResponse,
     emitEvent,
     getNativeOrigin,
@@ -186,41 +157,28 @@ export function createInjectedProviderRouter(
     }
   }
 
-  const proxyToRpc = async (
+  // Read-only methods (eth_call, eth_getBalance, …) are dispatched to the VM
+  // module — the same source WalletConnect uses — instead of a bespoke fetch +
+  // allowlist. The module classifies/validates the method against its manifest
+  // and proxies the request to the per-tab browser network's RPC endpoint.
+  const dispatchReadOnly = async (
     id: number,
     method: string,
     params: unknown[]
   ): Promise<void> => {
     try {
-      const rpcUrl = getBrowserNetwork().rpcUrl
-      if (!rpcUrl) {
-        sendResponse(id, rpcErrors.internal('No RPC URL configured'), undefined)
-        return
-      }
-
-      const body = JSON.stringify({
-        jsonrpc: '2.0',
+      const result = await requestReadOnly({
         id,
         method,
-        params
+        params,
+        chainId: getBrowserNetwork().chainId
       })
-
-      const response = await nitroFetch(rpcUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body
-      })
-
-      const json = await response.json()
-
-      if (json.error) {
-        sendResponse(id, json.error, undefined)
-      } else {
-        sendResponse(id, null, json.result)
-      }
+      sendResponse(id, null, result)
     } catch (e) {
-      Logger.error('[InjectedProvider] RPC proxy error', e)
-      sendResponse(id, rpcErrors.internal('RPC request failed'), undefined)
+      // requestReadOnly rejects with an RpcError for known cases (methodNotFound
+      // for unsupported methods, internal otherwise); any other thrown value is
+      // serialized by sendResponse, which preserves a numeric code when present.
+      sendResponse(id, e, undefined)
     }
   }
 
@@ -578,8 +536,11 @@ export function createInjectedProviderRouter(
       handleWatchAsset(id, params)
     } else if (method in SIGNING_METHODS) {
       dispatchSigningRequest(id, method, safeParams)
-    } else if (READ_ONLY_METHODS.has(method)) {
-      proxyToRpc(id, method, safeParams)
+    } else {
+      // Anything not injected-specific and not a signing method is treated as
+      // read-only and validated by the VM module's manifest (unsupported
+      // methods reject with methodNotFound).
+      dispatchReadOnly(id, method, safeParams)
     }
   }
 
@@ -627,14 +588,10 @@ export function createInjectedProviderRouter(
 
     Logger.trace(`[InjectedProvider] ${method}`, params)
 
-    if (!ALLOWED_METHODS.has(method)) {
-      sendResponse(
-        id,
-        rpcErrors.methodNotFound(`Unsupported method: ${method}`),
-        undefined
-      )
-      return
-    }
+    // Method validity is no longer gated by a static allowlist: injected and
+    // signing methods are handled explicitly in dispatchMethod, and read-only
+    // methods are validated by the VM module's manifest (unsupported →
+    // methodNotFound). Origin must still be verified first, below.
 
     // Every method requires a known native origin. Requests that arrive
     // before the WebView has reported its first URL, or from an iframe or

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -28,6 +28,15 @@ export const SIGNING_METHODS: Record<string, RpcMethod> = {
   [RpcMethod.SIGN_TYPED_DATA_V4]: RpcMethod.SIGN_TYPED_DATA_V4
 }
 
+// `method` comes straight from the dApp, so an own-property check is required:
+// `method in SIGNING_METHODS` / `SIGNING_METHODS[method]` walk the prototype
+// chain, so names like `toString`, `constructor`, or `__proto__` would otherwise
+// hit the signing branch and call requestSigning with a non-RPC value.
+const signingMethodFor = (method: string): RpcMethod | undefined =>
+  Object.prototype.hasOwnProperty.call(SIGNING_METHODS, method)
+    ? SIGNING_METHODS[method]
+    : undefined
+
 // EIP-2255 — only eth_accounts is supported; no other restricted methods today.
 function buildAccountsPermission(addresses: string[]): unknown[] {
   if (addresses.length === 0) return []
@@ -193,7 +202,7 @@ export function createInjectedProviderRouter(
     method: string,
     params: unknown[]
   ): Promise<void> => {
-    const rpcMethod = SIGNING_METHODS[method]
+    const rpcMethod = signingMethodFor(method)
     if (!rpcMethod) {
       sendResponse(
         id,
@@ -540,7 +549,7 @@ export function createInjectedProviderRouter(
       handleRevokePermissions(id)
     } else if (method === 'wallet_watchAsset') {
       handleWatchAsset(id, params)
-    } else if (method in SIGNING_METHODS) {
+    } else if (signingMethodFor(method)) {
       dispatchSigningRequest(id, method, safeParams)
     } else {
       // Anything not injected-specific and not a signing method is treated as

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -12,8 +12,14 @@ import { MAX_MESSAGE_SIZE, ProviderRequest, RouterDeps } from './types'
 // `requestSigning`. Everything else is treated as read-only and dispatched to
 // the VM module, which validates it against its manifest — so the read-only
 // allowlist is no longer hand-maintained here (CP-14384).
-const SIGNING_METHODS: Record<string, RpcMethod> = {
+//
+// This list must cover every EVM (eth_*/personal_*) method in the vm-module
+// RpcMethod enum: a signing method missing here silently falls through to the
+// read-only branch. A drift guard in router.test.ts cross-checks it against the
+// enum so it can't quietly fall out of sync.
+export const SIGNING_METHODS: Record<string, RpcMethod> = {
   [RpcMethod.ETH_SEND_TRANSACTION]: RpcMethod.ETH_SEND_TRANSACTION,
+  [RpcMethod.ETH_SEND_TRANSACTION_BATCH]: RpcMethod.ETH_SEND_TRANSACTION_BATCH,
   [RpcMethod.PERSONAL_SIGN]: RpcMethod.PERSONAL_SIGN,
   [RpcMethod.ETH_SIGN]: RpcMethod.ETH_SIGN,
   [RpcMethod.SIGN_TYPED_DATA]: RpcMethod.SIGN_TYPED_DATA,

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/types.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/types.ts
@@ -48,9 +48,11 @@ export type RouterDeps = {
 
   // Read-only RPC routed through the VM module (the same `module.onRpcRequest`
   // path WalletConnect uses) instead of a bespoke fetch + allowlist. Resolves
-  // with the JSON-RPC result; rejects with an RpcError-shaped `{ code, message }`
-  // (methodNotFound when the module manifest doesn't permit the method). The
-  // module manifest is the single source of read-only method classification.
+  // with the JSON-RPC result; rejects with an RpcError for the known cases
+  // (methodNotFound when the manifest doesn't permit the method, internal
+  // otherwise), but may also reject with other thrown values, which
+  // `sendResponse` serializes. The module manifest is the single source of
+  // read-only method classification.
   requestReadOnly: (args: {
     id: number
     method: string

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/types.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/types.ts
@@ -46,6 +46,18 @@ export type RouterDeps = {
   dispatch: Dispatch
   requestSigning: InAppRequest
 
+  // Read-only RPC routed through the VM module (the same `module.onRpcRequest`
+  // path WalletConnect uses) instead of a bespoke fetch + allowlist. Resolves
+  // with the JSON-RPC result; rejects with an RpcError-shaped `{ code, message }`
+  // (methodNotFound when the module manifest doesn't permit the method). The
+  // module manifest is the single source of read-only method classification.
+  requestReadOnly: (args: {
+    id: number
+    method: string
+    params: unknown
+    chainId: number
+  }) => Promise<unknown>
+
   sendResponse: (id: number, error: unknown, result: unknown) => void
   emitEvent: (eventName: string, data: unknown) => void
 

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -3,13 +3,13 @@ import { useSelector, useDispatch, useStore } from 'react-redux'
 import { NetworkVMType } from '@avalabs/core-chains-sdk'
 import { RpcMethod } from 'store/rpc/types'
 import RNWebView from 'react-native-webview'
-import { fetch as nitroFetch } from 'react-native-nitro-fetch'
 import {
   selectAllNetworks,
   selectActiveNetwork,
   setActive
 } from 'store/network/slice'
 import { selectTabChainId, setTabChainId } from 'store/browser/slices/tabs'
+import { ModuleErrors, VmModuleErrors } from 'vmModule/errors'
 import {
   EIP1193_USER_REJECTED_CODE,
   JSON_RPC_INTERNAL_ERROR_CODE,
@@ -17,10 +17,21 @@ import {
 } from './injectedProvider/errors'
 import { useEvmInjectedProvider } from './useEvmInjectedProvider'
 
-// proxyToRpc calls nitroFetch; mock it explicitly (the root __mocks__ manual
-// mock also covers node_modules auto-mocking, but this keeps the intent local).
-jest.mock('react-native-nitro-fetch')
-const mockNitroFetch = nitroFetch as jest.MockedFunction<typeof nitroFetch>
+// Read-only RPC now routes through the VM module (CP-14384). Mock the module
+// loader + onRpcRequest so the read-only path can be asserted without a network.
+const mockOnRpcRequest = jest.fn()
+const mockLoadModule = jest.fn(async (..._args: unknown[]) => ({
+  onRpcRequest: mockOnRpcRequest
+}))
+jest.mock('vmModule/ModuleManager', () => ({
+  __esModule: true,
+  default: {
+    loadModule: (...args: unknown[]) => mockLoadModule(...args)
+  }
+}))
+jest.mock('vmModule/utils/mapToVmNetwork', () => ({
+  mapToVmNetwork: (network: unknown) => network
+}))
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -126,6 +137,10 @@ function setupMocks(
   const mockTabChainIdSelector = jest.fn(() => undefined)
   ;(selectTabChainId as jest.Mock).mockReturnValue(mockTabChainIdSelector)
 
+  // requestReadOnly resolves networks via selectAllNetworks(store.getState())
+  // (direct call, not useSelector), so the mock must return the map directly.
+  ;(selectAllNetworks as jest.Mock).mockReturnValue(allNetworks)
+
   mockUseSelector.mockImplementation(
     (selector: (state: unknown) => unknown) => {
       if (selector === (selectAllNetworks as unknown)) return allNetworks
@@ -161,6 +176,9 @@ describe('useEvmInjectedProvider', () => {
     jest.clearAllMocks()
     mockUseDispatch.mockReturnValue(mockDispatch)
     mockUseStore.mockReturnValue(mockStore)
+    // Default read-only path: module loads and resolves a result.
+    mockLoadModule.mockResolvedValue({ onRpcRequest: mockOnRpcRequest })
+    mockOnRpcRequest.mockResolvedValue({ result: '0x0' })
     setupMocks()
   })
 
@@ -306,12 +324,8 @@ describe('useEvmInjectedProvider', () => {
         )
       })
 
-      it('uses browser chain RPC URL for read-only methods after wallet_switchEthereumChain', async () => {
-        const mockResponse = {
-          ok: true,
-          json: jest.fn().mockResolvedValue({ result: '0x1' })
-        }
-        mockNitroFetch.mockResolvedValue(mockResponse as unknown as Response)
+      it('routes read-only methods to the browser chain after wallet_switchEthereumChain', async () => {
+        mockOnRpcRequest.mockResolvedValue({ result: '0x1' })
 
         setupMocks({
           allNetworks: {
@@ -339,7 +353,8 @@ describe('useEvmInjectedProvider', () => {
           )
         })
 
-        // Read-only call — should use chain 1's RPC, not Avalanche's
+        // Read-only call — should target chain 1 (the per-tab browser chain),
+        // not the wallet's active Avalanche chain.
         await act(async () => {
           result.current.handleProviderMessage(
             JSON.stringify({
@@ -349,9 +364,13 @@ describe('useEvmInjectedProvider', () => {
           )
         })
 
-        expect(mockNitroFetch).toHaveBeenCalledWith(
-          'https://eth.rpc',
-          expect.anything()
+        expect(mockLoadModule).toHaveBeenLastCalledWith(
+          'eip155:1',
+          'eth_blockNumber'
+        )
+        expect(mockOnRpcRequest).toHaveBeenCalledWith(
+          expect.objectContaining({ chainId: 'eip155:1' }),
+          expect.objectContaining({ chainId: 1, rpcUrl: 'https://eth.rpc' })
         )
       })
 
@@ -1025,40 +1044,37 @@ describe('useEvmInjectedProvider', () => {
         'eth_getBlockTransactionCountByNumber'
       ]
 
-      it.each(readOnlyMethods)('proxies %s to RPC node', async method => {
-        const mockResponse = {
-          ok: true,
-          json: jest.fn().mockResolvedValue({ result: '0xABC' })
-        }
-        mockNitroFetch.mockResolvedValue(mockResponse as unknown as Response)
+      it.each(readOnlyMethods)(
+        'routes %s through module.onRpcRequest',
+        async method => {
+          mockOnRpcRequest.mockResolvedValue({ result: '0xABC' })
 
-        const { result } = renderProvider()
+          const { result } = renderProvider()
 
-        const payload = JSON.stringify({
-          id: 100,
-          request: { method, params: [] }
-        })
-
-        await act(async () => {
-          result.current.handleProviderMessage(payload)
-        })
-
-        expect(mockNitroFetch).toHaveBeenCalledWith(
-          'https://api.avax.network/ext/bc/C/rpc',
-          expect.objectContaining({
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: expect.stringContaining(`"method":"${method}"`)
+          const payload = JSON.stringify({
+            id: 100,
+            request: { method, params: [] }
           })
-        )
-      })
+
+          await act(async () => {
+            result.current.handleProviderMessage(payload)
+          })
+
+          // Loaded by the active chain's caip2 id, validated against the manifest.
+          expect(mockLoadModule).toHaveBeenCalledWith('eip155:43114', method)
+          expect(mockOnRpcRequest).toHaveBeenCalledWith(
+            expect.objectContaining({
+              method,
+              chainId: 'eip155:43114',
+              params: []
+            }),
+            expect.objectContaining({ chainId: 43114 })
+          )
+        }
+      )
 
       it('returns RPC result to WebView', async () => {
-        const mockResponse = {
-          ok: true,
-          json: jest.fn().mockResolvedValue({ result: '0xBalanceValue' })
-        }
-        mockNitroFetch.mockResolvedValue(mockResponse as unknown as Response)
+        mockOnRpcRequest.mockResolvedValue({ result: '0xBalanceValue' })
 
         const { result } = renderProvider()
 
@@ -1083,11 +1099,7 @@ describe('useEvmInjectedProvider', () => {
 
       it('returns RPC error to WebView', async () => {
         const rpcError = { code: -32000, message: 'execution reverted' }
-        const mockResponse = {
-          ok: true,
-          json: jest.fn().mockResolvedValue({ error: rpcError })
-        }
-        mockNitroFetch.mockResolvedValue(mockResponse as unknown as Response)
+        mockOnRpcRequest.mockResolvedValue({ error: rpcError })
 
         const { result } = renderProvider()
 
@@ -1105,8 +1117,8 @@ describe('useEvmInjectedProvider', () => {
         )
       })
 
-      it('handles fetch failure gracefully', async () => {
-        mockNitroFetch.mockRejectedValue(new Error('Network error'))
+      it('surfaces an internal error when the module call throws', async () => {
+        mockOnRpcRequest.mockRejectedValue(new Error('Network error'))
 
         const { result } = renderProvider()
 
@@ -1122,41 +1134,20 @@ describe('useEvmInjectedProvider', () => {
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
           expect.stringContaining(`"code":${JSON_RPC_INTERNAL_ERROR_CODE}`)
         )
-        expect(mockInjectJavaScript).toHaveBeenCalledWith(
-          expect.stringContaining('RPC request failed')
-        )
-      })
-
-      it('handles missing RPC URL', async () => {
-        const emptyRpcNetwork = { ...mockActiveNetwork, rpcUrl: '' }
-        setupMocks({
-          network: emptyRpcNetwork as typeof mockActiveNetwork,
-          allNetworks: {
-            43114: emptyRpcNetwork,
-            1: { ...mockActiveNetwork, chainId: 1 }
-          }
-        })
-
-        const { result } = renderProvider()
-
-        const payload = JSON.stringify({
-          id: 104,
-          request: { method: 'eth_getBalance', params: ['0x1'] }
-        })
-
-        await act(async () => {
-          result.current.handleProviderMessage(payload)
-        })
-
-        expect(mockInjectJavaScript).toHaveBeenCalledWith(
-          expect.stringContaining('No RPC URL configured')
-        )
-        expect(mockNitroFetch).not.toHaveBeenCalled()
       })
     })
 
     describe('unsupported methods', () => {
-      it('returns error -32601 for unknown methods', () => {
+      it('returns error -32601 when the module manifest rejects the method', async () => {
+        // loadModule throws UNSUPPORTED_METHOD for methods the manifest doesn't
+        // permit; the hook maps that to methodNotFound (-32601).
+        mockLoadModule.mockRejectedValueOnce(
+          new VmModuleErrors({
+            name: ModuleErrors.UNSUPPORTED_METHOD,
+            message: 'unsupported method'
+          })
+        )
+
         const { result } = renderProvider()
 
         const payload = JSON.stringify({
@@ -1164,7 +1155,7 @@ describe('useEvmInjectedProvider', () => {
           request: { method: 'eth_unknownMethod', params: [] }
         })
 
-        act(() => {
+        await act(async () => {
           result.current.handleProviderMessage(payload)
         })
 
@@ -1173,6 +1164,35 @@ describe('useEvmInjectedProvider', () => {
         )
         expect(mockInjectJavaScript).toHaveBeenCalledWith(
           expect.stringContaining('eth_unknownMethod')
+        )
+      })
+
+      it('returns an internal error (not -32601) when loadModule fails for a non-method reason', async () => {
+        // Unsupported chainId / module init failure must surface as a real
+        // internal error, not masquerade as methodNotFound.
+        mockLoadModule.mockRejectedValueOnce(
+          new VmModuleErrors({
+            name: ModuleErrors.UNSUPPORTED_CHAIN_ID,
+            message: 'unsupported chain'
+          })
+        )
+
+        const { result } = renderProvider()
+
+        const payload = JSON.stringify({
+          id: 201,
+          request: { method: 'eth_blockNumber', params: [] }
+        })
+
+        await act(async () => {
+          result.current.handleProviderMessage(payload)
+        })
+
+        expect(mockInjectJavaScript).toHaveBeenCalledWith(
+          expect.stringContaining('"code":-32603')
+        )
+        expect(mockInjectJavaScript).not.toHaveBeenCalledWith(
+          expect.stringContaining('"code":-32601')
         )
       })
     })
@@ -1221,7 +1241,16 @@ describe('useEvmInjectedProvider', () => {
         )
       })
 
-      it('rejects unknown methods with -32601', () => {
+      it('rejects unknown methods with -32601', async () => {
+        // Unsupported methods are rejected by the module manifest (loadModule
+        // throws UNSUPPORTED_METHOD), which the hook maps to methodNotFound (-32601).
+        mockLoadModule.mockRejectedValueOnce(
+          new VmModuleErrors({
+            name: ModuleErrors.UNSUPPORTED_METHOD,
+            message: 'unsupported method'
+          })
+        )
+
         const { result } = renderProvider()
 
         const payload = JSON.stringify({
@@ -1229,7 +1258,7 @@ describe('useEvmInjectedProvider', () => {
           request: { method: 'eth_unknownMethod', params: [] }
         })
 
-        act(() => {
+        await act(async () => {
           result.current.handleProviderMessage(payload)
         })
 

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -1135,6 +1135,32 @@ describe('useEvmInjectedProvider', () => {
           expect.stringContaining(`"code":${JSON_RPC_INTERNAL_ERROR_CODE}`)
         )
       })
+
+      it('returns an internal error and never loads the module when no network is configured for the chain', async () => {
+        // The browser/active chain isn't present in the network store (e.g. not
+        // yet synced, or removed). requestReadOnly must surface a real internal
+        // error up front rather than calling the module with a missing network.
+        setupMocks({ allNetworks: {} })
+
+        const { result } = renderProvider()
+
+        const payload = JSON.stringify({
+          id: 202,
+          request: { method: 'eth_blockNumber', params: [] }
+        })
+
+        await act(async () => {
+          result.current.handleProviderMessage(payload)
+        })
+
+        expect(mockLoadModule).not.toHaveBeenCalled()
+        expect(mockInjectJavaScript).toHaveBeenCalledWith(
+          expect.stringContaining(`"code":${JSON_RPC_INTERNAL_ERROR_CODE}`)
+        )
+        expect(mockInjectJavaScript).toHaveBeenCalledWith(
+          expect.stringContaining('No network configured')
+        )
+      })
     })
 
     describe('unsupported methods', () => {

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -9,7 +9,12 @@ import RNWebView from 'react-native-webview'
 import Logger from 'utils/Logger'
 import { createInAppRequest } from 'store/rpc/utils/createInAppRequest'
 import { PeerMeta } from 'store/rpc/types'
-import { serializeError } from '@metamask/rpc-errors'
+import { rpcErrors, serializeError } from '@metamask/rpc-errors'
+import { RpcMethod } from '@avalabs/vm-module-types'
+import ModuleManager from 'vmModule/ModuleManager'
+import { mapToVmNetwork } from 'vmModule/utils/mapToVmNetwork'
+import { ModuleErrors, VmModuleErrors } from 'vmModule/errors'
+import { getEvmCaip2ChainId } from 'utils/caip2ChainIds'
 import { router as appRouter } from 'expo-router'
 import { walletConnectCache } from 'services/walletconnectv2/walletConnectCache/walletConnectCache'
 import { approvalController } from 'vmModule/ApprovalController/ApprovalController'
@@ -32,7 +37,11 @@ import {
   JSON_RPC_INTERNAL_ERROR_CODE,
   USER_REJECTED_REQUEST_MESSAGE
 } from './injectedProvider/errors'
-import { BrowserNetwork, DomainMetadata } from './injectedProvider/types'
+import {
+  BrowserNetwork,
+  DomainMetadata,
+  RouterDeps
+} from './injectedProvider/types'
 
 // If the connect-approval screen never mounts or never resolves (e.g. Metro
 // hot-reloaded the cache, the page crashed mid-navigation, etc.), reject the
@@ -330,6 +339,65 @@ export function useEvmInjectedProvider(
     // latest references and rebuilds when dispatch changes.
     const requestSigning = createInAppRequest(dispatch, store.getState)
 
+    // Read-only RPC goes through the VM module — the same `module.onRpcRequest`
+    // path WalletConnect uses — so method classification and proxying come from
+    // the module manifest rather than a hand-maintained allowlist + raw fetch
+    // (CP-14384). Uses the per-tab browser network (which can diverge from the
+    // wallet's active network via wallet_switchEthereumChain), not the active one.
+    const requestReadOnly: RouterDeps['requestReadOnly'] = async ({
+      id,
+      method,
+      params,
+      chainId
+    }) => {
+      // Read networks from the store (not allNetworksRef) so a chain just added
+      // via wallet_addEthereumChain — which Redux has but the ref hasn't picked
+      // up until the next render — resolves without a stale-ref race.
+      const network = selectAllNetworks(store.getState())[chainId]
+      if (!network) {
+        throw rpcErrors.internal(`No network configured for chain ${chainId}`)
+      }
+      const caip2 = getEvmCaip2ChainId(chainId)
+      let module
+      try {
+        module = await ModuleManager.loadModule(caip2, method)
+      } catch (e) {
+        // Only an unsupported-method manifest rejection maps to methodNotFound;
+        // anything else (unsupported chainId, module init failure) is a real
+        // internal error and must not masquerade as -32601.
+        if (
+          e instanceof VmModuleErrors &&
+          e.name === ModuleErrors.UNSUPPORTED_METHOD
+        ) {
+          throw rpcErrors.methodNotFound(`Unsupported method: ${method}`)
+        }
+        Logger.error('[InjectedProvider] read-only module load failed', e)
+        throw rpcErrors.internal('Failed to load module for read-only request')
+      }
+      const peerMeta = getPeerMeta()
+      const response = await module.onRpcRequest(
+        {
+          requestId: String(id),
+          sessionId: String(tabId),
+          // Read-only methods aren't members of the RpcMethod (signing) enum,
+          // but the module proxies them at runtime — same cast the WC path makes.
+          method: method as RpcMethod,
+          chainId: caip2,
+          params,
+          dappInfo: {
+            name: peerMeta.name,
+            url: peerMeta.url,
+            icon: peerMeta.icons[0] ?? ''
+          }
+        },
+        mapToVmNetwork(network)
+      )
+      if ('error' in response) {
+        throw response.error
+      }
+      return response.result
+    }
+
     return createInjectedProviderRouter({
       getBrowserNetwork: () => browserNetworkRef.current,
       setBrowserNetwork: net => {
@@ -339,6 +407,7 @@ export function useEvmInjectedProvider(
       tabId,
       dispatch,
       requestSigning,
+      requestReadOnly,
       sendResponse,
       emitEvent,
       getNativeOrigin: () => getOriginFromUrl(currentUrlRef.current),

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -350,10 +350,14 @@ export function useEvmInjectedProvider(
       params,
       chainId
     }) => {
-      // Read networks from the store (not allNetworksRef) so a chain just added
-      // via wallet_addEthereumChain — which Redux has but the ref hasn't picked
-      // up until the next render — resolves without a stale-ref race.
-      const network = selectAllNetworks(store.getState())[chainId]
+      // Prefer the ref (avoids re-allocating the merged network map on every
+      // read-only call — a hot path for polling dApps). Fall back to the store
+      // only on a miss: a chain just added via wallet_addEthereumChain that
+      // Redux has but the ref hasn't picked up yet. That keeps the common path
+      // allocation-free while still closing the stale-ref race.
+      const network =
+        allNetworksRef.current[chainId] ??
+        selectAllNetworks(store.getState())[chainId]
       if (!network) {
         throw rpcErrors.internal(`No network configured for chain ${chainId}`)
       }


### PR DESCRIPTION
## Description

**Ticket: [CP-14384](https://ava-labs.atlassian.net/browse/CP-14384)**

Behavior-preserving refactor that consolidates the injected provider's **read-only** RPC dispatch onto `module.onRpcRequest` — the same path WalletConnect uses — instead of a bespoke `proxyToRpc` (raw `fetch`) plus a hand-maintained method allowlist.

**Summary of changes**
- `router.ts` — removed the drift-prone `READ_ONLY_METHODS` (an 18-method subset that had already drifted from the manifest) and `ALLOWED_METHODS` static allowlists, plus the raw-`fetch` `proxyToRpc`. Dispatch is now: injected-specific methods handled inline → signing methods via `requestSigning` → everything else routed to the VM module, which validates the method against its `manifest.json` (unsupported → `methodNotFound`).
- `types.ts` — added `requestReadOnly` to `RouterDeps`, mirroring the injected `requestSigning` pattern so the router stays pure and deps-mockable.
- `useEvmInjectedProvider.ts` — implemented `requestReadOnly` via `ModuleManager.loadModule(caip2, method).onRpcRequest(...)` + `mapToVmNetwork`, threading the **per-tab** `browserNetworkRef` chainId (which can diverge from the wallet's active network via `wallet_switchEthereumChain`) — resolved from the networks list, not the active network. Maps `{ result }` / `{ error }`; a `loadModule` rejection becomes `methodNotFound`.

**Motivation / context**
The injected provider duplicated read-only proxying and per-method taxonomy that the VM module already owns (signing was already shared via `createInAppRequest`). The modernization plan replicates this pattern per VM (Solana / BTC / X-P), so consolidating now means a single source of truth (the module manifest) and no per-VM re-implementation of the proxy + allowlist. Raised in staff review across the #3861–#3867 stack.

**Dependencies introduced**
None.

**Breaking changes**
None. Read-only methods the module manifest permits but that weren't in the old allowlist (e.g. `net_version`, additional `eth_*` reads) now succeed where they previously returned `methodNotFound` — a strict superset, not a regression.

> Stacked on #3867 (lifecycle-cleanup); the base will retarget to `main` once that merges. Review against the `boyer/injected-provider-lifecycle-cleanup` base.

## Screenshots/Videos

N/A — internal dispatch refactor with no UI surface change.

## Testing

**Dev Testing (if applicable)**
iOS: 8729
Android: 8730

- Happy path: open the in-app browser against EVM dApps (app.uniswap.org, opensea.io, etherscan.io, revoke.cash). Confirm pages load, balances render, and `eth_call`/`eth_estimateGas` resolve — these all exercise the read-only path.
- Connect (`eth_requestAccounts`) and signing (`personal_sign`, `eth_sendTransaction`, typed data) — unchanged; verify still work.
- Per-tab chain: `wallet_switchEthereumChain` to another chain, then interact — read-only calls must hit the switched chain's RPC, not the wallet's active chain.
- Edge/error: an unsupported method returns `methodNotFound` (-32601); a node error (e.g. execution reverted) surfaces with its original code.
- Perf sanity: on a polling dApp (Uniswap), confirm `eth_blockNumber`/`eth_call` polling latency is unchanged (module is cached after first load).
- Trigger a Bitrise build and reference it here.
- Move CP-14384 into the "Testing" column on Jira.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14384]: https://ava-labs.atlassian.net/browse/CP-14384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ