### PR TITLE
Propagate active-account switch to connected dApps (with ungranted-active reconciliation)

### DIFF
--- a/packages/core-mobile/app/hooks/browser/injectedProvider/resolveGrantedAccounts.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/resolveGrantedAccounts.test.ts
@@ -28,13 +28,28 @@ describe('resolveGrantedAccounts', () => {
     ])
   })
 
-  it('is case-sensitive on the active-address comparison', () => {
-    // Documents current behavior — case normalization is intentionally
-    // deferred to the permissions slice.
-    expect(resolveGrantedAccounts(['0xABC', '0xDEF'], '0xabc')).toEqual([
+  it('matches the active address case-insensitively and sorts the stored grant first', () => {
+    // EVM addresses vary by hex casing; a lowercased active address must still
+    // match a mixed-case grant and be sorted first, preserving the stored
+    // casing in the output.
+    expect(resolveGrantedAccounts(['0xDEF', '0xABC'], '0xabc')).toEqual([
       '0xABC',
       '0xDEF'
     ])
+  })
+
+  it('de-dupes addresses that differ only by hex casing, keeping the first-seen casing', () => {
+    // Permissions are keyed by raw address string and not normalized on grant,
+    // so the same address can be stored twice under different casing.
+    expect(
+      resolveGrantedAccounts(['0xABC', '0xabc', '0xDEF'], undefined)
+    ).toEqual(['0xABC', '0xDEF'])
+  })
+
+  it('de-dupes case-insensitive duplicates before applying active-first ordering', () => {
+    expect(
+      resolveGrantedAccounts(['0xDEF', '0xABC', '0xabc'], '0xabc')
+    ).toEqual(['0xABC', '0xDEF'])
   })
 })
 
@@ -61,5 +76,13 @@ describe('resolveActiveConnectedAccounts', () => {
 
   it('returns [] when nothing is granted', () => {
     expect(resolveActiveConnectedAccounts([], '0xActive')).toEqual([])
+  })
+
+  it('treats the active address as granted regardless of hex casing', () => {
+    // The signing gate lowercases; connection state must agree, so an active
+    // address that differs from a stored grant only by casing is still granted.
+    expect(resolveActiveConnectedAccounts(['0xABC', '0xDEF'], '0xabc')).toEqual(
+      ['0xABC', '0xDEF']
+    )
   })
 })

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/resolveGrantedAccounts.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/resolveGrantedAccounts.test.ts
@@ -1,0 +1,65 @@
+import {
+  resolveGrantedAccounts,
+  resolveActiveConnectedAccounts
+} from './resolveGrantedAccounts'
+
+describe('resolveGrantedAccounts', () => {
+  it('returns an empty list when nothing is granted', () => {
+    expect(resolveGrantedAccounts([], '0xActive')).toEqual([])
+    expect(resolveGrantedAccounts([], undefined)).toEqual([])
+  })
+
+  it('sorts the active address first when it is in the granted set', () => {
+    expect(
+      resolveGrantedAccounts(['0xOther', '0xActive', '0xAnother'], '0xActive')
+    ).toEqual(['0xActive', '0xOther', '0xAnother'])
+  })
+
+  it('returns the granted list unchanged when active is absent', () => {
+    expect(
+      resolveGrantedAccounts(['0xOther', '0xAnother'], '0xActive')
+    ).toEqual(['0xOther', '0xAnother'])
+  })
+
+  it('returns the granted list unchanged when active is undefined', () => {
+    expect(resolveGrantedAccounts(['0xA', '0xB'], undefined)).toEqual([
+      '0xA',
+      '0xB'
+    ])
+  })
+
+  it('is case-sensitive on the active-address comparison', () => {
+    // Documents current behavior — case normalization is intentionally
+    // deferred to the permissions slice.
+    expect(resolveGrantedAccounts(['0xABC', '0xDEF'], '0xabc')).toEqual([
+      '0xABC',
+      '0xDEF'
+    ])
+  })
+})
+
+describe('resolveActiveConnectedAccounts', () => {
+  it('returns the granted set (active first) when active is granted', () => {
+    expect(
+      resolveActiveConnectedAccounts(['0xOther', '0xActive'], '0xActive')
+    ).toEqual(['0xActive', '0xOther'])
+  })
+
+  it('returns [] when the active account is NOT in the granted set', () => {
+    // The reconciliation rule: the injected signer always uses the active
+    // account, so an ungranted active must look disconnected to the dApp.
+    expect(
+      resolveActiveConnectedAccounts(['0xA', '0xB'], '0xUngranted')
+    ).toEqual([])
+  })
+
+  it('returns [] when active is undefined', () => {
+    expect(resolveActiveConnectedAccounts(['0xA', '0xB'], undefined)).toEqual(
+      []
+    )
+  })
+
+  it('returns [] when nothing is granted', () => {
+    expect(resolveActiveConnectedAccounts([], '0xActive')).toEqual([])
+  })
+})

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/resolveGrantedAccounts.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/resolveGrantedAccounts.ts
@@ -11,16 +11,35 @@
  * - Active address present in the granted set → active sorted first, other
  *   granted addresses follow in their original slice order.
  * - Active address not in the granted set → granted list returned as-is.
+ *
+ * Address matching is case-insensitive (EVM addresses vary by hex casing, and
+ * the signing gate lowercases) so connection state can't disagree with signing
+ * authorization over casing alone.
  */
 export function resolveGrantedAccounts(
   granted: string[],
   active: string | undefined
 ): string[] {
   if (granted.length === 0) return []
-  if (active && granted.includes(active)) {
-    return [active, ...granted.filter(addr => addr !== active)]
+  // De-dupe case-insensitively before ordering: permissions are keyed by the
+  // raw address string and not normalized on grant, so the same address can
+  // appear under different hex casing. Returning it twice via accountsChanged /
+  // EIP-2255 is non-standard and confuses dApps. Keep the first-seen casing.
+  const seen = new Set<string>()
+  const deduped = granted.filter(addr => {
+    const lower = addr.toLowerCase()
+    if (seen.has(lower)) return false
+    seen.add(lower)
+    return true
+  })
+  const activeLower = active?.toLowerCase()
+  const activeGranted = activeLower
+    ? deduped.find(addr => addr.toLowerCase() === activeLower)
+    : undefined
+  if (activeGranted) {
+    return [activeGranted, ...deduped.filter(addr => addr !== activeGranted)]
   }
-  return granted
+  return deduped
 }
 
 /**
@@ -40,6 +59,8 @@ export function resolveActiveConnectedAccounts(
   granted: string[],
   active: string | undefined
 ): string[] {
-  if (!active || !granted.includes(active)) return []
+  const activeLower = active?.toLowerCase()
+  if (!activeLower || !granted.some(addr => addr.toLowerCase() === activeLower))
+    return []
   return resolveGrantedAccounts(granted, active)
 }

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/resolveGrantedAccounts.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/resolveGrantedAccounts.ts
@@ -1,0 +1,45 @@
+/**
+ * Ordering rule for the granted addresses returned to a dApp by the EIP-2255
+ * handlers (`eth_requestAccounts` / `wallet_getPermissions`).
+ *
+ * Used by the router so an explicit account request returns the full granted
+ * set — switching the wallet's active account must not force the dApp to
+ * re-grant.
+ *
+ * Rules:
+ * - Empty granted list → `[]` (caller typically falls through to a prompt).
+ * - Active address present in the granted set → active sorted first, other
+ *   granted addresses follow in their original slice order.
+ * - Active address not in the granted set → granted list returned as-is.
+ */
+export function resolveGrantedAccounts(
+  granted: string[],
+  active: string | undefined
+): string[] {
+  if (granted.length === 0) return []
+  if (active && granted.includes(active)) {
+    return [active, ...granted.filter(addr => addr !== active)]
+  }
+  return granted
+}
+
+/**
+ * Accounts to advertise to the dApp via `accountsChanged` on the *passive*
+ * paths — page-load priming and wallet active-account switches.
+ *
+ * Differs from {@link resolveGrantedAccounts}: when the active account is NOT
+ * in the granted set this returns `[]`, not the granted list. The injected
+ * signer always signs with the wallet's active account (the dApp's requested
+ * `from` is ignored), so advertising other granted addresses while an
+ * ungranted account is active would let the dApp believe it can transact as an
+ * account that will never actually sign. Emitting `[]` makes the dApp reflect a
+ * disconnected state (transacting UI disabled) until the user switches back to
+ * a granted account or reconnects (CP-14382).
+ */
+export function resolveActiveConnectedAccounts(
+  granted: string[],
+  active: string | undefined
+): string[] {
+  if (!active || !granted.includes(active)) return []
+  return resolveGrantedAccounts(granted, active)
+}

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -851,7 +851,9 @@ describe('createInjectedProviderRouter', () => {
 
   describe('signing methods', () => {
     it('calls requestSigning with caip2 chain and peer meta, resolves with result', async () => {
-      const { deps, sendResponse, requestSigning } = makeDeps()
+      const { deps, sendResponse, requestSigning } = makeDeps({
+        grantedAddresses: [MOCK_ADDR]
+      })
       requestSigning.mockResolvedValueOnce('0xSig')
       const router = createInjectedProviderRouter(deps)
 
@@ -870,8 +872,30 @@ describe('createInjectedProviderRouter', () => {
       expect(sendResponse).toHaveBeenCalledWith(1, null, '0xSig')
     })
 
+    it('rejects (4100) without prompting when the active account is not granted to the origin', async () => {
+      // The injected signer is active-only; if the dApp was never told about the
+      // active account, a signing request must reject up front, never prompt —
+      // otherwise the dApp would learn of the account by it being signed for.
+      const { deps, sendResponse, requestSigning } = makeDeps({
+        grantedAddresses: ['0xOtherGrantedAddr']
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'personal_sign', ['0xMsg', '0xAddr'])
+      await new Promise(r => setImmediate(r))
+
+      expect(requestSigning).not.toHaveBeenCalled()
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: 4100 }),
+        undefined
+      )
+    })
+
     it('propagates rejection from requestSigning', async () => {
-      const { deps, sendResponse, requestSigning } = makeDeps()
+      const { deps, sendResponse, requestSigning } = makeDeps({
+        grantedAddresses: [MOCK_ADDR]
+      })
       const err = {
         code: EIP1193_USER_REJECTED_CODE,
         message: USER_REJECTED_REQUEST_MESSAGE
@@ -886,7 +910,9 @@ describe('createInjectedProviderRouter', () => {
     })
 
     it('routes eth_sendTransactionBatch through requestSigning, not the read-only path', async () => {
-      const { deps, requestSigning, requestReadOnly } = makeDeps()
+      const { deps, requestSigning, requestReadOnly } = makeDeps({
+        grantedAddresses: [MOCK_ADDR]
+      })
       requestSigning.mockResolvedValueOnce('0xBatch')
       const router = createInjectedProviderRouter(deps)
 
@@ -950,7 +976,9 @@ describe('createInjectedProviderRouter', () => {
 
   describe('cancelByOrigin', () => {
     it('aborts in-flight signing requests whose origin does not match the new origin', async () => {
-      const { deps, requestSigning } = makeDeps()
+      const { deps, requestSigning } = makeDeps({
+        grantedAddresses: [MOCK_ADDR]
+      })
       // Never resolves — simulates a signing request sitting on an approval
       // screen while the user navigates away.
       let capturedSignal: AbortSignal | undefined
@@ -974,7 +1002,9 @@ describe('createInjectedProviderRouter', () => {
     })
 
     it('does not abort requests whose origin matches the new origin', async () => {
-      const { deps, requestSigning } = makeDeps()
+      const { deps, requestSigning } = makeDeps({
+        grantedAddresses: [MOCK_ADDR]
+      })
       let capturedSignal: AbortSignal | undefined
       requestSigning.mockImplementationOnce(args => {
         capturedSignal = args.signal
@@ -1005,7 +1035,9 @@ describe('createInjectedProviderRouter', () => {
     })
 
     it('cleans up in-flight tracking after abort', async () => {
-      const { deps, requestSigning } = makeDeps()
+      const { deps, requestSigning } = makeDeps({
+        grantedAddresses: [MOCK_ADDR]
+      })
       const signals: AbortSignal[] = []
       requestSigning.mockImplementation(args => {
         if (args.signal) signals.push(args.signal)

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -48,7 +48,11 @@ type MockDeps = {
   activeAccount: { value: Account | undefined }
 }
 
-const MOCK_ADDR = '0xTestAddress1234567890'
+// A real 40-hex address — the signing gate validates `from`/signer args are
+// well-formed EVM addresses, so signer-grant tests need valid ones.
+const MOCK_ADDR = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const OTHER_GRANTED_ADDR = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+const UNGRANTED_ADDR = '0xcccccccccccccccccccccccccccccccccccccccc'
 const MOCK_ACCOUNT = { addressC: MOCK_ADDR } as Account
 
 function makeDeps(overrides?: {
@@ -566,10 +570,11 @@ describe('createInjectedProviderRouter', () => {
       ])
     })
 
-    it('rejects when the approved selection does not include the active account', async () => {
+    it('rejects with unauthorized (4100) when the approved selection does not include the active account', async () => {
       // Phantom-connection guard: the injected signer is active-only, so if the
-      // user approves only non-active accounts we must not advertise them — reject
-      // rather than report a connection Core won't sign for (CP-14382).
+      // user approves only non-active accounts we must not advertise them. The
+      // user DID approve, so it's an authorization failure (4100), not a user
+      // cancel (4001) — dApps treat the two differently (CP-14382).
       const { deps, sendResponse, requestConnectApproval, emitEvent } =
         makeDeps()
       requestConnectApproval.mockResolvedValueOnce([
@@ -582,7 +587,7 @@ describe('createInjectedProviderRouter', () => {
 
       expect(sendResponse).toHaveBeenCalledWith(
         1,
-        expect.objectContaining({ code: EIP1193_USER_REJECTED_CODE }),
+        expect.objectContaining({ code: 4100 }),
         undefined
       )
       expect(emitEvent).not.toHaveBeenCalledWith(
@@ -716,9 +721,10 @@ describe('createInjectedProviderRouter', () => {
       expect(requestConnectApproval).toHaveBeenCalledTimes(1)
     })
 
-    it('rejects when the approved selection does not include the active account', async () => {
-      // Same phantom-connection guard as eth_requestAccounts: don't return a
-      // permission set for an address the active-only signer won't use.
+    it('rejects with unauthorized (4100) when the approved selection does not include the active account', async () => {
+      // Same phantom-connection guard as eth_requestAccounts: the user approved,
+      // but not the active account, so it's an authorization failure (4100), not
+      // a user cancel.
       const { deps, sendResponse, requestConnectApproval } = makeDeps()
       requestConnectApproval.mockResolvedValueOnce([
         { addressC: '0xNonActiveSelected' } as Account
@@ -730,7 +736,7 @@ describe('createInjectedProviderRouter', () => {
 
       expect(sendResponse).toHaveBeenCalledWith(
         1,
-        expect.objectContaining({ code: EIP1193_USER_REJECTED_CODE }),
+        expect.objectContaining({ code: 4100 }),
         undefined
       )
     })
@@ -882,6 +888,153 @@ describe('createInjectedProviderRouter', () => {
       const router = createInjectedProviderRouter(deps)
 
       send(router, 'personal_sign', ['0xMsg', '0xAddr'])
+      await new Promise(r => setImmediate(r))
+
+      expect(requestSigning).not.toHaveBeenCalled()
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: 4100 }),
+        undefined
+      )
+    })
+
+    it('rejects eth_sendTransaction (4100) when `from` is an account not granted to the origin', async () => {
+      // An's repro: connected/active is the granted account, but the dApp sets
+      // `from` to a different, ungranted address. The signer resolves the
+      // account from `from`, so this must reject up front — no approval prompt —
+      // rather than sign with an account the dApp was never granted.
+      const { deps, sendResponse, requestSigning } = makeDeps({
+        grantedAddresses: [MOCK_ADDR]
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'eth_sendTransaction', [
+        { from: UNGRANTED_ADDR, to: '0xdead', value: '0x0' }
+      ])
+      await new Promise(r => setImmediate(r))
+
+      expect(requestSigning).not.toHaveBeenCalled()
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: 4100 }),
+        undefined
+      )
+    })
+
+    it('allows eth_sendTransaction when `from` is the active account (hex case-insensitive)', async () => {
+      const { deps, requestSigning } = makeDeps({
+        grantedAddresses: [MOCK_ADDR]
+      })
+      requestSigning.mockResolvedValueOnce('0xTxHash')
+      const router = createInjectedProviderRouter(deps)
+
+      // Same address, uppercased hex (checksum-style) — must still match.
+      send(router, 'eth_sendTransaction', [
+        { from: '0x' + MOCK_ADDR.slice(2).toUpperCase(), to: '0xdead' }
+      ])
+      await new Promise(r => setImmediate(r))
+
+      expect(requestSigning).toHaveBeenCalled()
+    })
+
+    it('allows eth_sendTransaction from a granted account that is not the active one', async () => {
+      // Multi-account: the dApp may transact from any account it was granted,
+      // not only the active one. The signer resolves that account from `from`.
+      const { deps, requestSigning } = makeDeps({
+        grantedAddresses: [MOCK_ADDR, OTHER_GRANTED_ADDR] // active is MOCK_ADDR
+      })
+      requestSigning.mockResolvedValueOnce('0xTxHash')
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'eth_sendTransaction', [
+        { from: OTHER_GRANTED_ADDR, to: '0xdead', value: '0x0' }
+      ])
+      await new Promise(r => setImmediate(r))
+
+      expect(requestSigning).toHaveBeenCalled()
+    })
+
+    it('rejects eth_sendTransactionBatch (4100) when the active account is not granted, even if every tx `from` is granted', async () => {
+      // The batch handler signs with the active account index, not the per-tx
+      // `from` — so the gate must check the active account. Otherwise a dApp
+      // could set `from` to a granted address while the ungranted active account
+      // does the signing (the bypass Copilot flagged).
+      const { deps, sendResponse, requestSigning } = makeDeps({
+        grantedAddresses: [OTHER_GRANTED_ADDR] // active (MOCK_ADDR) NOT granted
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'eth_sendTransactionBatch', [
+        [{ from: OTHER_GRANTED_ADDR, to: '0x0' }]
+      ])
+      await new Promise(r => setImmediate(r))
+
+      expect(requestSigning).not.toHaveBeenCalled()
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: 4100 }),
+        undefined
+      )
+    })
+
+    it('allows eth_sendTransactionBatch when the active account is granted, regardless of tx `from`', async () => {
+      // `from` is irrelevant for batch (the handler signs with the active
+      // account); only the active account's grant matters.
+      const { deps, requestSigning } = makeDeps({
+        grantedAddresses: [MOCK_ADDR] // active is granted
+      })
+      requestSigning.mockResolvedValueOnce('0xBatch')
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'eth_sendTransactionBatch', [
+        [{ from: UNGRANTED_ADDR, to: '0x0' }]
+      ])
+      await new Promise(r => setImmediate(r))
+
+      expect(requestSigning).toHaveBeenCalled()
+    })
+
+    it('rejects personal_sign (4100) when the signer address arg is not granted', async () => {
+      // personal_sign(message, address) — params[1] is the signer. A Permit-
+      // style signature from an ungranted account is the same fund-loss class
+      // as a tx, so reject up front.
+      const { deps, sendResponse, requestSigning } = makeDeps({
+        grantedAddresses: [MOCK_ADDR]
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'personal_sign', ['0xdeadbeef', UNGRANTED_ADDR])
+      await new Promise(r => setImmediate(r))
+
+      expect(requestSigning).not.toHaveBeenCalled()
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: 4100 }),
+        undefined
+      )
+    })
+
+    it('allows personal_sign when the signer address arg is granted', async () => {
+      const { deps, requestSigning } = makeDeps({
+        grantedAddresses: [MOCK_ADDR]
+      })
+      requestSigning.mockResolvedValueOnce('0xSig')
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'personal_sign', ['0xdeadbeef', MOCK_ADDR])
+      await new Promise(r => setImmediate(r))
+
+      expect(requestSigning).toHaveBeenCalled()
+    })
+
+    it('rejects eth_signTypedData_v4 (4100) when the signer address arg is not granted', async () => {
+      // signTypedData_v4(address, typedData) — params[0] is the signer.
+      const { deps, sendResponse, requestSigning } = makeDeps({
+        grantedAddresses: [MOCK_ADDR]
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'eth_signTypedData_v4', [UNGRANTED_ADDR, '{"types":{}}'])
       await new Promise(r => setImmediate(r))
 
       expect(requestSigning).not.toHaveBeenCalled()

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -41,7 +41,7 @@ type MockDeps = {
   trackPendingOrigin: jest.Mock
   setBrowserNetworkSpy: jest.Mock
   currentNetwork: { value: BrowserNetwork }
-  hasPermission: jest.Mock
+  getGrantedAddresses: jest.Mock
   grantPermission: jest.Mock
   revokePermission: jest.Mock
   requestConnectApproval: jest.Mock
@@ -57,7 +57,7 @@ function makeDeps(overrides?: {
   nativeOrigin?: string | undefined
   tabId?: string
   activeAccount?: Account | undefined
-  hasPermission?: boolean
+  grantedAddresses?: string[]
 }): MockDeps {
   const currentNetwork = {
     value: overrides?.browserNetwork ?? {
@@ -87,7 +87,7 @@ function makeDeps(overrides?: {
   const setBrowserNetworkSpy = jest.fn((net: BrowserNetwork) => {
     currentNetwork.value = net
   })
-  const hasPermission = jest.fn(() => overrides?.hasPermission ?? false)
+  const getGrantedAddresses = jest.fn(() => overrides?.grantedAddresses ?? [])
   const grantPermission = jest.fn()
   const revokePermission = jest.fn()
   const requestConnectApproval = jest.fn()
@@ -120,7 +120,7 @@ function makeDeps(overrides?: {
       icons: []
     }),
     getActiveAccount: () => activeAccount.value,
-    hasPermission,
+    getGrantedAddresses,
     grantPermission,
     revokePermission,
     requestConnectApproval
@@ -134,7 +134,7 @@ function makeDeps(overrides?: {
     requestReadOnly,
     dispatch,
     trackPendingOrigin,
-    hasPermission,
+    getGrantedAddresses,
     grantPermission,
     revokePermission,
     requestConnectApproval,
@@ -507,7 +507,7 @@ describe('createInjectedProviderRouter', () => {
   describe('eth_requestAccounts', () => {
     it('returns the active address without prompting when already granted', async () => {
       const { deps, sendResponse, requestConnectApproval, grantPermission } =
-        makeDeps({ hasPermission: true })
+        makeDeps({ grantedAddresses: [MOCK_ADDR] })
       const router = createInjectedProviderRouter(deps)
 
       send(router, 'eth_requestAccounts')
@@ -515,6 +515,43 @@ describe('createInjectedProviderRouter', () => {
 
       expect(requestConnectApproval).not.toHaveBeenCalled()
       expect(grantPermission).not.toHaveBeenCalled()
+      expect(sendResponse).toHaveBeenCalledWith(1, null, [MOCK_ADDR])
+    })
+
+    it('returns ALL granted addresses (active first) without prompting, not just the active one', async () => {
+      // Multi-account: switching the wallet's active account must not force a
+      // re-prompt — every previously-granted address is returned, active first.
+      const OTHER = '0xOtherGrantedAddr'
+      const { deps, sendResponse, requestConnectApproval } = makeDeps({
+        grantedAddresses: [OTHER, MOCK_ADDR]
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'eth_requestAccounts')
+      await new Promise(r => setImmediate(r))
+
+      expect(requestConnectApproval).not.toHaveBeenCalled()
+      expect(sendResponse).toHaveBeenCalledWith(1, null, [MOCK_ADDR, OTHER])
+    })
+
+    it('prompts (does NOT short-circuit) when the origin has grants but the active account is not among them', async () => {
+      // Reconciliation: the active-only signer can't authorize an ungranted
+      // active account, so eth_requestAccounts must prompt rather than report a
+      // connection to other granted addresses.
+      const { deps, sendResponse, requestConnectApproval, grantPermission } =
+        makeDeps({ grantedAddresses: ['0xOtherGrantedAddr'] })
+      requestConnectApproval.mockResolvedValueOnce([MOCK_ACCOUNT])
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'eth_requestAccounts')
+      await new Promise(r => setImmediate(r))
+
+      expect(requestConnectApproval).toHaveBeenCalled()
+      expect(grantPermission).toHaveBeenCalledWith({
+        domain: 'https://example.com',
+        address: MOCK_ADDR,
+        vmType: NetworkVMType.EVM
+      })
       expect(sendResponse).toHaveBeenCalledWith(1, null, [MOCK_ADDR])
     })
 
@@ -590,7 +627,7 @@ describe('createInjectedProviderRouter', () => {
 
   describe('wallet_requestPermissions', () => {
     it('returns EIP-2255 permission object when already granted', async () => {
-      const { deps, sendResponse } = makeDeps({ hasPermission: true })
+      const { deps, sendResponse } = makeDeps({ grantedAddresses: [MOCK_ADDR] })
       const router = createInjectedProviderRouter(deps)
 
       send(router, 'wallet_requestPermissions')
@@ -629,11 +666,24 @@ describe('createInjectedProviderRouter', () => {
         expect.objectContaining({ parentCapability: 'eth_accounts' })
       ])
     })
+
+    it('prompts when the origin has grants but the active account is not among them', async () => {
+      const { deps, requestConnectApproval } = makeDeps({
+        grantedAddresses: ['0xOtherGrantedAddr']
+      })
+      requestConnectApproval.mockResolvedValueOnce([MOCK_ACCOUNT])
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'wallet_requestPermissions')
+      await new Promise(r => setImmediate(r))
+
+      expect(requestConnectApproval).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('wallet_getPermissions', () => {
     it('returns an EIP-2255 permission list when the active account is granted', () => {
-      const { deps, sendResponse } = makeDeps({ hasPermission: true })
+      const { deps, sendResponse } = makeDeps({ grantedAddresses: [MOCK_ADDR] })
       const router = createInjectedProviderRouter(deps)
 
       send(router, 'wallet_getPermissions')
@@ -647,8 +697,22 @@ describe('createInjectedProviderRouter', () => {
       )
     })
 
-    it('returns an empty array when the active account is not granted', () => {
-      const { deps, sendResponse } = makeDeps({ hasPermission: false })
+    it('returns an empty array when there are no grants for the origin', () => {
+      const { deps, sendResponse } = makeDeps({ grantedAddresses: [] })
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'wallet_getPermissions')
+
+      expect(sendResponse).toHaveBeenCalledWith(1, null, [])
+    })
+
+    it('returns [] when the origin has grants but the active account is not among them', () => {
+      // Reconciliation: a dApp polling wallet_getPermissions must see a
+      // disconnected state when the active-only signer is an ungranted account,
+      // not the other granted addresses.
+      const { deps, sendResponse } = makeDeps({
+        grantedAddresses: ['0xOtherGrantedAddr']
+      })
       const router = createInjectedProviderRouter(deps)
 
       send(router, 'wallet_getPermissions')

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -87,8 +87,14 @@ function makeDeps(overrides?: {
   const setBrowserNetworkSpy = jest.fn((net: BrowserNetwork) => {
     currentNetwork.value = net
   })
-  const getGrantedAddresses = jest.fn(() => overrides?.grantedAddresses ?? [])
-  const grantPermission = jest.fn()
+  // Back getGrantedAddresses with a live set that grantPermission mutates, so a
+  // grant during an approval flow is reflected when the handler re-reads the
+  // granted addresses to reconcile them against the active account.
+  const grantedSet = new Set<string>(overrides?.grantedAddresses ?? [])
+  const getGrantedAddresses = jest.fn(() => [...grantedSet])
+  const grantPermission = jest.fn(({ address }: { address: string }) =>
+    grantedSet.add(address)
+  )
   const revokePermission = jest.fn()
   const requestConnectApproval = jest.fn()
   const activeAccount = {
@@ -552,7 +558,37 @@ describe('createInjectedProviderRouter', () => {
         address: MOCK_ADDR,
         vmType: NetworkVMType.EVM
       })
-      expect(sendResponse).toHaveBeenCalledWith(1, null, [MOCK_ADDR])
+      // After granting the (active) selection, the advertised set is reconciled
+      // against the active account: the full granted set, active first.
+      expect(sendResponse).toHaveBeenCalledWith(1, null, [
+        MOCK_ADDR,
+        '0xOtherGrantedAddr'
+      ])
+    })
+
+    it('rejects when the approved selection does not include the active account', async () => {
+      // Phantom-connection guard: the injected signer is active-only, so if the
+      // user approves only non-active accounts we must not advertise them — reject
+      // rather than report a connection Core won't sign for (CP-14382).
+      const { deps, sendResponse, requestConnectApproval, emitEvent } =
+        makeDeps()
+      requestConnectApproval.mockResolvedValueOnce([
+        { addressC: '0xNonActiveSelected' } as Account
+      ])
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'eth_requestAccounts')
+      await new Promise(r => setImmediate(r))
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: EIP1193_USER_REJECTED_CODE }),
+        undefined
+      )
+      expect(emitEvent).not.toHaveBeenCalledWith(
+        'accountsChanged',
+        expect.anything()
+      )
     })
 
     it('opens approval when not granted, grants, and returns selected accounts', async () => {
@@ -678,6 +714,25 @@ describe('createInjectedProviderRouter', () => {
       await new Promise(r => setImmediate(r))
 
       expect(requestConnectApproval).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects when the approved selection does not include the active account', async () => {
+      // Same phantom-connection guard as eth_requestAccounts: don't return a
+      // permission set for an address the active-only signer won't use.
+      const { deps, sendResponse, requestConnectApproval } = makeDeps()
+      requestConnectApproval.mockResolvedValueOnce([
+        { addressC: '0xNonActiveSelected' } as Account
+      ])
+      const router = createInjectedProviderRouter(deps)
+
+      send(router, 'wallet_requestPermissions')
+      await new Promise(r => setImmediate(r))
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ code: EIP1193_USER_REJECTED_CODE }),
+        undefined
+      )
     })
   })
 

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -38,6 +38,54 @@ const signingMethodFor = (method: string): RpcMethod | undefined =>
     ? SIGNING_METHODS[method]
     : undefined
 
+const isEvmAddress = (value: unknown): value is string =>
+  typeof value === 'string' && /^0x[0-9a-fA-F]{40}$/.test(value)
+
+// The account address(es) a signing request will be signed with, when the dApp
+// names one in the request. The approval screen resolves the signing account
+// from the address the request carries (selectAccountByAddress) — the tx
+// `from`, or the signer-address arg of a message-sign method — so the caller
+// must validate each against the origin's grants and never sign with an account
+// the dApp wasn't granted (An's repro: connected as account 2, then
+// eth_sendTransaction with from = account 1).
+//
+// Arg positions follow the EIP/MetaMask conventions the VM module parses:
+//   personal_sign(message, address)            → params[1]
+//   eth_sign(address, message)                 → params[0]
+//   eth_signTypedData / _v1 (typedData, addr)  → params[1]
+//   eth_signTypedData_v3 / _v4 (addr, data)    → params[0]
+//
+// NOTE eth_sendTransactionBatch is intentionally absent: its handler signs with
+// the wallet's *active account index* and ignores the per-tx `from`, so gating
+// on `from` would be both wrong and bypassable (a granted `from` with an
+// ungranted active account). It falls through to [] here so the caller gates on
+// the active account instead.
+//
+// Only well-formed addresses are returned: a malformed/unexpected param is
+// skipped (the caller falls back to the active account) so a parse mismatch can
+// never reject a valid request.
+const requestedSignerAddresses = (
+  method: RpcMethod,
+  params: unknown[]
+): string[] => {
+  switch (method) {
+    case RpcMethod.ETH_SEND_TRANSACTION: {
+      const from = (params[0] as { from?: unknown } | null | undefined)?.from
+      return isEvmAddress(from) ? [from] : []
+    }
+    case RpcMethod.PERSONAL_SIGN:
+    case RpcMethod.SIGN_TYPED_DATA:
+    case RpcMethod.SIGN_TYPED_DATA_V1:
+      return isEvmAddress(params[1]) ? [params[1]] : []
+    case RpcMethod.ETH_SIGN:
+    case RpcMethod.SIGN_TYPED_DATA_V3:
+    case RpcMethod.SIGN_TYPED_DATA_V4:
+      return isEvmAddress(params[0]) ? [params[0]] : []
+    default:
+      return []
+  }
+}
+
 // EIP-2255 — only eth_accounts is supported; no other restricted methods today.
 function buildAccountsPermission(addresses: string[]): unknown[] {
   if (addresses.length === 0) return []
@@ -234,16 +282,37 @@ export function createInjectedProviderRouter(
     // a synthetic '' so cancelByOrigin comparisons stay meaningful.
     if (!origin) return
 
-    // The injected signer always signs with the wallet's active account, so
-    // refuse to even prompt unless the dApp has been granted that account (i.e.
-    // it was told about it via connect / accountsChanged). Otherwise a page
-    // could trigger a signing approval for an account it was never connected to
-    // — and the dApp would only learn of the account by it being signed for.
-    // Reject up front, no prompt (CP-14382).
-    if (resolveActiveConnectedAddresses(origin).length === 0) {
+    // Every account this request will be signed with must be granted to the
+    // origin. The approval screen resolves the signer from the address the
+    // request carries (selectAccountByAddress) — the tx `from`, or a message-
+    // sign method's signer-address arg — falling back to the active account when
+    // none is given. Reject up front, no prompt, if any of those isn't granted:
+    // the injected provider must never sign — a tx OR a message (e.g. a Permit /
+    // signTypedData, which can authorize transfers off-chain) — with an account
+    // the dApp was never granted (An's repro: connected as account 2, then
+    // eth_sendTransaction with from = account 1). A granted account that isn't
+    // currently active is fine — the dApp has permission for it. CP-14382.
+    const grantedAddresses = new Set(
+      getGrantedAddresses({ domain: origin, vmType: NetworkVMType.EVM }).map(
+        addr => addr.toLowerCase()
+      )
+    )
+    const requestedSigners = requestedSignerAddresses(rpcMethod, params)
+    const signerAddresses =
+      requestedSigners.length > 0
+        ? requestedSigners
+        : [getActiveAccount()?.addressC].filter((addr): addr is string =>
+            Boolean(addr)
+          )
+    const allSignersGranted =
+      signerAddresses.length > 0 &&
+      signerAddresses.every(addr => grantedAddresses.has(addr.toLowerCase()))
+    if (!allSignersGranted) {
       sendResponse(
         id,
-        providerErrors.unauthorized('Account not connected to this origin'),
+        providerErrors.unauthorized(
+          'Account not granted access to this origin'
+        ),
         undefined
       )
       return
@@ -412,8 +481,23 @@ export function createInjectedProviderRouter(
       // CP-14382). Grants for non-active selections still persist, so switching
       // to one later connects without re-prompting.
       const reconciled = resolveActiveConnectedAddresses(origin)
-      if (!anyGranted || reconciled.length === 0) {
+      if (!anyGranted) {
+        // No account approved → genuine user rejection (4001).
         sendResponse(id, providerErrors.userRejectedRequest(), undefined)
+        return
+      }
+      if (reconciled.length === 0) {
+        // Approved, but the active account isn't among the grants: an
+        // authorization failure (the dApp would otherwise be told about an
+        // account the active-only signer can't honor), not a user cancel. Use
+        // 4100 so dApps treat it as "not connected" rather than "rejected".
+        sendResponse(
+          id,
+          providerErrors.unauthorized(
+            'Active account not granted for this origin'
+          ),
+          undefined
+        )
         return
       }
       // Emit accountsChanged before resolving the Promise — matches
@@ -475,8 +559,23 @@ export function createInjectedProviderRouter(
       // set for an address the injected signer won't use (phantom connection,
       // CP-14382).
       const reconciled = resolveActiveConnectedAddresses(origin)
-      if (!anyGranted || reconciled.length === 0) {
+      if (!anyGranted) {
+        // No account approved → genuine user rejection (4001).
         sendResponse(id, providerErrors.userRejectedRequest(), undefined)
+        return
+      }
+      if (reconciled.length === 0) {
+        // Approved, but the active account isn't among the grants: an
+        // authorization failure (the dApp would otherwise be told about an
+        // account the active-only signer can't honor), not a user cancel. Use
+        // 4100 so dApps treat it as "not connected" rather than "rejected".
+        sendResponse(
+          id,
+          providerErrors.unauthorized(
+            'Active account not granted for this origin'
+          ),
+          undefined
+        )
         return
       }
       // Emit accountsChanged before resolving the Promise (see handleRequestAccounts).

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -173,6 +173,21 @@ export function createInjectedProviderRouter(
     }
   }
 
+  // EIP-2255: the accounts/permissions to advertise for this origin. The
+  // injected signer is active-only, so we mirror the passive accountsChanged
+  // reconciliation here: if the wallet's active account is granted, return the
+  // granted set (active sorted first) — switching among granted accounts never
+  // re-prompts (multi-account, Phase 3c). If the active account is NOT granted,
+  // return [] so the connect/permission handlers don't tell the dApp it's
+  // connected to an address the active-only signer can't authorize (CP-14382).
+  // The shared helper keeps this identical to the hook's switch-effect / prime
+  // path, so the active and passive paths never disagree.
+  const resolveActiveConnectedAddresses = (origin: string): string[] =>
+    resolveActiveConnectedAccounts(
+      getGrantedAddresses({ domain: origin, vmType: NetworkVMType.EVM }),
+      getActiveAccount()?.addressC
+    )
+
   // Read-only methods (eth_call, eth_getBalance, …) are dispatched to the VM
   // module — the same source WalletConnect uses — instead of a bespoke fetch +
   // allowlist. The module classifies/validates the method against its manifest
@@ -218,6 +233,22 @@ export function createInjectedProviderRouter(
     // gated by handleProviderMessage (rejects 4100 when absent); never register
     // a synthetic '' so cancelByOrigin comparisons stay meaningful.
     if (!origin) return
+
+    // The injected signer always signs with the wallet's active account, so
+    // refuse to even prompt unless the dApp has been granted that account (i.e.
+    // it was told about it via connect / accountsChanged). Otherwise a page
+    // could trigger a signing approval for an account it was never connected to
+    // — and the dApp would only learn of the account by it being signed for.
+    // Reject up front, no prompt (CP-14382).
+    if (resolveActiveConnectedAddresses(origin).length === 0) {
+      sendResponse(
+        id,
+        providerErrors.unauthorized('Account not connected to this origin'),
+        undefined
+      )
+      return
+    }
+
     const controller = registerInFlight(id, origin)
 
     try {
@@ -329,21 +360,6 @@ export function createInjectedProviderRouter(
       clearInFlight(id, controller)
     }
   }
-
-  // EIP-2255: the accounts/permissions to advertise for this origin. The
-  // injected signer is active-only, so we mirror the passive accountsChanged
-  // reconciliation here: if the wallet's active account is granted, return the
-  // granted set (active sorted first) — switching among granted accounts never
-  // re-prompts (multi-account, Phase 3c). If the active account is NOT granted,
-  // return [] so the connect/permission handlers don't tell the dApp it's
-  // connected to an address the active-only signer can't authorize (CP-14382).
-  // The shared helper keeps this identical to the hook's switch-effect / prime
-  // path, so the active and passive paths never disagree.
-  const resolveActiveConnectedAddresses = (origin: string): string[] =>
-    resolveActiveConnectedAccounts(
-      getGrantedAddresses({ domain: origin, vmType: NetworkVMType.EVM }),
-      getActiveAccount()?.addressC
-    )
 
   const handleRequestAccounts = async (id: number): Promise<void> => {
     const origin = getNativeOrigin()

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -379,7 +379,7 @@ export function createInjectedProviderRouter(
     try {
       const peerMeta = getPeerMeta()
       const selected = await requestConnectApproval(peerMeta)
-      const addresses: string[] = []
+      let anyGranted = false
       for (const account of selected) {
         if (!account.addressC) continue
         grantPermission({
@@ -387,17 +387,24 @@ export function createInjectedProviderRouter(
           address: account.addressC,
           vmType: NetworkVMType.EVM
         })
-        addresses.push(account.addressC)
+        anyGranted = true
       }
-      if (addresses.length === 0) {
+      // Advertise the reconciled set, not the raw selection. The injected signer
+      // is active-only, so report [active, ...granted] when the active account is
+      // among the grants, and reject otherwise — never tell the dApp it's
+      // connected to an address Core won't sign for (phantom connection,
+      // CP-14382). Grants for non-active selections still persist, so switching
+      // to one later connects without re-prompting.
+      const reconciled = resolveActiveConnectedAddresses(origin)
+      if (!anyGranted || reconciled.length === 0) {
         sendResponse(id, providerErrors.userRejectedRequest(), undefined)
         return
       }
       // Emit accountsChanged before resolving the Promise — matches
       // MetaMask/Rabby ordering so wagmi listeners see the event alongside
       // the resolution rather than one render later.
-      emitEvent('accountsChanged', addresses)
-      sendResponse(id, null, addresses)
+      emitEvent('accountsChanged', reconciled)
+      sendResponse(id, null, reconciled)
     } catch (e) {
       sendResponse(id, e, undefined)
     }
@@ -437,7 +444,7 @@ export function createInjectedProviderRouter(
     try {
       const peerMeta = getPeerMeta()
       const selected = await requestConnectApproval(peerMeta)
-      const addresses: string[] = []
+      let anyGranted = false
       for (const account of selected) {
         if (!account.addressC) continue
         grantPermission({
@@ -445,15 +452,20 @@ export function createInjectedProviderRouter(
           address: account.addressC,
           vmType: NetworkVMType.EVM
         })
-        addresses.push(account.addressC)
+        anyGranted = true
       }
-      if (addresses.length === 0) {
+      // Reconcile against the active account before returning permissions — same
+      // active-only reasoning as handleRequestAccounts: never return a permission
+      // set for an address the injected signer won't use (phantom connection,
+      // CP-14382).
+      const reconciled = resolveActiveConnectedAddresses(origin)
+      if (!anyGranted || reconciled.length === 0) {
         sendResponse(id, providerErrors.userRejectedRequest(), undefined)
         return
       }
       // Emit accountsChanged before resolving the Promise (see handleRequestAccounts).
-      emitEvent('accountsChanged', addresses)
-      sendResponse(id, null, buildAccountsPermission(addresses))
+      emitEvent('accountsChanged', reconciled)
+      sendResponse(id, null, buildAccountsPermission(reconciled))
     } catch (e) {
       sendResponse(id, e, undefined)
     }

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -5,6 +5,7 @@ import Logger from 'utils/Logger'
 import { getEvmCaip2ChainId } from 'utils/caip2ChainIds'
 import { setTabChainId } from 'store/browser/slices/tabs'
 import { isUserRejectedRpcError } from './errors'
+import { resolveActiveConnectedAccounts } from './resolveGrantedAccounts'
 import { MAX_MESSAGE_SIZE, ProviderRequest, RouterDeps } from './types'
 
 // Injected-specific methods (connect / EIP-2255 permissions / chain management)
@@ -148,7 +149,7 @@ export function createInjectedProviderRouter(
     trackPendingOrigin,
     getPeerMeta,
     getActiveAccount,
-    hasPermission,
+    getGrantedAddresses,
     grantPermission,
     revokePermission,
     requestConnectApproval
@@ -329,19 +330,20 @@ export function createInjectedProviderRouter(
     }
   }
 
-  // EIP-2255: resolve permissions for the current origin against the active
-  // EVM account. Today only `eth_accounts` is supported — there is no notion
-  // of a restricted method beyond account access.
-  const resolveActiveAccountAddresses = (origin: string): string[] => {
-    const active = getActiveAccount()
-    if (!active?.addressC) return []
-    const granted = hasPermission({
-      domain: origin,
-      address: active.addressC,
-      vmType: NetworkVMType.EVM
-    })
-    return granted ? [active.addressC] : []
-  }
+  // EIP-2255: the accounts/permissions to advertise for this origin. The
+  // injected signer is active-only, so we mirror the passive accountsChanged
+  // reconciliation here: if the wallet's active account is granted, return the
+  // granted set (active sorted first) — switching among granted accounts never
+  // re-prompts (multi-account, Phase 3c). If the active account is NOT granted,
+  // return [] so the connect/permission handlers don't tell the dApp it's
+  // connected to an address the active-only signer can't authorize (CP-14382).
+  // The shared helper keeps this identical to the hook's switch-effect / prime
+  // path, so the active and passive paths never disagree.
+  const resolveActiveConnectedAddresses = (origin: string): string[] =>
+    resolveActiveConnectedAccounts(
+      getGrantedAddresses({ domain: origin, vmType: NetworkVMType.EVM }),
+      getActiveAccount()?.addressC
+    )
 
   const handleRequestAccounts = async (id: number): Promise<void> => {
     const origin = getNativeOrigin()
@@ -363,15 +365,14 @@ export function createInjectedProviderRouter(
       return
     }
 
-    // Already connected: return without prompting.
-    if (
-      hasPermission({
-        domain: origin,
-        address: active.addressC,
-        vmType: NetworkVMType.EVM
-      })
-    ) {
-      sendResponse(id, null, [active.addressC])
+    // Short-circuit only when the active account is itself granted — return the
+    // granted set (active first) without prompting. If the active account is
+    // ungranted, fall through to the approval prompt rather than reporting a
+    // connection the active-only signer can't honor (keeps this consistent with
+    // the accountsChanged([]) reconciliation).
+    const connected = resolveActiveConnectedAddresses(origin)
+    if (connected.length > 0) {
+      sendResponse(id, null, connected)
       return
     }
 
@@ -425,14 +426,11 @@ export function createInjectedProviderRouter(
       return
     }
 
-    const alreadyGranted = hasPermission({
-      domain: origin,
-      address: active.addressC,
-      vmType: NetworkVMType.EVM
-    })
-
-    if (alreadyGranted) {
-      sendResponse(id, null, buildAccountsPermission([active.addressC]))
+    // Same active-account gate as eth_requestAccounts: only short-circuit when
+    // the active account is granted; otherwise prompt.
+    const connected = resolveActiveConnectedAddresses(origin)
+    if (connected.length > 0) {
+      sendResponse(id, null, buildAccountsPermission(connected))
       return
     }
 
@@ -467,10 +465,13 @@ export function createInjectedProviderRouter(
       sendResponse(id, null, [])
       return
     }
+    // Returns [] when the active account isn't granted, so a dApp that polls
+    // wallet_getPermissions sees a disconnected state consistent with the
+    // accountsChanged([]) reconciliation (never a phantom connection).
     sendResponse(
       id,
       null,
-      buildAccountsPermission(resolveActiveAccountAddresses(origin))
+      buildAccountsPermission(resolveActiveConnectedAddresses(origin))
     )
   }
 

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/types.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/types.ts
@@ -70,11 +70,16 @@ export type RouterDeps = {
   getActiveAccount: () => Account | undefined
 
   // Permissions
-  hasPermission: (args: {
+  /**
+   * Every address at `domain` granted for `vmType`. Used by
+   * `wallet_getPermissions` / `eth_requestAccounts` so that switching the
+   * active wallet account does not spuriously disconnect a dApp that was
+   * previously authorized for some other address.
+   */
+  getGrantedAddresses: (args: {
     domain: string
-    address: string
     vmType: NetworkVMType
-  }) => boolean
+  }) => string[]
   grantPermission: (args: {
     domain: string
     address: string

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -122,6 +122,19 @@ const mockStore = {
   subscribe: jest.fn(() => () => undefined)
 } as unknown as ReturnType<typeof useStore>
 
+// Signing requires the resolved signer account to be granted for the origin.
+// Signing tests use this to grant the default active account for their origin.
+const grantStoreForOrigin = (origin: string): ReturnType<typeof useStore> =>
+  ({
+    getState: () => ({
+      permissions: {
+        grants: { [origin]: { [mockActiveAccount.addressC]: ['EVM'] } }
+      }
+    }),
+    dispatch: jest.fn(),
+    subscribe: jest.fn(() => () => undefined)
+  } as unknown as ReturnType<typeof useStore>)
+
 function setupMocks(
   overrides: {
     account?: typeof mockActiveAccount | null
@@ -289,6 +302,8 @@ describe('useEvmInjectedProvider', () => {
       it('uses browser chain for signing after wallet_switchEthereumChain', async () => {
         const mockSignFn = jest.fn().mockResolvedValue('0xSig')
         mockCreateInAppRequest.mockReturnValue(mockSignFn)
+        // Signing requires the active account granted for the origin.
+        mockUseStore.mockReturnValue(grantStoreForOrigin('https://example.com'))
 
         const { result } = renderProvider()
 
@@ -738,6 +753,12 @@ describe('useEvmInjectedProvider', () => {
         }
       ]
 
+      // The signing gate requires the signer account to be granted for the
+      // origin; these tests render at https://example.com as the active account.
+      beforeEach(() => {
+        mockUseStore.mockReturnValue(grantStoreForOrigin('https://example.com'))
+      })
+
       it.each(signingMethods)(
         'dispatches $dappMethod through createInAppRequest',
         async ({ dappMethod, rpcMethod }) => {
@@ -783,6 +804,10 @@ describe('useEvmInjectedProvider', () => {
       it('derives peerMeta.name from the native URL hostname, not from page-supplied domain_metadata', async () => {
         const mockRequest = jest.fn().mockResolvedValue('0xSig')
         mockCreateInAppRequest.mockReturnValue(mockRequest)
+        // Signing requires the active account granted for the (real) origin.
+        mockUseStore.mockReturnValue(
+          grantStoreForOrigin('https://malicious.example')
+        )
 
         const { result } = renderHook(() =>
           useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
@@ -1227,6 +1252,8 @@ describe('useEvmInjectedProvider', () => {
       it('defaults params to empty array for signing methods', async () => {
         const mockRequest = jest.fn().mockResolvedValue('0xResult')
         mockCreateInAppRequest.mockReturnValue(mockRequest)
+        // Signing requires the active account granted for the origin.
+        mockUseStore.mockReturnValue(grantStoreForOrigin('https://example.com'))
 
         const { result } = renderProvider()
 
@@ -1391,6 +1418,8 @@ describe('useEvmInjectedProvider', () => {
         return new Promise(() => undefined)
       })
       mockCreateInAppRequest.mockReturnValue(mockRequest)
+      // Signing requires the active account granted for the origin.
+      mockUseStore.mockReturnValue(grantStoreForOrigin('https://uniswap.org'))
 
       const { result } = renderProvider('https://uniswap.org')
 
@@ -1420,6 +1449,8 @@ describe('useEvmInjectedProvider', () => {
         return new Promise(() => undefined)
       })
       mockCreateInAppRequest.mockReturnValue(mockRequest)
+      // Signing requires the active account granted for the origin.
+      mockUseStore.mockReturnValue(grantStoreForOrigin('https://uniswap.org'))
 
       const { result } = renderProvider('https://uniswap.org/swap')
 

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -1527,6 +1527,26 @@ describe('useEvmInjectedProvider', () => {
         )
       })
 
+      it('injects accountsChanged([]) on reload when the active account is NOT granted', () => {
+        // Origin granted to a different address than the active account.
+        // Priming the granted set here would re-establish a phantom connection
+        // the injected signer can't honor, so we emit [] instead (CP-14382).
+        mockUseStore.mockReturnValue(withPermission('0xSomeOtherGrantedAddr'))
+        const { result } = renderProvider()
+        act(() => {
+          result.current.setCurrentUrl('https://opensea.io/')
+        })
+        mockInjectJavaScript.mockClear()
+
+        act(() => {
+          result.current.handleDomainMetadata(metadata)
+        })
+
+        expect(mockInjectJavaScript).toHaveBeenCalledWith(
+          expect.stringContaining("__coreProviderEmit('accountsChanged', [])")
+        )
+      })
+
       it('does not inject accountsChanged when origin is missing', () => {
         const { result } = renderProvider('')
         // currentUrlRef is never set, so origin stays ''
@@ -1557,6 +1577,142 @@ describe('useEvmInjectedProvider', () => {
           expect.stringContaining("__coreProviderEmit('accountsChanged'")
         )
       })
+    })
+  })
+
+  describe('active-account switch propagation (CP-14382)', () => {
+    const ORIGIN = 'https://opensea.io/'
+    const A = mockActiveAccount.addressC
+    const B = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+    const C = '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC'
+    const accountA = mockActiveAccount
+    const accountB = { ...mockActiveAccount, addressC: B }
+    const accountC = { ...mockActiveAccount, addressC: C }
+
+    // A store whose grants for opensea.io cover exactly `addrs` (EVM).
+    const storeGranting = (addrs: string[]): ReturnType<typeof useStore> =>
+      ({
+        getState: () => ({
+          permissions: {
+            grants: {
+              'https://opensea.io': Object.fromEntries(
+                addrs.map(addr => [addr, ['EVM']])
+              )
+            }
+          }
+        }),
+        dispatch: jest.fn(),
+        subscribe: jest.fn(() => () => undefined)
+      } as unknown as ReturnType<typeof useStore>)
+
+    it('emits [newActive, ...others] when switching to a granted account', () => {
+      mockUseStore.mockReturnValue(storeGranting([A, B]))
+      setupMocks({ account: accountA })
+      const { rerender, result } = renderProvider()
+      act(() => result.current.setCurrentUrl(ORIGIN))
+      mockInjectJavaScript.mockClear()
+
+      setupMocks({ account: accountB })
+      act(() => rerender())
+
+      expect(mockInjectJavaScript).toHaveBeenCalledWith(
+        expect.stringContaining(`'accountsChanged', ["${B}","${A}"]`)
+      )
+    })
+
+    it('emits [] when switching to an ungranted account', () => {
+      mockUseStore.mockReturnValue(storeGranting([A, B]))
+      setupMocks({ account: accountA })
+      const { rerender, result } = renderProvider()
+      act(() => result.current.setCurrentUrl(ORIGIN))
+      mockInjectJavaScript.mockClear()
+
+      setupMocks({ account: accountC })
+      act(() => rerender())
+
+      expect(mockInjectJavaScript).toHaveBeenCalledWith(
+        expect.stringContaining("'accountsChanged', []")
+      )
+    })
+
+    it('re-emits the granted set when switching back from an ungranted account', () => {
+      mockUseStore.mockReturnValue(storeGranting([A, B]))
+      setupMocks({ account: accountC })
+      const { rerender, result } = renderProvider()
+      act(() => result.current.setCurrentUrl(ORIGIN))
+      // Switch to ungranted-adjacent path then back to a granted account.
+      setupMocks({ account: accountA })
+      act(() => rerender())
+      mockInjectJavaScript.mockClear()
+
+      setupMocks({ account: accountB })
+      act(() => rerender())
+
+      expect(mockInjectJavaScript).toHaveBeenCalledWith(
+        expect.stringContaining(`'accountsChanged', ["${B}","${A}"]`)
+      )
+    })
+
+    it('emits accountsChanged([]) after grants are revoked and the active account switches', () => {
+      // Origin starts connected to [A, B]; the first switch advertises that set.
+      mockUseStore.mockReturnValue(storeGranting([A, B]))
+      setupMocks({ account: accountA })
+      const { rerender, result } = renderProvider()
+      act(() => result.current.setCurrentUrl(ORIGIN))
+      setupMocks({ account: accountB })
+      act(() => rerender())
+      mockInjectJavaScript.mockClear()
+
+      // Grants revoked (e.g. via Connected Sites), then the user switches
+      // accounts. The dApp's stale _accounts must be cleared with [] rather than
+      // left advertising the now-revoked set.
+      mockUseStore.mockReturnValue(storeGranting([]))
+      setupMocks({ account: accountA })
+      act(() => rerender())
+
+      expect(mockInjectJavaScript).toHaveBeenCalledWith(
+        expect.stringContaining("'accountsChanged', []")
+      )
+    })
+
+    it('does not re-emit [] for a never-connected origin already primed to []', () => {
+      // No grant at all: the page-load prime emits [] and seeds the dedupe ref,
+      // so a subsequent account switch must not produce a redundant emit.
+      mockUseStore.mockReturnValue(storeGranting([]))
+      setupMocks({ account: accountA })
+      const { rerender, result } = renderProvider()
+      act(() => result.current.setCurrentUrl(ORIGIN))
+      act(() =>
+        result.current.handleDomainMetadata(JSON.stringify({ name: 'x' }))
+      )
+      mockInjectJavaScript.mockClear()
+
+      setupMocks({ account: accountB })
+      act(() => rerender())
+
+      expect(mockInjectJavaScript).not.toHaveBeenCalledWith(
+        expect.stringContaining("'accountsChanged'")
+      )
+    })
+
+    it('suppresses duplicate emits for the same resolved accounts', () => {
+      mockUseStore.mockReturnValue(storeGranting([A, B]))
+      setupMocks({ account: accountA })
+      const { rerender, result } = renderProvider()
+      act(() => result.current.setCurrentUrl(ORIGIN))
+      // First switch emits [A, B].
+      setupMocks({ account: { ...mockActiveAccount } })
+      act(() => rerender())
+      mockInjectJavaScript.mockClear()
+
+      // New active object, same addressC → resolves to the same [A, B];
+      // must not re-emit.
+      setupMocks({ account: { ...mockActiveAccount } })
+      act(() => rerender())
+
+      expect(mockInjectJavaScript).not.toHaveBeenCalledWith(
+        expect.stringContaining("'accountsChanged'")
+      )
     })
   })
 })

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -1620,6 +1620,26 @@ describe('useEvmInjectedProvider', () => {
       )
     })
 
+    it('origin-gates the accountsChanged emit to the resolved origin', () => {
+      // The injected JS must be wrapped in a window.location.origin check so an
+      // account switch racing a cross-origin nav can't leak addresses to a
+      // different page (same guard as sendResponse).
+      mockUseStore.mockReturnValue(storeGranting([A, B]))
+      setupMocks({ account: accountA })
+      const { rerender, result } = renderProvider()
+      act(() => result.current.setCurrentUrl(ORIGIN))
+      mockInjectJavaScript.mockClear()
+
+      setupMocks({ account: accountB })
+      act(() => rerender())
+
+      expect(mockInjectJavaScript).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'if(window.location.origin==="https://opensea.io")'
+        )
+      )
+    })
+
     it('emits [] when switching to an ungranted account', () => {
       mockUseStore.mockReturnValue(storeGranting([A, B]))
       setupMocks({ account: accountA })

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -287,8 +287,14 @@ export function useEvmInjectedProvider(
     const serialized = JSON.stringify(accounts)
     if (lastEmittedAccountsRef.current === serialized) return
     lastEmittedAccountsRef.current = serialized
+    // Origin-gate delivery (same guard as sendResponse): only inject if the page
+    // is still on the origin we resolved accounts for, so an account switch
+    // racing a cross-origin navigation (briefly-stale currentUrlRef) can't leak
+    // one origin's granted addresses to a different page.
     webViewRef.current?.injectJavaScript(
-      `window.__coreProviderEmit && window.__coreProviderEmit('accountsChanged', ${serialized}); true;`
+      `if(window.location.origin===${JSON.stringify(
+        origin
+      )}){window.__coreProviderEmit && window.__coreProviderEmit('accountsChanged', ${serialized})};true;`
     )
   }, [activeAccount, store, webViewRef])
 

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -21,7 +21,7 @@ import { approvalController } from 'vmModule/ApprovalController/ApprovalControll
 import {
   grantPermission as grantPermissionAction,
   revokePermission as revokePermissionAction,
-  selectHasPermission
+  selectGrantedAddressesForDomain
 } from 'store/permissions/slice'
 import type { RootState } from 'store/types'
 import type { Account } from 'store/account'
@@ -31,6 +31,7 @@ import {
   createInjectedProviderRouter,
   InjectedProviderRouter
 } from './injectedProvider/router'
+import { resolveActiveConnectedAccounts } from './injectedProvider/resolveGrantedAccounts'
 import {
   CONNECT_PROMPT_TIMED_OUT_MESSAGE,
   EIP1193_USER_REJECTED_CODE,
@@ -252,6 +253,45 @@ export function useEvmInjectedProvider(
     activeAccountRef.current = activeAccount
   }, [activeAccount])
 
+  // Last accounts list advertised to the dApp (serialized). Shared by the
+  // page-load prime path and the active-account switch effect below so they
+  // never emit a duplicate accountsChanged for the same set.
+  const lastEmittedAccountsRef = useRef<string | undefined>(undefined)
+
+  // Propagate wallet active-account switches to the dApp. MetaMask users
+  // expect the wallet's account selector to drive the dApp's connected
+  // account — dApps in the in-app browser have no account picker of their own.
+  //   - new active IS granted at this origin → emit [active, ...otherGranted]
+  //     (active first) so the dApp follows the wallet.
+  //   - new active is NOT granted → emit [] so the dApp reflects a disconnected
+  //     state (transacting UI disabled). The injected signer always signs with
+  //     the active account, so we must never leave the dApp believing it can
+  //     transact as an account that won't actually sign (CP-14382).
+  // We don't short-circuit on an empty granted set: a revoke-then-switch (grants
+  // cleared via Connected Sites, then the user switches accounts) must still emit
+  // accountsChanged([]) to clear the dApp's stale _accounts, matching the prime
+  // path. A genuinely never-connected origin is already covered by the prime
+  // path's [] emit, so the dedupe below suppresses any redundant emit here.
+  useEffect(() => {
+    const origin = getOriginFromUrl(currentUrlRef.current)
+    if (!origin) return
+    const granted = selectGrantedAddressesForDomain({
+      domain: origin,
+      vmType: NetworkVMType.EVM
+    })(store.getState())
+
+    const accounts = resolveActiveConnectedAccounts(
+      granted,
+      activeAccount?.addressC
+    )
+    const serialized = JSON.stringify(accounts)
+    if (lastEmittedAccountsRef.current === serialized) return
+    lastEmittedAccountsRef.current = serialized
+    webViewRef.current?.injectJavaScript(
+      `window.__coreProviderEmit && window.__coreProviderEmit('accountsChanged', ${serialized}); true;`
+    )
+  }, [activeAccount, store, webViewRef])
+
   // When this browser tab unmounts (tab closed), reject any parked connect
   // approval with 4001 so the dApp's eth_requestAccounts promise settles instead
   // of hanging until supersede or the 90s timeout. Inactive tabs stay mounted
@@ -420,8 +460,8 @@ export function useEvmInjectedProvider(
       },
       getPeerMeta,
       getActiveAccount: () => activeAccountRef.current,
-      hasPermission: ({ domain, address, vmType }) =>
-        selectHasPermission({ domain, address, vmType })(store.getState()),
+      getGrantedAddresses: ({ domain, vmType }) =>
+        selectGrantedAddressesForDomain({ domain, vmType })(store.getState()),
       grantPermission: ({ domain, address, vmType }) =>
         dispatch(grantPermissionAction({ domain, address, vmType })),
       revokePermission: ({ domain, address, vmType }) =>
@@ -461,21 +501,24 @@ export function useEvmInjectedProvider(
         Logger.error('[InjectedProvider] Invalid domain_metadata payload')
       }
 
-      // Prime the shim's _accounts cache on page load: if the current origin
-      // already has an EVM grant for the active account, emit accountsChanged
-      // so dApps with auto-reconnect (wagmi autoConnect, etc.) see the
-      // connection immediately without prompting. If no grant exists, emit
-      // an empty array to keep the shim in sync (e.g. after the user revoked
-      // the grant from Connected Sites while the tab was open).
+      // Prime the shim's _accounts cache on page load so dApps with
+      // auto-reconnect (wagmi autoConnect, etc.) see the connection
+      // immediately without prompting. We emit the accounts the dApp may
+      // actually transact as: if the active account is in this origin's
+      // granted set, the granted addresses (active first); otherwise []. The
+      // injected signer always signs with the active account, so priming the
+      // granted set while an ungranted account is active would re-establish a
+      // phantom connection on reload (the gap An flagged on #3862) — emit []
+      // instead so the dApp reflects a disconnected state (CP-14382).
       const origin = getOriginFromUrl(currentUrlRef.current)
       const active = activeAccountRef.current
       if (!origin || !active?.addressC) return
-      const granted = selectHasPermission({
+      const granted = selectGrantedAddressesForDomain({
         domain: origin,
-        address: active.addressC,
         vmType: NetworkVMType.EVM
       })(store.getState())
-      const accounts = granted ? [active.addressC] : []
+      const accounts = resolveActiveConnectedAccounts(granted, active.addressC)
+      lastEmittedAccountsRef.current = JSON.stringify(accounts)
       webViewRef.current?.injectJavaScript(
         `window.__coreProviderEmit && window.__coreProviderEmit('accountsChanged', ${JSON.stringify(
           accounts

--- a/packages/core-mobile/app/store/permissions/slice.test.ts
+++ b/packages/core-mobile/app/store/permissions/slice.test.ts
@@ -6,6 +6,7 @@ import {
   revokePermission,
   selectAddressesForDomain,
   selectConnectedDomains,
+  selectGrantedAddressesForDomain,
   selectGrantsForDomain,
   selectHasPermission
 } from './slice'
@@ -250,6 +251,52 @@ describe('permissions slice', () => {
     it("selectAddressesForDomain returns that domain's address keys", () => {
       expect(selectAddressesForDomain(DOMAIN_UNI)(state)).toEqual([ADDR_A])
       expect(selectAddressesForDomain('https://nope.test')(state)).toEqual([])
+    })
+
+    it('selectGrantedAddressesForDomain returns addresses granted for the vmType, or [] for unknown domain', () => {
+      // Shared state: DOMAIN_UNI granted ADDR_A for EVM only.
+      expect(
+        selectGrantedAddressesForDomain({
+          domain: DOMAIN_UNI,
+          vmType: NetworkVMType.EVM
+        })(state)
+      ).toEqual([ADDR_A])
+      expect(
+        selectGrantedAddressesForDomain({
+          domain: DOMAIN_UNI,
+          vmType: NetworkVMType.SVM
+        })(state)
+      ).toEqual([])
+      expect(
+        selectGrantedAddressesForDomain({
+          domain: 'https://nope.test',
+          vmType: NetworkVMType.EVM
+        })(state)
+      ).toEqual([])
+    })
+
+    it('selectGrantedAddressesForDomain filters by vmType across multiple addresses', () => {
+      const multiState = buildRootState({
+        grants: {
+          [DOMAIN_UNI]: {
+            [ADDR_A]: [NetworkVMType.EVM, NetworkVMType.SVM],
+            [ADDR_B]: [NetworkVMType.SVM]
+          }
+        }
+      })
+      // EVM grant → only ADDR_A; SVM grant → both addresses (insertion order).
+      expect(
+        selectGrantedAddressesForDomain({
+          domain: DOMAIN_UNI,
+          vmType: NetworkVMType.EVM
+        })(multiState)
+      ).toEqual([ADDR_A])
+      expect(
+        selectGrantedAddressesForDomain({
+          domain: DOMAIN_UNI,
+          vmType: NetworkVMType.SVM
+        })(multiState)
+      ).toEqual([ADDR_A, ADDR_B])
     })
   })
 })

--- a/packages/core-mobile/app/store/permissions/slice.ts
+++ b/packages/core-mobile/app/store/permissions/slice.ts
@@ -98,6 +98,26 @@ export const selectAddressesForDomain =
     return Object.keys(domainGrants)
   }
 
+/**
+ * Returns every address under `domain` that has been granted access for the
+ * given `vmType`. Used by the injected provider to answer
+ * `wallet_getPermissions` / `eth_requestAccounts` with the full authorized
+ * set rather than only the currently-active account — so switching the
+ * wallet's active account does not force the user to re-grant the dApp.
+ */
+export const selectGrantedAddressesForDomain =
+  ({ domain, vmType }: { domain: Domain; vmType: NetworkVMType }) =>
+  (state: RootState): Address[] => {
+    const domainGrants = state.permissions.grants[domain]
+    if (!domainGrants) return []
+    const granted: Address[] = []
+    for (const address of Object.keys(domainGrants)) {
+      const vmTypes = domainGrants[address]
+      if (vmTypes?.includes(vmType)) granted.push(address)
+    }
+    return granted
+  }
+
 export const { grantPermission, revokePermission } = permissionsSlice.actions
 
 export const permissionsReducer = permissionsSlice.reducer


### PR DESCRIPTION
## Description

**Ticket: [CP-14382](https://ava-labs.atlassian.net/browse/CP-14382)**

Propagates the wallet's active-account switches to connected dApps, and reconciles the case where the active account isn't in a dApp's granted set. Combines the old Phase 3c (multi-account read path, #3788) and Phase 3d (active-switch propagation, #3791) into one branch, plus the new reconciliation logic.

**Summary of changes**
- **Multi-account read path (folds in 3c):** new `resolveGrantedAccounts` helper + `selectGrantedAddressesForDomain` selector; `RouterDeps.hasPermission` → `getGrantedAddresses`. `eth_requestAccounts` / `wallet_getPermissions` / `wallet_requestPermissions` now return **all** granted addresses for the origin (active sorted first), so switching the active wallet account doesn't force a re-prompt.
- **Active-switch propagation (3d):** a `useEffect` on `activeAccount` emits `accountsChanged([newActive, ...others])` when the new active account is granted at the open origin, so the dApp follows the wallet's selector (MetaMask-style).
- **Ungranted-active reconciliation (the gap An flagged on #3862):** new shared `resolveActiveConnectedAccounts` rule — when the active account is **not** in the granted set, emit `accountsChanged([])` on both the switch effect and page-load priming, so the dApp reflects a disconnected state instead of believing it can transact as an account the injected signer (always the active account) won't actually sign. A shared `lastEmittedAccountsRef` dedupes.

**Motivation / context**
The injected signer always signs with the active account; the dApp's requested `from` is ignored. Without reconciliation, switching to an ungranted account left the dApp showing the old account while a different (ungranted) account would sign. Subsumes the narrower "honor dApp-requested `from`" concern from the #3862 review (and the standalone CP-14379, now a duplicate).

**Dependencies introduced**
None.

**Breaking changes**
None.

> Stacked on #3876 (read-only consolidation); base will retarget to `main` as the stack lands. Review against the `boyer/injected-provider-rpc-consolidation` base.

## Screenshots/Videos

N/A — behavior is dApp-facing `accountsChanged` events; no Core UI surface change.

## Testing

**Dev Testing (if applicable)**

iOS: 8781
Android: 8782

- Connect a dApp (e.g. app.uniswap.org) granting account A. Switch the wallet's active account to another **granted** account B → dApp follows (shows B first).
- Switch to an **ungranted** account C → dApp reflects a disconnected state (`accountsChanged([])`, transacting UI disabled).
- Switch back to a granted account → dApp re-connects to the granted set.
- Reload the page while an ungranted account is active → dApp does **not** auto-reconnect.
- Confirm no transaction is ever signed by an account the dApp wasn't told about.
- Trigger a Bitrise build and reference it here.
- Move CP-14382 into the "Testing" column on Jira.

**QA Testing (if applicable)**

- Acceptance: granted-switch emits `[newActive, …]`; ungranted-switch emits `[]`; switch-back re-emits the set; reload-while-ungranted stays disconnected; duplicate emits suppressed.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14382]: https://ava-labs.atlassian.net/browse/CP-14382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ