### PR TITLE
CP-14058: fix blank sessionExpired modal trap on iOS 26

### DIFF
--- a/packages/core-mobile/app/new/routes/RootNavigator.tsx
+++ b/packages/core-mobile/app/new/routes/RootNavigator.tsx
@@ -35,8 +35,12 @@ export function RootNavigator(): JSX.Element {
       <Stack
         // @ts-ignore: to set the current route name globally
         screenListeners={({ navigation }) => {
-          const state =
-            navigation.getState().routes[navigation.getState().index]?.state
+          const rootState = navigation.getState()
+          const topRoute = rootState.routes[rootState.index]?.name
+          if (topRoute) {
+            currentRouteStore.getState().setTopRoute(topRoute)
+          }
+          const state = rootState.routes[rootState.index]?.state
           if (state && state.index !== undefined) {
             const currentRoute = state?.routes[state.index]?.name
             if (currentRoute) {
@@ -74,6 +78,11 @@ export function RootNavigator(): JSX.Element {
             name="sessionExpired"
             options={{
               ...modalScreensOptions,
+              // formSheet renders blank on iOS 26 when presented at root from a
+              // deep child route, which traps the user with no escape gestures.
+              // fullScreenModal bypasses the broken sheet presentation path and
+              // matches this screen's hard-blocking re-auth semantics anyway.
+              presentation: 'fullScreenModal',
               gestureEnabled: false
             }}
           />

--- a/packages/core-mobile/app/new/routes/sessionExpired/index.tsx
+++ b/packages/core-mobile/app/new/routes/sessionExpired/index.tsx
@@ -1,16 +1,8 @@
 import { useFocusEffect, useRouter } from 'expo-router'
 import React, { useCallback } from 'react'
 import { BackHandler } from 'react-native'
-import {
-  Button,
-  Icons,
-  SafeAreaView,
-  showAlert,
-  Text,
-  useTheme,
-  View
-} from '@avalabs/k2-alpine'
-import { Space } from 'common/components/Space'
+import { Icons, SafeAreaView, showAlert, useTheme } from '@avalabs/k2-alpine'
+import { ErrorState } from 'common/components/ErrorState'
 import { startRefreshSeedlessTokenFlow } from 'common/utils/startRefreshSeedlessTokenFlow'
 import SeedlessService from 'seedless/services/SeedlessService'
 import { useDispatch } from 'react-redux'
@@ -103,33 +95,29 @@ const SessionExpiredScreen = (): React.JSX.Element => {
       .catch(e => {
         Logger.error('startRefreshSeedlessTokenFlow error', e)
         router.canDismiss() && router.dismiss()
-        dispatch(onLogOut)
+        dispatch(onLogOut())
       })
   }, [dispatch, unlock, mfaMethods, router])
 
   return (
-    <SafeAreaView
-      style={{
-        flex: 1,
-        justifyContent: 'space-between',
-        marginHorizontal: 16
-      }}>
-      <View style={{ alignItems: 'center', justifyContent: 'center', flex: 1 }}>
-        <Icons.Action.Info color={colors.$textPrimary} width={36} height={36} />
-        <Space y={24} />
-        <Text variant={'heading5'}>Your session has timed out</Text>
-        <Space y={8} />
-        <Text variant={'body2'} style={{ textAlign: 'center' }}>
-          Tap Retry to continue
-        </Text>
-      </View>
-      <Button
-        size={'large'}
-        type={'primary'}
-        onPress={onRetry}
-        style={{ width: '100%', marginBottom: 16 }}>
-        Retry
-      </Button>
+    <SafeAreaView style={{ flex: 1, justifyContent: 'center' }}>
+      <ErrorState
+        icon={
+          <Icons.Action.Info
+            color={colors.$textPrimary}
+            width={56}
+            height={56}
+          />
+        }
+        title="Your session has timed out"
+        description="Tap Retry to continue"
+        button={{
+          title: 'Retry',
+          onPress: () => {
+            onRetry()
+          }
+        }}
+      />
     </SafeAreaView>
   )
 }

--- a/packages/core-mobile/app/new/routes/store.ts
+++ b/packages/core-mobile/app/new/routes/store.ts
@@ -2,8 +2,12 @@ import { create } from 'zustand'
 
 export const currentRouteStore = create<{
   currentRoute: string | undefined
+  topRoute: string | undefined
   setCurrentRoute: (route: string) => void
+  setTopRoute: (route: string) => void
 }>(set => ({
   currentRoute: undefined,
-  setCurrentRoute: (route: string) => set({ currentRoute: route })
+  topRoute: undefined,
+  setCurrentRoute: (route: string) => set({ currentRoute: route }),
+  setTopRoute: (route: string) => set({ topRoute: route })
 }))

--- a/packages/core-mobile/app/seedless/store/listeners.test.ts
+++ b/packages/core-mobile/app/seedless/store/listeners.test.ts
@@ -61,6 +61,12 @@ jest.mock('expo-router', () => ({
   }
 }))
 
+jest.mock('new/routes/store', () => ({
+  currentRouteStore: {
+    getState: jest.fn(() => ({ topRoute: undefined }))
+  }
+}))
+
 jest.mock('contexts/ReactQueryProvider', () => ({
   queryClient: {
     clear: jest.fn()
@@ -89,6 +95,7 @@ let store: ReturnType<typeof setupTestStore>
 
 describe('seedless - listeners', () => {
   beforeEach(() => {
+    jest.clearAllMocks()
     // reset store and stop all active listeners
     listenerMiddlewareInstance.clearListeners()
     store = setupTestStore()
@@ -146,5 +153,30 @@ describe('seedless - listeners', () => {
   it('should have signed out', async () => {
     store.dispatch(onLogOut())
     expect(GoogleSigninService.signOut).toHaveBeenCalled()
+  })
+
+  describe('onTokenExpired', () => {
+    it('navigates to /sessionExpired when the modal is not already on screen', async () => {
+      const { currentRouteStore } = require('new/routes/store')
+      const { router } = require('expo-router')
+      currentRouteStore.getState.mockReturnValue({ topRoute: '(signedIn)' })
+
+      store.dispatch(onTokenExpired())
+      // flush the listener microtask
+      await Promise.resolve()
+
+      expect(router.navigate).toHaveBeenCalledWith('/sessionExpired')
+    })
+
+    it('does not navigate when the modal is already on screen', async () => {
+      const { currentRouteStore } = require('new/routes/store')
+      const { router } = require('expo-router')
+      currentRouteStore.getState.mockReturnValue({ topRoute: 'sessionExpired' })
+
+      store.dispatch(onTokenExpired())
+      await Promise.resolve()
+
+      expect(router.navigate).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/core-mobile/app/seedless/store/listeners.ts
+++ b/packages/core-mobile/app/seedless/store/listeners.ts
@@ -14,6 +14,7 @@ import { AppStartListening, AppListenerEffectAPI } from 'store/types'
 import { onTokenExpired } from 'seedless/store/slice'
 import { selectAccountById, setAccountTitle } from 'store/account/slice'
 import { router } from 'expo-router'
+import { currentRouteStore } from 'new/routes/store'
 import { selectSeedlessWallet } from 'store/wallet/slice'
 import { SeedlessPubKeysStorage } from 'seedless/services/storage/SeedlessPubKeysStorage'
 
@@ -57,6 +58,10 @@ const terminateSeedless = async (): Promise<void> => {
 }
 
 const handleTokenExpired = async (): Promise<void> => {
+  // Skip if the modal is already on screen — no need to re-trigger this logic.
+  if (currentRouteStore.getState().topRoute === 'sessionExpired') {
+    return
+  }
   Logger.error(
     '[SeedlessListeners] handleTokenExpired - navigating to /sessionExpired'
   )

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -83,7 +83,14 @@ jest.mock('features/ledger/store', () => ({
   }
 }))
 jest.mock('new/routes/store', () => ({
-  currentRouteStore: { getState: jest.fn(() => ({ currentRoute: '' })) }
+  currentRouteStore: {
+    getState: jest.fn(() => ({
+      currentRoute: '',
+      topRoute: undefined,
+      setCurrentRoute: jest.fn(),
+      setTopRoute: jest.fn()
+    }))
+  }
 }))
 jest.mock('./onApprove', () => ({ onApprove: jest.fn() }))
 jest.mock('./onReject', () => ({ onReject: jest.fn() }))
@@ -779,7 +786,9 @@ describe('ApprovalController', () => {
     it('goes back when on the approval screen and canGoBack is true', () => {
       mockCurrentRouteStore.getState.mockReturnValue({
         currentRoute: '/approval',
-        setCurrentRoute: jest.fn()
+        topRoute: undefined,
+        setCurrentRoute: jest.fn(),
+        setTopRoute: jest.fn()
       })
       mockRouter.canGoBack.mockReturnValue(true)
 
@@ -791,7 +800,9 @@ describe('ApprovalController', () => {
     it('goes back when on the ledgerReviewTransaction screen and canGoBack is true', () => {
       mockCurrentRouteStore.getState.mockReturnValue({
         currentRoute: '/ledgerReviewTransaction',
-        setCurrentRoute: jest.fn()
+        topRoute: undefined,
+        setCurrentRoute: jest.fn(),
+        setTopRoute: jest.fn()
       })
       mockRouter.canGoBack.mockReturnValue(true)
 
@@ -803,7 +814,9 @@ describe('ApprovalController', () => {
     it('does not go back when canGoBack is false', () => {
       mockCurrentRouteStore.getState.mockReturnValue({
         currentRoute: '/approval',
-        setCurrentRoute: jest.fn()
+        topRoute: undefined,
+        setCurrentRoute: jest.fn(),
+        setTopRoute: jest.fn()
       })
       mockRouter.canGoBack.mockReturnValue(false)
 
@@ -815,7 +828,9 @@ describe('ApprovalController', () => {
     it('does not go back when on an unrelated route', () => {
       mockCurrentRouteStore.getState.mockReturnValue({
         currentRoute: '/home',
-        setCurrentRoute: jest.fn()
+        topRoute: undefined,
+        setCurrentRoute: jest.fn(),
+        setTopRoute: jest.fn()
       })
       mockRouter.canGoBack.mockReturnValue(true)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -36742,7 +36742,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: e08d1254d04f3074970b63cdf0a363d6b189009270d457e868a26ef534addd69b320b85bef2a22e4eddb79006751bded431b56aaf2baf41976a6d0a5a2a2b91e
+  checksum: d6ceb75e1d0f5755370d6d91f67902bd2b8a23a3ca43cb853d2964b43798f30477e8ab0223ea8b620534fbdf5f56d39550f40d24bec2d2398c323ccfe8a5a556
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: [CP-14058](https://ava-labs.atlassian.net/browse/CP-14058)**

### The bug
Seedless users on iOS 26 hit a blank, un-dismissable modal that survived force-quit/restart. Originally suspected to be the Nest Egg campaign modal (since disabled in #3860), but a Sentry user on the disable-shipped build was still reporting it — the actual culprit is `/sessionExpired`.

`/sessionExpired` is registered at the root navigator with `formSheet` presentation. On iOS 26, navigating to a root-level formSheet from inside `(signedIn)` renders **blank** even on a single, clean navigation. Combined with the screen's intentional hard-block (no swipe, no header close, hardware-back intercepted, no Retry button visible if blank), users had literally no way out. Reproduced on iPhone 17 Pro Max iOS 26.5 simulator.

Going offline made the modal "disappear" for affected users — that's because going offline kills the 401 traffic, the seedless token-expired listener stops re-navigating, and the React tree finally settles.

### Audit of other modals

Audited every root-level Stack.Screen and modal in the app. `sessionExpired` is the only one that matches all three preconditions for the trap (root-level registration + `formSheet` presentation + navigated to from inside `(signedIn)`).

| Screen | Presentation | Risk |
|---|---|---|
| `(signedIn)` | default `card` | Not a modal. Safe. |
| `sessionExpired` | **was** `formSheet` (via `modalScreensOptions`), **now** `fullScreenModal` | ✅ Fixed |
| `loginWithPinOrBiometry` | `fullScreenModal` (already) | Safe — same approach we used |
| `forgotPin` | default `card` | Not a modal. Safe. |
| `signup`, `onboarding`, `accessWallet` | default `card` / stack screens | Not modals. Safe. |
| `+not-found` | default | Safe. |
| All `(signedIn)/(modals)/*` (33 screens) | `formSheet` via `modalScreensOptions` | Children of `(signedIn)`, not root — different stack mutation pattern. Empirically verified rendering fine on iOS 26.5 in testing. |

### What this changes

**Main fix — `presentation: 'fullScreenModal'` for `/sessionExpired`** in `RootNavigator.tsx`. This is what unblanks the modal. Bypasses the broken sheet presentation path and matches the screen's hard-blocking re-auth semantics. (`loginWithPinOrBiometry`, the sibling root-level screen, already uses `fullScreenModal` and works fine.)

Secondary changes shipped alongside:

- **Route guard in `handleTokenExpired`** ([seedless/store/listeners.ts](packages/core-mobile/app/seedless/store/listeners.ts)). The listener was firing on every 401 in flight — Sentry shows ~16 events per affected user. Now bails out if we're already on `sessionExpired`. Should cut the duplicate Sentry noise dramatically and stop redundant re-navigations.

- **`topRoute` added to `currentRouteStore`** ([store.ts](packages/core-mobile/app/new/routes/store.ts) + `RootNavigator` screenListeners). The existing `currentRoute` resolves to the leaf inside the active nested stack (e.g., `'index'` when on sessionExpired), so the route guard needed the top-level name to check.

- **`sessionExpired` UI realigned to the global `ErrorState` pattern** with the original Info icon at 56×56. The previous custom layout used `justifyContent: 'space-between'` that put the Retry button at the bottom of the now-fullscreen viewport; the unified ErrorState layout centers it correctly.

- **`dispatch(onLogOut())`** — added the missing parens in the retry-catch path. Every other call site uses parens; this was the lone outlier. Functionally it happened to work via the listener middleware reading `.type` off the action creator, but it's sketchy code that shouldn't ship.

- **`ApprovalController.test.ts`** mock updates to match the new `currentRouteStore` shape.

## Screenshots/Videos
**Before**
https://github.com/user-attachments/assets/7be4bd60-805d-44d4-8bac-61466e252486

**After**
https://github.com/user-attachments/assets/3a995ec3-f203-476b-83c0-39671567947c


## Testing

Drop this into `PortfolioScreen.tsx` to trigger the production action 10× in quick succession:

```tsx
import { useDispatch } from 'react-redux'
import { onTokenExpired } from 'seedless/store/slice'
import { Pressable, Text, View } from 'react-native'

// inside the component:
const debugDispatch = useDispatch()

// inside the return, somewhere visible:
<View
  pointerEvents="box-none"
  style={{ position: 'absolute', bottom: 120, left: 0, right: 0, alignItems: 'center', zIndex: 9999 }}>
  <Pressable
    onPress={() => {
      for (let i = 0; i < 10; i++) {
        setTimeout(() => debugDispatch(onTokenExpired()), i * 50)
      }
    }}
    style={{ backgroundColor: '#0ea5e9', paddingHorizontal: 16, paddingVertical: 12, borderRadius: 8 }}>
    <Text style={{ color: 'white', fontWeight: '700' }}>DBG: tokenExpired x10</Text>
  </Pressable>
</View>
```

1. On `main` (pre-fix) + iOS 26.5 simulator/device: tap the button → sessionExpired modal mounts **blank**, no way to dismiss.
2. On this branch + iOS 26.5 simulator/device: tap the button → sessionExpired renders normally (Info icon + title + description + Retry button) as a full-screen modal.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14058]: https://ava-labs.atlassian.net/browse/CP-14058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ