### PR TITLE
EVM state sync: non-EVM disconnect, SPA-nav re-prime, testnet-toggle resync

### DIFF
--- a/packages/core-mobile/app/hooks/browser/evmProviderShim.test.ts
+++ b/packages/core-mobile/app/hooks/browser/evmProviderShim.test.ts
@@ -50,18 +50,38 @@ describe('buildEvmProviderShim', () => {
     })
   })
 
-  describe('pre-connected state', () => {
-    it('always returns true from isConnected (EIP-1193: network connectivity, not account auth)', () => {
+  describe('connection state', () => {
+    it('starts connected (EIP-1193: network connectivity, not account auth)', () => {
       const shim = buildEvmProviderShim(defaultParams)
+      expect(shim).toContain('var _connected = true')
       expect(shim).toContain('_isConnected: true')
     })
 
-    it('stays true even when address is empty', () => {
+    it('starts connected even when address is empty', () => {
       const shim = buildEvmProviderShim({
         ...defaultParams,
         address: ''
       })
-      expect(shim).toContain('_isConnected: true')
+      expect(shim).toContain('var _connected = true')
+    })
+
+    it('isConnected() returns the tracked flag, not a hard-coded true', () => {
+      const shim = buildEvmProviderShim(defaultParams)
+      expect(shim).toContain('return _connected;')
+    })
+
+    it('flips the flag false on a disconnect event and true on connect/chainChanged', () => {
+      // Native emits disconnect(4901) for a non-servable (non-EVM) chain and
+      // chainChanged when it recovers; isConnected() must follow (CP-13671).
+      const shim = buildEvmProviderShim(defaultParams)
+      expect(shim).toContain("eventName === 'disconnect'")
+      expect(shim).toContain('_connected = false;')
+      expect(shim).toContain("eventName === 'connect'")
+    })
+
+    it('keeps the legacy _isConnected property in sync with the flag', () => {
+      const shim = buildEvmProviderShim(defaultParams)
+      expect(shim).toContain('provider._isConnected = _connected;')
     })
 
     it('starts _accounts empty — native primes on load based on permissions', () => {

--- a/packages/core-mobile/app/hooks/browser/evmProviderShim.ts
+++ b/packages/core-mobile/app/hooks/browser/evmProviderShim.ts
@@ -113,6 +113,12 @@ export function buildEvmProviderShim({
   // eth_requestAccounts to trigger the approval UI.
   var _accounts = [];
 
+  // EIP-1193 connection state. Native emits disconnect(4901) when the active
+  // chain isn't a servable EVM chain (CP-13671) and chainChanged when it
+  // recovers; isConnected() must track that, since some dApps poll
+  // isConnected() and ignore the disconnect event.
+  var _connected = true;
+
   // ──────────────────────────────────────────────
   // 4. Native response / event bridge
   // ──────────────────────────────────────────────
@@ -135,11 +141,22 @@ export function buildEvmProviderShim({
       _chainId = data;
       provider.chainId = data;
       provider.networkVersion = String(parseInt(data, 16));
+      // Re-pointing to a servable EVM chain recovers from a CP-13671 disconnect.
+      _connected = true;
     }
     if (eventName === 'accountsChanged') {
       _accounts = data || [];
       provider.selectedAddress = _accounts.length > 0 ? _accounts[0] : null;
     }
+    if (eventName === 'connect') {
+      _connected = true;
+    }
+    if (eventName === 'disconnect') {
+      _connected = false;
+    }
+    // Keep the legacy _isConnected property in sync with the flag for dApps
+    // that read provider._isConnected directly instead of calling isConnected().
+    provider._isConnected = _connected;
     emit(eventName, data);
   };
 
@@ -335,7 +352,7 @@ export function buildEvmProviderShim({
     },
 
     isConnected: function() {
-      return true;
+      return _connected;
     },
 
     _metamask: {

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -1877,5 +1877,76 @@ describe('useEvmInjectedProvider', () => {
         expect.stringContaining("'accountsChanged'")
       )
     })
+
+    // Build a store whose subscribe callback we can fire on demand, with a
+    // mutable `grants` so we can simulate a Connected Sites revoke (a fresh
+    // grants object, as Redux/Immer produces) with no active-account change.
+    const subscribableStore = (
+      initialGrants: Record<string, Record<string, string[]>>
+    ): {
+      store: ReturnType<typeof useStore>
+      revoke: (next: Record<string, Record<string, string[]>>) => void
+    } => {
+      let grants = initialGrants
+      let fire = (): void => undefined
+      const store = {
+        getState: () => ({ permissions: { grants } }),
+        dispatch: jest.fn(),
+        subscribe: jest.fn((cb: () => void) => {
+          fire = cb
+          return () => undefined
+        })
+      } as unknown as ReturnType<typeof useStore>
+      return {
+        store,
+        revoke: next => {
+          grants = next
+          fire()
+        }
+      }
+    }
+
+    it('emits accountsChanged([]) immediately when grants are revoked from Connected Sites (no account switch)', () => {
+      const { store, revoke } = subscribableStore({
+        'https://opensea.io': { [A]: ['EVM'] }
+      })
+      mockUseStore.mockReturnValue(store)
+      setupMocks({ account: accountA })
+      const { result } = renderProvider()
+      act(() => result.current.setCurrentUrl(ORIGIN))
+      // Prime so the dApp is seen connected to [A].
+      act(() =>
+        result.current.handleDomainMetadata(JSON.stringify({ name: 'OpenSea' }))
+      )
+      mockInjectJavaScript.mockClear()
+
+      // Revoke from Connected Sites — active account unchanged.
+      act(() => revoke({}))
+
+      expect(mockInjectJavaScript).toHaveBeenCalledWith(
+        expect.stringContaining("__coreProviderEmit('accountsChanged', [])")
+      )
+    })
+
+    it('does not emit on store changes that leave the origin grants unchanged', () => {
+      const grants = { 'https://opensea.io': { [A]: ['EVM'] } }
+      // Same grants object reference on the next store change (e.g. an unrelated
+      // slice updated) — must not produce a spurious accountsChanged.
+      const { store, revoke } = subscribableStore(grants)
+      mockUseStore.mockReturnValue(store)
+      setupMocks({ account: accountA })
+      const { result } = renderProvider()
+      act(() => result.current.setCurrentUrl(ORIGIN))
+      act(() =>
+        result.current.handleDomainMetadata(JSON.stringify({ name: 'OpenSea' }))
+      )
+      mockInjectJavaScript.mockClear()
+
+      act(() => revoke(grants))
+
+      expect(mockInjectJavaScript).not.toHaveBeenCalledWith(
+        expect.stringContaining("'accountsChanged'")
+      )
+    })
   })
 })

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -1703,6 +1703,28 @@ describe('useEvmInjectedProvider', () => {
         )
       })
 
+      it('origin-gates the prime emit to the current page origin', () => {
+        // The prime injection must be wrapped in a window.location.origin check
+        // so a prime racing a cross-origin nav can't leak the previous origin's
+        // granted accounts into the next origin's page.
+        mockUseStore.mockReturnValue(withPermission(mockActiveAccount.addressC))
+        const { result } = renderProvider()
+        act(() => {
+          result.current.setCurrentUrl('https://opensea.io/')
+        })
+        mockInjectJavaScript.mockClear()
+
+        act(() => {
+          result.current.handleDomainMetadata(metadata)
+        })
+
+        expect(mockInjectJavaScript).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'if(window.location.origin==="https://opensea.io")'
+          )
+        )
+      })
+
       it('injects accountsChanged([]) when no grant exists for the origin', () => {
         const { result } = renderProvider()
         act(() => {
@@ -1974,6 +1996,13 @@ describe('useEvmInjectedProvider', () => {
 
       expect(mockInjectJavaScript).toHaveBeenCalledWith(
         expect.stringContaining("__coreProviderEmit('accountsChanged', [])")
+      )
+      // ...and the emit is origin-gated so a revoke racing a cross-origin nav
+      // can't deliver into a different page (same guard as the switch/prime).
+      expect(mockInjectJavaScript).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'if(window.location.origin==="https://opensea.io")'
+        )
       )
     })
 

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -9,6 +9,7 @@ import {
   setActive
 } from 'store/network/slice'
 import { selectTabChainId, setTabChainId } from 'store/browser/slices/tabs'
+import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { ModuleErrors, VmModuleErrors } from 'vmModule/errors'
 import {
   EIP1193_USER_REJECTED_CODE,
@@ -53,6 +54,10 @@ jest.mock('store/browser/slices/tabs', () => ({
   selectTabChainId: jest.fn(() => jest.fn(() => undefined)),
   setTabChainId: jest.fn((payload: { tabId: string; chainId: number }) => ({
     type: 'browser/tabs/setTabChainId',
+    payload
+  })),
+  clearTabChainId: jest.fn((payload: { tabId: string }) => ({
+    type: 'browser/tabs/clearTabChainId',
     payload
   }))
 }))
@@ -140,12 +145,14 @@ function setupMocks(
     account?: typeof mockActiveAccount | null
     network?: typeof mockActiveNetwork
     allNetworks?: Record<number, unknown>
+    developerMode?: boolean
   } = {}
 ): void {
   const account =
     overrides.account === undefined ? mockActiveAccount : overrides.account
   const network = overrides.network ?? mockActiveNetwork
   const allNetworks = overrides.allNetworks ?? mockAllNetworks
+  const developerMode = overrides.developerMode ?? false
 
   const mockTabChainIdSelector = jest.fn(() => undefined)
   ;(selectTabChainId as jest.Mock).mockReturnValue(mockTabChainIdSelector)
@@ -158,6 +165,7 @@ function setupMocks(
     (selector: (state: unknown) => unknown) => {
       if (selector === (selectAllNetworks as unknown)) return allNetworks
       if (selector === (selectActiveNetwork as unknown)) return network
+      if (selector === (selectIsDeveloperMode as unknown)) return developerMode
       if (selector === mockTabChainIdSelector) return undefined
       const selectorStr = selector.toString()
       if (
@@ -1403,6 +1411,79 @@ describe('useEvmInjectedProvider', () => {
       )
       expect(chainChangedCalls).toHaveLength(0)
     })
+
+    it('emits disconnect (not chainChanged) when the active network is non-EVM (CP-13671)', () => {
+      setupMocks({ network: mockActiveNetwork })
+      const { rerender } = renderHook(() =>
+        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+      )
+      mockInjectJavaScript.mockClear()
+
+      // Switch the wallet's active network to a non-EVM chain (e.g. Bitcoin).
+      setupMocks({
+        network: {
+          ...mockActiveNetwork,
+          chainId: 999,
+          vmName: NetworkVMType.BITCOIN
+        }
+      })
+      rerender()
+
+      expect(mockInjectJavaScript).toHaveBeenCalledWith(
+        expect.stringContaining("__coreProviderEmit('disconnect'")
+      )
+      const chainChangedCalls = mockInjectJavaScript.mock.calls.filter(call =>
+        call[0].includes("__coreProviderEmit('chainChanged'")
+      )
+      expect(chainChangedCalls).toHaveLength(0)
+    })
+
+    it('re-emits chainChanged when returning to the SAME EVM chain after a non-EVM disconnect (CP-13671)', () => {
+      // Recovery path: entering non-EVM invalidates the cached chainId, so
+      // switching back to the original EVM chain still fires chainChanged and the
+      // dApp can reconnect (otherwise the equality guard would skip it).
+      setupMocks({ network: mockActiveNetwork })
+      const { rerender } = renderHook(() =>
+        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+      )
+
+      // Go to a non-EVM network (emits disconnect, invalidates cached chain).
+      setupMocks({
+        network: {
+          ...mockActiveNetwork,
+          chainId: 999,
+          vmName: NetworkVMType.BITCOIN
+        }
+      })
+      rerender()
+      mockInjectJavaScript.mockClear()
+
+      // Return to the SAME EVM chain (43114) we started on.
+      setupMocks({ network: mockActiveNetwork })
+      rerender()
+
+      const chainChangedCalls = mockInjectJavaScript.mock.calls.filter(call =>
+        call[0].includes("__coreProviderEmit('chainChanged'")
+      )
+      expect(chainChangedCalls).toHaveLength(1)
+      expect(chainChangedCalls[0][0]).toContain("'chainChanged', '0xa86a'")
+    })
+
+    it('clears the per-tab chain pin when developer mode flips (CP-13775)', () => {
+      setupMocks({ developerMode: false })
+      const { rerender } = renderHook(() =>
+        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+      )
+      mockDispatch.mockClear()
+
+      // Toggle testnet/developer mode on.
+      setupMocks({ developerMode: true })
+      rerender()
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'browser/tabs/clearTabChainId' })
+      )
+    })
   })
 
   describe('setCurrentUrl origin-change cleanup', () => {
@@ -1469,6 +1550,37 @@ describe('useEvmInjectedProvider', () => {
       })
 
       expect(capturedSignal?.aborted).toBe(false)
+    })
+
+    it('re-primes accountsChanged on same-origin SPA navigation to a new path (CP-13772)', () => {
+      // Origin granted to the active account so priming yields a non-empty list.
+      mockUseStore.mockReturnValue({
+        getState: () => ({
+          permissions: {
+            grants: {
+              'https://uniswap.org': {
+                [mockActiveAccount.addressC]: ['EVM']
+              }
+            }
+          }
+        }),
+        dispatch: jest.fn(),
+        subscribe: jest.fn(() => () => undefined)
+      } as unknown as ReturnType<typeof useStore>)
+
+      const { result } = renderProvider('https://uniswap.org')
+      mockInjectJavaScript.mockClear()
+
+      act(() => {
+        // SPA route change within the same origin (e.g. core.app -> /stake).
+        result.current.setCurrentUrl('https://uniswap.org/stake')
+      })
+
+      expect(mockInjectJavaScript).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `__coreProviderEmit('accountsChanged', ["${mockActiveAccount.addressC}"]`
+        )
+      )
     })
   })
 

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -146,6 +146,7 @@ function setupMocks(
     network?: typeof mockActiveNetwork
     allNetworks?: Record<number, unknown>
     developerMode?: boolean
+    tabChainId?: number
   } = {}
 ): void {
   const account =
@@ -153,8 +154,9 @@ function setupMocks(
   const network = overrides.network ?? mockActiveNetwork
   const allNetworks = overrides.allNetworks ?? mockAllNetworks
   const developerMode = overrides.developerMode ?? false
+  const tabChainId = overrides.tabChainId
 
-  const mockTabChainIdSelector = jest.fn(() => undefined)
+  const mockTabChainIdSelector = jest.fn(() => tabChainId)
   ;(selectTabChainId as jest.Mock).mockReturnValue(mockTabChainIdSelector)
 
   // requestReadOnly resolves networks via selectAllNetworks(store.getState())
@@ -166,7 +168,7 @@ function setupMocks(
       if (selector === (selectAllNetworks as unknown)) return allNetworks
       if (selector === (selectActiveNetwork as unknown)) return network
       if (selector === (selectIsDeveloperMode as unknown)) return developerMode
-      if (selector === mockTabChainIdSelector) return undefined
+      if (selector === mockTabChainIdSelector) return tabChainId
       const selectorStr = selector.toString()
       if (
         selectorStr.includes('activeAccount') ||
@@ -1438,6 +1440,36 @@ describe('useEvmInjectedProvider', () => {
       expect(chainChangedCalls).toHaveLength(0)
     })
 
+    it('does NOT disconnect a pinned tab when the active network flips to non-EVM (CP-13671)', () => {
+      // Per-tab insulation invariant: a tab that pinned its chain via
+      // wallet_switchEthereumChain must ignore wallet-wide network changes —
+      // including a flip to a non-EVM chain. This is what makes the per-tab
+      // model hold.
+      setupMocks({ tabChainId: 1 })
+      const { rerender } = renderHook(() =>
+        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+      )
+      mockInjectJavaScript.mockClear()
+
+      // Wallet flips to a non-EVM chain; the pinned tab must not react.
+      setupMocks({
+        tabChainId: 1,
+        network: {
+          ...mockActiveNetwork,
+          chainId: 999,
+          vmName: NetworkVMType.BITCOIN
+        }
+      })
+      rerender()
+
+      expect(mockInjectJavaScript).not.toHaveBeenCalledWith(
+        expect.stringContaining("__coreProviderEmit('disconnect'")
+      )
+      expect(mockInjectJavaScript).not.toHaveBeenCalledWith(
+        expect.stringContaining("__coreProviderEmit('chainChanged'")
+      )
+    })
+
     it('re-emits chainChanged when returning to the SAME EVM chain after a non-EVM disconnect (CP-13671)', () => {
       // Recovery path: entering non-EVM invalidates the cached chainId, so
       // switching back to the original EVM chain still fires chainChanged and the
@@ -1470,17 +1502,34 @@ describe('useEvmInjectedProvider', () => {
     })
 
     it('clears the per-tab chain pin when developer mode flips (CP-13775)', () => {
-      setupMocks({ developerMode: false })
+      setupMocks({ developerMode: false, tabChainId: 1 })
       const { rerender } = renderHook(() =>
         useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
       )
       mockDispatch.mockClear()
 
       // Toggle testnet/developer mode on.
-      setupMocks({ developerMode: true })
+      setupMocks({ developerMode: true, tabChainId: 1 })
       rerender()
 
       expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'browser/tabs/clearTabChainId' })
+      )
+    })
+
+    it('does not dispatch clearTabChainId on a dev-mode flip when the tab has no pin', () => {
+      // Guard against a redundant store update/rerender on every toggle when
+      // there's nothing to clear.
+      setupMocks({ developerMode: false })
+      const { rerender } = renderHook(() =>
+        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+      )
+      mockDispatch.mockClear()
+
+      setupMocks({ developerMode: true })
+      rerender()
+
+      expect(mockDispatch).not.toHaveBeenCalledWith(
         expect.objectContaining({ type: 'browser/tabs/clearTabChainId' })
       )
     })

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -339,6 +339,40 @@ export function useEvmInjectedProvider(
     )
   }, [activeAccount, store, webViewRef])
 
+  // Connected Sites revokes a dApp from another screen without changing this
+  // tab's active account, so only a store subscription can react (CP-14382).
+  useEffect(() => {
+    let prevGrants = store.getState().permissions.grants
+    return store.subscribe(() => {
+      // store.subscribe fires on every dispatch — bail unless grants changed.
+      const grants = store.getState().permissions.grants
+      if (grants === prevGrants) return
+      prevGrants = grants
+
+      const origin = getOriginFromUrl(currentUrlRef.current)
+      if (!origin) return
+
+      // What this origin may transact as now: active-first, or [] if the active
+      // account is no longer granted.
+      const granted = selectGrantedAddressesForDomain({
+        domain: origin,
+        vmType: NetworkVMType.EVM
+      })(store.getState())
+      const accounts = resolveActiveConnectedAccounts(
+        granted,
+        activeAccountRef.current?.addressC
+      )
+
+      // Shared dedupe ref so this never double-fires with the switch/prime paths.
+      const serialized = JSON.stringify(accounts)
+      if (lastEmittedAccountsRef.current === serialized) return
+      lastEmittedAccountsRef.current = serialized
+      webViewRef.current?.injectJavaScript(
+        `window.__coreProviderEmit && window.__coreProviderEmit('accountsChanged', ${serialized}); true;`
+      )
+    })
+  }, [store, webViewRef])
+
   // When this browser tab unmounts (tab closed), reject any parked connect
   // approval with 4001 so the dApp's eth_requestAccounts promise settles instead
   // of hanging until supersede or the 90s timeout. Inactive tabs stay mounted

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -301,6 +301,23 @@ export function useEvmInjectedProvider(
   // never emit a duplicate accountsChanged for the same set.
   const lastEmittedAccountsRef = useRef<string | undefined>(undefined)
 
+  // Inject an accountsChanged emit gated on the page still being on `origin`
+  // (the same guard sendResponse uses). An emit racing a cross-origin
+  // navigation can find currentUrlRef briefly ahead of the JS context that
+  // injectJavaScript actually runs in, so without this gate one origin's
+  // granted addresses could leak into the next origin's page. Shared by every
+  // accountsChanged path (active-account switch, Connected Sites revoke, prime).
+  const injectAccountsChanged = useCallback(
+    (origin: string, serialized: string) => {
+      webViewRef.current?.injectJavaScript(
+        `if(window.location.origin===${JSON.stringify(
+          origin
+        )}){window.__coreProviderEmit && window.__coreProviderEmit('accountsChanged', ${serialized})};true;`
+      )
+    },
+    [webViewRef]
+  )
+
   // Propagate wallet active-account switches to the dApp. MetaMask users
   // expect the wallet's account selector to drive the dApp's connected
   // account — dApps in the in-app browser have no account picker of their own.
@@ -330,16 +347,8 @@ export function useEvmInjectedProvider(
     const serialized = JSON.stringify(accounts)
     if (lastEmittedAccountsRef.current === serialized) return
     lastEmittedAccountsRef.current = serialized
-    // Origin-gate delivery (same guard as sendResponse): only inject if the page
-    // is still on the origin we resolved accounts for, so an account switch
-    // racing a cross-origin navigation (briefly-stale currentUrlRef) can't leak
-    // one origin's granted addresses to a different page.
-    webViewRef.current?.injectJavaScript(
-      `if(window.location.origin===${JSON.stringify(
-        origin
-      )}){window.__coreProviderEmit && window.__coreProviderEmit('accountsChanged', ${serialized})};true;`
-    )
-  }, [activeAccount, store, webViewRef])
+    injectAccountsChanged(origin, serialized)
+  }, [activeAccount, store, injectAccountsChanged])
 
   // Connected Sites revokes a dApp from another screen without changing this
   // tab's active account, so only a store subscription can react (CP-14382).
@@ -369,11 +378,9 @@ export function useEvmInjectedProvider(
       const serialized = JSON.stringify(accounts)
       if (lastEmittedAccountsRef.current === serialized) return
       lastEmittedAccountsRef.current = serialized
-      webViewRef.current?.injectJavaScript(
-        `window.__coreProviderEmit && window.__coreProviderEmit('accountsChanged', ${serialized}); true;`
-      )
+      injectAccountsChanged(origin, serialized)
     })
-  }, [store, webViewRef])
+  }, [store, injectAccountsChanged])
 
   // When this browser tab unmounts (tab closed), reject any parked connect
   // approval with 4001 so the dApp's eth_requestAccounts promise settles instead
@@ -592,13 +599,10 @@ export function useEvmInjectedProvider(
       vmType: NetworkVMType.EVM
     })(store.getState())
     const accounts = resolveActiveConnectedAccounts(granted, active.addressC)
-    lastEmittedAccountsRef.current = JSON.stringify(accounts)
-    webViewRef.current?.injectJavaScript(
-      `window.__coreProviderEmit && window.__coreProviderEmit('accountsChanged', ${JSON.stringify(
-        accounts
-      )}); true;`
-    )
-  }, [store, webViewRef])
+    const serialized = JSON.stringify(accounts)
+    lastEmittedAccountsRef.current = serialized
+    injectAccountsChanged(origin, serialized)
+  }, [store, injectAccountsChanged])
   // Publish to the ref so setCurrentUrl (defined above) can re-prime on SPA nav.
   // useLayoutEffect (not a render-phase assignment) to match routerRef: the ref
   // must be set synchronously on commit, before a navigation event can fire

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -143,8 +143,10 @@ export function useEvmInjectedProvider(
   useEffect(() => {
     if (prevDevModeRef.current === isDeveloperMode) return
     prevDevModeRef.current = isDeveloperMode
-    dispatch(clearTabChainId({ tabId }))
-  }, [isDeveloperMode, dispatch, tabId])
+    // Only clear an actual pin — dispatching for an un-pinned tab is a redundant
+    // store update + rerender on every dev-mode toggle.
+    if (tabChainId !== undefined) dispatch(clearTabChainId({ tabId }))
+  }, [isDeveloperMode, dispatch, tabId, tabChainId])
 
   // Router is assigned below (after useMemo). setCurrentUrl may fire before
   // the router is constructed on first render, so we route through a ref.
@@ -598,7 +600,12 @@ export function useEvmInjectedProvider(
     )
   }, [store, webViewRef])
   // Publish to the ref so setCurrentUrl (defined above) can re-prime on SPA nav.
-  primeAccountsRef.current = primeAccounts
+  // useLayoutEffect (not a render-phase assignment) to match routerRef: the ref
+  // must be set synchronously on commit, before a navigation event can fire
+  // setCurrentUrl and read it.
+  useLayoutEffect(() => {
+    primeAccountsRef.current = primeAccounts
+  }, [primeAccounts])
 
   const handleDomainMetadata = useCallback(
     (payload: string) => {

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import { shallowEqual, useDispatch, useSelector, useStore } from 'react-redux'
 import { selectActiveAccount } from 'store/account/slice'
 import { selectActiveNetwork, selectAllNetworks } from 'store/network/slice'
-import { selectTabChainId } from 'store/browser/slices/tabs'
+import { clearTabChainId, selectTabChainId } from 'store/browser/slices/tabs'
+import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { TabId } from 'store/browser/types'
 import { NetworkVMType } from '@avalabs/core-chains-sdk'
 import RNWebView from 'react-native-webview'
@@ -85,6 +86,7 @@ export function useEvmInjectedProvider(
   const activeNetwork = useSelector(selectActiveNetwork)
   const allNetworks = useSelector(selectAllNetworks, shallowEqual)
   const tabChainId = useSelector(selectTabChainId(tabId))
+  const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const dappMetadata = useRef<DomainMetadata | null>(null)
   const currentUrlRef = useRef<string>('')
   const pendingOrigins = useRef<Map<number, string>>(new Map())
@@ -106,6 +108,21 @@ export function useEvmInjectedProvider(
   // to the correct chain after the user switches networks wallet-wide.
   useEffect(() => {
     if (tabChainId !== undefined) return
+    // Non-EVM active network (BTC/SVM/AVM/PVM): the EVM provider can't serve it,
+    // so tell the dApp it's disconnected rather than emitting a bogus EVM
+    // chainChanged for a non-EVM chainId (EIP-1193 disconnect, code 4901).
+    // CP-13671.
+    if (activeNetwork.vmName !== NetworkVMType.EVM) {
+      // Invalidate the cached EVM chain (sentinel 0 — no real EVM chainId) so
+      // returning to the SAME EVM chainId later still re-emits chainChanged.
+      // Otherwise the equality guard below would skip it and a dApp that reacted
+      // to this disconnect would never get a follow-up event to recover. CP-13671.
+      browserNetworkRef.current = { chainId: 0, rpcUrl: '' }
+      webViewRef.current?.injectJavaScript(
+        `window.__coreProviderEmit && window.__coreProviderEmit('disconnect', { code: 4901, message: 'Disconnected from chain' }); true;`
+      )
+      return
+    }
     if (browserNetworkRef.current.chainId === activeNetwork.chainId) return
     browserNetworkRef.current = {
       chainId: activeNetwork.chainId,
@@ -117,9 +134,25 @@ export function useEvmInjectedProvider(
     )
   }, [activeNetwork, tabChainId, webViewRef])
 
+  // When developer (testnet) mode flips, drop any per-tab chain pin so the tab
+  // follows the wallet's active network for the NEW environment (the sync effect
+  // above then re-points browserNetworkRef + emits chainChanged). Otherwise the
+  // tab keeps signing with the prior environment's chainId and the RPC env check
+  // rejects every tx with "Invalid environment". CP-13775.
+  const prevDevModeRef = useRef(isDeveloperMode)
+  useEffect(() => {
+    if (prevDevModeRef.current === isDeveloperMode) return
+    prevDevModeRef.current = isDeveloperMode
+    dispatch(clearTabChainId({ tabId }))
+  }, [isDeveloperMode, dispatch, tabId])
+
   // Router is assigned below (after useMemo). setCurrentUrl may fire before
   // the router is constructed on first render, so we route through a ref.
   const routerRef = useRef<InjectedProviderRouter | null>(null)
+
+  // primeAccounts is defined later (it reads refs declared further down), so
+  // setCurrentUrl's SPA re-prime routes through a ref — same pattern as routerRef.
+  const primeAccountsRef = useRef<(() => void) | null>(null)
 
   // Tracks the reject fn of an in-flight connect approval so a later request
   // or an origin change can unstick it. Also used by requestConnectApproval
@@ -129,14 +162,14 @@ export function useEvmInjectedProvider(
   )
 
   const setCurrentUrl = useCallback((url: string) => {
-    const prevOrigin = getOriginFromUrl(currentUrlRef.current)
+    const prevUrl = currentUrlRef.current
+    const prevOrigin = getOriginFromUrl(prevUrl)
     currentUrlRef.current = url
     const newOrigin = getOriginFromUrl(url)
 
-    // Only cancel on actual origin change — within-origin SPA nav (nav_change
-    // messages firing on pushState/replaceState) keeps the tab connected to
-    // the same dApp, so stale approvals remain legitimate.
     if (prevOrigin && prevOrigin !== newOrigin) {
+      // Cross-origin navigation — cancel in-flight requests and unstick any
+      // parked approval tied to the prior page.
       routerRef.current?.cancelByOrigin(newOrigin)
       prevInflightConnectReject.current?.({
         code: EIP1193_USER_REJECTED_CODE,
@@ -144,6 +177,14 @@ export function useEvmInjectedProvider(
       })
       prevInflightConnectReject.current = null
       approvalController.handleGoBackIfNeeded()
+    } else if (prevOrigin && prevOrigin === newOrigin && prevUrl !== url) {
+      // Same-origin SPA navigation to a new URL (pushState/replaceState) — note
+      // prevOrigin must be set, so this excludes the initial page load (which is
+      // primed via domain_metadata). The one-time connect/accountsChanged events
+      // already fired on first load, so a provider consumer mounted by the new
+      // route sees no accounts and appears disconnected. Re-prime so it
+      // reconnects. CP-13772.
+      primeAccountsRef.current?.()
     }
   }, [])
 
@@ -498,6 +539,33 @@ export function useEvmInjectedProvider(
     [router]
   )
 
+  // Emit accountsChanged for the current origin's connected accounts: the
+  // granted addresses (active first) when the active account is granted,
+  // otherwise [] (CP-14382). Shared by page-load priming (handleDomainMetadata)
+  // and same-origin SPA navigation (setCurrentUrl, via primeAccountsRef) so a
+  // freshly-mounted provider consumer on a new route re-establishes the
+  // connection. The injected signer always signs with the active account, so
+  // priming the granted set while an ungranted account is active would
+  // re-establish a phantom connection — emit [] instead.
+  const primeAccounts = useCallback(() => {
+    const origin = getOriginFromUrl(currentUrlRef.current)
+    const active = activeAccountRef.current
+    if (!origin || !active?.addressC) return
+    const granted = selectGrantedAddressesForDomain({
+      domain: origin,
+      vmType: NetworkVMType.EVM
+    })(store.getState())
+    const accounts = resolveActiveConnectedAccounts(granted, active.addressC)
+    lastEmittedAccountsRef.current = JSON.stringify(accounts)
+    webViewRef.current?.injectJavaScript(
+      `window.__coreProviderEmit && window.__coreProviderEmit('accountsChanged', ${JSON.stringify(
+        accounts
+      )}); true;`
+    )
+  }, [store, webViewRef])
+  // Publish to the ref so setCurrentUrl (defined above) can re-prime on SPA nav.
+  primeAccountsRef.current = primeAccounts
+
   const handleDomainMetadata = useCallback(
     (payload: string) => {
       try {
@@ -506,32 +574,11 @@ export function useEvmInjectedProvider(
       } catch {
         Logger.error('[InjectedProvider] Invalid domain_metadata payload')
       }
-
       // Prime the shim's _accounts cache on page load so dApps with
-      // auto-reconnect (wagmi autoConnect, etc.) see the connection
-      // immediately without prompting. We emit the accounts the dApp may
-      // actually transact as: if the active account is in this origin's
-      // granted set, the granted addresses (active first); otherwise []. The
-      // injected signer always signs with the active account, so priming the
-      // granted set while an ungranted account is active would re-establish a
-      // phantom connection on reload (the gap An flagged on #3862) — emit []
-      // instead so the dApp reflects a disconnected state (CP-14382).
-      const origin = getOriginFromUrl(currentUrlRef.current)
-      const active = activeAccountRef.current
-      if (!origin || !active?.addressC) return
-      const granted = selectGrantedAddressesForDomain({
-        domain: origin,
-        vmType: NetworkVMType.EVM
-      })(store.getState())
-      const accounts = resolveActiveConnectedAccounts(granted, active.addressC)
-      lastEmittedAccountsRef.current = JSON.stringify(accounts)
-      webViewRef.current?.injectJavaScript(
-        `window.__coreProviderEmit && window.__coreProviderEmit('accountsChanged', ${JSON.stringify(
-          accounts
-        )}); true;`
-      )
+      // auto-reconnect (wagmi autoConnect, etc.) see the connection immediately.
+      primeAccounts()
     },
-    [store, webViewRef]
+    [primeAccounts]
   )
 
   return {


### PR DESCRIPTION
## Description

**Tickets: [CP-13671](https://ava-labs.atlassian.net/browse/CP-13671) · [CP-13772](https://ava-labs.atlassian.net/browse/CP-13772) · [CP-13775](https://ava-labs.atlassian.net/browse/CP-13775)**

Wraps up the EVM injected-provider work by closing the remaining state-sync gaps so the dApp stays in sync with wallet state across network changes, testnet toggles, and in-dApp (SPA) navigation. All three are in `useEvmInjectedProvider.ts`.

**Summary of changes**
- **CP-13671 — non-EVM network → `disconnect`.** The active-network sync effect emitted `chainChanged` unconditionally. It now emits an EIP-1193 `disconnect` (code 4901) when the wallet's active network is non-EVM (BTC/SVM/AVM/PVM), instead of a bogus EVM `chainChanged`.
- **CP-13772 — SPA-nav connection loss.** `domain_metadata` (and thus account priming) only fired on full page load, so a same-origin SPA route change (e.g. core.app → Stake) left the freshly-mounted provider consumer with no accounts. `setCurrentUrl` now re-primes `accountsChanged` on same-origin navigation to a new URL (shared `primeAccounts` helper; excludes the initial load, which is still primed via `domain_metadata`).
- **CP-13775 — testnet/developer-mode env mismatch.** The hook had no developer-mode awareness, so after toggling testnet it kept signing with the prior environment's chainId and the RPC env check rejected every tx with *"Invalid environment."* The hook now watches `selectIsDeveloperMode` and, on flip, drops the per-tab chain pin (`clearTabChainId`) so the sync effect re-points the tab to the active (correct-environment) network.

**Dependencies introduced**
None.

**Breaking changes**
None.

> Stacked on #3878 (active-account switch). Base will retarget to `main` as the EVM train lands. Review against the `boyer/injected-provider-account-switch` base.

## Screenshots/Videos

N/A — dApp-facing `accountsChanged`/`chainChanged`/`disconnect` events; no Core UI surface change.

## Testing

**Dev Testing (if applicable)**

- **CP-13772:** open core.app in the in-app browser, confirm auto-connect, tap hamburger → Stake → still connected (no manual reconnect needed).
- **CP-13775:** connect on mainnet, toggle developer/testnet mode in settings, return to the dApp → transactions succeed (no "Invalid environment" toast).
- **CP-13671:** switch the wallet's active network to a non-EVM chain (Bitcoin/Solana) → dApp reflects a disconnected state (no bogus chainChanged).
- Trigger a Bitrise build and reference it here.
- Move CP-13671 / CP-13772 / CP-13775 into the "Testing" column on Jira.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-13671]: https://ava-labs.atlassian.net/browse/CP-13671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-13772]: https://ava-labs.atlassian.net/browse/CP-13772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-13775]: https://ava-labs.atlassian.net/browse/CP-13775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ