### PR TITLE
Pin react-native-nitro-fetch NDK to project ndkVersion

### DIFF
--- a/packages/core-mobile/patches/react-native-nitro-fetch+0.2.0.patch
+++ b/packages/core-mobile/patches/react-native-nitro-fetch+0.2.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native-nitro-fetch/android/build.gradle b/node_modules/react-native-nitro-fetch/android/build.gradle
+index 9b326ff..b84e65a 100644
+--- a/node_modules/react-native-nitro-fetch/android/build.gradle
++++ b/node_modules/react-native-nitro-fetch/android/build.gradle
+@@ -33,6 +33,8 @@ def getExtOrIntegerDefault(name) {
+ android {
+   namespace "com.margelo.nitro.nitrofetch"
+ 
++  ndkVersion getExtOrDefault("ndkVersion")
++
+   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
+ 
+   defaultConfig {


### PR DESCRIPTION
react-native-nitro-fetch's android/build.gradle compiles C++ via externalNativeBuild but never sets ndkVersion, so AGP 8.7.2 falls back to its default NDK 27.0.12077973 — which isn't installed on the Bitrise image (CXX1101: missing source.properties). Patch the module to use getExtOrDefault("ndkVersion"), resolving to the repo-pinned 27.1.12297006 that is installed.

## Description

**Ticket: [CP-]**

Please provide:

- A summary of the changes
- Motivation and context for this change
- Any dependencies introduced
- (If breaking) migration steps and instructions

## Screenshots/Videos

Include relevant screenshots or screen recordings of iOS and Android.

## Testing

**Dev Testing (if applicable)**

- Provide steps to test the happy path of your feature
- Provide steps to test edge cases and error states
- Trigger a build on bitrise and reference it here
- Move the ticket into the "Testing" column on Jira

**QA Testing (if applicable)**

- Provide instructions for QA to test this feature thoroughly
- State expected behavior / acceptance criteria

## Checklist

Please check all that apply (if applicable)

- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation
