### PR TITLE
Fix coverage report workflow: add pull-requests:write so PR comments can post

### DIFF
--- a/.github/workflows/mobile-pr-coverage-report.yml
+++ b/.github/workflows/mobile-pr-coverage-report.yml
@@ -12,6 +12,7 @@ permissions:
   checks: write
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   report:


### PR DESCRIPTION
## Description

**Ticket: [CP-]**

Fixes the `Mobile PR Coverage Report` workflow, which has failed on **every** run since it was added. The final step (`Sync coverage PR comment`) always 403'd with `Resource not accessible by integration` when posting the coverage comment to the PR.

**Root cause:** The 403 response carried `x-accepted-github-permissions: issues=write; pull_requests=write`. In that header the semicolon means **AND, not OR** — commenting on a *pull request* (even via the issues comments endpoint) requires both `issues: write` **and** `pull-requests: write`. The workflow only granted `issues: write`, so the call was rejected. The earlier `Publish coverage check` step succeeded because it only needs `checks: write`, which was granted.

**Fix:** add `pull-requests: write` to the workflow's `permissions:` block (the upstream `Mobile PR` workflow already declares it).

Note: because this is a `workflow_run` workflow, GitHub always runs the copy of the file on the default branch — so the fix only takes effect once it lands on `main`.

No dependencies introduced.

## Screenshots/Videos

N/A — CI workflow permissions change only.

## Testing

**Dev Testing (if applicable)**

- After merge to `main`, the next `Mobile PR` run's coverage report should post/update a `<!-- mobile-coverage-report -->` comment on the PR instead of failing the `Sync coverage PR comment` step.

**QA Testing (if applicable)**

N/A

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation
