### PR TITLE
CP-14374: revoke dApp grants on account/wallet removal

### DIFF
--- a/packages/core-mobile/app/store/middleware/listener.ts
+++ b/packages/core-mobile/app/store/middleware/listener.ts
@@ -2,6 +2,7 @@ import { addListener, createListenerMiddleware } from '@reduxjs/toolkit'
 import { addAppListeners } from 'store/app/listeners'
 import { addBalanceListeners } from 'store/balance/listeners'
 import { addAccountListeners } from 'store/account/listeners'
+import { addPermissionsListeners } from 'store/permissions/listeners'
 import { addNetworkListeners } from 'store/network/listeners'
 import { addBrowserListener } from 'store/browser/listener'
 import { addPosthogListeners } from 'store/posthog/listeners'
@@ -35,6 +36,8 @@ addAppListeners(startListening)
 addBalanceListeners(startListening)
 
 addAccountListeners(startListening)
+
+addPermissionsListeners(startListening)
 
 addNetworkListeners(startListening)
 

--- a/packages/core-mobile/app/store/permissions/listeners.test.ts
+++ b/packages/core-mobile/app/store/permissions/listeners.test.ts
@@ -1,0 +1,350 @@
+import { configureStore, createListenerMiddleware } from '@reduxjs/toolkit'
+import { NetworkVMType } from '@avalabs/core-chains-sdk'
+import { AppStartListening, AppThunkDispatch } from 'store/types'
+import {
+  accountsReducer,
+  removeAccount,
+  setAccounts
+} from 'store/account/slice'
+import type { Account } from 'store/account/types'
+import { walletsReducer } from 'store/wallet/slice'
+import { removeWallet } from 'store/wallet/thunks'
+import { WalletType } from 'services/wallet/types'
+import { grantPermission, permissionsReducer } from './slice'
+import { addPermissionsListeners } from './listeners'
+
+// removeWallet's side-effect deps — only the cache clear + secret removal run on
+// the path under test; stub them so the real thunk executes synchronously.
+jest.mock('utils/BiometricsSDK')
+jest.mock('services/account/AccountsService')
+jest.mock('services/analytics/AnalyticsService', () => ({
+  __esModule: true,
+  default: { capture: jest.fn() }
+}))
+jest.mock('services/wallet/WalletFactory', () => ({
+  __esModule: true,
+  default: { cache: { clearWallet: jest.fn() } }
+}))
+
+const DOMAIN_UNI = 'https://app.uniswap.org'
+const DOMAIN_OS = 'https://opensea.io'
+
+const EVM_1 = '0x1111111111111111111111111111111111111111'
+const SVM_1 = 'So1ana1111111111111111111111111111111111111'
+const BTC_1 = 'bc1qaccount1111111111111111111111111111111'
+const EVM_2 = '0x2222222222222222222222222222222222222222'
+
+// Minimal Account stub — the listener only reads id + the per-VM address fields.
+const account = (id: string, fields: Partial<Account>): Account =>
+  ({ id, walletId: 'wallet-1', ...fields } as unknown as Account)
+
+const listenerMiddleware = createListenerMiddleware()
+
+const setupStore = () => {
+  listenerMiddleware.clearListeners()
+  const store = configureStore({
+    reducer: {
+      account: accountsReducer,
+      permissions: permissionsReducer
+    },
+    middleware: gDM =>
+      gDM({ serializableCheck: false }).prepend(listenerMiddleware.middleware)
+  })
+  addPermissionsListeners(
+    listenerMiddleware.startListening as AppStartListening
+  )
+  return store
+}
+
+describe('permissions listeners — revoke grants on account removal', () => {
+  it("revokes the removed account's grants across all domains, leaving others", () => {
+    const store = setupStore()
+    store.dispatch(
+      setAccounts({
+        acc1: account('acc1', { addressC: EVM_1, addressBTC: BTC_1 }),
+        acc2: account('acc2', { addressC: EVM_2, addressBTC: '' })
+      })
+    )
+    // acc1 (EVM_1) connected to two dApps; acc2 (EVM_2) connected to one.
+    store.dispatch(
+      grantPermission({
+        domain: DOMAIN_UNI,
+        address: EVM_1,
+        vmType: NetworkVMType.EVM
+      })
+    )
+    store.dispatch(
+      grantPermission({
+        domain: DOMAIN_OS,
+        address: EVM_1,
+        vmType: NetworkVMType.EVM
+      })
+    )
+    store.dispatch(
+      grantPermission({
+        domain: DOMAIN_UNI,
+        address: EVM_2,
+        vmType: NetworkVMType.EVM
+      })
+    )
+
+    store.dispatch(removeAccount('acc1'))
+
+    const { grants } = store.getState().permissions
+    // EVM_1 scrubbed everywhere; DOMAIN_OS pruned; EVM_2 untouched.
+    expect(grants[DOMAIN_UNI]).toEqual({ [EVM_2]: [NetworkVMType.EVM] })
+    expect(grants[DOMAIN_OS]).toBeUndefined()
+  })
+
+  it('revokes every VM address the account holds (EVM + Solana + BTC)', () => {
+    const store = setupStore()
+    store.dispatch(
+      setAccounts({
+        acc1: account('acc1', {
+          addressC: EVM_1,
+          addressSVM: SVM_1,
+          addressBTC: BTC_1
+        })
+      })
+    )
+    store.dispatch(
+      grantPermission({
+        domain: DOMAIN_UNI,
+        address: EVM_1,
+        vmType: NetworkVMType.EVM
+      })
+    )
+    store.dispatch(
+      grantPermission({
+        domain: DOMAIN_UNI,
+        address: SVM_1,
+        vmType: NetworkVMType.SVM
+      })
+    )
+    store.dispatch(
+      grantPermission({
+        domain: DOMAIN_OS,
+        address: BTC_1,
+        vmType: NetworkVMType.BITCOIN
+      })
+    )
+
+    store.dispatch(removeAccount('acc1'))
+
+    expect(store.getState().permissions.grants).toEqual({})
+  })
+
+  it('clears every account when a wallet is removed (removeWallet fans out to removeAccount per account)', () => {
+    // store/wallet/thunks.ts removeWallet dispatches removeAccount(account.id)
+    // for each account in the wallet, so the per-account listener covers bulk
+    // wallet removal. This simulates that fan-out.
+    const store = setupStore()
+    store.dispatch(
+      setAccounts({
+        acc1: account('acc1', { addressC: EVM_1, addressBTC: BTC_1 }),
+        acc2: account('acc2', { addressC: EVM_2, addressBTC: '' })
+      })
+    )
+    store.dispatch(
+      grantPermission({
+        domain: DOMAIN_UNI,
+        address: EVM_1,
+        vmType: NetworkVMType.EVM
+      })
+    )
+    store.dispatch(
+      grantPermission({
+        domain: DOMAIN_UNI,
+        address: EVM_2,
+        vmType: NetworkVMType.EVM
+      })
+    )
+
+    store.dispatch(removeAccount('acc1'))
+    store.dispatch(removeAccount('acc2'))
+
+    expect(store.getState().permissions.grants).toEqual({})
+  })
+
+  it('is a no-op when the removed account had no grants', () => {
+    const store = setupStore()
+    store.dispatch(
+      setAccounts({
+        acc1: account('acc1', { addressC: EVM_1, addressBTC: BTC_1 }),
+        acc2: account('acc2', { addressC: EVM_2, addressBTC: '' })
+      })
+    )
+    store.dispatch(
+      grantPermission({
+        domain: DOMAIN_UNI,
+        address: EVM_2,
+        vmType: NetworkVMType.EVM
+      })
+    )
+
+    store.dispatch(removeAccount('acc1'))
+
+    // Only EVM_2 was ever granted; removing acc1 changes nothing.
+    expect(store.getState().permissions.grants).toEqual({
+      [DOMAIN_UNI]: { [EVM_2]: [NetworkVMType.EVM] }
+    })
+  })
+
+  it('keeps a shared address grant until the LAST owning account is removed', () => {
+    const store = setupStore()
+    const SHARED = EVM_1
+    // Same EVM address owned by two accounts in different wallets (e.g. a key
+    // imported that also exists under a mnemonic).
+    store.dispatch(
+      setAccounts({
+        acc1: account('acc1', { addressC: SHARED, addressBTC: BTC_1 }),
+        acc2: account('acc2', {
+          addressC: SHARED,
+          addressBTC: '',
+          walletId: 'wallet-2'
+        })
+      })
+    )
+    store.dispatch(
+      grantPermission({
+        domain: DOMAIN_UNI,
+        address: SHARED,
+        vmType: NetworkVMType.EVM
+      })
+    )
+
+    // Removing one owner must NOT revoke — acc2 still owns SHARED.
+    store.dispatch(removeAccount('acc1'))
+    expect(store.getState().permissions.grants).toEqual({
+      [DOMAIN_UNI]: { [SHARED]: [NetworkVMType.EVM] }
+    })
+
+    // Removing the last owner orphans the address → grant revoked.
+    store.dispatch(removeAccount('acc2'))
+    expect(store.getState().permissions.grants).toEqual({})
+  })
+
+  it('treats a shared EVM address case-insensitively when checking surviving owners', () => {
+    const store = setupStore()
+    const CHECKSUMMED = '0xAbCdEf0000000000000000000000000000000001'
+    const LOWER = '0xabcdef0000000000000000000000000000000001'
+    // Two accounts own the SAME address under different hex casing.
+    store.dispatch(
+      setAccounts({
+        acc1: account('acc1', { addressC: CHECKSUMMED, addressBTC: BTC_1 }),
+        acc2: account('acc2', {
+          addressC: LOWER,
+          addressBTC: '',
+          walletId: 'wallet-2'
+        })
+      })
+    )
+    store.dispatch(
+      grantPermission({
+        domain: DOMAIN_UNI,
+        address: CHECKSUMMED,
+        vmType: NetworkVMType.EVM
+      })
+    )
+
+    store.dispatch(removeAccount('acc1'))
+    // acc2 owns the same address (different casing) → grant must survive.
+    expect(store.getState().permissions.grants[DOMAIN_UNI]).toEqual({
+      [CHECKSUMMED]: [NetworkVMType.EVM]
+    })
+  })
+
+  it('is a no-op when the account is already gone from state', () => {
+    const store = setupStore()
+    store.dispatch(
+      grantPermission({
+        domain: DOMAIN_UNI,
+        address: EVM_1,
+        vmType: NetworkVMType.EVM
+      })
+    )
+
+    // No account 'acc1' seeded → getOriginalState() lookup misses → no revoke.
+    store.dispatch(removeAccount('acc1'))
+
+    expect(store.getState().permissions.grants).toEqual({
+      [DOMAIN_UNI]: { [EVM_1]: [NetworkVMType.EVM] }
+    })
+  })
+})
+
+// Integration: run the REAL removeWallet thunk (not a simulated fan-out) so a
+// future refactor that stops dispatching removeAccount per account is caught.
+describe('permissions listeners — real removeWallet thunk integration', () => {
+  it('revokes grants for every account in a removed wallet', async () => {
+    listenerMiddleware.clearListeners()
+    const store = configureStore({
+      reducer: {
+        account: accountsReducer,
+        permissions: permissionsReducer,
+        wallet: walletsReducer
+      },
+      // Two wallets so removeWallet is allowed (it refuses to remove the last);
+      // active = wallet-2 (the one we keep) to skip the active-switch branch.
+      preloadedState: {
+        wallet: {
+          wallets: {
+            'wallet-1': {
+              id: 'wallet-1',
+              name: 'W1',
+              type: WalletType.MNEMONIC
+            },
+            'wallet-2': {
+              id: 'wallet-2',
+              name: 'W2',
+              type: WalletType.MNEMONIC
+            }
+          },
+          activeWalletId: 'wallet-2',
+          isMigratingActiveAccounts: false
+        }
+      },
+      middleware: gDM =>
+        gDM({ serializableCheck: false }).prepend(listenerMiddleware.middleware)
+    })
+    addPermissionsListeners(
+      listenerMiddleware.startListening as AppStartListening
+    )
+
+    // Two accounts in wallet-1 (the account() helper defaults walletId to
+    // 'wallet-1'), both connected to a dApp.
+    store.dispatch(
+      setAccounts({
+        acc1: account('acc1', { addressC: EVM_1, addressBTC: BTC_1 }),
+        acc2: account('acc2', { addressC: EVM_2, addressBTC: '' })
+      })
+    )
+    store.dispatch(
+      grantPermission({
+        domain: DOMAIN_UNI,
+        address: EVM_1,
+        vmType: NetworkVMType.EVM
+      })
+    )
+    store.dispatch(
+      grantPermission({
+        domain: DOMAIN_UNI,
+        address: EVM_2,
+        vmType: NetworkVMType.EVM
+      })
+    )
+
+    // Real thunk: fans out to removeAccount per account → listener revokes each.
+    // Fake timers so the thunk's 250ms persist-flush delay adds no real
+    // wall-time and can't flake under CI load.
+    jest.useFakeTimers()
+    const removal = (store.dispatch as AppThunkDispatch)(
+      removeWallet('wallet-1')
+    )
+    await jest.runAllTimersAsync()
+    await removal
+    jest.useRealTimers()
+
+    expect(store.getState().permissions.grants).toEqual({})
+  })
+})

--- a/packages/core-mobile/app/store/permissions/listeners.ts
+++ b/packages/core-mobile/app/store/permissions/listeners.ts
@@ -1,0 +1,65 @@
+import { AppListenerEffectAPI, AppStartListening } from 'store/types'
+import { removeAccount, selectAccounts } from 'store/account/slice'
+import { canonicalizeAddress, revokeAllGrantsForAddresses } from './slice'
+import { collectAccountAddresses } from './utils'
+
+/**
+ * Revoke a removed account's dApp connection grants (CP-14374).
+ *
+ * The invariant: grants are revoked whenever the base `removeAccount` action
+ * fires. Every removal path dispatches it — `removeAccountWithActiveCheck`
+ * (single account), `removeWallet` (fans out to `removeAccount` per account
+ * before `_removeWallet`, see store/wallet/thunks.ts), and the direct
+ * `removeAccount` dispatch in useManageWallet's "remove all accounts" flow. So
+ * keying on the base action covers all wallet types and bulk wallet removal by
+ * construction, without editing each removal branch.
+ *
+ * Reads from `getOriginalState()` because `removeAccount`'s payload is only the
+ * accountId — the account's addresses must be read from the state *before* the
+ * reducer deletes the account.
+ *
+ * Only revokes addresses the removed account UNIQUELY owns. The same address
+ * (notably an EVM address) can belong to multiple accounts — e.g. a key
+ * imported that also exists under a mnemonic — so an address still held by a
+ * surviving account keeps its grant. During a wallet's per-account fan-out this
+ * still converges: each sibling is already gone from the original state by the
+ * time the last owner's `removeAccount` fires, so the final owner orphans and
+ * revokes it.
+ */
+const revokeGrantsForRemovedAccount = (
+  action: ReturnType<typeof removeAccount>,
+  listenerApi: AppListenerEffectAPI
+): void => {
+  const accountId = action.payload
+  const originalState = listenerApi.getOriginalState()
+  const account = selectAccounts(originalState)[accountId]
+  if (!account) return
+
+  const removedAddresses = collectAccountAddresses(account)
+  if (removedAddresses.length === 0) return
+
+  // Addresses still owned by another account that survives this removal must
+  // keep their grants (same canonicalization as the slice so checksum-vs-
+  // lowercase EVM duplicates count as the same owner).
+  const survivingAddresses = new Set(
+    Object.values(selectAccounts(originalState))
+      .filter(other => other.id !== accountId)
+      .flatMap(collectAccountAddresses)
+      .map(canonicalizeAddress)
+  )
+  const orphanedAddresses = removedAddresses.filter(
+    address => !survivingAddresses.has(canonicalizeAddress(address))
+  )
+  if (orphanedAddresses.length === 0) return
+
+  listenerApi.dispatch(revokeAllGrantsForAddresses(orphanedAddresses))
+}
+
+export const addPermissionsListeners = (
+  startListening: AppStartListening
+): void => {
+  startListening({
+    actionCreator: removeAccount,
+    effect: revokeGrantsForRemovedAccount
+  })
+}

--- a/packages/core-mobile/app/store/permissions/slice.test.ts
+++ b/packages/core-mobile/app/store/permissions/slice.test.ts
@@ -3,6 +3,7 @@ import { RootState } from 'store/types'
 import {
   grantPermission,
   permissionsReducer,
+  revokeAllGrantsForAddresses,
   revokePermission,
   selectAddressesForDomain,
   selectConnectedDomains,
@@ -189,6 +190,98 @@ describe('permissions slice', () => {
         revokePermission({ domain: DOMAIN_UNI, address: '0xCCCC' })
       )
       expect(next2).toEqual(seeded)
+    })
+  })
+
+  describe('revokeAllGrantsForAddresses', () => {
+    const ADDR_C = '0xCCCC'
+    const seeded: PermissionsState = {
+      grants: {
+        [DOMAIN_UNI]: {
+          [ADDR_A]: [NetworkVMType.EVM, NetworkVMType.SVM],
+          [ADDR_B]: [NetworkVMType.EVM]
+        },
+        [DOMAIN_OS]: {
+          [ADDR_A]: [NetworkVMType.EVM]
+        }
+      }
+    }
+
+    it('removes one address everywhere and prunes domains it empties', () => {
+      const next = permissionsReducer(
+        seeded,
+        revokeAllGrantsForAddresses([ADDR_A])
+      )
+      // ADDR_A gone from both domains; DOMAIN_OS pruned (it only had ADDR_A).
+      expect(next.grants[DOMAIN_UNI]).toEqual({ [ADDR_B]: [NetworkVMType.EVM] })
+      expect(next.grants[DOMAIN_OS]).toBeUndefined()
+    })
+
+    it('revokes multiple addresses (e.g. an account spanning VMs) in one pass', () => {
+      const next = permissionsReducer(
+        seeded,
+        revokeAllGrantsForAddresses([ADDR_A, ADDR_B])
+      )
+      // Every grant for both addresses is gone → both domains pruned.
+      expect(next.grants).toEqual({})
+    })
+
+    it('de-dupes the address list (shared X/P addresses) without error', () => {
+      const next = permissionsReducer(
+        seeded,
+        revokeAllGrantsForAddresses([ADDR_A, ADDR_A])
+      )
+      expect(next.grants[DOMAIN_UNI]).toEqual({ [ADDR_B]: [NetworkVMType.EVM] })
+      expect(next.grants[DOMAIN_OS]).toBeUndefined()
+    })
+
+    it('matches EVM grant keys case-insensitively (checksummed vs lowercased)', () => {
+      const checksummed: PermissionsState = {
+        grants: {
+          [DOMAIN_UNI]: {
+            '0xAbCdEf0000000000000000000000000000000001': [NetworkVMType.EVM]
+          }
+        }
+      }
+      const next = permissionsReducer(
+        checksummed,
+        revokeAllGrantsForAddresses([
+          '0xabcdef0000000000000000000000000000000001'
+        ])
+      )
+      expect(next.grants[DOMAIN_UNI]).toBeUndefined()
+    })
+
+    it('matches case-sensitive (base58 Solana / BTC) addresses exactly — no case-fold collision', () => {
+      // Two DISTINCT base58 pubkeys that differ only by letter case must not
+      // cross-revoke (base58 is case-sensitive). Lowercasing both would wrongly
+      // collapse them.
+      const svmGranted = 'So1anaPubKeyAbc111111111111111111111111111'
+      const svmRemoved = 'so1anapubkeyABC111111111111111111111111111'
+      const state: PermissionsState = {
+        grants: { [DOMAIN_UNI]: { [svmGranted]: [NetworkVMType.SVM] } }
+      }
+      const next = permissionsReducer(
+        state,
+        revokeAllGrantsForAddresses([svmRemoved])
+      )
+      // The granted account's key is untouched (different address, case-sensitive).
+      expect(next.grants[DOMAIN_UNI]).toEqual({
+        [svmGranted]: [NetworkVMType.SVM]
+      })
+    })
+
+    it('is a no-op for an address with no grants', () => {
+      const next = permissionsReducer(
+        seeded,
+        revokeAllGrantsForAddresses([ADDR_C])
+      )
+      expect(next).toEqual(seeded)
+    })
+
+    it('is a no-op for an empty address list', () => {
+      const next = permissionsReducer(seeded, revokeAllGrantsForAddresses([]))
+      expect(next).toEqual(seeded)
     })
   })
 

--- a/packages/core-mobile/app/store/permissions/slice.ts
+++ b/packages/core-mobile/app/store/permissions/slice.ts
@@ -21,6 +21,14 @@ type RevokePayload = {
   vmType?: NetworkVMType
 }
 
+// EVM addresses vary by hex casing (checksummed vs lowercased), so they must
+// match case-insensitively. Base58 (Solana) and legacy Bitcoin addresses are
+// case-SENSITIVE — case-folding them could collapse two distinct addresses, so
+// only EVM-shaped addresses are lowercased; everything else matches exactly.
+const EVM_ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/
+export const canonicalizeAddress = (address: Address): Address =>
+  EVM_ADDRESS_REGEX.test(address) ? address.toLowerCase() : address
+
 const permissionsSlice = createSlice({
   name: reducerName,
   initialState,
@@ -59,6 +67,34 @@ const permissionsSlice = createSlice({
 
       if (Object.keys(domainGrants).length === 0) {
         delete state.grants[domain]
+      }
+    },
+    /**
+     * Revoke every grant held by any of the given addresses, across all
+     * domains, pruning domains left empty. Address-oriented and VM-agnostic:
+     * the caller (permissions listener) maps a removed account/wallet to its
+     * per-VM addresses — the slice never imports the `Account` type.
+     *
+     * EVM addresses match case-insensitively (a re-cased `addressC` — e.g. a
+     * SeedlessWallet-lowercased one — still matches its stored grant key,
+     * consistent with the injected-provider signing gate). Case-sensitive
+     * address families (Solana base58, legacy Bitcoin) match exactly. See
+     * `canonicalizeAddress`. (CP-14374)
+     */
+    revokeAllGrantsForAddresses: (state, action: PayloadAction<Address[]>) => {
+      const targets = new Set(action.payload.map(canonicalizeAddress))
+      if (targets.size === 0) return
+      for (const domain of Object.keys(state.grants)) {
+        const domainGrants = state.grants[domain]
+        if (!domainGrants) continue
+        for (const address of Object.keys(domainGrants)) {
+          if (targets.has(canonicalizeAddress(address))) {
+            delete domainGrants[address]
+          }
+        }
+        if (Object.keys(domainGrants).length === 0) {
+          delete state.grants[domain]
+        }
       }
     }
   }
@@ -118,6 +154,10 @@ export const selectGrantedAddressesForDomain =
     return granted
   }
 
-export const { grantPermission, revokePermission } = permissionsSlice.actions
+export const {
+  grantPermission,
+  revokePermission,
+  revokeAllGrantsForAddresses
+} = permissionsSlice.actions
 
 export const permissionsReducer = permissionsSlice.reducer

--- a/packages/core-mobile/app/store/permissions/utils.ts
+++ b/packages/core-mobile/app/store/permissions/utils.ts
@@ -1,0 +1,22 @@
+import type { Account } from 'store/account/types'
+import { Address } from './types'
+
+/**
+ * Collect every non-empty per-VM address a Core account holds, de-duped.
+ *
+ * Used at the listener boundary to map a removed account → the address keys its
+ * dApp grants are stored under, so removal can revoke all of them across VMs.
+ * (AVM/PVM/CoreEth addresses can coincide, hence the dedupe.) Keeping this here
+ * — not in the slice — preserves the slice's address-only, VM-agnostic shape.
+ */
+export const collectAccountAddresses = (account: Account): Address[] => {
+  const addresses = [
+    account.addressC,
+    account.addressSVM,
+    account.addressBTC,
+    account.addressAVM,
+    account.addressPVM,
+    account.addressCoreEth
+  ].filter((address): address is string => Boolean(address))
+  return Array.from(new Set(addresses))
+}


### PR DESCRIPTION
## Description

**Ticket: [CP-14374](https://ava-labs.atlassian.net/browse/CP-14374)**

When an account or wallet is removed, revoke that account's dApp connection grants from the `permissions` slice.

- **Summary of changes**
  - New `revokeAllGrantsForAddresses(addresses: Address[])` reducer on the `permissions` slice — deletes every grant for the given addresses across all domains and prunes any domain left empty. Address-oriented and VM-agnostic (the slice never imports the `Account` type).
  - New `permissions` listener keyed on the base `removeAccount` action. Every removal path funnels through it — `removeAccountWithActiveCheck` (single account), `removeWallet` (fans out to `removeAccount` per account), and `useManageWallet`'s bulk remove — so this one listener covers all wallet types and bulk wallet removal by construction. It reads the account's addresses from `getOriginalState()` (the action payload is only the accountId) and maps account → per-VM addresses (`addressC/SVM/BTC/AVM/PVM/CoreEth`, de-duped).
  - **Shared-address safety:** only addresses the removed account *uniquely* owns are revoked. The same address (notably an EVM address) can belong to multiple accounts (e.g. a key imported that also exists under a mnemonic); an address still held by a surviving account keeps its grant.
  - **Case handling:** EVM addresses match case-insensitively (`canonicalizeAddress`), while case-sensitive families (Solana base58, legacy Bitcoin) match exactly — so checksum-vs-lowercase EVM dupes are treated as one address without risking a base58 case-fold collision.

- **Motivation and context**
  - Previously, deleting an account/wallet left its dApp grants lingering in the persisted `permissions` slice indefinitely. Because Core accounts are deterministic, a re-derived account at the same address would silently inherit the prior account's dApp connections — a privacy/correctness gap. The dead, mis-shaped `revokeAllGrantsForAddress` reducer added speculatively in #3862 was removed there with a pointer to this ticket; this PR builds the real feature.

- **Dependencies introduced:** none.

- **Breaking changes / migration:** none (no persisted-state shape change).

## Screenshots/Videos

N/A — store/logic-only change, no UI.

## Testing

**Dev Testing**

iOS: 8797
Android: 8798

- Connect a dApp in the in-app browser with account A granted, then remove account A → the dApp reflects a disconnected state (it disappears from Connected Sites / `accountsChanged([])` is emitted to any open tab).
- Remove an entire wallet → every account in that wallet has its grants revoked.
- Edge — shared address: have two accounts (e.g. an imported private key and a mnemonic account) that resolve to the same EVM address, both connected to a dApp. Remove the first → the dApp stays connected (the surviving account still owns the address). Remove the last owner → the grant is revoked.
- Edge — no grants: removing an account with no dApp connections is a no-op.
- Trigger a Bitrise build and reference it here. _(pending)_
- Move the ticket into the "Testing" column on Jira.

**QA Testing**

Acceptance criteria:

- Removing an account revokes that account's dApp grants for every VM address it holds, across all domains.
- Removing a wallet revokes grants for all accounts in that wallet.
- Works for all wallet types (mnemonic, private key, Ledger, Keystone).
- An address still owned by another account keeps its grant (no over-revoke).
- Empty domains are pruned from the grants store.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios (N/A — no UI)
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation (N/A)


[CP-14374]: https://ava-labs.atlassian.net/browse/CP-14374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ