### PR TITLE
CP-14422: request-aware approval cancellation on cross-origin nav

### DIFF
--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -1195,6 +1195,61 @@ describe('createInjectedProviderRouter', () => {
       ).not.toThrow()
     })
 
+    it('aborts a signing request that registers AFTER a cross-origin nav (pre-registration race)', async () => {
+      // The edge-triggered cancelByOrigin runs (page navigated away) BEFORE this
+      // request registers its in-flight controller — so the abort loop finds
+      // nothing and never re-fires. Without live-origin tracking the request
+      // would park a modal that can never be cancelled and hang. (CP-14422)
+      const { deps, requestSigning } = makeDeps({
+        grantedAddresses: [MOCK_ADDR]
+      })
+      let capturedSignal: AbortSignal | undefined
+      requestSigning.mockImplementationOnce(args => {
+        capturedSignal = args.signal
+        return new Promise(() => undefined)
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      // Cross-origin nav lands first (no in-flight request yet to abort).
+      router.cancelByOrigin('https://other.example')
+
+      // Then the signing request for the now-stale origin registers.
+      sendWithId(router, 42, {
+        method: 'personal_sign',
+        params: ['0xMsg', '0xAddr']
+      })
+      await new Promise(r => setImmediate(r))
+
+      // Its signal must be born aborted, so the signing pipeline short-circuits
+      // to userRejectedRequest instead of opening an uncancellable modal.
+      expect(capturedSignal?.aborted).toBe(true)
+    })
+
+    it('does not abort a request that registers for the new (post-nav) origin', async () => {
+      // Guard against over-aborting: after navigating to other.example, a request
+      // legitimately originating from other.example must NOT be aborted.
+      const { deps, requestSigning } = makeDeps({
+        grantedAddresses: [MOCK_ADDR],
+        nativeOrigin: 'https://other.example'
+      })
+      let capturedSignal: AbortSignal | undefined
+      requestSigning.mockImplementationOnce(args => {
+        capturedSignal = args.signal
+        return new Promise(() => undefined)
+      })
+      const router = createInjectedProviderRouter(deps)
+
+      router.cancelByOrigin('https://other.example')
+
+      sendWithId(router, 42, {
+        method: 'personal_sign',
+        params: ['0xMsg', '0xAddr']
+      })
+      await new Promise(r => setImmediate(r))
+
+      expect(capturedSignal?.aborted).toBe(false)
+    })
+
     it('cleans up in-flight tracking after abort', async () => {
       const { deps, requestSigning } = makeDeps({
         grantedAddresses: [MOCK_ADDR]
@@ -1212,10 +1267,11 @@ describe('createInjectedProviderRouter', () => {
       router.cancelByOrigin('https://other.example')
       expect(signals[0]?.aborted).toBe(true)
 
-      // A second cancel round should not re-abort the same controller.
-      // (If it did, reading .aborted still returns true, but the important
-      // thing is the entry was removed from the map.) Fire another request
-      // and confirm it gets its own independent signal.
+      // The entry was removed from the map (re-cancel won't double-abort it).
+      // Now the page returns to its origin (getNativeOrigin), so a fresh request
+      // from that origin gets its own independent, non-aborted signal — the
+      // live-origin guard only aborts requests whose origin is now stale.
+      router.cancelByOrigin('https://example.com')
       sendWithId(router, 2, { method: 'personal_sign', params: ['c', 'd'] })
       await new Promise(r => setImmediate(r))
       expect(signals[1]).toBeDefined()

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -205,8 +205,23 @@ export function createInjectedProviderRouter(
 
   const inFlightRequests = new Map<number, InFlightRequest>()
 
+  // The origin the WebView has most recently navigated TO (set by cancelByOrigin
+  // on every cross-origin nav). `cancelByOrigin` is edge-triggered and only
+  // aborts requests ALREADY in `inFlightRequests`, so a signing request that
+  // registers AFTER that edge would be missed — it'd park a modal that can never
+  // be cancelled and hang. Recording the live origin lets `registerInFlight`
+  // catch that late registration and abort it on arrival. (CP-14422)
+  let liveOrigin: string | undefined
+
   const registerInFlight = (id: number, origin: string): AbortController => {
     const controller = new AbortController()
+    // The page already navigated away from this request's origin before it
+    // registered (the cross-origin abort edge has passed and won't re-fire) —
+    // born aborted so the signing pipeline short-circuits to userRejectedRequest
+    // instead of opening an uncancellable modal. (CP-14422)
+    if (liveOrigin !== undefined && origin !== liveOrigin) {
+      controller.abort()
+    }
     inFlightRequests.set(id, { origin, controller })
     return controller
   }
@@ -755,6 +770,10 @@ export function createInjectedProviderRouter(
   }
 
   const cancelByOrigin = (currentOrigin: string | undefined): void => {
+    // Record where the page navigated to, so a signing request that registers
+    // AFTER this edge (and would be missed by the loop below) is aborted on
+    // arrival in registerInFlight. (CP-14422)
+    liveOrigin = currentOrigin
     if (inFlightRequests.size === 0) return
     for (const [id, entry] of inFlightRequests.entries()) {
       if (entry.origin !== currentOrigin) {

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -1605,7 +1605,7 @@ describe('useEvmInjectedProvider', () => {
       })
 
       act(() => {
-        result.current.setCurrentUrl('https://opensea.io')
+        result.current.handleCommittedUrl('https://opensea.io')
       })
 
       // Settlement still no-ops in the controller for this phase, and the abort

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -87,7 +87,8 @@ jest.mock('expo-router', () => ({
 
 jest.mock('vmModule/ApprovalController/ApprovalController', () => ({
   approvalController: {
-    handleGoBackIfNeeded: jest.fn()
+    handleGoBackIfNeeded: jest.fn(),
+    isLedgerSigningInProgress: jest.fn()
   }
 }))
 
@@ -1572,6 +1573,46 @@ describe('useEvmInjectedProvider', () => {
 
       expect(capturedSignal?.aborted).toBe(true)
       expect(mockApprovalController.handleGoBackIfNeeded).toHaveBeenCalled()
+    })
+
+    it('does NOT pop the screen on cross-origin nav while on-device Ledger signing is in progress (CP-14422)', async () => {
+      const { approvalController: mockApprovalController } = jest.requireMock(
+        'vmModule/ApprovalController/ApprovalController'
+      )
+      ;(mockApprovalController.handleGoBackIfNeeded as jest.Mock).mockClear()
+      // Uncancellable window: a signature is being confirmed on the device.
+      ;(
+        mockApprovalController.isLedgerSigningInProgress as jest.Mock
+      ).mockReturnValueOnce(true)
+
+      let capturedSignal: AbortSignal | undefined
+      const mockRequest = jest.fn(args => {
+        capturedSignal = args.signal
+        return new Promise(() => undefined)
+      })
+      mockCreateInAppRequest.mockReturnValue(mockRequest)
+      mockUseStore.mockReturnValue(grantStoreForOrigin('https://uniswap.org'))
+
+      const { result } = renderProvider('https://uniswap.org')
+
+      await act(async () => {
+        result.current.handleProviderMessage(
+          JSON.stringify({
+            id: 99,
+            request: { method: 'personal_sign', params: ['0xMsg', '0xAddr'] }
+          })
+        )
+      })
+
+      act(() => {
+        result.current.setCurrentUrl('https://opensea.io')
+      })
+
+      // Settlement still no-ops in the controller for this phase, and the abort
+      // still fires — but the review screen must NOT be popped out from under a
+      // signature the user is confirming on the device.
+      expect(capturedSignal?.aborted).toBe(true)
+      expect(mockApprovalController.handleGoBackIfNeeded).not.toHaveBeenCalled()
     })
 
     it('does NOT abort in-flight request on same-origin navigation (SPA route change)', async () => {

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -191,13 +191,16 @@ export function useEvmInjectedProvider(
         // the cancel is already a no-op in that phase (the signing completes), so
         // popping would just yank the review screen out from under the user
         // mid-sign. The controller dismisses it itself once signing settles.
-        // (CP-14422)
+        // `excludeApproval`: the signing approval screen dismisses itself
+        // (event-driven on its request's abort), so popping it here too would
+        // double `router.back()` — and its async route tracking made this pop
+        // miss anyway. Other modal types still dismiss via this pop. (CP-14422)
         if (
           !handled &&
           !connectApprovalRegistry.hasActive() &&
           !approvalController.isLedgerSigningInProgress()
         ) {
-          approvalController.handleGoBackIfNeeded()
+          approvalController.handleGoBackIfNeeded({ excludeApproval: true })
         }
       }
 

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -187,7 +187,16 @@ export function useEvmInjectedProvider(
             message: USER_REJECTED_REQUEST_MESSAGE
           })
         )
-        if (!handled && !connectApprovalRegistry.hasActive()) {
+        // Skip the generic pop while a signature is being confirmed on a Ledger:
+        // the cancel is already a no-op in that phase (the signing completes), so
+        // popping would just yank the review screen out from under the user
+        // mid-sign. The controller dismisses it itself once signing settles.
+        // (CP-14422)
+        if (
+          !handled &&
+          !connectApprovalRegistry.hasActive() &&
+          !approvalController.isLedgerSigningInProgress()
+        ) {
           approvalController.handleGoBackIfNeeded()
         }
       }

--- a/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.test.ts
+++ b/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.test.ts
@@ -2,46 +2,53 @@ import { renderHook } from '@testing-library/react-hooks'
 import { router } from 'expo-router'
 import { useDismissOnCancelledRequest } from './useDismissOnCancelledRequest'
 
+// Capture the navigation transitionEnd listener so tests can simulate the
+// native present animation completing.
+let transitionEndCb: (() => void) | undefined
+const mockAddListener = jest.fn((event: string, cb: () => void) => {
+  if (event === 'transitionEnd') transitionEndCb = cb
+  return jest.fn() // unsubscribe
+})
+
 jest.mock('expo-router', () => ({
-  router: { canGoBack: jest.fn(() => true), back: jest.fn() }
+  router: { canGoBack: jest.fn(() => true), back: jest.fn() },
+  useNavigation: () => ({ addListener: mockAddListener })
 }))
 
 const mockCanGoBack = router.canGoBack as jest.Mock
 const mockBack = router.back as jest.Mock
 
+// Simulate the formSheet finishing its present animation.
+const completePresent = (): void => transitionEndCb?.()
+
 describe('useDismissOnCancelledRequest', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockCanGoBack.mockReturnValue(true)
+    transitionEndCb = undefined
   })
 
-  it('dismisses on mount when the request signal is already aborted', () => {
+  it('does NOT dismiss until the present transition completes, then dismisses (abort before present)', () => {
     const controller = new AbortController()
     controller.abort()
 
     renderHook(() => useDismissOnCancelledRequest(controller.signal))
+    // Aborted at mount, but the sheet is still presenting — must NOT pop yet
+    // (iOS drops a back() mid-present).
+    expect(mockBack).not.toHaveBeenCalled()
 
+    completePresent()
     expect(mockBack).toHaveBeenCalledTimes(1)
   })
 
-  it('dismisses when the signal aborts after mount', () => {
+  it('dismisses immediately when the signal aborts after the sheet has presented', () => {
     const controller = new AbortController()
 
     renderHook(() => useDismissOnCancelledRequest(controller.signal))
+    completePresent() // sheet finished presenting
     expect(mockBack).not.toHaveBeenCalled()
 
     controller.abort()
-
-    expect(mockBack).toHaveBeenCalledTimes(1)
-  })
-
-  it('dismisses at most once', () => {
-    const controller = new AbortController()
-
-    renderHook(() => useDismissOnCancelledRequest(controller.signal))
-    controller.abort()
-    controller.abort()
-
     expect(mockBack).toHaveBeenCalledTimes(1)
   })
 
@@ -49,12 +56,14 @@ describe('useDismissOnCancelledRequest', () => {
     const controller = new AbortController()
 
     renderHook(() => useDismissOnCancelledRequest(controller.signal))
+    completePresent()
 
     expect(mockBack).not.toHaveBeenCalled()
   })
 
   it('does not dismiss when there is no signal (non-browser request)', () => {
     renderHook(() => useDismissOnCancelledRequest(undefined))
+    completePresent()
 
     expect(mockBack).not.toHaveBeenCalled()
   })
@@ -65,7 +74,20 @@ describe('useDismissOnCancelledRequest', () => {
     controller.abort()
 
     renderHook(() => useDismissOnCancelledRequest(controller.signal))
+    completePresent()
 
     expect(mockBack).not.toHaveBeenCalled()
+  })
+
+  it('dismisses at most once', () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    renderHook(() => useDismissOnCancelledRequest(controller.signal))
+    completePresent()
+    completePresent()
+    controller.abort()
+
+    expect(mockBack).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.test.ts
+++ b/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.test.ts
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { router } from 'expo-router'
+import { useDismissOnCancelledRequest } from './useDismissOnCancelledRequest'
+
+jest.mock('expo-router', () => ({
+  router: { canGoBack: jest.fn(() => true), back: jest.fn() }
+}))
+
+const mockCanGoBack = router.canGoBack as jest.Mock
+const mockBack = router.back as jest.Mock
+
+describe('useDismissOnCancelledRequest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCanGoBack.mockReturnValue(true)
+  })
+
+  it('dismisses on mount when the request signal is already aborted', () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    renderHook(() => useDismissOnCancelledRequest(controller.signal))
+
+    expect(mockBack).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not dismiss when the signal is not aborted', () => {
+    const controller = new AbortController()
+
+    renderHook(() => useDismissOnCancelledRequest(controller.signal))
+
+    expect(mockBack).not.toHaveBeenCalled()
+  })
+
+  it('does not dismiss when there is no signal (non-browser request)', () => {
+    renderHook(() => useDismissOnCancelledRequest(undefined))
+
+    expect(mockBack).not.toHaveBeenCalled()
+  })
+
+  it('does not call back when there is nothing to go back to', () => {
+    mockCanGoBack.mockReturnValue(false)
+    const controller = new AbortController()
+    controller.abort()
+
+    renderHook(() => useDismissOnCancelledRequest(controller.signal))
+
+    expect(mockBack).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.test.ts
+++ b/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.test.ts
@@ -24,6 +24,27 @@ describe('useDismissOnCancelledRequest', () => {
     expect(mockBack).toHaveBeenCalledTimes(1)
   })
 
+  it('dismisses when the signal aborts after mount', () => {
+    const controller = new AbortController()
+
+    renderHook(() => useDismissOnCancelledRequest(controller.signal))
+    expect(mockBack).not.toHaveBeenCalled()
+
+    controller.abort()
+
+    expect(mockBack).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismisses at most once', () => {
+    const controller = new AbortController()
+
+    renderHook(() => useDismissOnCancelledRequest(controller.signal))
+    controller.abort()
+    controller.abort()
+
+    expect(mockBack).toHaveBeenCalledTimes(1)
+  })
+
   it('does not dismiss when the signal is not aborted', () => {
     const controller = new AbortController()
 

--- a/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.test.ts
+++ b/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.test.ts
@@ -15,6 +15,13 @@ jest.mock('expo-router', () => ({
   useNavigation: () => ({ addListener: mockAddListener })
 }))
 
+const mockIsLedgerSigning = jest.fn(() => false)
+jest.mock('vmModule/ApprovalController/ApprovalController', () => ({
+  approvalController: {
+    isLedgerSigningInProgress: () => mockIsLedgerSigning()
+  }
+}))
+
 const mockCanGoBack = router.canGoBack as jest.Mock
 const mockBack = router.back as jest.Mock
 
@@ -25,6 +32,7 @@ describe('useDismissOnCancelledRequest', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockCanGoBack.mockReturnValue(true)
+    mockIsLedgerSigning.mockReturnValue(false)
     transitionEndCb = undefined
   })
 
@@ -75,6 +83,36 @@ describe('useDismissOnCancelledRequest', () => {
 
     renderHook(() => useDismissOnCancelledRequest(controller.signal))
     completePresent()
+
+    expect(mockBack).not.toHaveBeenCalled()
+  })
+
+  it('dismisses via the fallback timer when transitionEnd never fires (nested-stack initial route)', () => {
+    // ApprovalScreen is the initial route of a nested stack presented as a sheet
+    // by its parent, so its own navigator never emits transitionEnd. Dismissal
+    // must not depend solely on that event. (CP-14422)
+    jest.useFakeTimers()
+    const controller = new AbortController()
+
+    renderHook(() => useDismissOnCancelledRequest(controller.signal))
+    // transitionEnd never fires — do NOT call completePresent().
+    controller.abort()
+    expect(mockBack).not.toHaveBeenCalled() // deferred: not yet "presented"
+
+    jest.advanceTimersByTime(2000) // fallback elapses
+    expect(mockBack).toHaveBeenCalledTimes(1)
+    jest.useRealTimers()
+  })
+
+  it('does NOT dismiss while on-device Ledger signing is in progress', () => {
+    // Once signing has begun the cross-origin nav must not pop the review screen
+    // out from under a signature; the controller dismisses on settle. (CP-14422)
+    mockIsLedgerSigning.mockReturnValue(true)
+    const controller = new AbortController()
+
+    renderHook(() => useDismissOnCancelledRequest(controller.signal))
+    completePresent()
+    controller.abort()
 
     expect(mockBack).not.toHaveBeenCalled()
   })

--- a/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.ts
+++ b/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { router } from 'expo-router'
+import { router, useNavigation } from 'expo-router'
 
 /**
  * Dismiss the approval screen when its injected signing request is cancelled by
@@ -7,32 +7,58 @@ import { router } from 'expo-router'
  *
  * Why event-driven and not the generic `handleGoBackIfNeeded` pop in
  * `setCurrentUrl`: that pop is edge-triggered and gated on the route store's
- * `currentRoute`, which React Navigation updates asynchronously. The abort can
- * land before the screen mounts (pop fires too early, `currentRoute` not yet
- * `approval`) OR just after it mounts but before `currentRoute` catches up —
- * either way the pop misses and the defunct sheet lingers. Reacting to the
- * request's own signal dismisses regardless of timing, and is request-scoped
- * (never pops another request's sheet). `setCurrentUrl` excludes the `approval`
- * route from its pop so the two don't double `router.back()`. (CP-14422)
+ * `currentRoute`, which React Navigation updates asynchronously, so it races the
+ * screen's mount and misses. Reacting to the request's own signal dismisses
+ * regardless of timing and is request-scoped (never pops another request's
+ * sheet). `setCurrentUrl` excludes the `approval` route so the two don't double
+ * `router.back()`. (CP-14422)
+ *
+ * Why gated on `transitionEnd`: on iOS the approval is a native `formSheet`, and
+ * iOS silently drops a `router.back()` issued while that sheet is still
+ * animating IN — the exact 0ms cross-origin case (sheet starts presenting, the
+ * abort fires almost immediately, the pop is ignored, the defunct sheet
+ * lingers). We therefore only dismiss once the present transition has finished:
+ * if the abort lands first we defer to the next `transitionEnd`; if the sheet is
+ * already presented we dismiss immediately. (CP-14422)
  */
 export const useDismissOnCancelledRequest = (signal?: AbortSignal): void => {
+  const navigation = useNavigation()
+
   useEffect(() => {
     if (!signal) return
 
     let dismissed = false
+    let presented = false
+    let abortedWhilePresenting = false
+
     const dismiss = (): void => {
       if (dismissed) return
       dismissed = true
       if (router.canGoBack()) router.back()
     }
 
-    // Aborted before the screen mounted — dismiss now; otherwise dismiss when it
-    // aborts later.
-    if (signal.aborted) {
-      dismiss()
-      return
+    const onAbort = (): void => {
+      // Dismiss now if the sheet has finished presenting; otherwise wait for the
+      // present transition to end so iOS doesn't drop the pop mid-animation.
+      if (presented) dismiss()
+      else abortedWhilePresenting = true
     }
-    signal.addEventListener('abort', dismiss, { once: true })
-    return () => signal.removeEventListener('abort', dismiss)
-  }, [signal])
+
+    // The first transitionEnd after mount marks the present animation complete.
+    const unsubscribe = navigation.addListener(
+      'transitionEnd' as never,
+      (() => {
+        presented = true
+        if (abortedWhilePresenting) dismiss()
+      }) as never
+    )
+
+    if (signal.aborted) onAbort()
+    else signal.addEventListener('abort', onAbort, { once: true })
+
+    return () => {
+      unsubscribe()
+      signal.removeEventListener('abort', onAbort)
+    }
+  }, [signal, navigation])
 }

--- a/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.ts
+++ b/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react'
+import { router } from 'expo-router'
+
+/**
+ * Dismiss the approval screen on mount if its injected signing request was
+ * already cancelled by a cross-origin navigation.
+ *
+ * A cross-origin nav aborts + settles the request and fires the generic
+ * `handleGoBackIfNeeded` pop in `setCurrentUrl`. But that pop can run in the
+ * window between `router.navigate('/approval')` and this screen actually
+ * mounting (the route's `currentRoute` is set asynchronously), so it misses and
+ * the defunct sheet lingers. Reacting to the request's own `AbortSignal` makes
+ * dismissal request-scoped (never pops another request's sheet) and robust to
+ * that mount-vs-pop race.
+ *
+ * Mount-time only by design: a nav that aborts the request while this screen is
+ * already mounted is handled by `setCurrentUrl`'s pop (the screen is the current
+ * route, so it lands), and adding a live `abort` listener here would race that
+ * pop into a double `router.back()`. (CP-14422)
+ */
+export const useDismissOnCancelledRequest = (signal?: AbortSignal): void => {
+  useEffect(() => {
+    if (signal?.aborted && router.canGoBack()) {
+      router.back()
+    }
+    // Run once on mount for this request's signal; see docblock for why we don't
+    // subscribe to later aborts.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+}

--- a/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.ts
+++ b/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.ts
@@ -2,29 +2,37 @@ import { useEffect } from 'react'
 import { router } from 'expo-router'
 
 /**
- * Dismiss the approval screen on mount if its injected signing request was
- * already cancelled by a cross-origin navigation.
+ * Dismiss the approval screen when its injected signing request is cancelled by
+ * a cross-origin navigation (the request's `AbortSignal` fires).
  *
- * A cross-origin nav aborts + settles the request and fires the generic
- * `handleGoBackIfNeeded` pop in `setCurrentUrl`. But that pop can run in the
- * window between `router.navigate('/approval')` and this screen actually
- * mounting (the route's `currentRoute` is set asynchronously), so it misses and
- * the defunct sheet lingers. Reacting to the request's own `AbortSignal` makes
- * dismissal request-scoped (never pops another request's sheet) and robust to
- * that mount-vs-pop race.
- *
- * Mount-time only by design: a nav that aborts the request while this screen is
- * already mounted is handled by `setCurrentUrl`'s pop (the screen is the current
- * route, so it lands), and adding a live `abort` listener here would race that
- * pop into a double `router.back()`. (CP-14422)
+ * Why event-driven and not the generic `handleGoBackIfNeeded` pop in
+ * `setCurrentUrl`: that pop is edge-triggered and gated on the route store's
+ * `currentRoute`, which React Navigation updates asynchronously. The abort can
+ * land before the screen mounts (pop fires too early, `currentRoute` not yet
+ * `approval`) OR just after it mounts but before `currentRoute` catches up —
+ * either way the pop misses and the defunct sheet lingers. Reacting to the
+ * request's own signal dismisses regardless of timing, and is request-scoped
+ * (never pops another request's sheet). `setCurrentUrl` excludes the `approval`
+ * route from its pop so the two don't double `router.back()`. (CP-14422)
  */
 export const useDismissOnCancelledRequest = (signal?: AbortSignal): void => {
   useEffect(() => {
-    if (signal?.aborted && router.canGoBack()) {
-      router.back()
+    if (!signal) return
+
+    let dismissed = false
+    const dismiss = (): void => {
+      if (dismissed) return
+      dismissed = true
+      if (router.canGoBack()) router.back()
     }
-    // Run once on mount for this request's signal; see docblock for why we don't
-    // subscribe to later aborts.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+
+    // Aborted before the screen mounted — dismiss now; otherwise dismiss when it
+    // aborts later.
+    if (signal.aborted) {
+      dismiss()
+      return
+    }
+    signal.addEventListener('abort', dismiss, { once: true })
+    return () => signal.removeEventListener('abort', dismiss)
+  }, [signal])
 }

--- a/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.ts
+++ b/packages/core-mobile/app/new/features/approval/hooks/useDismissOnCancelledRequest.ts
@@ -1,5 +1,12 @@
 import { useEffect } from 'react'
 import { router, useNavigation } from 'expo-router'
+import { approvalController } from 'vmModule/ApprovalController/ApprovalController'
+
+// Outlasts the sheet present animation (~0.5s on iOS) so a deferred dismiss is
+// never issued mid-present (iOS drops those), yet guarantees we stop waiting on
+// a `transitionEnd` that, for this nested-stack initial route, never arrives.
+// (CP-14422)
+const PRESENT_SETTLED_FALLBACK_MS = 700
 
 /**
  * Dismiss the approval screen when its injected signing request is cancelled by
@@ -13,13 +20,25 @@ import { router, useNavigation } from 'expo-router'
  * sheet). `setCurrentUrl` excludes the `approval` route so the two don't double
  * `router.back()`. (CP-14422)
  *
- * Why gated on `transitionEnd`: on iOS the approval is a native `formSheet`, and
- * iOS silently drops a `router.back()` issued while that sheet is still
- * animating IN — the exact 0ms cross-origin case (sheet starts presenting, the
- * abort fires almost immediately, the pop is ignored, the defunct sheet
- * lingers). We therefore only dismiss once the present transition has finished:
- * if the abort lands first we defer to the next `transitionEnd`; if the sheet is
- * already presented we dismiss immediately. (CP-14422)
+ * Why we wait for the sheet to be "presented": on iOS the approval is a native
+ * `formSheet`, and iOS silently drops a `router.back()` issued while that sheet
+ * is still animating IN — the 0ms cross-origin case (sheet starts presenting,
+ * the abort fires almost immediately, the pop is ignored, the defunct sheet
+ * lingers). So we only dismiss once the present transition has finished: if the
+ * abort lands first we defer; if the sheet is already presented we dismiss now.
+ *
+ * Why not transitionEnd alone: `ApprovalScreen` is the initial route of a nested
+ * stack that its parent presents as a sheet, and that inner navigator does not
+ * emit `transitionEnd` for its initial route (notably on Android), so the event
+ * never fires and the deferred dismiss would hang forever. A fallback timer
+ * sized to outlast the present animation marks the sheet presented regardless;
+ * whichever fires first wins, the other no-ops. (CP-14422)
+ *
+ * Why the `isLedgerSigningInProgress` guard: once on-device Ledger signing has
+ * begun, a cross-origin nav must NOT pop the review screen out from under a
+ * signature the user is confirming on the device (the controller's settlement
+ * already no-ops in that phase, and dismissal happens on settle). Mirrors the
+ * same guard in `setCurrentUrl`'s `handleGoBackIfNeeded` call. (CP-14422)
  */
 export const useDismissOnCancelledRequest = (signal?: AbortSignal): void => {
   const navigation = useNavigation()
@@ -33,31 +52,43 @@ export const useDismissOnCancelledRequest = (signal?: AbortSignal): void => {
 
     const dismiss = (): void => {
       if (dismissed) return
+      // Don't yank the sheet while signing on the device; the controller pops it
+      // when the signature settles. Bail without latching `dismissed` so a later
+      // settle/cancel can still dismiss through its own path.
+      if (approvalController.isLedgerSigningInProgress()) return
       dismissed = true
       if (router.canGoBack()) router.back()
     }
 
-    const onAbort = (): void => {
-      // Dismiss now if the sheet has finished presenting; otherwise wait for the
-      // present transition to end so iOS doesn't drop the pop mid-animation.
-      if (presented) dismiss()
-      else abortedWhilePresenting = true
+    const markPresented = (): void => {
+      if (presented) return
+      presented = true
+      if (abortedWhilePresenting) dismiss()
     }
 
-    // The first transitionEnd after mount marks the present animation complete.
+    const onAbort = (): void => {
+      // Wait for the present transition to settle before popping, so iOS doesn't
+      // drop the pop mid-animation; otherwise dismiss now.
+      if (!presented) {
+        abortedWhilePresenting = true
+        return
+      }
+      dismiss()
+    }
+
+    // transitionEnd is the fast path; the timer is the guarantee (see above).
     const unsubscribe = navigation.addListener(
       'transitionEnd' as never,
-      (() => {
-        presented = true
-        if (abortedWhilePresenting) dismiss()
-      }) as never
+      markPresented as never
     )
+    const fallback = setTimeout(markPresented, PRESENT_SETTLED_FALLBACK_MS)
 
     if (signal.aborted) onAbort()
     else signal.addEventListener('abort', onAbort, { once: true })
 
     return () => {
       unsubscribe()
+      clearTimeout(fallback)
       signal.removeEventListener('abort', onAbort)
     }
   }, [signal, navigation])

--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
@@ -6,6 +6,7 @@ import { useActiveWallet } from 'common/hooks/useActiveWallet'
 import { useLedgerApproval } from 'features/approval/hooks/useLedgerApproval'
 import { useRecurringApprovalContext } from 'features/approval/hooks/useRecurringApprovalContext'
 import { RecurrenceDetails } from 'features/approval/components/RecurrenceDetails'
+import { useDismissOnCancelledRequest } from 'features/approval/hooks/useDismissOnCancelledRequest'
 import { dismissKeyboardIfNeeded } from 'common/utils/dismissKeyboardIfNeeded'
 import { L2_NETWORK_SYMBOL_MAPPING } from 'consts/chainIdsWithIncorrectSymbol'
 import { router } from 'expo-router'
@@ -79,7 +80,7 @@ const ApprovalScreen = (props: {
 }
 
 const ApprovalScreenInner = ({
-  params: { request, displayData, signingData, onApprove, onReject },
+  params: { request, displayData, signingData, signal, onApprove, onReject },
   recurringContext
 }: {
   params: ApprovalParams
@@ -87,6 +88,9 @@ const ApprovalScreenInner = ({
     typeof useRecurringApprovalContext
   >['recurringContext']
 }): JSX.Element => {
+  // Self-dismiss if a cross-origin nav already cancelled this request before the
+  // screen mounted (the generic pop can race the mount and miss). (CP-14422)
+  useDismissOnCancelledRequest(signal)
   const isSeedlessSigningBlocked = useSelector(selectIsSeedlessSigningBlocked)
   const { getNetwork } = useNetworks()
   const caip2ChainId = request.chainId

--- a/packages/core-mobile/app/services/walletconnectv2/walletConnectCache/types.ts
+++ b/packages/core-mobile/app/services/walletconnectv2/walletConnectCache/types.ts
@@ -41,6 +41,14 @@ export type ApprovalParams = {
   request: RpcRequest
   displayData: DisplayData
   signingData: SigningData
+  /**
+   * The in-flight request's AbortSignal, present only for cancellable injected
+   * browser signing requests. A cross-origin nav can abort + settle the request
+   * in the window between navigating to the approval screen and the screen
+   * mounting, so the generic dismissal may miss; the screen reads this to
+   * self-dismiss on mount if its request is already cancelled. (CP-14422)
+   */
+  signal?: AbortSignal
   onApprove: ({
     walletId,
     walletType,

--- a/packages/core-mobile/app/store/rpc/utils/createInAppRequest.ts
+++ b/packages/core-mobile/app/store/rpc/utils/createInAppRequest.ts
@@ -147,10 +147,12 @@ export const createInAppRequest = (
           unsubscribe()
           // Keep the aborted signal in the map so a requestApproval that hasn't
           // parked yet (abort landed in the pre-park window) still sees it and
-          // cancels itself instead of opening a stale modal. The approval
-          // bridge clears it when it claims the signal; this deferred clear is
-          // the fallback for when no approval ever parks. (CP-14422)
-          setTimeout(() => clearRequestSignal(requestKey), 0)
+          // cancels itself instead of opening a stale modal. Do NOT clear it on
+          // a timer here: a slow `requestApproval` (observed on iOS, where the
+          // approval parks AFTER the cross-origin nav) would otherwise find the
+          // signal already gone, park an uncancellable sheet, and leave it
+          // lingering. The approval bridge clears it when it claims the signal;
+          // the never-claimed case ages out via the bounded signal map. (CP-14422)
           // Propagate a rejection so any handler currently sitting on the
           // approval screen (e.g. eth_sendTransaction) short-circuits
           // before broadcasting. The handler's machinery will dispatch

--- a/packages/core-mobile/app/store/rpc/utils/createInAppRequest.ts
+++ b/packages/core-mobile/app/store/rpc/utils/createInAppRequest.ts
@@ -12,6 +12,7 @@ import {
 } from '../slice'
 import { PeerMeta, RequestContext, RpcMethod } from '../types'
 import { generateInAppRequestPayload } from './generateInAppRequestPayload'
+import { clearRequestSignal, setRequestSignal } from './inFlightRequestSignals'
 
 const EVENTS_TO_SUBSCRIBE = isAnyOf(
   onInAppRequestSucceeded,
@@ -97,6 +98,8 @@ export const createInAppRequest = (
         return
       }
 
+      const requestKey = String(inAppRequest.data.id)
+
       dispatch(onRequest(inAppRequest))
 
       let settled = false
@@ -117,12 +120,14 @@ export const createInAppRequest = (
               // @ts-ignore unsubscribe is a valid function
               unsubscribe()
               signal?.removeEventListener('abort', onAbort)
+              clearRequestSignal(requestKey)
               resolve(action.payload.txHash)
             } else if (onInAppRequestFailed.match(action)) {
               settled = true
               // @ts-ignore unsubscribe is a valid function
               unsubscribe()
               signal?.removeEventListener('abort', onAbort)
+              clearRequestSignal(requestKey)
               reject(action.payload.error)
             }
           }
@@ -130,11 +135,22 @@ export const createInAppRequest = (
       )
 
       if (signal) {
+        // Expose the signal so ApprovalController can settle a parked approval
+        // (and tear down Ledger BLE) if this request is cancelled by a
+        // cross-origin nav. Set here (same sync tick, before the listener effect
+        // runs) and cleared on every settle path. (CP-14422)
+        setRequestSignal(requestKey, signal)
         onAbort = () => {
           if (settled) return
           settled = true
           // @ts-ignore unsubscribe is a valid function
           unsubscribe()
+          // Keep the aborted signal in the map so a requestApproval that hasn't
+          // parked yet (abort landed in the pre-park window) still sees it and
+          // cancels itself instead of opening a stale modal. The approval
+          // bridge clears it when it claims the signal; this deferred clear is
+          // the fallback for when no approval ever parks. (CP-14422)
+          setTimeout(() => clearRequestSignal(requestKey), 0)
           // Propagate a rejection so any handler currently sitting on the
           // approval screen (e.g. eth_sendTransaction) short-circuits
           // before broadcasting. The handler's machinery will dispatch

--- a/packages/core-mobile/app/store/rpc/utils/inFlightRequestSignals.ts
+++ b/packages/core-mobile/app/store/rpc/utils/inFlightRequestSignals.ts
@@ -11,8 +11,10 @@ import { BoundedMap } from 'common/utils/boundedMap'
  * Why a side-channel and not a direct call / Redux subscription: the store
  * wiring transitively imports `ModuleManager` → `ApprovalController`, so the
  * controller can't import the store/listener middleware and `createInAppRequest`
- * can't import the controller without a require cycle. This module is a leaf
- * (imports nothing), so both sides can depend on it safely.
+ * can't import the controller without a require cycle. This module is a leaf in
+ * the store/vmModule dependency graph (it imports only the dependency-free
+ * `BoundedMap` util, nothing from those layers), so both sides can depend on it
+ * safely.
  *
  * Scope: only injected-provider signing requests pass an AbortSignal (the
  * browser router threads `controller.signal` into `requestSigning`), so only

--- a/packages/core-mobile/app/store/rpc/utils/inFlightRequestSignals.ts
+++ b/packages/core-mobile/app/store/rpc/utils/inFlightRequestSignals.ts
@@ -1,3 +1,5 @@
+import { BoundedMap } from 'common/utils/boundedMap'
+
 /**
  * Side-channel mapping an in-flight in-app request id (`String(data.id)`) to its
  * AbortSignal.
@@ -16,8 +18,13 @@
  * browser router threads `controller.signal` into `requestSigning`), so only
  * those become cancellable here. WalletConnect and signal-less in-app approvals
  * register no signal and are untouched. (CP-14422)
+ *
+ * Bounded so a signal that's never claimed by an approval bridge (the rare case
+ * where a request is aborted before it ever reaches `requestApproval`) ages out
+ * via FIFO instead of lingering. Entries are normally removed when the approval
+ * bridge detaches or the request settles. (CP-14422)
  */
-const requestSignals = new Map<string, AbortSignal>()
+const requestSignals = new BoundedMap<string, AbortSignal>(20)
 
 export const setRequestSignal = (
   requestId: string,

--- a/packages/core-mobile/app/store/rpc/utils/inFlightRequestSignals.ts
+++ b/packages/core-mobile/app/store/rpc/utils/inFlightRequestSignals.ts
@@ -1,0 +1,34 @@
+/**
+ * Side-channel mapping an in-flight in-app request id (`String(data.id)`) to its
+ * AbortSignal.
+ *
+ * Lets `ApprovalController` observe cancellation of the request whose approval
+ * it has parked, so a programmatic cross-origin browser navigation can settle
+ * the parked promise (and tear down Ledger BLE) instead of orphaning it.
+ *
+ * Why a side-channel and not a direct call / Redux subscription: the store
+ * wiring transitively imports `ModuleManager` → `ApprovalController`, so the
+ * controller can't import the store/listener middleware and `createInAppRequest`
+ * can't import the controller without a require cycle. This module is a leaf
+ * (imports nothing), so both sides can depend on it safely.
+ *
+ * Scope: only injected-provider signing requests pass an AbortSignal (the
+ * browser router threads `controller.signal` into `requestSigning`), so only
+ * those become cancellable here. WalletConnect and signal-less in-app approvals
+ * register no signal and are untouched. (CP-14422)
+ */
+const requestSignals = new Map<string, AbortSignal>()
+
+export const setRequestSignal = (
+  requestId: string,
+  signal: AbortSignal
+): void => {
+  requestSignals.set(requestId, signal)
+}
+
+export const getRequestSignal = (requestId: string): AbortSignal | undefined =>
+  requestSignals.get(requestId)
+
+export const clearRequestSignal = (requestId: string): void => {
+  requestSignals.delete(requestId)
+}

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -860,6 +860,37 @@ describe('ApprovalController', () => {
 
       expect(mockRouter.back).not.toHaveBeenCalled()
     })
+
+    it('does NOT pop the approval route when excludeApproval is set (screen self-dismisses)', () => {
+      // The cross-origin nav path passes excludeApproval: the approval screen
+      // owns its own dismissal via its request signal, so popping here too would
+      // double router.back(). (CP-14422)
+      mockCurrentRouteStore.getState.mockReturnValue({
+        currentRoute: '/approval',
+        topRoute: undefined,
+        setCurrentRoute: jest.fn(),
+        setTopRoute: jest.fn()
+      })
+      mockRouter.canGoBack.mockReturnValue(true)
+
+      approvalController.handleGoBackIfNeeded({ excludeApproval: true })
+
+      expect(mockRouter.back).not.toHaveBeenCalled()
+    })
+
+    it('still pops non-approval modals when excludeApproval is set', () => {
+      mockCurrentRouteStore.getState.mockReturnValue({
+        currentRoute: '(modals)/addEthereumChain',
+        topRoute: undefined,
+        setCurrentRoute: jest.fn(),
+        setTopRoute: jest.fn()
+      })
+      mockRouter.canGoBack.mockReturnValue(true)
+
+      approvalController.handleGoBackIfNeeded({ excludeApproval: true })
+
+      expect(mockRouter.back).toHaveBeenCalledTimes(1)
+    })
   })
 
   // ── requestApproval ───────────────────────────────────────────────────────
@@ -1413,6 +1444,22 @@ describe('ApprovalController', () => {
       mockOnReject.mockClear()
       controller.abort()
       await flushMicrotasks()
+      expect(mockOnReject).toHaveBeenCalled()
+    })
+
+    it('settles the parked promise immediately on abort even if Ledger BLE disconnect hangs', async () => {
+      // BLE disconnect that never resolves — settlement must not be gated behind
+      // it, or a hung disconnect would leave the dApp request hanging (the whole
+      // point of the abort path is prompt settlement). (CP-14422)
+      mockDisconnect.mockReturnValue(new Promise(() => undefined))
+      const controller = new AbortController()
+      const parked = park(controller.signal)
+      await parked.onApprove({ walletType: WalletType.LEDGER }) // ledgerPending
+      mockOnReject.mockClear()
+
+      controller.abort()
+      // No flush: the reject must have already fired synchronously, not be
+      // queued behind the (hanging) disconnect.
       expect(mockOnReject).toHaveBeenCalled()
     })
 

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -1405,6 +1405,27 @@ describe('ApprovalController', () => {
       expect(mockDisconnect).not.toHaveBeenCalled()
     })
 
+    it('isLedgerSigningInProgress is false while only parked', () => {
+      const controller = new AbortController()
+      park(controller.signal)
+
+      expect(approvalController.isLedgerSigningInProgress()).toBe(false)
+    })
+
+    it('isLedgerSigningInProgress flips true once on-device Ledger signing begins', async () => {
+      const controller = new AbortController()
+      const parked = park(controller.signal)
+      // Ledger sheet up (BLE connecting) — still cancellable, not signing yet.
+      await parked.onApprove({ walletType: WalletType.LEDGER })
+      expect(approvalController.isLedgerSigningInProgress()).toBe(false)
+
+      // On-device signing begins → ledgerSigning (uncancellable).
+      const ledgerParams = mockSetReviewTransactionParams.mock.calls[0][0]
+      ledgerParams.onApprove()
+
+      expect(approvalController.isLedgerSigningInProgress()).toBe(true)
+    })
+
     it('does not bridge requests without a signal (WalletConnect / in-app)', () => {
       const other = new AbortController()
       setRequestSignal('some-other-id', other.signal)

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -1388,6 +1388,34 @@ describe('ApprovalController', () => {
       expect(mockOnReject).toHaveBeenCalled()
     })
 
+    it('drops out of ledgerSigning if the signing pipeline rejects without settling (no app-wide dismissal wedge)', async () => {
+      mockDisconnect.mockResolvedValue(undefined)
+      const controller = new AbortController()
+      const parked = park(controller.signal)
+      await parked.onApprove({ walletType: WalletType.LEDGER }) // ledgerPending
+      const ledgerParams =
+        mockSetReviewTransactionParams.mock.calls[
+          mockSetReviewTransactionParams.mock.calls.length - 1
+        ][0]
+      // On-device signing begins, then the handler pipeline rejects WITHOUT ever
+      // calling resolve (e.g. a handler that throws before settling).
+      mockOnApprove.mockRejectedValueOnce(new Error('signing blew up'))
+      await ledgerParams.onApprove().catch(() => undefined)
+
+      // Phase must NOT be stuck in ledgerSigning — otherwise
+      // isLedgerSigningInProgress() stays true forever and every future
+      // cross-origin nav across all tabs silently stops dismissing the approval
+      // screen. (CP-14422)
+      expect(approvalController.isLedgerSigningInProgress()).toBe(false)
+
+      // And the orphaned request is cancellable again (back in ledgerPending):
+      // a nav now tears down BLE + settles it.
+      mockOnReject.mockClear()
+      controller.abort()
+      await flushMicrotasks()
+      expect(mockOnReject).toHaveBeenCalled()
+    })
+
     it('is a no-op when aborted after on-device Ledger signing has started', async () => {
       const controller = new AbortController()
       const parked = park(controller.signal)
@@ -1452,17 +1480,27 @@ describe('ApprovalController', () => {
       clearRequestSignal('some-other-id')
     })
 
-    it('cancels immediately and skips opening the modal if already aborted before parking', () => {
+    it('cancels immediately and neither caches params nor opens a modal if already aborted before parking', () => {
       const controller = new AbortController()
       controller.abort()
+      setRequestSignal(REQ_ID, controller.signal)
       mockOnReject.mockClear()
       mockRouter.navigate.mockClear()
+      mockWalletConnectCacheSet.mockClear()
 
-      park(controller.signal)
+      approvalController.requestApproval({
+        request: makeRequest({ requestId: REQ_ID, sessionId: 'core-mobile' }),
+        displayData,
+        signingData
+      })
 
       expect(mockOnReject).toHaveBeenCalled()
       // No stale modal for a request that's already dead. (pre-park race)
       expect(mockRouter.navigate).not.toHaveBeenCalled()
+      // And we must NOT leave the parked callbacks (incl. the now-dead resolve
+      // closure) + request data sitting in the single-slot cache: nothing would
+      // consume/clear it since the approval screen never mounts. (CP-14422)
+      expect(mockWalletConnectCacheSet).not.toHaveBeenCalled()
     })
 
     it('stays cancellable during a retryable Ledger error (BLE torn down if aborted then)', async () => {

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -1403,6 +1403,12 @@ describe('ApprovalController', () => {
 
       expect(mockOnReject).not.toHaveBeenCalled()
       expect(mockDisconnect).not.toHaveBeenCalled()
+
+      // Settle the on-device signing so this ledgerSigning entry doesn't leak
+      // into the singleton and bleed into later tests' isLedgerSigningInProgress.
+      mockOnApprove.mock.calls[mockOnApprove.mock.calls.length - 1][0].resolve(
+        {}
+      )
     })
 
     it('isLedgerSigningInProgress is false while only parked', () => {
@@ -1410,6 +1416,8 @@ describe('ApprovalController', () => {
       park(controller.signal)
 
       expect(approvalController.isLedgerSigningInProgress()).toBe(false)
+
+      controller.abort() // settle the parked entry so it doesn't linger
     })
 
     it('isLedgerSigningInProgress flips true once on-device Ledger signing begins', async () => {
@@ -1424,6 +1432,12 @@ describe('ApprovalController', () => {
       ledgerParams.onApprove()
 
       expect(approvalController.isLedgerSigningInProgress()).toBe(true)
+
+      // Settle signing so the ledgerSigning entry is cleared (test isolation).
+      mockOnApprove.mock.calls[mockOnApprove.mock.calls.length - 1][0].resolve(
+        {}
+      )
+      expect(approvalController.isLedgerSigningInProgress()).toBe(false)
     })
 
     it('does not bridge requests without a signal (WalletConnect / in-app)', () => {
@@ -1546,7 +1560,77 @@ describe('ApprovalController', () => {
       controllers[1]?.abort()
       expect(mockOnReject).toHaveBeenCalledTimes(1)
 
+      // Settle the remaining parked entries (evict-2..9 + overflow evict-10) so
+      // nothing leaks into the singleton for later tests.
+      overflow.abort()
+      for (let i = 2; i < 10; i++) controllers[i]?.abort()
+
       for (let i = 0; i <= 10; i++) clearRequestSignal(`evict-${i}`)
+    })
+
+    it('keeps a ledgerSigning oldest and evicts the oldest cancellable entry at capacity (CP-14422)', async () => {
+      // Guard against contamination from a prior test leaking signing state.
+      expect(approvalController.isLedgerSigningInProgress()).toBe(false)
+
+      mockDisconnect.mockResolvedValue(undefined)
+      const base = mockWalletConnectCacheSet.mock.calls.length
+      const controllers: AbortController[] = []
+      for (let i = 0; i < 10; i++) {
+        const c = new AbortController()
+        controllers.push(c)
+        setRequestSignal(`sign-${i}`, c.signal)
+        approvalController.requestApproval({
+          request: makeRequest({
+            requestId: `sign-${i}`,
+            sessionId: 'core-mobile'
+          }),
+          displayData,
+          signingData
+        })
+      }
+
+      // Drive the OLDEST (sign-0) into on-device signing → uncancellable.
+      await mockWalletConnectCacheSet.mock.calls[base][0].onApprove({
+        walletType: WalletType.LEDGER
+      })
+      mockSetReviewTransactionParams.mock.calls[
+        mockSetReviewTransactionParams.mock.calls.length - 1
+      ][0].onApprove()
+      expect(approvalController.isLedgerSigningInProgress()).toBe(true)
+      mockOnReject.mockClear()
+
+      // An 11th request at capacity. The oldest is ledgerSigning (uncancellable),
+      // so it must NOT be the eviction victim — picking it would no-op and fall
+      // through to BoundedMap's silent delete(), leaking its listener/signal and
+      // dropping the in-progress signing. The oldest *cancellable* entry (sign-1)
+      // is settled+detached instead. (CP-14422)
+      const overflow = new AbortController()
+      setRequestSignal('sign-10', overflow.signal)
+      approvalController.requestApproval({
+        request: makeRequest({
+          requestId: 'sign-10',
+          sessionId: 'core-mobile'
+        }),
+        displayData,
+        signingData
+      })
+
+      // The in-progress signing survived — not silently dropped.
+      expect(approvalController.isLedgerSigningInProgress()).toBe(true)
+      // Exactly one eviction settlement: the oldest cancellable victim (sign-1).
+      expect(mockOnReject).toHaveBeenCalledTimes(1)
+      // That victim's bridge was detached: re-aborting it is now a no-op.
+      mockOnReject.mockClear()
+      controllers[1]?.abort()
+      expect(mockOnReject).not.toHaveBeenCalled()
+
+      // Cleanup: settle sign-0's signing + drop the rest so nothing leaks.
+      mockOnApprove.mock.calls[mockOnApprove.mock.calls.length - 1][0].resolve(
+        {}
+      )
+      overflow.abort()
+      for (let i = 2; i < 10; i++) controllers[i]?.abort()
+      for (let i = 0; i <= 10; i++) clearRequestSignal(`sign-${i}`)
     })
   })
 })

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -1439,6 +1439,23 @@ describe('ApprovalController', () => {
       )
     })
 
+    it('caches the request AbortSignal so the approval screen can self-dismiss on cancel', () => {
+      // The cross-origin nav can abort + settle the request in the window between
+      // navigate('/approval') and the screen mounting, so the generic pop may
+      // miss. Caching the signal lets the screen dismiss itself on mount if its
+      // request is already dead. (CP-14422)
+      const controller = new AbortController()
+      park(controller.signal)
+
+      const cached =
+        mockWalletConnectCacheSet.mock.calls[
+          mockWalletConnectCacheSet.mock.calls.length - 1
+        ][0]
+      expect(cached.signal).toBe(controller.signal)
+
+      controller.abort() // settle so nothing lingers
+    })
+
     it('isLedgerSigningInProgress is false while only parked', () => {
       const controller = new AbortController()
       park(controller.signal)

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -1479,5 +1479,53 @@ describe('ApprovalController', () => {
       clearRequestSignal('req-A')
       clearRequestSignal('req-B')
     })
+
+    it('evicts the oldest parked approval with full teardown when at capacity', () => {
+      // Fill activeApprovals to capacity (ACTIVE_APPROVALS_MAX = 10) with distinct
+      // browser signing requests, each with its own cancel bridge.
+      const controllers: AbortController[] = []
+      for (let i = 0; i < 10; i++) {
+        const c = new AbortController()
+        controllers.push(c)
+        setRequestSignal(`evict-${i}`, c.signal)
+        approvalController.requestApproval({
+          request: makeRequest({
+            requestId: `evict-${i}`,
+            sessionId: 'core-mobile'
+          }),
+          displayData,
+          signingData
+        })
+      }
+      mockOnReject.mockClear()
+
+      // An 11th request must evict the oldest (evict-0) — and that eviction must
+      // run the real teardown (settle the promise + detach), NOT BoundedMap's
+      // silent plain-delete that would leak the listener/signal. (CP-14422)
+      const overflow = new AbortController()
+      setRequestSignal('evict-10', overflow.signal)
+      approvalController.requestApproval({
+        request: makeRequest({
+          requestId: 'evict-10',
+          sessionId: 'core-mobile'
+        }),
+        displayData,
+        signingData
+      })
+
+      // Oldest was settled exactly once via the real onReject.
+      expect(mockOnReject).toHaveBeenCalledTimes(1)
+
+      // Oldest's bridge was detached: re-aborting it is now a no-op.
+      mockOnReject.mockClear()
+      controllers[0]?.abort()
+      expect(mockOnReject).not.toHaveBeenCalled()
+
+      // A still-parked entry keeps its bridge — aborting it still cancels.
+      controllers[1]?.abort()
+      expect(mockOnReject).toHaveBeenCalledTimes(1)
+
+      for (let i = 0; i <= 10; i++) clearRequestSignal(`evict-${i}`)
+    })
   })
 })

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -11,6 +11,10 @@ import { promptForAppReviewAfterSuccessfulTransaction } from 'features/appReview
 import AnalyticsService from 'services/analytics/AnalyticsService'
 import { getAddressForChainId } from 'store/rpc/handlers/wc_sessionRequest/utils'
 import {
+  clearRequestSignal,
+  setRequestSignal
+} from 'store/rpc/utils/inFlightRequestSignals'
+import {
   isTxFeedbackEnabled,
   isInAppAvalancheRequest,
   isConfettiEnabled,
@@ -1307,6 +1311,173 @@ describe('ApprovalController', () => {
       )
       expect('error' in result).toBe(true)
       expect(mockSign).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── cross-origin cancel bridge (CP-14422) ──────────────────────────────────
+  describe('requestApproval — cross-origin cancel bridge', () => {
+    const signingData = { type: 'eth_sendTransaction', data: {} } as never
+    const displayData = {} as never
+    const REQ_ID = 'req-1'
+
+    // Park an approval (as requestApproval does) and return the cached callbacks.
+    // Pass a signal to register the cancel bridge for this request.
+    const park = (
+      signal?: AbortSignal
+    ): {
+      onApprove: (p: unknown) => Promise<void>
+      onReject: (m?: string) => void
+    } => {
+      if (signal) setRequestSignal(REQ_ID, signal)
+      approvalController.requestApproval({
+        request: makeRequest({ requestId: REQ_ID, sessionId: 'core-mobile' }),
+        displayData,
+        signingData
+      })
+      return mockWalletConnectCacheSet.mock.calls[
+        mockWalletConnectCacheSet.mock.calls.length - 1
+      ][0]
+    }
+
+    const flushMicrotasks = (): Promise<void> =>
+      new Promise(resolve => setTimeout(resolve, 0))
+
+    afterEach(() => clearRequestSignal(REQ_ID))
+
+    it('settles the parked promise via the real onReject when the request is aborted', () => {
+      const controller = new AbortController()
+      park(controller.signal)
+      mockOnReject.mockClear()
+
+      controller.abort()
+
+      expect(mockOnReject).toHaveBeenCalledWith(
+        expect.objectContaining({ resolve: expect.any(Function) })
+      )
+      // Dismissal stays with setCurrentUrl's handleGoBackIfNeeded — the bridge
+      // must NOT also pop the screen (would double router.back()).
+      expect(mockRouter.back).not.toHaveBeenCalled()
+    })
+
+    it('blocks a late Approve tap after the request was aborted', async () => {
+      const controller = new AbortController()
+      const parked = park(controller.signal)
+      controller.abort()
+      mockOnApprove.mockClear()
+
+      await parked.onApprove({ walletType: WalletType.MNEMONIC })
+
+      expect(mockOnApprove).not.toHaveBeenCalled()
+    })
+
+    it('tears down Ledger BLE + clears the review store when aborted while Ledger is pending', async () => {
+      mockDisconnect.mockResolvedValue(undefined)
+      const controller = new AbortController()
+      const parked = park(controller.signal)
+      // Enter the Ledger sheet (ledgerPending) — BLE connecting, not yet signing.
+      await parked.onApprove({ walletType: WalletType.LEDGER })
+      mockOnReject.mockClear()
+      mockDisconnect.mockClear()
+      mockSetReviewTransactionParams.mockClear()
+
+      controller.abort()
+      await flushMicrotasks()
+
+      expect(mockDisconnect).toHaveBeenCalled()
+      expect(mockSetReviewTransactionParams).toHaveBeenCalledWith(null)
+      expect(mockOnReject).toHaveBeenCalled()
+    })
+
+    it('is a no-op when aborted after on-device Ledger signing has started', async () => {
+      const controller = new AbortController()
+      const parked = park(controller.signal)
+      await parked.onApprove({ walletType: WalletType.LEDGER })
+      // Run the stored on-device onApprove → enters ledgerSigning (uncancellable).
+      const ledgerParams = mockSetReviewTransactionParams.mock.calls[0][0]
+      ledgerParams.onApprove()
+      mockOnReject.mockClear()
+      mockDisconnect.mockClear()
+
+      controller.abort()
+      await flushMicrotasks()
+
+      expect(mockOnReject).not.toHaveBeenCalled()
+      expect(mockDisconnect).not.toHaveBeenCalled()
+    })
+
+    it('does not bridge requests without a signal (WalletConnect / in-app)', () => {
+      const other = new AbortController()
+      setRequestSignal('some-other-id', other.signal)
+      park() // no signal registered for REQ_ID → no bridge
+      mockOnReject.mockClear()
+
+      other.abort()
+
+      expect(mockOnReject).not.toHaveBeenCalled()
+      clearRequestSignal('some-other-id')
+    })
+
+    it('cancels immediately and skips opening the modal if already aborted before parking', () => {
+      const controller = new AbortController()
+      controller.abort()
+      mockOnReject.mockClear()
+      mockRouter.navigate.mockClear()
+
+      park(controller.signal)
+
+      expect(mockOnReject).toHaveBeenCalled()
+      // No stale modal for a request that's already dead. (pre-park race)
+      expect(mockRouter.navigate).not.toHaveBeenCalled()
+    })
+
+    it('stays cancellable during a retryable Ledger error (BLE torn down if aborted then)', async () => {
+      mockDisconnect.mockResolvedValue(undefined)
+      const controller = new AbortController()
+      const parked = park(controller.signal)
+      await parked.onApprove({ walletType: WalletType.LEDGER }) // ledgerPending
+      const ledgerParams = mockSetReviewTransactionParams.mock.calls[0][0]
+      ledgerParams.onApprove() // on-device signing begins → ledgerSigning
+      // Device returns a retryable error → Retry/Cancel alert; phase must drop
+      // back to ledgerPending so a nav can still cancel + tear down BLE.
+      const onApproveArg =
+        mockOnApprove.mock.calls[mockOnApprove.mock.calls.length - 1][0]
+      onApproveArg.resolve({ error: { message: 'retryable' } })
+      mockOnReject.mockClear()
+      mockDisconnect.mockClear()
+
+      controller.abort()
+      await flushMicrotasks()
+
+      expect(mockDisconnect).toHaveBeenCalled()
+      expect(mockOnReject).toHaveBeenCalled()
+    })
+
+    it('bridges overlapping requests independently (aborting one does not clobber the other)', () => {
+      const cA = new AbortController()
+      const cB = new AbortController()
+      setRequestSignal('req-A', cA.signal)
+      approvalController.requestApproval({
+        request: makeRequest({ requestId: 'req-A', sessionId: 'core-mobile' }),
+        displayData,
+        signingData
+      })
+      setRequestSignal('req-B', cB.signal)
+      approvalController.requestApproval({
+        request: makeRequest({ requestId: 'req-B', sessionId: 'core-mobile' }),
+        displayData,
+        signingData
+      })
+      mockOnReject.mockClear()
+
+      cA.abort()
+      expect(mockOnReject).toHaveBeenCalledTimes(1)
+
+      mockOnReject.mockClear()
+      cB.abort() // would no-op if req-B's bridge had been clobbered by req-A
+      expect(mockOnReject).toHaveBeenCalledTimes(1)
+
+      clearRequestSignal('req-A')
+      clearRequestSignal('req-B')
     })
   })
 })

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -286,10 +286,16 @@ class ApprovalController implements VmModuleApprovalController {
 
   // Make room for an incoming entry without BoundedMap's silent FIFO eviction,
   // which would plain-delete the oldest and skip its detach()/settlement. Cancel
-  // the oldest parked approval instead so its abort listener + request signal are
-  // cleaned up and its promise is settled (rejected). A `ledgerSigning` oldest is
-  // left untouched by cancelParkedApproval (never cancel mid-device-signing); in
-  // that extraordinary case BoundedMap's own cap remains the backstop. (CP-14422)
+  // the oldest *cancellable* approval instead so its abort listener + request
+  // signal are cleaned up and its promise is settled (rejected).
+  //
+  // We must skip `ledgerSigning` entries: cancelParkedApproval no-ops on those
+  // (never cancel mid-device-signing), so picking one would leave the map full
+  // and let the subsequent set() fall through to BoundedMap's silent delete() —
+  // dropping the in-progress signing entry and leaking its listener/signal. With
+  // a single Ledger device at most one entry is ever ledgerSigning, so a
+  // cancellable victim effectively always exists; if somehow none does,
+  // BoundedMap's own cap remains the backstop. (CP-14422)
   private freeActiveApprovalCapacity(incomingKey: string): void {
     if (
       this.activeApprovals.has(incomingKey) ||
@@ -297,8 +303,12 @@ class ApprovalController implements VmModuleApprovalController {
     ) {
       return
     }
-    const oldestKey = this.activeApprovals.keys().next().value
-    if (oldestKey !== undefined) this.cancelParkedApproval(oldestKey)
+    for (const [key, entry] of this.activeApprovals) {
+      if (entry.phase !== 'ledgerSigning') {
+        this.cancelParkedApproval(key)
+        return
+      }
+    }
   }
 
   private setApprovalPhase(

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -220,6 +220,20 @@ class ApprovalController implements VmModuleApprovalController {
     onReject({ resolve })
   }
 
+  // True while any parked approval is mid on-device Ledger signing — the
+  // uncancellable window. `cancelParkedApproval` already no-ops in this phase so
+  // the signature completes; the cross-origin nav dismissal in `setCurrentUrl`
+  // checks this so it doesn't pop the `ledgerReviewTransaction` screen out from
+  // under a signature the user is still confirming on the device. Dismissals
+  // driven by the controller's own ledger lifecycle (completion / reject) call
+  // `handleGoBackIfNeeded` directly and are unaffected. (CP-14422)
+  isLedgerSigningInProgress = (): boolean => {
+    for (const entry of this.activeApprovals.values()) {
+      if (entry.phase === 'ledgerSigning') return true
+    }
+    return false
+  }
+
   handleGoBackIfNeeded = (): void => {
     const currentRoute = currentRouteStore.getState().currentRoute
     if (!router.canGoBack()) return

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -53,6 +53,11 @@ import {
   runRequestValidatorBypass
 } from './quickSwapsBypass'
 
+// Max concurrently-parked cancellable approvals. Entries are removed on every
+// normal settle (clearCancelBridge), so this is a defensive cap; eviction is
+// handled with full teardown via freeActiveApprovalCapacity. (CP-14422)
+const ACTIVE_APPROVALS_MAX = 10
+
 class ApprovalController implements VmModuleApprovalController {
   private userCancelledMap = new BoundedMap<string, boolean>(10)
   private signingAddressMap = new BoundedMap<string, string>(10)
@@ -73,7 +78,7 @@ class ApprovalController implements VmModuleApprovalController {
       phase: 'parked' | 'ledgerPending' | 'ledgerSigning'
       detach: () => void
     }
-  >(10)
+  >(ACTIVE_APPROVALS_MAX)
 
   async requestPublicKey({
     secretId,
@@ -248,6 +253,11 @@ class ApprovalController implements VmModuleApprovalController {
       signal.removeEventListener('abort', onAbort)
       clearRequestSignal(requestId)
     }
+    // Free a slot ourselves before inserting: BoundedMap would FIFO-evict the
+    // oldest via a plain delete() that skips detach() + promise settlement,
+    // leaking the abort listener + request signal and orphaning the parked
+    // promise. (CP-14422)
+    this.freeActiveApprovalCapacity(requestId)
     this.activeApprovals.set(requestId, { resolve, phase: 'parked', detach })
 
     // Aborted in the window between request creation and parking the modal:
@@ -258,6 +268,23 @@ class ApprovalController implements VmModuleApprovalController {
     }
     signal.addEventListener('abort', onAbort, { once: true })
     return false
+  }
+
+  // Make room for an incoming entry without BoundedMap's silent FIFO eviction,
+  // which would plain-delete the oldest and skip its detach()/settlement. Cancel
+  // the oldest parked approval instead so its abort listener + request signal are
+  // cleaned up and its promise is settled (rejected). A `ledgerSigning` oldest is
+  // left untouched by cancelParkedApproval (never cancel mid-device-signing); in
+  // that extraordinary case BoundedMap's own cap remains the backstop. (CP-14422)
+  private freeActiveApprovalCapacity(incomingKey: string): void {
+    if (
+      this.activeApprovals.has(incomingKey) ||
+      this.activeApprovals.size < ACTIVE_APPROVALS_MAX
+    ) {
+      return
+    }
+    const oldestKey = this.activeApprovals.keys().next().value
+    if (oldestKey !== undefined) this.cancelParkedApproval(oldestKey)
   }
 
   private setApprovalPhase(

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -210,14 +210,19 @@ class ApprovalController implements VmModuleApprovalController {
     }
   }
 
-  handleLedgerOnReject = async ({
+  handleLedgerOnReject = ({
     resolve
   }: {
     resolve: (value: ApprovalResponse | PromiseLike<ApprovalResponse>) => void
-  }): Promise<void> => {
-    ledgerParamsStore.getState().setReviewTransactionParams(null)
-    await LedgerService.disconnect().catch()
+  }): void => {
+    // Settle the request promise FIRST so a slow or hung BLE disconnect can't
+    // delay the rejection — the cross-origin abort path exists to settle
+    // orphaned promises promptly, and no caller needs the Ledger torn down
+    // before the reject. Clear the review store and disconnect BLE
+    // fire-and-forget. (CP-14422)
     onReject({ resolve })
+    ledgerParamsStore.getState().setReviewTransactionParams(null)
+    LedgerService.disconnect().catch(() => undefined)
   }
 
   // True while any parked approval is mid on-device Ledger signing — the
@@ -234,12 +239,18 @@ class ApprovalController implements VmModuleApprovalController {
     return false
   }
 
-  handleGoBackIfNeeded = (): void => {
+  // `excludeApproval` skips the `approval` route: the approval screen now
+  // dismisses itself (event-driven on its request's AbortSignal) when a
+  // cross-origin nav cancels it, so the nav-path caller must NOT also pop it or
+  // the two race into a double `router.back()`. The controller's own ledger
+  // settle paths still pass no option, so they dismiss `approval` as before.
+  // (CP-14422)
+  handleGoBackIfNeeded = (options?: { excludeApproval?: boolean }): void => {
     const currentRoute = currentRouteStore.getState().currentRoute
     if (!router.canGoBack()) return
     if (
       currentRoute?.endsWith('ledgerReviewTransaction') ||
-      currentRoute?.endsWith('approval') ||
+      (!options?.excludeApproval && currentRoute?.endsWith('approval')) ||
       currentRoute?.endsWith('addEthereumChain') ||
       currentRoute?.endsWith('authorizeInjectedDapp') ||
       currentRoute?.endsWith('authorizeDapp') ||

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -435,7 +435,19 @@ class ApprovalController implements VmModuleApprovalController {
       onApprove: () => {
         // On-device signing begins — uncancellable from here. (CP-14422)
         this.setApprovalPhase(requestId, 'ledgerSigning')
-        return onApprove({ ...params, signingData, resolve: resolveWithRetry })
+        // Defensive: a signing handler that rejects WITHOUT ever calling resolve
+        // would otherwise strand this entry in `ledgerSigning` — wedging
+        // isLedgerSigningInProgress() so cross-origin dismissal silently dies
+        // app-wide. Drop back to `ledgerPending` on such a throw so a nav can
+        // still cancel + tear down (and re-throw to preserve the UI's existing
+        // error handling). Promise.resolve wraps the (mockable) call so a
+        // non-promise return is handled too. (CP-14422)
+        return Promise.resolve(
+          onApprove({ ...params, signingData, resolve: resolveWithRetry })
+        ).catch(error => {
+          this.setApprovalPhase(requestId, 'ledgerPending')
+          throw error
+        })
       },
       onReject: (_message?: string) => {
         this.userCancelledMap.set(requestId, true)
@@ -506,6 +518,16 @@ class ApprovalController implements VmModuleApprovalController {
     })
 
     return new Promise<ApprovalResponse>(resolve => {
+      // Settle (and clean up Ledger BLE) if this request is cancelled by a
+      // cross-origin nav while the modal is parked. No-op for non-browser
+      // requests (they register no AbortSignal). If the request was already
+      // aborted before we got here (nav landed in the pre-park window), it's
+      // cancelled synchronously via the resolve we hand it — return BEFORE
+      // caching params or navigating, so we neither open a stale modal nor leave
+      // the parked callbacks (incl. this resolve closure) + request data sitting
+      // in the single-slot cache with nothing to consume/clear them. (CP-14422)
+      if (this.registerCancelBridge(requestId, resolve)) return
+
       walletConnectCache.approvalParams.set({
         request,
         displayData: enrichedDisplayData,
@@ -523,14 +545,6 @@ class ApprovalController implements VmModuleApprovalController {
           onReject({ resolve, message })
         }
       })
-
-      // Settle (and clean up Ledger BLE) if this request is cancelled by a
-      // cross-origin nav while the modal is parked. No-op for non-browser
-      // requests (they register no AbortSignal). If the request was already
-      // aborted before we got here (nav landed in the pre-park window), it's
-      // cancelled synchronously — don't open a modal that's already stale.
-      // (CP-14422)
-      if (this.registerCancelBridge(requestId, resolve)) return
 
       router.navigate({
         pathname: '/approval',

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -13,6 +13,10 @@ import { walletConnectCache } from 'services/walletconnectv2/walletConnectCache/
 import { transactionSnackbar } from 'new/common/utils/toast'
 import { isInAppRequest } from 'store/rpc/utils/isInAppRequest'
 import {
+  clearRequestSignal,
+  getRequestSignal
+} from 'store/rpc/utils/inFlightRequestSignals'
+import {
   isTxSendMethod,
   TxSendConfirmedEvent,
   TxSendFailedEvent
@@ -57,6 +61,19 @@ class ApprovalController implements VmModuleApprovalController {
   // so the two handlers can never disagree (e.g. if the upstream InfoAPI
   // cache expired or a refetch errored between the two callbacks).
   private optimisticGateMap = new BoundedMap<string, boolean>(20)
+
+  // Parked approvals a cross-origin browser nav can cancel, keyed by requestId
+  // (CP-14422). Keyed (not single-slot) so overlapping browser signing requests
+  // each keep their own cancel bridge. `phase` gates the uncancellable window:
+  // once Ledger on-device signing has begun, a nav must not cancel.
+  private activeApprovals = new BoundedMap<
+    string,
+    {
+      resolve: (value: ApprovalResponse | PromiseLike<ApprovalResponse>) => void
+      phase: 'parked' | 'ledgerPending' | 'ledgerSigning'
+      detach: () => void
+    }
+  >(10)
 
   async requestPublicKey({
     secretId,
@@ -213,6 +230,75 @@ class ApprovalController implements VmModuleApprovalController {
     }
   }
 
+  // Bridge a parked approval to its request's AbortSignal so a cross-origin
+  // browser nav (which aborts the request) settles the otherwise-orphaned
+  // approval promise. Only browser signing requests register a signal, so WC /
+  // signal-less in-app approvals are not affected. Returns true if the request
+  // was already aborted and cancelled synchronously, so the caller skips
+  // navigating to a modal that would immediately be stale. (CP-14422)
+  private registerCancelBridge(
+    requestId: string,
+    resolve: (value: ApprovalResponse | PromiseLike<ApprovalResponse>) => void
+  ): boolean {
+    const signal = getRequestSignal(requestId)
+    if (!signal) return false
+
+    const onAbort = (): void => this.cancelParkedApproval(requestId)
+    const detach = (): void => {
+      signal.removeEventListener('abort', onAbort)
+      clearRequestSignal(requestId)
+    }
+    this.activeApprovals.set(requestId, { resolve, phase: 'parked', detach })
+
+    // Aborted in the window between request creation and parking the modal:
+    // cancel now and tell the caller not to open the modal.
+    if (signal.aborted) {
+      this.cancelParkedApproval(requestId)
+      return true
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+    return false
+  }
+
+  private setApprovalPhase(
+    requestId: string,
+    phase: 'parked' | 'ledgerPending' | 'ledgerSigning'
+  ): void {
+    const entry = this.activeApprovals.get(requestId)
+    if (entry) entry.phase = phase
+  }
+
+  private clearCancelBridge(requestId: string): void {
+    const entry = this.activeApprovals.get(requestId)
+    if (!entry) return
+    entry.detach()
+    this.activeApprovals.delete(requestId)
+  }
+
+  // Cancel a parked approval whose request was aborted. Runs the REAL reject so
+  // the orphaned promise settles and Ledger BLE + store are torn down; once
+  // on-device Ledger signing has begun (`ledgerSigning`) the cancel is a no-op.
+  //
+  // Screen DISMISSAL is intentionally NOT done here: the caller
+  // (setCurrentUrl's cross-origin branch) already calls `handleGoBackIfNeeded`
+  // — the generic dismissal for every modal type — right after aborting. Since
+  // the abort fires this synchronously, dismissing here too would double
+  // `router.back()`. Settlement and dismissal stay separate. (CP-14422)
+  private cancelParkedApproval(requestId: string): void {
+    const entry = this.activeApprovals.get(requestId)
+    if (!entry || entry.phase === 'ledgerSigning') return
+
+    // Mark cancelled so a late Approve tap can't sign/broadcast (guarded in the
+    // cache `onApprove`) and Ledger retry alerts stay suppressed.
+    this.userCancelledMap.set(requestId, true)
+    if (entry.phase === 'ledgerPending') {
+      this.handleLedgerOnReject({ resolve: entry.resolve })
+    } else {
+      onReject({ resolve: entry.resolve })
+    }
+    this.clearCancelBridge(requestId)
+  }
+
   private cacheSigningAddress(
     requestId: string,
     chainId: string,
@@ -237,6 +323,10 @@ class ApprovalController implements VmModuleApprovalController {
     signingData: ApprovalParams['signingData']
     resolve: (value: ApprovalResponse | PromiseLike<ApprovalResponse>) => void
   }): void {
+    // Ledger sheet is up: still cancellable (BLE connecting), until on-device
+    // signing actually begins below. (CP-14422)
+    this.setApprovalPhase(requestId, 'ledgerPending')
+
     const resolveWithRetry = (
       value: ApprovalResponse | PromiseLike<ApprovalResponse>
     ): void => {
@@ -246,6 +336,12 @@ class ApprovalController implements VmModuleApprovalController {
           this.userCancelledMap.delete(requestId)
           return
         }
+
+        // On-device signing failed but is retryable; while the Retry/Cancel
+        // alert is up we're waiting on the user again, so a cross-origin nav
+        // must be able to cancel (tear down BLE + settle) — drop back out of
+        // the uncancellable `ledgerSigning` phase. (CP-14422)
+        this.setApprovalPhase(requestId, 'ledgerPending')
 
         handleLedgerErrorAndShowAlert({
           error: value.error,
@@ -258,6 +354,8 @@ class ApprovalController implements VmModuleApprovalController {
               this.userCancelledMap.delete(requestId)
               return
             }
+            // Retrying restarts on-device signing — uncancellable again.
+            this.setApprovalPhase(requestId, 'ledgerSigning')
             onApprove({
               ...params,
               signingData,
@@ -268,6 +366,7 @@ class ApprovalController implements VmModuleApprovalController {
             this.userCancelledMap.set(requestId, true)
             this.handleGoBackIfNeeded()
             this.handleLedgerOnReject({ resolve })
+            this.clearCancelBridge(requestId)
           }
         })
       } else {
@@ -275,24 +374,64 @@ class ApprovalController implements VmModuleApprovalController {
         ledgerParamsStore.getState().setReviewTransactionParams(null)
         this.handleGoBackIfNeeded()
         this.userCancelledMap.delete(requestId)
+        this.clearCancelBridge(requestId)
       }
     }
 
     ledgerParamsStore.getState().setReviewTransactionParams({
       rpcMethod: request.method,
       network: params.network,
-      onApprove: () =>
-        onApprove({
-          ...params,
-          signingData,
-          resolve: resolveWithRetry
-        }),
+      onApprove: () => {
+        // On-device signing begins — uncancellable from here. (CP-14422)
+        this.setApprovalPhase(requestId, 'ledgerSigning')
+        return onApprove({ ...params, signingData, resolve: resolveWithRetry })
+      },
       onReject: (_message?: string) => {
         this.userCancelledMap.set(requestId, true)
         this.handleLedgerOnReject({ resolve })
         this.handleGoBackIfNeeded()
+        this.clearCancelBridge(requestId)
       }
     })
+  }
+
+  private async handleApprovalApprove({
+    requestId,
+    request,
+    signingData,
+    resolve,
+    params
+  }: {
+    requestId: string
+    request: ApprovalParams['request']
+    signingData: ApprovalParams['signingData']
+    resolve: (value: ApprovalResponse | PromiseLike<ApprovalResponse>) => void
+    params: OnApproveParams
+  }): Promise<void> {
+    // A cross-origin nav may have cancelled this request while the modal was
+    // up; a late Approve tap must not sign/broadcast. (CP-14422)
+    if (this.userCancelledMap.get(requestId)) return
+
+    if (!isInAppRequest(request) && isTxSendMethod(request.method)) {
+      this.cacheSigningAddress(requestId, request.chainId, params.account)
+    }
+
+    if (
+      params.walletType === WalletType.LEDGER ||
+      params.walletType === WalletType.LEDGER_LIVE
+    ) {
+      this.handleLedgerApproval({
+        requestId,
+        request,
+        params,
+        signingData,
+        resolve
+      })
+    } else {
+      // Standard signing starts now — past the cancellable window.
+      this.clearCancelBridge(requestId)
+      await onApprove({ ...params, resolve, signingData })
+    }
   }
 
   async requestApproval(params: ApprovalParams): Promise<ApprovalResponse> {
@@ -320,28 +459,27 @@ class ApprovalController implements VmModuleApprovalController {
         request,
         displayData: enrichedDisplayData,
         signingData,
-        onApprove: async (params: OnApproveParams) => {
-          if (!isInAppRequest(request) && isTxSendMethod(request.method)) {
-            this.cacheSigningAddress(requestId, request.chainId, params.account)
-          }
-
-          if (
-            params.walletType === WalletType.LEDGER ||
-            params.walletType === WalletType.LEDGER_LIVE
-          ) {
-            this.handleLedgerApproval({
-              requestId,
-              request,
-              params,
-              signingData,
-              resolve
-            })
-          } else {
-            return onApprove({ ...params, resolve, signingData })
-          }
-        },
-        onReject: (message?: string) => onReject({ resolve, message })
+        onApprove: (approveParams: OnApproveParams) =>
+          this.handleApprovalApprove({
+            requestId,
+            request,
+            signingData,
+            resolve,
+            params: approveParams
+          }),
+        onReject: (message?: string) => {
+          this.clearCancelBridge(requestId)
+          onReject({ resolve, message })
+        }
       })
+
+      // Settle (and clean up Ledger BLE) if this request is cancelled by a
+      // cross-origin nav while the modal is parked. No-op for non-browser
+      // requests (they register no AbortSignal). If the request was already
+      // aborted before we got here (nav landed in the pre-park window), it's
+      // cancelled synchronously — don't open a modal that's already stale.
+      // (CP-14422)
+      if (this.registerCancelBridge(requestId, resolve)) return
 
       router.navigate({
         pathname: '/approval',

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -532,6 +532,10 @@ class ApprovalController implements VmModuleApprovalController {
         request,
         displayData: enrichedDisplayData,
         signingData,
+        // Hand the screen the request's signal so it can self-dismiss on mount
+        // if a cross-origin nav already cancelled it (the generic pop can race
+        // the mount and miss). Undefined for non-browser requests. (CP-14422)
+        signal: getRequestSignal(requestId),
         onApprove: (approveParams: OnApproveParams) =>
           this.handleApprovalApprove({
             requestId,


### PR DESCRIPTION
## Description

**Ticket: [CP-14422](https://ava-labs.atlassian.net/browse/CP-14422)**

Request-aware cancellation for the injected-provider approval flow. Follow-up from the #3867 review (An).

- **Summary of changes**
  - When a programmatic cross-origin navigation aborts an in-flight injected signing request while its approval modal is parked, the wallet-side `requestApproval` promise is now **settled** (via the real `onReject`) instead of being orphaned, and any Ledger session is **torn down** (`handleLedgerOnReject` → `LedgerService.disconnect()` + clears `ledgerParamsStore`).
  - Reuses the cancellation that already fires on nav (`router.cancelByOrigin` → the request's `AbortSignal`) rather than adding a new mechanism. A leaf side-channel (`inFlightRequestSignals`) exposes the signal to `ApprovalController` without a `store` ↔ `vmModule` import cycle.
  - **Scoped to the browser:** only injected signing requests register a signal, so WalletConnect and in-app approvals are untouched.
  - **Uncancellable window respected:** once on-device Ledger signing has begun, a nav cannot cancel (and the window correctly re-opens if the device returns a retryable error).
  - **Late-tap guarded:** an Approve tap that lands after cancellation can't sign/broadcast.
  - Screen dismissal is unchanged — it stays with `setCurrentUrl`'s existing `handleGoBackIfNeeded` (settlement and dismissal are kept separate to avoid a double `router.back()`).
  - **Pre-registration race closed:** a cross-origin nav that lands *before* a signing request registers its in-flight `AbortController` (the `0`-delay harness case) was previously missed — `cancelByOrigin` is edge-triggered and only aborts already-registered requests, so the late registration parked an uncancellable sheet and hung. The router now tracks the live origin and aborts such a late registration on arrival, so it rejects (`userRejectedRequest`) without opening a sheet.

- **Motivation and context**
  - Previously, a self-navigating (hostile) page could leave the parked VM-module approval promise hanging (a leak retaining its closure) and, for Ledger, a live BLE connection + stale store. The dApp already received `userRejectedRequest`, so this is robustness/cleanup, not a security fix. The connect flow already handled this via its parked-promise reject; this generalizes it to VM-module signing + Ledger.

- **Dependencies introduced:** none.

- **Breaking changes / migration:** none.

## Screenshots/Videos

N/A — store/controller logic, no UI changes.

## Testing

**This is only reproducible with a local build + a purpose-built test page.** The change only fires in an adversarial scenario — a page that programmatically navigates itself to a *different origin* while a signing approval sheet is parked. No normal dApp does this, and you can't tap fast enough to race a real navigation by hand, so a self-navigating harness page is required. (The dApp already receives `userRejectedRequest` today; this PR is the wallet-side leak/BLE cleanup, not user-facing behavior — so this is mainly QA confidence on top of the unit suite.)

**Dev Testing (local only)**

1. Run a local build (`yarn core ios` / `yarn core android`) against Metro.
2. Save the harness below as `cancel-bridge-harness.html` and serve it on its own origin, reachable from the device/simulator:
   ```bash
   npx serve -l 5050 .   # then open http://<your-LAN-IP>:5050 in the in-app browser
   ```
3. In the in-app browser, open that URL → tap **Connect** → tap **Sign**, then **leave the approval sheet alone**.
4. At ~3s the page navigates itself to a different origin (`example.com`). **Expected:** the on-page log shows `rejected as expected: ...` (not `SIGNED`) and no request is left hanging; if a sheet was up, it dismisses. The **settlement (reject, no `SIGNED`, no hang)** is what this change guarantees, regardless of timing. With a tiny/`0` delay, whether a sheet briefly appears is a race: register-before-nav → it opens then cancels; register-after-nav → it's born-aborted and no sheet opens. Either way it must **reject** — "modal never opens" is not a required outcome. (If at `0` delay a sheet *opens and lingers* even though the request rejected, that's the separate dismissal-timing follow-up — the cross-origin pop racing the sheet mount — not the settlement this PR covers.)
5. **WalletConnect / in-app unaffected:** do a normal WC sign or in-app send and navigate the browser around — nothing should cancel (those register no `AbortSignal`).
6. **Ledger (hardware smoke test):** open the approval, connect the Ledger (sheet shows `ledgerPending`), then let the page navigate **before** tapping the device → BLE tears down and the request settles. Once you've started signing on-device, a nav must NOT interrupt it. The `ledgerPending` / `ledgerSigning` / retryable-error matrix is fully covered by the unit tests, so manual Ledger checking can stay a light smoke test.

<details>
<summary><code>cancel-bridge-harness.html</code></summary>

```html
<!doctype html>
<html>
<head>
  <meta name="viewport" content="width=device-width, initial-scale=1" />
  <title>CP-14422 cancel-bridge harness</title>
</head>
<body>
  <h2>CP-14422 cancel-bridge harness</h2>
  <button id="connect">1. Connect</button>
  <button id="sign">2. Sign + self-navigate</button>
  <pre id="log"></pre>
  <script>
    const log = m => (document.getElementById('log').textContent += m + '\n')
    const eth = window.ethereum

    document.getElementById('connect').onclick = async () => {
      const a = await eth.request({ method: 'eth_requestAccounts' })
      log('connected ' + a[0])
    }

    document.getElementById('sign').onclick = async () => {
      const [from] = await eth.request({ method: 'eth_accounts' })
      // Fire a cross-origin nav while the approval sheet is parked.
      // Bump the delay if your sheet is slow to appear. A tiny/0 delay races
      // the nav against the request: it may be born-aborted (no sheet) or
      // open-then-cancel — either way it must reject, not hang.
      setTimeout(() => {
        log('navigating cross-origin...')
        location.replace('https://example.com/')
      }, 3000)
      log('requesting personal_sign — sheet should appear, do NOT tap')
      try {
        const sig = await eth.request({
          method: 'personal_sign',
          params: ['0x68656c6c6f', from]
        })
        log('SIGNED (unexpected): ' + sig) // <-- a bug if you see this
      } catch (e) {
        log('rejected as expected: ' + (e && e.message)) // <-- expected
      }
    }
  </script>
</body>
</html>
```

</details>

**QA Testing**

Acceptance criteria:

- A cross-origin nav while a signing approval is up settles the request and dismisses the sheet (no hung request).
- Ledger BLE is disconnected and its review store cleared on such a cancel.
- On-device Ledger signing, once started, is not interrupted by navigation.
- WalletConnect / in-app approvals are not cancelled by browser navigation.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios (N/A — no UI)
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation (N/A)


[CP-14422]: https://ava-labs.atlassian.net/browse/CP-14422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


