### PR TITLE
CP-13825: fire dApp-transaction (MTU) analytics for the injected provider

### DIFF
--- a/packages/core-mobile/app/store/rpc/providers/coreMobile.test.ts
+++ b/packages/core-mobile/app/store/rpc/providers/coreMobile.test.ts
@@ -24,22 +24,27 @@ const mockListenerApi = {
   getState: jest.fn().mockReturnValue({})
 } as unknown as AppListenerEffectAPI
 
+const DEFAULT_PEER_META: PeerMeta = {
+  name: 'Test Dapp',
+  description: 'Test dapp',
+  url: 'https://test.dapp.com',
+  icons: []
+}
+
 const makeMockRequest = (
   method: RpcMethod,
   chainId: string,
-  peerMeta: PeerMeta = {
-    name: 'Test Dapp',
-    description: 'Test dapp',
-    url: 'https://test.dapp.com',
-    icons: []
-  }
+  {
+    peerMeta = DEFAULT_PEER_META,
+    params = {}
+  }: { peerMeta?: PeerMeta; params?: unknown } = {}
 ): Parameters<typeof coreMobileProvider.onSuccess>[0]['request'] => ({
   method,
   data: {
     id: 1,
     topic: 'core-mobile-topic',
     params: {
-      request: { method, params: {} },
+      request: { method, params },
       chainId
     }
   },
@@ -74,6 +79,49 @@ describe('coreMobileProvider', () => {
             chainId: 'eip155:1',
             txHash: '0xdeadbeef'
           }
+        }
+      )
+    })
+
+    it('uses the tx `from` as the address, not the active account (granted non-active signer)', async () => {
+      const NON_ACTIVE_FROM = '0xAAAA000000000000000000000000000000000001'
+      const request = makeMockRequest(
+        RpcMethod.ETH_SEND_TRANSACTION,
+        'eip155:1',
+        { params: [{ from: NON_ACTIVE_FROM, to: '0xbbbb', value: '0x0' }] }
+      )
+
+      await coreMobileProvider.onSuccess({
+        request,
+        result: '0xdeadbeef',
+        listenerApi: mockListenerApi
+      })
+
+      expect(AnalyticsService.capture).toHaveBeenCalledWith(
+        'eth_sendTransaction_success',
+        { encrypted: expect.objectContaining({ address: NON_ACTIVE_FROM }) }
+      )
+    })
+
+    it('falls back to the active account when the tx `from` is missing', async () => {
+      const request = makeMockRequest(
+        RpcMethod.ETH_SEND_TRANSACTION,
+        'eip155:1',
+        { params: [{ to: '0xbbbb', value: '0x0' }] }
+      )
+
+      await coreMobileProvider.onSuccess({
+        request,
+        result: '0xdeadbeef',
+        listenerApi: mockListenerApi
+      })
+
+      expect(AnalyticsService.capture).toHaveBeenCalledWith(
+        'eth_sendTransaction_success',
+        {
+          encrypted: expect.objectContaining({
+            address: mockActiveAccount.addressC
+          })
         }
       )
     })
@@ -118,7 +166,7 @@ describe('coreMobileProvider', () => {
       const request = makeMockRequest(
         RpcMethod.ETH_SEND_TRANSACTION,
         'eip155:1',
-        CORE_MOBILE_META
+        { peerMeta: CORE_MOBILE_META }
       )
 
       await coreMobileProvider.onSuccess({
@@ -134,7 +182,14 @@ describe('coreMobileProvider', () => {
       const request = makeMockRequest(
         RpcMethod.ETH_SEND_TRANSACTION,
         'eip155:1',
-        { name: 'Unknown site', description: '', url: '', icons: [] }
+        {
+          peerMeta: {
+            name: 'Unknown site',
+            description: '',
+            url: '',
+            icons: []
+          }
+        }
       )
 
       await coreMobileProvider.onSuccess({
@@ -175,11 +230,9 @@ describe('coreMobileProvider', () => {
 
     it('still dispatches onInAppRequestSucceeded regardless of analytics', async () => {
       await coreMobileProvider.onSuccess({
-        request: makeMockRequest(
-          RpcMethod.ETH_SEND_TRANSACTION,
-          'eip155:1',
-          CORE_MOBILE_META
-        ),
+        request: makeMockRequest(RpcMethod.ETH_SEND_TRANSACTION, 'eip155:1', {
+          peerMeta: CORE_MOBILE_META
+        }),
         result: '0xdeadbeef',
         listenerApi: mockListenerApi
       })

--- a/packages/core-mobile/app/store/rpc/providers/coreMobile.test.ts
+++ b/packages/core-mobile/app/store/rpc/providers/coreMobile.test.ts
@@ -73,6 +73,7 @@ describe('coreMobileProvider', () => {
       expect(AnalyticsService.capture).toHaveBeenCalledWith(
         'eth_sendTransaction_success',
         {
+          provider: 'injected',
           encrypted: {
             dAppUrl: 'https://test.dapp.com',
             // EVM address is lowercased to a canonical form (CP-13825)
@@ -103,6 +104,7 @@ describe('coreMobileProvider', () => {
       expect(AnalyticsService.capture).toHaveBeenCalledWith(
         'eth_sendTransaction_success',
         {
+          provider: 'injected',
           encrypted: expect.objectContaining({
             address: NON_ACTIVE_FROM.toLowerCase()
           })
@@ -126,6 +128,7 @@ describe('coreMobileProvider', () => {
       expect(AnalyticsService.capture).toHaveBeenCalledWith(
         'eth_sendTransaction_success',
         {
+          provider: 'injected',
           encrypted: expect.objectContaining({
             address: mockActiveAccount.addressC.toLowerCase()
           })
@@ -145,6 +148,7 @@ describe('coreMobileProvider', () => {
       expect(AnalyticsService.capture).toHaveBeenCalledWith(
         'avalanche_sendTransaction_success',
         {
+          provider: 'injected',
           encrypted: expect.objectContaining({
             address: mockActiveAccount.addressPVM
           })
@@ -162,6 +166,7 @@ describe('coreMobileProvider', () => {
       expect(AnalyticsService.capture).toHaveBeenCalledWith(
         'bitcoin_sendTransaction_success',
         {
+          provider: 'injected',
           encrypted: expect.objectContaining({
             address: mockActiveAccount.addressBTC
           })

--- a/packages/core-mobile/app/store/rpc/providers/coreMobile.test.ts
+++ b/packages/core-mobile/app/store/rpc/providers/coreMobile.test.ts
@@ -75,7 +75,8 @@ describe('coreMobileProvider', () => {
         {
           encrypted: {
             dAppUrl: 'https://test.dapp.com',
-            address: mockActiveAccount.addressC,
+            // EVM address is lowercased to a canonical form (CP-13825)
+            address: mockActiveAccount.addressC.toLowerCase(),
             chainId: 'eip155:1',
             txHash: '0xdeadbeef'
           }
@@ -83,7 +84,7 @@ describe('coreMobileProvider', () => {
       )
     })
 
-    it('uses the tx `from` as the address, not the active account (granted non-active signer)', async () => {
+    it('uses the tx `from` (lowercased) as the address, not the active account (granted non-active signer)', async () => {
       const NON_ACTIVE_FROM = '0xAAAA000000000000000000000000000000000001'
       const request = makeMockRequest(
         RpcMethod.ETH_SEND_TRANSACTION,
@@ -97,9 +98,15 @@ describe('coreMobileProvider', () => {
         listenerApi: mockListenerApi
       })
 
+      // The dApp-supplied `from` is normalized to lowercase so it matches the
+      // casing of the _confirmed / _failed signer address (CP-13825).
       expect(AnalyticsService.capture).toHaveBeenCalledWith(
         'eth_sendTransaction_success',
-        { encrypted: expect.objectContaining({ address: NON_ACTIVE_FROM }) }
+        {
+          encrypted: expect.objectContaining({
+            address: NON_ACTIVE_FROM.toLowerCase()
+          })
+        }
       )
     })
 
@@ -120,7 +127,7 @@ describe('coreMobileProvider', () => {
         'eth_sendTransaction_success',
         {
           encrypted: expect.objectContaining({
-            address: mockActiveAccount.addressC
+            address: mockActiveAccount.addressC.toLowerCase()
           })
         }
       )

--- a/packages/core-mobile/app/store/rpc/providers/coreMobile.test.ts
+++ b/packages/core-mobile/app/store/rpc/providers/coreMobile.test.ts
@@ -1,0 +1,194 @@
+import AnalyticsService from 'services/analytics/AnalyticsService'
+import {
+  AvalancheCaip2ChainId,
+  BitcoinCaip2ChainId
+} from '@avalabs/core-chains-sdk'
+import mockAccounts from 'tests/fixtures/accounts.json'
+import { AppListenerEffectAPI } from 'store/types'
+import { CORE_MOBILE_META, PeerMeta, RpcMethod, RpcProvider } from '../types'
+import { coreMobileProvider } from './coreMobile'
+
+jest.mock('services/analytics/AnalyticsService')
+
+const mockActiveAccount = mockAccounts[0]
+jest.mock('store/account/slice', () => {
+  const actual = jest.requireActual('store/account/slice')
+  return {
+    ...actual,
+    selectActiveAccount: () => mockActiveAccount
+  }
+})
+
+const mockListenerApi = {
+  dispatch: jest.fn(),
+  getState: jest.fn().mockReturnValue({})
+} as unknown as AppListenerEffectAPI
+
+const makeMockRequest = (
+  method: RpcMethod,
+  chainId: string,
+  peerMeta: PeerMeta = {
+    name: 'Test Dapp',
+    description: 'Test dapp',
+    url: 'https://test.dapp.com',
+    icons: []
+  }
+): Parameters<typeof coreMobileProvider.onSuccess>[0]['request'] => ({
+  method,
+  data: {
+    id: 1,
+    topic: 'core-mobile-topic',
+    params: {
+      request: { method, params: {} },
+      chainId
+    }
+  },
+  peerMeta,
+  provider: RpcProvider.CORE_MOBILE
+})
+
+describe('coreMobileProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('onSuccess — MTU analytics (CP-13825)', () => {
+    it('fires eth_sendTransaction_success for an injected dApp request', async () => {
+      const request = makeMockRequest(
+        RpcMethod.ETH_SEND_TRANSACTION,
+        'eip155:1'
+      )
+
+      await coreMobileProvider.onSuccess({
+        request,
+        result: '0xdeadbeef',
+        listenerApi: mockListenerApi
+      })
+
+      expect(AnalyticsService.capture).toHaveBeenCalledWith(
+        'eth_sendTransaction_success',
+        {
+          encrypted: {
+            dAppUrl: 'https://test.dapp.com',
+            address: mockActiveAccount.addressC,
+            chainId: 'eip155:1',
+            txHash: '0xdeadbeef'
+          }
+        }
+      )
+    })
+
+    it('resolves the correct address per chain', async () => {
+      await coreMobileProvider.onSuccess({
+        request: makeMockRequest(
+          RpcMethod.AVALANCHE_SEND_TRANSACTION,
+          AvalancheCaip2ChainId.P
+        ),
+        result: '0xpchain',
+        listenerApi: mockListenerApi
+      })
+      expect(AnalyticsService.capture).toHaveBeenCalledWith(
+        'avalanche_sendTransaction_success',
+        {
+          encrypted: expect.objectContaining({
+            address: mockActiveAccount.addressPVM
+          })
+        }
+      )
+
+      await coreMobileProvider.onSuccess({
+        request: makeMockRequest(
+          RpcMethod.BITCOIN_SEND_TRANSACTION,
+          BitcoinCaip2ChainId.MAINNET
+        ),
+        result: 'btchash',
+        listenerApi: mockListenerApi
+      })
+      expect(AnalyticsService.capture).toHaveBeenCalledWith(
+        'bitcoin_sendTransaction_success',
+        {
+          encrypted: expect.objectContaining({
+            address: mockActiveAccount.addressBTC
+          })
+        }
+      )
+    })
+
+    it('does NOT fire for a wallet-internal request (CORE_MOBILE_META)', async () => {
+      const request = makeMockRequest(
+        RpcMethod.ETH_SEND_TRANSACTION,
+        'eip155:1',
+        CORE_MOBILE_META
+      )
+
+      await coreMobileProvider.onSuccess({
+        request,
+        result: '0xdeadbeef',
+        listenerApi: mockListenerApi
+      })
+
+      expect(AnalyticsService.capture).not.toHaveBeenCalled()
+    })
+
+    it('does NOT fire for an empty-url peerMeta (getPeerMeta placeholder)', async () => {
+      const request = makeMockRequest(
+        RpcMethod.ETH_SEND_TRANSACTION,
+        'eip155:1',
+        { name: 'Unknown site', description: '', url: '', icons: [] }
+      )
+
+      await coreMobileProvider.onSuccess({
+        request,
+        result: '0xdeadbeef',
+        listenerApi: mockListenerApi
+      })
+
+      expect(AnalyticsService.capture).not.toHaveBeenCalled()
+    })
+
+    it('does NOT fire for a non-tx-send method', async () => {
+      const request = makeMockRequest(RpcMethod.ETH_SIGN, 'eip155:1')
+
+      await coreMobileProvider.onSuccess({
+        request,
+        result: '0xsignature',
+        listenerApi: mockListenerApi
+      })
+
+      expect(AnalyticsService.capture).not.toHaveBeenCalled()
+    })
+
+    it('does NOT fire when the result is not a non-empty string (no txHash)', async () => {
+      await coreMobileProvider.onSuccess({
+        request: makeMockRequest(RpcMethod.ETH_SEND_TRANSACTION, 'eip155:1'),
+        result: '',
+        listenerApi: mockListenerApi
+      })
+      await coreMobileProvider.onSuccess({
+        request: makeMockRequest(RpcMethod.ETH_SEND_TRANSACTION, 'eip155:1'),
+        result: undefined,
+        listenerApi: mockListenerApi
+      })
+
+      expect(AnalyticsService.capture).not.toHaveBeenCalled()
+    })
+
+    it('still dispatches onInAppRequestSucceeded regardless of analytics', async () => {
+      await coreMobileProvider.onSuccess({
+        request: makeMockRequest(
+          RpcMethod.ETH_SEND_TRANSACTION,
+          'eip155:1',
+          CORE_MOBILE_META
+        ),
+        result: '0xdeadbeef',
+        listenerApi: mockListenerApi
+      })
+
+      expect(mockListenerApi.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: { requestId: 1, txHash: '0xdeadbeef' }
+        })
+      )
+    })
+  })
+})

--- a/packages/core-mobile/app/store/rpc/providers/coreMobile.ts
+++ b/packages/core-mobile/app/store/rpc/providers/coreMobile.ts
@@ -71,6 +71,7 @@ class CoreMobileProvider implements AgnosticRpcProvider {
           (account ? getAddressForChainId(chainId, account) ?? '' : '')
       )
       AnalyticsService.capture(`${request.method}_success`, {
+        provider: 'injected',
         encrypted: {
           dAppUrl: request.peerMeta.url,
           address,

--- a/packages/core-mobile/app/store/rpc/providers/coreMobile.ts
+++ b/packages/core-mobile/app/store/rpc/providers/coreMobile.ts
@@ -5,6 +5,7 @@ import { onInAppRequestFailed, onInAppRequestSucceeded } from '../slice'
 import { AgnosticRpcProvider, RpcMethod, RpcProvider } from '../types'
 import { isTxSendMethod } from '../utils/txSendMethods'
 import { isDappOriginatedUrl } from '../utils/isDappOriginatedRequest'
+import { normalizeAnalyticsAddress } from '../utils/normalizeAnalyticsAddress'
 import { isSessionProposal } from './walletConnect/utils'
 
 // For eth_sendTransaction the dApp names the signer via the tx `from`, which the
@@ -65,9 +66,10 @@ class CoreMobileProvider implements AgnosticRpcProvider {
         request.data.params.request.params
       )
       const account = selectActiveAccount(listenerApi.getState())
-      const address =
+      const address = normalizeAnalyticsAddress(
         fromAddress ??
-        (account ? getAddressForChainId(chainId, account) ?? '' : '')
+          (account ? getAddressForChainId(chainId, account) ?? '' : '')
+      )
       AnalyticsService.capture(`${request.method}_success`, {
         encrypted: {
           dAppUrl: request.peerMeta.url,

--- a/packages/core-mobile/app/store/rpc/providers/coreMobile.ts
+++ b/packages/core-mobile/app/store/rpc/providers/coreMobile.ts
@@ -2,10 +2,27 @@ import { selectActiveAccount } from 'store/account'
 import AnalyticsService from 'services/analytics/AnalyticsService'
 import { getAddressForChainId } from 'store/rpc/handlers/wc_sessionRequest/utils'
 import { onInAppRequestFailed, onInAppRequestSucceeded } from '../slice'
-import { AgnosticRpcProvider, RpcProvider } from '../types'
+import { AgnosticRpcProvider, RpcMethod, RpcProvider } from '../types'
 import { isTxSendMethod } from '../utils/txSendMethods'
 import { isDappOriginatedUrl } from '../utils/isDappOriginatedRequest'
 import { isSessionProposal } from './walletConnect/utils'
+
+// For eth_sendTransaction the dApp names the signer via the tx `from`, which the
+// injected router validates and which may be a granted, NON-active account.
+// Prefer it so _success reports the actual signer (matching _confirmed/_failed,
+// which read the cached signer) rather than the active account. CP-13825.
+const getTxFromAddress = (
+  method: RpcMethod,
+  params: unknown
+): string | undefined => {
+  if (method !== RpcMethod.ETH_SEND_TRANSACTION) return undefined
+  const tx = Array.isArray(params) ? params[0] : undefined
+  const from =
+    tx && typeof tx === 'object' && 'from' in tx
+      ? (tx as { from?: unknown }).from
+      : undefined
+  return typeof from === 'string' && from ? from : undefined
+}
 
 class CoreMobileProvider implements AgnosticRpcProvider {
   provider = RpcProvider.CORE_MOBILE
@@ -43,10 +60,14 @@ class CoreMobileProvider implements AgnosticRpcProvider {
       isDappOriginatedUrl(request.peerMeta?.url)
     ) {
       const chainId = request.data.params.chainId
+      const fromAddress = getTxFromAddress(
+        request.method,
+        request.data.params.request.params
+      )
       const account = selectActiveAccount(listenerApi.getState())
-      const address = account
-        ? getAddressForChainId(chainId, account) ?? ''
-        : ''
+      const address =
+        fromAddress ??
+        (account ? getAddressForChainId(chainId, account) ?? '' : '')
       AnalyticsService.capture(`${request.method}_success`, {
         encrypted: {
           dAppUrl: request.peerMeta.url,

--- a/packages/core-mobile/app/store/rpc/providers/coreMobile.ts
+++ b/packages/core-mobile/app/store/rpc/providers/coreMobile.ts
@@ -1,5 +1,11 @@
+import { selectActiveAccount } from 'store/account'
+import AnalyticsService from 'services/analytics/AnalyticsService'
+import { getAddressForChainId } from 'store/rpc/handlers/wc_sessionRequest/utils'
 import { onInAppRequestFailed, onInAppRequestSucceeded } from '../slice'
 import { AgnosticRpcProvider, RpcProvider } from '../types'
+import { isTxSendMethod } from '../utils/txSendMethods'
+import { isDappOriginatedUrl } from '../utils/isDappOriginatedRequest'
+import { isSessionProposal } from './walletConnect/utils'
 
 class CoreMobileProvider implements AgnosticRpcProvider {
   provider = RpcProvider.CORE_MOBILE
@@ -22,6 +28,34 @@ class CoreMobileProvider implements AgnosticRpcProvider {
     listenerApi.dispatch(
       onInAppRequestSucceeded({ requestId, txHash: result as string })
     )
+
+    // Mirror the WalletConnect provider's _success capture so dApp transactions
+    // made through the injected browser are not dropped from per-network (MTU)
+    // analytics. Gated to dApp-originated requests so wallet-internal flows
+    // (Send / Swap / Stake) — which carry CORE_MOBILE_META — are excluded.
+    // CP-13825.
+    if (isSessionProposal(request)) return
+
+    if (
+      isTxSendMethod(request.method) &&
+      typeof result === 'string' &&
+      result &&
+      isDappOriginatedUrl(request.peerMeta?.url)
+    ) {
+      const chainId = request.data.params.chainId
+      const account = selectActiveAccount(listenerApi.getState())
+      const address = account
+        ? getAddressForChainId(chainId, account) ?? ''
+        : ''
+      AnalyticsService.capture(`${request.method}_success`, {
+        encrypted: {
+          dAppUrl: request.peerMeta.url,
+          address,
+          chainId,
+          txHash: result
+        }
+      })
+    }
   }
   validateRequest: AgnosticRpcProvider['validateRequest'] = (): void => {
     // do nothing

--- a/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.test.ts
+++ b/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.test.ts
@@ -92,6 +92,7 @@ describe('walletConnectProvider', () => {
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_success',
           {
+            provider: 'walletConnect',
             encrypted: {
               dAppUrl: 'https://test.dapp.com',
               // EVM address is lowercased to a canonical form (CP-13825)
@@ -118,6 +119,7 @@ describe('walletConnectProvider', () => {
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'avalanche_sendTransaction_success',
           {
+            provider: 'walletConnect',
             encrypted: expect.objectContaining({
               dAppUrl: 'https://test.dapp.com',
               // C-chain is EVM; address is lowercased to canonical form (CP-13825)
@@ -143,6 +145,7 @@ describe('walletConnectProvider', () => {
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'avalanche_sendTransaction_success',
           {
+            provider: 'walletConnect',
             encrypted: expect.objectContaining({
               address: mockActiveAccount.addressPVM
             })
@@ -165,6 +168,7 @@ describe('walletConnectProvider', () => {
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'avalanche_sendTransaction_success',
           {
+            provider: 'walletConnect',
             encrypted: expect.objectContaining({
               address: mockActiveAccount.addressAVM
             })
@@ -187,6 +191,7 @@ describe('walletConnectProvider', () => {
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'bitcoin_sendTransaction_success',
           {
+            provider: 'walletConnect',
             encrypted: expect.objectContaining({
               dAppUrl: 'https://test.dapp.com',
               address: mockActiveAccount.addressBTC,
@@ -211,6 +216,7 @@ describe('walletConnectProvider', () => {
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'solana_signAndSendTransaction_success',
           {
+            provider: 'walletConnect',
             encrypted: expect.objectContaining({
               dAppUrl: 'https://test.dapp.com',
               address: mockActiveAccount.addressSVM,

--- a/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.test.ts
+++ b/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.test.ts
@@ -94,7 +94,8 @@ describe('walletConnectProvider', () => {
           {
             encrypted: {
               dAppUrl: 'https://test.dapp.com',
-              address: mockActiveAccount.addressC,
+              // EVM address is lowercased to a canonical form (CP-13825)
+              address: mockActiveAccount.addressC.toLowerCase(),
               chainId: 'eip155:1',
               txHash: '0xdeadbeef'
             }
@@ -119,7 +120,8 @@ describe('walletConnectProvider', () => {
           {
             encrypted: expect.objectContaining({
               dAppUrl: 'https://test.dapp.com',
-              address: mockActiveAccount.addressC,
+              // C-chain is EVM; address is lowercased to canonical form (CP-13825)
+              address: mockActiveAccount.addressC.toLowerCase(),
               txHash: '0xcafebabe'
             })
           }

--- a/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.ts
+++ b/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.ts
@@ -15,6 +15,7 @@ import { Account } from 'store/account/types'
 import { getAddressForChainId } from 'store/rpc/handlers/wc_sessionRequest/utils'
 import { AgnosticRpcProvider, RpcMethod, RpcProvider } from '../../types'
 import { isTxSendMethod } from '../../utils/txSendMethods'
+import { normalizeAnalyticsAddress } from '../../utils/normalizeAnalyticsAddress'
 import { isSessionProposal, isUserRejectedError } from './utils'
 import { transformSolanaParams } from './solanaRequestUtils'
 
@@ -165,9 +166,11 @@ class WalletConnectProvider implements AgnosticRpcProvider {
         result
       ) {
         const chainId = request.data.params.chainId
-        const address = getAddressForChain(
-          selectActiveAccount(listenerApi.getState()),
-          chainId
+        const address = normalizeAnalyticsAddress(
+          getAddressForChain(
+            selectActiveAccount(listenerApi.getState()),
+            chainId
+          )
         )
         AnalyticsService.capture(`${request.method}_success`, {
           encrypted: {

--- a/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.ts
+++ b/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.ts
@@ -173,6 +173,7 @@ class WalletConnectProvider implements AgnosticRpcProvider {
           )
         )
         AnalyticsService.capture(`${request.method}_success`, {
+          provider: 'walletConnect',
           encrypted: {
             dAppUrl: request.peerMeta.url,
             address,

--- a/packages/core-mobile/app/store/rpc/utils/isDappOriginatedRequest.test.ts
+++ b/packages/core-mobile/app/store/rpc/utils/isDappOriginatedRequest.test.ts
@@ -1,0 +1,30 @@
+import { CORE_MOBILE_META } from '../types'
+import { isDappOriginatedUrl } from './isDappOriginatedRequest'
+
+describe('isDappOriginatedUrl', () => {
+  it('returns true for a real dApp url (WalletConnect or injected browser)', () => {
+    expect(isDappOriginatedUrl('https://test.dapp.com')).toBe(true)
+    expect(isDappOriginatedUrl('https://app.uniswap.org')).toBe(true)
+  })
+
+  it('returns false for the wallet-internal CORE_MOBILE_META url', () => {
+    expect(isDappOriginatedUrl(CORE_MOBILE_META.url)).toBe(false)
+    expect(isDappOriginatedUrl('https://core.app/')).toBe(false)
+  })
+
+  it('returns false for an empty url (getPeerMeta placeholder)', () => {
+    expect(isDappOriginatedUrl('')).toBe(false)
+  })
+
+  it('returns false for an undefined url', () => {
+    expect(isDappOriginatedUrl(undefined)).toBe(false)
+  })
+
+  // Documents the known limitation: the real core.app dApp collides with the
+  // CORE_MOBILE_META internal marker and is treated as wallet-internal. A path
+  // under core.app does NOT collide.
+  it('treats the exact core.app root as internal, but not a sub-path', () => {
+    expect(isDappOriginatedUrl('https://core.app/')).toBe(false)
+    expect(isDappOriginatedUrl('https://core.app/stake')).toBe(true)
+  })
+})

--- a/packages/core-mobile/app/store/rpc/utils/isDappOriginatedRequest.test.ts
+++ b/packages/core-mobile/app/store/rpc/utils/isDappOriginatedRequest.test.ts
@@ -1,5 +1,9 @@
-import { CORE_MOBILE_META } from '../types'
-import { isDappOriginatedUrl } from './isDappOriginatedRequest'
+import { RpcRequest } from '@avalabs/vm-module-types'
+import { CORE_MOBILE_META, CORE_MOBILE_TOPIC } from '../types'
+import {
+  isDappOriginatedUrl,
+  isInjectedDappRequest
+} from './isDappOriginatedRequest'
 
 describe('isDappOriginatedUrl', () => {
   it('returns true for a real dApp url (WalletConnect or injected browser)', () => {
@@ -26,5 +30,42 @@ describe('isDappOriginatedUrl', () => {
   it('treats the exact core.app root as internal, but not a sub-path', () => {
     expect(isDappOriginatedUrl('https://core.app/')).toBe(false)
     expect(isDappOriginatedUrl('https://core.app/stake')).toBe(true)
+  })
+})
+
+describe('isInjectedDappRequest', () => {
+  const makeRequest = (sessionId: string, url?: string): RpcRequest =>
+    ({
+      requestId: 'req-1',
+      sessionId,
+      dappInfo: url === undefined ? undefined : { name: 'd', url, icon: '' }
+    } as unknown as RpcRequest)
+
+  it('returns true for the injected browser (real url + in-app topic)', () => {
+    expect(
+      isInjectedDappRequest(
+        makeRequest(CORE_MOBILE_TOPIC, 'https://app.uniswap.org')
+      )
+    ).toBe(true)
+  })
+
+  it('returns false for WalletConnect (real url, but NOT in-app topic)', () => {
+    expect(
+      isInjectedDappRequest(
+        makeRequest('wc-topic-abc123', 'https://app.uniswap.org')
+      )
+    ).toBe(false)
+  })
+
+  it('returns false for wallet-internal flows (in-app topic, but CORE_MOBILE_META url)', () => {
+    expect(
+      isInjectedDappRequest(
+        makeRequest(CORE_MOBILE_TOPIC, CORE_MOBILE_META.url)
+      )
+    ).toBe(false)
+  })
+
+  it('returns false when the in-app request carries no origin url', () => {
+    expect(isInjectedDappRequest(makeRequest(CORE_MOBILE_TOPIC))).toBe(false)
   })
 })

--- a/packages/core-mobile/app/store/rpc/utils/isDappOriginatedRequest.ts
+++ b/packages/core-mobile/app/store/rpc/utils/isDappOriginatedRequest.ts
@@ -1,4 +1,6 @@
+import { RpcRequest } from '@avalabs/vm-module-types'
 import { CORE_MOBILE_META } from '../types'
+import { isInAppRequest } from './isInAppRequest'
 
 /**
  * Whether a request originated from a dApp (WalletConnect OR the injected
@@ -23,3 +25,21 @@ import { CORE_MOBILE_META } from '../types'
  */
 export const isDappOriginatedUrl = (url?: string): boolean =>
   !!url && url !== CORE_MOBILE_META.url
+
+/**
+ * Whether a request came from the in-app injected browser provider, as opposed
+ * to WalletConnect or a wallet-internal flow.
+ *
+ * Both the injected browser and wallet-internal flows (Send / Swap / Stake /
+ * Bridge) ride the in-app session topic (`CORE_MOBILE_TOPIC`), so `isInAppRequest`
+ * alone does NOT mean "injected". The discriminator is the combination:
+ *   - dApp-originated url (carries a real origin, not `CORE_MOBILE_META`) — this
+ *     excludes wallet-internal flows, which never set a peerMeta; AND
+ *   - in-app session topic — this excludes WalletConnect, which carries a real
+ *     WC session topic.
+ *
+ * Used to label per-network dApp-transaction analytics (MTU) by transport
+ * (injected vs WalletConnect). CP-13825.
+ */
+export const isInjectedDappRequest = (request: RpcRequest): boolean =>
+  isDappOriginatedUrl(request.dappInfo?.url) && isInAppRequest(request)

--- a/packages/core-mobile/app/store/rpc/utils/isDappOriginatedRequest.ts
+++ b/packages/core-mobile/app/store/rpc/utils/isDappOriginatedRequest.ts
@@ -1,0 +1,25 @@
+import { CORE_MOBILE_META } from '../types'
+
+/**
+ * Whether a request originated from a dApp (WalletConnect OR the injected
+ * browser) as opposed to a wallet-internal flow (Send / Swap / Stake / Bridge).
+ *
+ * Wallet-internal requests are minted by `generateInAppRequestPayload` with the
+ * `CORE_MOBILE_META` peerMeta fallback (url `https://core.app/`); both dApp paths
+ * carry the dApp's real origin url. This is the correct discriminator for
+ * per-network dApp-transaction analytics (MTU) — unlike `isInAppRequest`, which
+ * keys on the session topic and so lumps the injected browser in with
+ * wallet-internal flows.
+ *
+ * An empty url (the `getPeerMeta()` placeholder for an unparseable WebView URL)
+ * is treated as NOT a dApp so we never emit an empty-`dAppUrl` analytics record.
+ *
+ * Known limitation: the `CORE_MOBILE_META` url (`https://core.app/`) doubles as a
+ * real, browsable domain. A dApp transaction made against the real core.app site
+ * inside the in-app browser is therefore misclassified as wallet-internal and not
+ * counted. This is a narrow edge (the exact root url only) and is not a regression
+ * — core.app via the injected provider emitted nothing before this change either.
+ * Removing it would require an explicit context marker instead of a url compare.
+ */
+export const isDappOriginatedUrl = (url?: string): boolean =>
+  !!url && url !== CORE_MOBILE_META.url

--- a/packages/core-mobile/app/store/rpc/utils/normalizeAnalyticsAddress.test.ts
+++ b/packages/core-mobile/app/store/rpc/utils/normalizeAnalyticsAddress.test.ts
@@ -1,0 +1,39 @@
+import { normalizeAnalyticsAddress } from './normalizeAnalyticsAddress'
+
+describe('normalizeAnalyticsAddress', () => {
+  it('lowercases EIP-55 checksummed EVM (hex) addresses', () => {
+    expect(
+      normalizeAnalyticsAddress('0xcA0E993876152ccA6053eeDFC753092c8cE712D0')
+    ).toBe('0xca0e993876152cca6053eedfc753092c8ce712d0')
+  })
+
+  it('leaves an already-lowercase hex address unchanged', () => {
+    const addr = '0xaaaa000000000000000000000000000000000001'
+    expect(normalizeAnalyticsAddress(addr)).toBe(addr)
+  })
+
+  it('normalizes a non-standard uppercase 0X prefix (dApp-supplied tx `from`)', () => {
+    expect(
+      normalizeAnalyticsAddress('0XAAAA000000000000000000000000000000000001')
+    ).toBe('0xaaaa000000000000000000000000000000000001')
+  })
+
+  it('does NOT alter case-sensitive Solana base58 addresses', () => {
+    const svm = '9gQmZ7fTTgv5hVScrr9QqT6SpBs7i4cKLDdj4tuae3sW'
+    expect(normalizeAnalyticsAddress(svm)).toBe(svm)
+  })
+
+  it('does NOT alter Bitcoin bech32 addresses', () => {
+    const btc = 'tb1qlzsvluv4cahzz8zzwud40x2hn3zq4c7zak6spw'
+    expect(normalizeAnalyticsAddress(btc)).toBe(btc)
+  })
+
+  it('does NOT alter Avalanche X/P bech32 addresses', () => {
+    const pchain = 'P-fuji1e0r9s2lf6v9mfqyy6pxrpkar8dm5jxqcvhg99n'
+    expect(normalizeAnalyticsAddress(pchain)).toBe(pchain)
+  })
+
+  it('returns an empty string untouched', () => {
+    expect(normalizeAnalyticsAddress('')).toBe('')
+  })
+})

--- a/packages/core-mobile/app/store/rpc/utils/normalizeAnalyticsAddress.ts
+++ b/packages/core-mobile/app/store/rpc/utils/normalizeAnalyticsAddress.ts
@@ -1,0 +1,25 @@
+/**
+ * Canonicalize an address for the dApp-transaction analytics lifecycle so the
+ * same signer is reported identically across `_success` / `_confirmed` /
+ * `_failed`, regardless of where each event sources the address.
+ *
+ * EVM (hex) addresses can arrive in different casings: `_success` for
+ * `eth_sendTransaction` uses the dApp-supplied tx `from` verbatim (whatever
+ * EIP-55 / lowercase form the dApp chose), while the wallet-derived address
+ * (`account.addressC`) and the WalletConnect path may differ. Hex addresses are
+ * case-insensitive, so we lowercase them to a single canonical form — preventing
+ * a case-sensitive `distinct(address)` downstream (e.g. MTU unique-transactor
+ * counts) from splitting one signer into two. CP-13825.
+ *
+ * Non-hex addresses are case-sensitive and/or already canonical and MUST NOT be
+ * lowercased: Bitcoin base58 (P2PKH/P2SH) and Solana base58 encode information in
+ * case, and Avalanche X/P bech32 is already lowercase. These are returned as-is.
+ * The `0x`/`0X` prefix uniquely identifies EVM hex here: base58 never contains a
+ * `0`, and every bech32 form (`bc1`/`tb1`/`X-`/`P-`/`avax1`) starts otherwise.
+ *
+ * Note: the WalletConnect `solana_signTransaction_approved` event intentionally
+ * does NOT pass through here — it carries an SVM (case-sensitive base58) address
+ * and has no paired `_confirmed`/`_failed` to stay consistent with.
+ */
+export const normalizeAnalyticsAddress = (address: string): string =>
+  /^0x/i.test(address) ? address.toLowerCase() : address

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -16,6 +16,22 @@ type DappTxEventPayload = {
 }
 
 /**
+ * Transport the dApp request came through. Sent as a top-level (plaintext)
+ * property — NOT inside `encrypted` — so MTU / usage dashboards can segment
+ * injected-browser vs WalletConnect traffic. CP-13825.
+ */
+export type DappTxProvider = 'injected' | 'walletConnect'
+
+/**
+ * Wrapper for every dApp-transaction lifecycle event: a queryable `provider`
+ * discriminator plus the encrypted per-tx payload.
+ */
+type DappTxEvent = {
+  provider: DappTxProvider
+  encrypted: DappTxEventPayload
+}
+
+/**
  * All analytics event payloads.
  *
  * Events with an `encrypted` field are automatically encrypted by
@@ -470,18 +486,18 @@ export type AnalyticsEvents = {
   }
 
   // dApp transaction lifecycle
-  eth_sendTransaction_success: { encrypted: DappTxEventPayload }
-  avalanche_sendTransaction_success: { encrypted: DappTxEventPayload }
-  bitcoin_sendTransaction_success: { encrypted: DappTxEventPayload }
-  solana_signAndSendTransaction_success: { encrypted: DappTxEventPayload }
-  eth_sendTransaction_confirmed: { encrypted: DappTxEventPayload }
-  avalanche_sendTransaction_confirmed: { encrypted: DappTxEventPayload }
-  bitcoin_sendTransaction_confirmed: { encrypted: DappTxEventPayload }
-  solana_signAndSendTransaction_confirmed: { encrypted: DappTxEventPayload }
-  eth_sendTransaction_failed: { encrypted: DappTxEventPayload }
-  avalanche_sendTransaction_failed: { encrypted: DappTxEventPayload }
-  bitcoin_sendTransaction_failed: { encrypted: DappTxEventPayload }
-  solana_signAndSendTransaction_failed: { encrypted: DappTxEventPayload }
+  eth_sendTransaction_success: DappTxEvent
+  avalanche_sendTransaction_success: DappTxEvent
+  bitcoin_sendTransaction_success: DappTxEvent
+  solana_signAndSendTransaction_success: DappTxEvent
+  eth_sendTransaction_confirmed: DappTxEvent
+  avalanche_sendTransaction_confirmed: DappTxEvent
+  bitcoin_sendTransaction_confirmed: DappTxEvent
+  solana_signAndSendTransaction_confirmed: DappTxEvent
+  eth_sendTransaction_failed: DappTxEvent
+  avalanche_sendTransaction_failed: DappTxEvent
+  bitcoin_sendTransaction_failed: DappTxEvent
+  solana_signAndSendTransaction_failed: DappTxEvent
   solana_signTransaction_approved: {
     encrypted: Omit<DappTxEventPayload, 'txHash'>
   }

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -509,7 +509,8 @@ describe('ApprovalController', () => {
           {
             encrypted: {
               dAppUrl: DAPP_URL,
-              address: EVM_ADDRESS,
+              // EVM address is lowercased to a canonical form (CP-13825)
+              address: EVM_ADDRESS.toLowerCase(),
               chainId: 'eip155:1',
               txHash: TX_HASH
             }
@@ -587,7 +588,8 @@ describe('ApprovalController', () => {
           {
             encrypted: {
               dAppUrl: DAPP_URL,
-              address: EVM_ADDRESS,
+              // EVM address is lowercased to a canonical form (CP-13825)
+              address: EVM_ADDRESS.toLowerCase(),
               chainId: 'eip155:1',
               txHash: TX_HASH
             }
@@ -610,7 +612,11 @@ describe('ApprovalController', () => {
 
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
-          { encrypted: expect.objectContaining({ address: NON_ACTIVE_SIGNER }) }
+          {
+            encrypted: expect.objectContaining({
+              address: NON_ACTIVE_SIGNER.toLowerCase()
+            })
+          }
         )
       })
 
@@ -633,7 +639,7 @@ describe('ApprovalController', () => {
         )
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
-          { encrypted: expect.objectContaining({ address: '0xBBBB' }) }
+          { encrypted: expect.objectContaining({ address: '0xbbbb' }) }
         )
       })
 
@@ -663,7 +669,11 @@ describe('ApprovalController', () => {
 
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
-          { encrypted: expect.objectContaining({ address: EVM_ADDRESS }) }
+          {
+            encrypted: expect.objectContaining({
+              address: EVM_ADDRESS.toLowerCase()
+            })
+          }
         )
 
         // Second call should get empty string (cache was cleaned up)
@@ -787,7 +797,8 @@ describe('ApprovalController', () => {
           {
             encrypted: {
               dAppUrl: DAPP_URL,
-              address: EVM_ADDRESS,
+              // EVM address is lowercased to a canonical form (CP-13825)
+              address: EVM_ADDRESS.toLowerCase(),
               chainId: 'eip155:1',
               txHash: TX_HASH
             }
@@ -842,7 +853,8 @@ describe('ApprovalController', () => {
           {
             encrypted: {
               dAppUrl: DAPP_URL,
-              address: EVM_ADDRESS,
+              // EVM address is lowercased to a canonical form (CP-13825)
+              address: EVM_ADDRESS.toLowerCase(),
               chainId: 'eip155:1',
               txHash: TX_HASH
             }

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -242,7 +242,14 @@ describe('ApprovalController', () => {
     mockIsInAppReview.mockReturnValue(false)
     mockIsSuccessToastEnabled.mockReturnValue(true)
     mockIsImmediateSentToast.mockReturnValue(false)
-    mockIsInAppRequest.mockReturnValue(false)
+    // Mirror the real isInAppRequest (sessionId === CORE_MOBILE_TOPIC) so the
+    // provider discriminator is genuinely driven by each request builder's
+    // topic — injected (CORE_MOBILE_TOPIC) → true, WalletConnect → false.
+    // Individual tests still override with mockReturnValue where they need a
+    // fixed value (e.g. confetti / presentation-mode checks). CP-13825.
+    mockIsInAppRequest.mockImplementation(
+      (request: RpcRequest) => request.sessionId === CORE_MOBILE_TOPIC
+    )
     // Default to post-Helicon (no optimistic UI), matching the steady state
     // this codepath will live in. Tests for the pre-Helicon path opt in.
     mockIsOptimisticConfirmationEnabled.mockResolvedValue(false)
@@ -367,7 +374,10 @@ describe('ApprovalController', () => {
 
       expect(AnalyticsService.capture).toHaveBeenCalledWith(
         'eth_sendTransaction_confirmed',
-        { encrypted: expect.objectContaining({ txHash: TX_HASH }) }
+        {
+          provider: 'walletConnect',
+          encrypted: expect.objectContaining({ txHash: TX_HASH })
+        }
       )
     })
 
@@ -507,6 +517,7 @@ describe('ApprovalController', () => {
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
           {
+            provider: 'walletConnect',
             encrypted: {
               dAppUrl: DAPP_URL,
               // EVM address is lowercased to a canonical form (CP-13825)
@@ -533,7 +544,10 @@ describe('ApprovalController', () => {
 
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'avalanche_sendTransaction_confirmed',
-          { encrypted: expect.objectContaining({ txHash: TX_HASH }) }
+          {
+            provider: 'walletConnect',
+            encrypted: expect.objectContaining({ txHash: TX_HASH })
+          }
         )
       })
 
@@ -553,6 +567,7 @@ describe('ApprovalController', () => {
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'avalanche_sendTransaction_confirmed',
           {
+            provider: 'walletConnect',
             encrypted: expect.objectContaining({
               chainId: AvalancheCaip2ChainId.C,
               txHash: TX_HASH
@@ -586,6 +601,7 @@ describe('ApprovalController', () => {
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
           {
+            provider: 'injected',
             encrypted: {
               dAppUrl: DAPP_URL,
               // EVM address is lowercased to a canonical form (CP-13825)
@@ -613,6 +629,7 @@ describe('ApprovalController', () => {
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
           {
+            provider: 'injected',
             encrypted: expect.objectContaining({
               address: NON_ACTIVE_SIGNER.toLowerCase()
             })
@@ -639,7 +656,10 @@ describe('ApprovalController', () => {
         )
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
-          { encrypted: expect.objectContaining({ address: '0xbbbb' }) }
+          {
+            provider: 'walletConnect',
+            encrypted: expect.objectContaining({ address: '0xbbbb' })
+          }
         )
       })
 
@@ -652,7 +672,10 @@ describe('ApprovalController', () => {
 
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
-          { encrypted: expect.objectContaining({ address: '' }) }
+          {
+            provider: 'walletConnect',
+            encrypted: expect.objectContaining({ address: '' })
+          }
         )
       })
 
@@ -670,6 +693,7 @@ describe('ApprovalController', () => {
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
           {
+            provider: 'walletConnect',
             encrypted: expect.objectContaining({
               address: EVM_ADDRESS.toLowerCase()
             })
@@ -686,7 +710,10 @@ describe('ApprovalController', () => {
 
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_confirmed',
-          { encrypted: expect.objectContaining({ address: '' }) }
+          {
+            provider: 'walletConnect',
+            encrypted: expect.objectContaining({ address: '' })
+          }
         )
       })
 
@@ -795,6 +822,7 @@ describe('ApprovalController', () => {
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_failed',
           {
+            provider: 'walletConnect',
             encrypted: {
               dAppUrl: DAPP_URL,
               // EVM address is lowercased to a canonical form (CP-13825)
@@ -822,6 +850,7 @@ describe('ApprovalController', () => {
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'bitcoin_sendTransaction_failed',
           {
+            provider: 'walletConnect',
             encrypted: expect.objectContaining({
               address: btcAddress,
               txHash: 'btctxhash'
@@ -851,6 +880,7 @@ describe('ApprovalController', () => {
         expect(AnalyticsService.capture).toHaveBeenCalledWith(
           'eth_sendTransaction_failed',
           {
+            provider: 'injected',
             encrypted: {
               dAppUrl: DAPP_URL,
               // EVM address is lowercased to a canonical form (CP-13825)

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -6,6 +6,7 @@ import { walletConnectCache } from 'services/walletconnectv2/walletConnectCache/
 import { router } from 'expo-router'
 import { currentRouteStore } from 'new/routes/store'
 import { isInAppRequest } from 'store/rpc/utils/isInAppRequest'
+import { CORE_MOBILE_META, CORE_MOBILE_TOPIC } from 'store/rpc/types'
 import { transactionSnackbar } from 'new/common/utils/toast'
 import { promptForAppReviewAfterSuccessfulTransaction } from 'features/appReview/utils/promptForAppReviewAfterSuccessfulTransaction'
 import AnalyticsService from 'services/analytics/AnalyticsService'
@@ -161,6 +162,40 @@ const makeDappRequest = (method: RpcMethod, chainId = 'eip155:1'): RpcRequest =>
     chainId,
     params: {},
     dappInfo: { name: 'Uniswap', url: DAPP_URL, icon: '' }
+  } as unknown as RpcRequest)
+
+// An injected-browser dApp request: in-app session topic, but a REAL dApp url.
+// This is the case CP-13825 fixes — it must count toward MTU analytics.
+const makeInjectedDappRequest = (
+  method: RpcMethod,
+  chainId = 'eip155:1'
+): RpcRequest =>
+  ({
+    requestId: 'req-1',
+    sessionId: CORE_MOBILE_TOPIC,
+    method,
+    chainId,
+    params: {},
+    dappInfo: { name: 'Uniswap', url: DAPP_URL, icon: '' }
+  } as unknown as RpcRequest)
+
+// A wallet-internal request (Send / Swap / Stake): carries CORE_MOBILE_META —
+// must NOT count toward dApp MTU analytics.
+const makeInternalRequest = (
+  method: RpcMethod,
+  chainId = 'eip155:1'
+): RpcRequest =>
+  ({
+    requestId: 'req-1',
+    sessionId: CORE_MOBILE_TOPIC,
+    method,
+    chainId,
+    params: {},
+    dappInfo: {
+      name: CORE_MOBILE_META.name,
+      url: CORE_MOBILE_META.url,
+      icon: ''
+    }
   } as unknown as RpcRequest)
 
 const mockAccount = {
@@ -525,16 +560,58 @@ describe('ApprovalController', () => {
         )
       })
 
-      it('does NOT fire analytics for in-app requests', () => {
-        mockIsInAppRequest.mockReturnValue(true)
+      it('does NOT fire analytics for wallet-internal requests (CORE_MOBILE_META)', () => {
+        approvalController.onTransactionConfirmed({
+          txHash: TX_HASH,
+          explorerLink: '',
+          request: makeInternalRequest(RpcMethod.ETH_SEND_TRANSACTION)
+        })
+
+        expect(AnalyticsService.capture).not.toHaveBeenCalled()
+      })
+
+      it('fires analytics for injected dApp requests (in-app topic, real url) — CP-13825', async () => {
+        const request = makeInjectedDappRequest(RpcMethod.ETH_SEND_TRANSACTION)
+        await populateSigningAddressCache(request)
 
         approvalController.onTransactionConfirmed({
           txHash: TX_HASH,
           explorerLink: '',
-          request: makeDappRequest(RpcMethod.ETH_SEND_TRANSACTION)
+          request
         })
 
-        expect(AnalyticsService.capture).not.toHaveBeenCalled()
+        // regression guard: the signer address is the cached one, not '' —
+        // proves the signing-address cache gate (CP-13825 3d) also moved.
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
+          'eth_sendTransaction_confirmed',
+          {
+            encrypted: {
+              dAppUrl: DAPP_URL,
+              address: EVM_ADDRESS,
+              chainId: 'eip155:1',
+              txHash: TX_HASH
+            }
+          }
+        )
+      })
+
+      it('emits the actual signer for injected reqs, not the active account (granted non-active) — CP-13825', async () => {
+        const NON_ACTIVE_SIGNER = '0xAAAA000000000000000000000000000000000001'
+        const request = makeInjectedDappRequest(RpcMethod.ETH_SEND_TRANSACTION)
+        // the injected router permits signing with a granted, non-active account;
+        // the cached address is the selected signer, which the event must reflect.
+        await populateSigningAddressCache(request, NON_ACTIVE_SIGNER)
+
+        approvalController.onTransactionConfirmed({
+          txHash: TX_HASH,
+          explorerLink: '',
+          request
+        })
+
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
+          'eth_sendTransaction_confirmed',
+          { encrypted: expect.objectContaining({ address: NON_ACTIVE_SIGNER }) }
+        )
       })
 
       it('uses getAddressForChainId to resolve the signing address', async () => {
@@ -603,9 +680,8 @@ describe('ApprovalController', () => {
         )
       })
 
-      it('does not cache signing address for in-app requests', async () => {
-        mockIsInAppRequest.mockReturnValue(true)
-        const request = makeRequest({ method: RpcMethod.ETH_SEND_TRANSACTION })
+      it('does not cache signing address for wallet-internal requests (CORE_MOBILE_META)', async () => {
+        const request = makeInternalRequest(RpcMethod.ETH_SEND_TRANSACTION)
 
         const signingData = { type: 'eth_sendTransaction', data: {} } as never
         const displayData = {} as never
@@ -626,6 +702,34 @@ describe('ApprovalController', () => {
         })
 
         expect(mockGetAddressForChainId).not.toHaveBeenCalled()
+      })
+
+      it('caches signing address for injected dApp requests — CP-13825', async () => {
+        const request = makeInjectedDappRequest(RpcMethod.ETH_SEND_TRANSACTION)
+        mockGetAddressForChainId.mockReturnValue(EVM_ADDRESS)
+
+        const signingData = { type: 'eth_sendTransaction', data: {} } as never
+        const displayData = {} as never
+        approvalController.requestApproval({
+          request,
+          displayData,
+          signingData
+        })
+        const { onApprove: capturedOnApprove } =
+          mockWalletConnectCacheSet.mock.calls[
+            mockWalletConnectCacheSet.mock.calls.length - 1
+          ][0]
+        await capturedOnApprove({
+          walletType: WalletType.MNEMONIC,
+          walletId: 'w1',
+          network: {},
+          account: mockAccount
+        })
+
+        expect(mockGetAddressForChainId).toHaveBeenCalledWith(
+          request.chainId,
+          mockAccount
+        )
       })
 
       it('does not cache signing address for non-tx-send methods', async () => {
@@ -715,15 +819,35 @@ describe('ApprovalController', () => {
         )
       })
 
-      it('does NOT fire analytics for in-app requests', () => {
-        mockIsInAppRequest.mockReturnValue(true)
-
+      it('does NOT fire analytics for wallet-internal requests (CORE_MOBILE_META)', () => {
         approvalController.onTransactionReverted({
           txHash: TX_HASH,
-          request: makeDappRequest(RpcMethod.ETH_SEND_TRANSACTION)
+          request: makeInternalRequest(RpcMethod.ETH_SEND_TRANSACTION)
         })
 
         expect(AnalyticsService.capture).not.toHaveBeenCalled()
+      })
+
+      it('fires _failed for injected dApp requests (in-app topic, real url) — CP-13825', async () => {
+        const request = makeInjectedDappRequest(RpcMethod.ETH_SEND_TRANSACTION)
+        await populateSigningAddressCache(request)
+
+        approvalController.onTransactionReverted({
+          txHash: TX_HASH,
+          request
+        })
+
+        expect(AnalyticsService.capture).toHaveBeenCalledWith(
+          'eth_sendTransaction_failed',
+          {
+            encrypted: {
+              dAppUrl: DAPP_URL,
+              address: EVM_ADDRESS,
+              chainId: 'eip155:1',
+              txHash: TX_HASH
+            }
+          }
+        )
       })
 
       it('always includes txHash in _failed payload (matches Extension behavior)', async () => {

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -12,7 +12,10 @@ import {
 import { walletConnectCache } from 'services/walletconnectv2/walletConnectCache/walletConnectCache'
 import { transactionSnackbar } from 'new/common/utils/toast'
 import { isInAppRequest } from 'store/rpc/utils/isInAppRequest'
-import { isDappOriginatedUrl } from 'store/rpc/utils/isDappOriginatedRequest'
+import {
+  isDappOriginatedUrl,
+  isInjectedDappRequest
+} from 'store/rpc/utils/isDappOriginatedRequest'
 import { normalizeAnalyticsAddress } from 'store/rpc/utils/normalizeAnalyticsAddress'
 import {
   clearRequestSignal,
@@ -148,8 +151,7 @@ class ApprovalController implements VmModuleApprovalController {
       this.signingAddressMap.delete(request.requestId)
       const eventName = `${request.method}_confirmed` as TxSendConfirmedEvent
       AnalyticsService.capture(eventName, {
-        // dApp-originated + in-app topic ⇒ injected browser; otherwise WC.
-        provider: isInAppRequest(request) ? 'injected' : 'walletConnect',
+        provider: isInjectedDappRequest(request) ? 'injected' : 'walletConnect',
         encrypted: {
           dAppUrl: request.dappInfo.url,
           address,
@@ -210,8 +212,7 @@ class ApprovalController implements VmModuleApprovalController {
       this.signingAddressMap.delete(request.requestId)
       const eventName = `${request.method}_failed` as TxSendFailedEvent
       AnalyticsService.capture(eventName, {
-        // dApp-originated + in-app topic ⇒ injected browser; otherwise WC.
-        provider: isInAppRequest(request) ? 'injected' : 'walletConnect',
+        provider: isInjectedDappRequest(request) ? 'injected' : 'walletConnect',
         encrypted: {
           dAppUrl: request.dappInfo.url,
           address,

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -148,6 +148,8 @@ class ApprovalController implements VmModuleApprovalController {
       this.signingAddressMap.delete(request.requestId)
       const eventName = `${request.method}_confirmed` as TxSendConfirmedEvent
       AnalyticsService.capture(eventName, {
+        // dApp-originated + in-app topic ⇒ injected browser; otherwise WC.
+        provider: isInAppRequest(request) ? 'injected' : 'walletConnect',
         encrypted: {
           dAppUrl: request.dappInfo.url,
           address,
@@ -208,6 +210,8 @@ class ApprovalController implements VmModuleApprovalController {
       this.signingAddressMap.delete(request.requestId)
       const eventName = `${request.method}_failed` as TxSendFailedEvent
       AnalyticsService.capture(eventName, {
+        // dApp-originated + in-app topic ⇒ injected browser; otherwise WC.
+        provider: isInAppRequest(request) ? 'injected' : 'walletConnect',
         encrypted: {
           dAppUrl: request.dappInfo.url,
           address,

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -12,6 +12,7 @@ import {
 import { walletConnectCache } from 'services/walletconnectv2/walletConnectCache/walletConnectCache'
 import { transactionSnackbar } from 'new/common/utils/toast'
 import { isInAppRequest } from 'store/rpc/utils/isInAppRequest'
+import { isDappOriginatedUrl } from 'store/rpc/utils/isDappOriginatedRequest'
 import {
   clearRequestSignal,
   getRequestSignal
@@ -138,7 +139,10 @@ class ApprovalController implements VmModuleApprovalController {
     explorerLink: string
     request: RpcRequest
   }): void => {
-    if (!isInAppRequest(request) && isTxSendMethod(request.method)) {
+    if (
+      isDappOriginatedUrl(request.dappInfo?.url) &&
+      isTxSendMethod(request.method)
+    ) {
       const address = this.signingAddressMap.get(request.requestId) ?? ''
       this.signingAddressMap.delete(request.requestId)
       const eventName = `${request.method}_confirmed` as TxSendConfirmedEvent
@@ -195,7 +199,10 @@ class ApprovalController implements VmModuleApprovalController {
     // Clear any cached gate decision for this requestId so it doesn't linger.
     this.optimisticGateMap.delete(request.requestId)
 
-    if (!isInAppRequest(request) && isTxSendMethod(request.method)) {
+    if (
+      isDappOriginatedUrl(request.dappInfo?.url) &&
+      isTxSendMethod(request.method)
+    ) {
       const address = this.signingAddressMap.get(request.requestId) ?? ''
       this.signingAddressMap.delete(request.requestId)
       const eventName = `${request.method}_failed` as TxSendFailedEvent
@@ -486,7 +493,14 @@ class ApprovalController implements VmModuleApprovalController {
     // up; a late Approve tap must not sign/broadcast. (CP-14422)
     if (this.userCancelledMap.get(requestId)) return
 
-    if (!isInAppRequest(request) && isTxSendMethod(request.method)) {
+    // Cache the actual selected signer so onTransactionConfirmed /
+    // onTransactionReverted emit the real address for dApp txs — including
+    // the injected browser (which the !isInAppRequest gate excluded,
+    // making those events fire with an empty address). CP-13825.
+    if (
+      isDappOriginatedUrl(request.dappInfo?.url) &&
+      isTxSendMethod(request.method)
+    ) {
       this.cacheSigningAddress(requestId, request.chainId, params.account)
     }
 

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -13,6 +13,7 @@ import { walletConnectCache } from 'services/walletconnectv2/walletConnectCache/
 import { transactionSnackbar } from 'new/common/utils/toast'
 import { isInAppRequest } from 'store/rpc/utils/isInAppRequest'
 import { isDappOriginatedUrl } from 'store/rpc/utils/isDappOriginatedRequest'
+import { normalizeAnalyticsAddress } from 'store/rpc/utils/normalizeAnalyticsAddress'
 import {
   clearRequestSignal,
   getRequestSignal
@@ -375,7 +376,10 @@ class ApprovalController implements VmModuleApprovalController {
   ): void {
     const address = getAddressForChainId(chainId, account)
     if (address) {
-      this.signingAddressMap.set(requestId, address)
+      // Normalize so _confirmed / _failed report the same casing as _success
+      // (which may use the dApp-supplied tx `from`). Hex-only; non-EVM addresses
+      // are left untouched. CP-13825.
+      this.signingAddressMap.set(requestId, normalizeAnalyticsAddress(address))
     }
   }
 


### PR DESCRIPTION
## Description

**Ticket: [CP-13825](https://ava-labs.atlassian.net/browse/CP-13825)**

WalletConnect tracks dApp transactions on a per-network basis (CP-13379 / `f52494977`) — a 3-event lifecycle (`${method}_success`, `_confirmed`, `_failed`) that feeds MTU / per-network usage analytics. While testing, Eunji found this was **not reporting for the injected provider**. Switching dApp traffic from WalletConnect to the new injected provider therefore regressed those metrics. This restores them.

- **Summary of the changes**
  - **Root cause:** these events were gated on `!isInAppRequest(request)` (and `_success` only fired in the WalletConnect provider). `isInAppRequest` keys on the session topic (`CORE_MOBILE_TOPIC`), which the injected browser now also uses — so injected dApp transactions were lumped in with wallet-internal flows (Send / Swap / Stake) and excluded from all three events.
  - Added `isDappOriginatedUrl(url)` — a request originates from a dApp (WalletConnect **or** the injected browser) when it carries a real origin url, vs. wallet-internal flows which carry the synthetic `CORE_MOBILE_META` identity (`https://core.app/`). This is the correct discriminator for dApp-tx analytics; `isInAppRequest` (topic-based) stays untouched for its UI/UX/security uses.
  - `coreMobileProvider.onSuccess` now fires `${method}_success` for dApp-originated tx-send requests (mirrors the WalletConnect provider).
  - Flipped the three analytics gates in `ApprovalController` from `!isInAppRequest` to `isDappOriginatedUrl(request.dappInfo?.url)`: `onTransactionConfirmed` (`_confirmed`), `onTransactionReverted` (`_failed`), **and** the `onApprove` signer-address cache (so injected `_confirmed`/`_failed` emit the real signer address — including a granted, non-active account — instead of an empty string).
  - All other `isInAppRequest` usages (confetti, presentation mode, optimistic UI, validator trust boundary, website-field hiding) are intentionally left as-is.

- **Motivation and context**
  - Without this, every dApp transaction made through the injected provider is invisible to MTU / per-network analytics, regressing the tracking added in CP-13379 as we move dApp traffic to injection.

- **Dependencies introduced:** none.

- **Breaking changes / migration:** none.

- **Known limitation:** the `CORE_MOBILE_META` url (`https://core.app/`) doubles as the wallet-internal marker, so a dApp transaction made against the real core.app site *inside the in-app browser* (exact root url only) is treated as internal and not counted. This is narrow and **not a regression** — core.app via the injected provider emitted nothing before this change either. Removing it would require an explicit context marker instead of a url compare (deferred).

## Screenshots/Videos

N/A — analytics-only change, no UI.

## Testing

**Dev Testing**

iOS: #9005
Android: #9006

- In the in-app browser, connect to a dApp (e.g. Uniswap) via the injected provider and send a transaction. Confirm `eth_sendTransaction_success` fires on submit, and `_confirmed` / `_failed` fire on finalize / revert — each with the dApp url, the actual signer address, chainId, and txHash.
- Repeat signing with a **granted, non-active** account; confirm the analytics `address` is the actual signer, not the active account.
- Do a wallet-internal Send / Swap / Stake; confirm **no** `_success` / `_confirmed` / `_failed` fire (unchanged).
- Confirm WalletConnect dApp transactions still fire all three events exactly as before.
- Trigger a Bitrise build and reference it here. _(pending)_
- Move the ticket into the "Testing" column on Jira.

**QA Testing**

Acceptance criteria:

- Injected-provider dApp transactions report per-network analytics (MTU) equivalent to WalletConnect.
- Wallet-internal transactions remain excluded.
- WalletConnect behavior is unchanged.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios (N/A — no UI change)
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation (N/A)


[CP-13825]: https://ava-labs.atlassian.net/browse/CP-13825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ