### PR TITLE
Device Farm: fire-and-forget scheduling, fail fast on empty device pool

### DIFF
--- a/packages/core-mobile/scripts/bitrise/devicefarm/android/androidDeviceFarmRegression.sh
+++ b/packages/core-mobile/scripts/bitrise/devicefarm/android/androidDeviceFarmRegression.sh
@@ -32,7 +32,10 @@ export DEVICEFARM_APP_PATH="$BITRISE_APK_PATH"
 export DEVICEFARM_TEST_PACKAGE_PATH="$TEST_PACKAGE"
 export DEVICEFARM_TEST_SPEC_PATH="$TEST_SPEC"
 export PLATFORM="android"
-export WAIT_FOR_COMPLETION="${WAIT_FOR_COMPLETION:-true}"
+# Fire-and-forget by default: results reach TestRail from the device-side reporter,
+# so polling GetRun only kept the Bitrise machine billing (~2h/night) and timed out
+# whenever the suite outlasted WAIT_FOR_COMPLETION_TIMEOUT_SEC.
+export WAIT_FOR_COMPLETION="${WAIT_FOR_COMPLETION:-false}"
 
 # 4. Extract only needed vars from env file
 if [ -f "$CORE_MOBILE_DIR/.env.production.e2e" ]; then

--- a/packages/core-mobile/scripts/bitrise/devicefarm/ios/iosDeviceFarmRegression.sh
+++ b/packages/core-mobile/scripts/bitrise/devicefarm/ios/iosDeviceFarmRegression.sh
@@ -34,7 +34,9 @@ export DEVICEFARM_APP_PATH="$BITRISE_IPA_PATH"
 export DEVICEFARM_TEST_PACKAGE_PATH="$TEST_PACKAGE"
 export DEVICEFARM_TEST_SPEC_PATH="$TEST_SPEC"
 export PLATFORM="ios"
-export WAIT_FOR_COMPLETION="${WAIT_FOR_COMPLETION:-true}"
+# Fire-and-forget by default: results reach TestRail from the device-side reporter,
+# so polling GetRun only kept the Bitrise machine billing while it waited.
+export WAIT_FOR_COMPLETION="${WAIT_FOR_COMPLETION:-false}"
 
 # 4. Extract only needed vars from env file
 if [ -f "$CORE_MOBILE_DIR/.env.production.e2e" ]; then

--- a/packages/core-mobile/scripts/devicefarm/test.js
+++ b/packages/core-mobile/scripts/devicefarm/test.js
@@ -50,7 +50,7 @@ const {
   GetUploadCommand,
   GetProjectCommand,
   GetDevicePoolCommand,
-  ListDevicePoolDevicesCommand,
+  GetDevicePoolCompatibleDevicesCommand,
   GetRunCommand,
   ScheduleRunCommand
 } = require('@aws-sdk/client-device-farm')
@@ -161,6 +161,7 @@ const deviceFarmClient = new DeviceFarmClient({ region: config.region })
  */
 async function inspectDevicePool(devicePoolArn) {
   console.log('🔍 Inspecting device pool...')
+  let compatibleCount = null
   try {
     const poolRes = await deviceFarmClient.send(
       new GetDevicePoolCommand({ arn: devicePoolArn })
@@ -170,21 +171,31 @@ async function inspectDevicePool(devicePoolArn) {
     console.log(`   Pool type: ${pool?.type}`)
     console.log(`   Pool rules: ${JSON.stringify(pool?.rules, null, 2)}`)
 
-    const devicesRes = await deviceFarmClient.send(
-      new ListDevicePoolDevicesCommand({ arn: devicePoolArn })
+    const compatRes = await deviceFarmClient.send(
+      new GetDevicePoolCompatibleDevicesCommand({
+        devicePoolArn,
+        testType: 'APPIUM_NODE'
+      })
     )
-    const devices = devicesRes.devices || []
-    console.log(`   Devices in pool (${devices.length}):`)
-    devices.forEach(d => {
+    const compatible = (compatRes.compatibleDevices || []).filter(
+      d => d.compatible
+    )
+    compatibleCount = compatible.length
+    console.log(`   Compatible devices (${compatible.length}):`)
+    compatible.forEach(({ device }) => {
       console.log(
-        `     - ${d.name} | ${d.platform} | OS: ${d.os} | Available: ${d.availability}`
+        `     - ${device?.name} | ${device?.platform} | OS: ${device?.os} | Availability: ${device?.availability}`
       )
     })
-    if (devices.length === 0) {
-      console.log('   ⚠️  No devices found in pool!')
-    }
   } catch (err) {
+    // Inspection is best-effort (e.g. IAM may lack these read calls) — don't block the run.
     console.warn(`   ⚠️  Could not inspect device pool: ${err.message}`)
+  }
+  if (compatibleCount === 0) {
+    throw new Error(
+      'Device pool matched 0 compatible devices — the run would complete as SKIPPED without executing any tests. ' +
+        'Check the pool rules (e.g. OS_VERSION) against the devices actually enrolled in the fleet.'
+    )
   }
 }
 
@@ -378,8 +389,8 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-/** Outcomes that exit 0 after status COMPLETED */
-const SUCCESS_RESULTS = new Set(['PASSED', 'WARNED', 'SKIPPED'])
+/** Outcomes that exit 0 after status COMPLETED. SKIPPED is not success: it means no tests executed (typically an empty/incompatible device pool). */
+const SUCCESS_RESULTS = new Set(['PASSED', 'WARNED'])
 
 function parseWaitForCompletionTimeoutSec() {
   const rawTimeout = process.env.WAIT_FOR_COMPLETION_TIMEOUT_SEC
@@ -395,6 +406,11 @@ function handleCompletedDeviceFarmRun(run) {
   if (result && SUCCESS_RESULTS.has(result)) {
     console.log(`✅ Run finished successfully (${result})`)
     return
+  }
+  if (result === 'SKIPPED') {
+    throw new Error(
+      'Run completed with result SKIPPED — no tests were executed (likely no compatible/available devices in the pool)'
+    )
   }
   const detail = run?.message ? ': ' + run.message : ''
   throw new Error(`Run completed with result ${result ?? 'UNKNOWN'}${detail}`)


### PR DESCRIPTION
## Description

**Ticket: [CP-]**

Fixes two problems in the nightly AWS Device Farm regression (`aws-full-regression-runs`) that cost ~2h of billed idle Bitrise machine time per platform leg per night, and could silently report green with zero tests executed:

- **Polling burn:** the Bitrise step polls `GetRun` for up to `WAIT_FOR_COMPLETION_TIMEOUT_SEC` (2h) while the device-side suite runs (full regression is ~2h per platform, 100+ cases). The machine is billed the entire wait, and when the suite outlasts the cap the build reds out as a timeout rather than reporting actual results. This polling is the largest single waste category in our Bitrise usage (~thousands of build-min/month).
- **Silent SKIPPED green:** if the device pool matches 0 devices (e.g. a temporary pool change — this happened on 2026-06-09 and the iOS leg went green having executed nothing), the run completes instantly as `SKIPPED`, which was whitelisted as success. Nothing ran, build showed green, no one was alerted.

Changes:
1. `WAIT_FOR_COMPLETION` now defaults to **false** in both wrapper scripts — the step uploads, schedules the run, and exits. Test results still reach TestRail via the reporter bundled in the device-side test package. Opt back into polling per-run with `WAIT_FOR_COMPLETION=true`.
2. **Pre-flight device-pool check fails fast** when the pool matches 0 compatible devices (would otherwise become a silent `SKIPPED` run — see 2026-06-09 iOS). Also fixes the existing broken inspection call: `ListDevicePoolDevicesCommand` doesn't exist in the AWS SDK (the `is not a constructor` warning in every run log); replaced with `GetDevicePoolCompatibleDevicesCommand`. Inspection stays warn-only on API errors (e.g. missing IAM read perms) so it can't break runs spuriously.
3. **`SKIPPED` removed from success results** for anyone who opts into waiting, with a descriptive error.

Note: with fire-and-forget, the Bitrise build status reflects "scheduled successfully," not AWS pass/fail — test outcomes live in TestRail / Device Farm console (as they already do; the Bitrise red was duplicating that signal at ~2h/leg/night of machine cost).

No dependencies introduced (`@aws-sdk/client-device-farm` already used).

## Screenshots/Videos

N/A — CI scripts only.

## Testing

**Dev Testing (if applicable)**

- [ ] Trigger `aws-full-regression-runs` on this branch; expect: pool inspection lists compatible devices for both legs, runs scheduled, steps exit in seconds instead of polling ~2h
- [ ] Confirm results from the runs appear in TestRail after the AWS runs finish
- [ ] Optional negative test: point `DEVICEFARM_DEVICE_POOL_ARN` at a pool matching no devices and confirm the step fails fast with the 0-compatible-devices error instead of scheduling a SKIPPED run
- [ ] Bitrise build numbers: _add after triggering_

**QA Testing (if applicable)**

- Heads-up for QA: Bitrise no longer waits on AWS results — nightly pass/fail signal moves entirely to TestRail / Device Farm console. If a Bitrise-visible red/green gate per nightly is still wanted, we can add a cheap scheduled results-check job instead of inline polling.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation