### PR TITLE
CP-14361: register AVALANCHE_CCT service + wire CCT callbacks

### DIFF
--- a/packages/core-mobile/app/new/features/swap/services/FusionService.test.ts
+++ b/packages/core-mobile/app/new/features/swap/services/FusionService.test.ts
@@ -23,6 +23,7 @@ jest.mock('@avalabs/fusion-sdk', () => ({
   ServiceType: {
     MARKR: 'MARKR',
     AVALANCHE_EVM: 'AVALANCHE_EVM',
+    AVALANCHE_CCT: 'AVALANCHE_CCT',
     LOMBARD_BTC_TO_BTCB: 'LOMBARD_BTC_TO_BTCB',
     LOMBARD_BTCB_TO_BTC: 'LOMBARD_BTCB_TO_BTC',
     WRAP_UNWRAP: 'WRAP_UNWRAP'
@@ -389,6 +390,133 @@ describe('FusionService', () => {
         (s: { type: string }) => s.type === ServiceType.MARKR
       )
       expect(markrInitializer).toMatchObject({ disableCrossChainSwaps: false })
+    })
+
+    describe('AVALANCHE_CCT', () => {
+      const mockCctDependencies = {
+        avalancheSendTx: jest.fn(),
+        getCoreEthAddress: jest.fn(),
+        getAtomicUtxos: jest.fn(),
+        getUtxos: jest.fn(),
+        getWalletAddressesForChainAlias: jest.fn(),
+        getWalletChangeAddressForChainAlias: jest.fn()
+      }
+
+      const mockManagerFactory = () => ({
+        getQuoter: jest.fn(),
+        getSupportedChains: jest.fn(),
+        transferAsset: jest.fn(),
+        estimateNativeFee: jest.fn()
+      })
+
+      it('enables AVALANCHE_CCT when the fusion-avalanche-cct flag is on', async () => {
+        ;(createTransferManager as jest.Mock).mockResolvedValue(
+          mockManagerFactory()
+        )
+
+        const featureFlags: Partial<FusionServiceFlags> = {
+          'fusion-avalanche-cct': true
+        }
+
+        await FusionService.initWithFeatureFlags({
+          bitcoinProvider: mockBitcoinProvider,
+          fetch: mockFetch,
+          environment: Environment.PROD,
+          featureFlags: featureFlags as FusionServiceFlags,
+          signers: mockSigners,
+          cctDependencies: mockCctDependencies
+        })
+
+        const call = (createTransferManager as jest.Mock).mock.calls[0][0]
+        expect(call.serviceInitializers).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ type: ServiceType.AVALANCHE_CCT })
+          ])
+        )
+      })
+
+      it('throws cctDependenciesMissing when the flag is on but no cctDependencies are provided', async () => {
+        ;(createTransferManager as jest.Mock).mockResolvedValue(
+          mockManagerFactory()
+        )
+
+        const featureFlags: Partial<FusionServiceFlags> = {
+          'fusion-avalanche-cct': true
+        }
+
+        // No cctDependencies provided — should throw before reaching the SDK.
+        await expect(
+          FusionService.initWithFeatureFlags({
+            bitcoinProvider: mockBitcoinProvider,
+            fetch: mockFetch,
+            environment: Environment.PROD,
+            featureFlags: featureFlags as FusionServiceFlags,
+            signers: mockSigners
+          })
+        ).rejects.toThrow(/cctDependencies not provided/)
+        expect(createTransferManager).not.toHaveBeenCalled()
+      })
+
+      it('produces an initializer carrying the six SDK callbacks when cctDependencies are provided', async () => {
+        ;(createTransferManager as jest.Mock).mockResolvedValue(
+          mockManagerFactory()
+        )
+
+        const featureFlags: Partial<FusionServiceFlags> = {
+          'fusion-avalanche-cct': true
+        }
+
+        await FusionService.initWithFeatureFlags({
+          bitcoinProvider: mockBitcoinProvider,
+          fetch: mockFetch,
+          environment: Environment.PROD,
+          featureFlags: featureFlags as FusionServiceFlags,
+          signers: mockSigners,
+          cctDependencies: mockCctDependencies
+        })
+
+        const call = (createTransferManager as jest.Mock).mock.calls[0][0]
+        const cctInitializer = call.serviceInitializers.find(
+          (s: { type: string }) => s.type === ServiceType.AVALANCHE_CCT
+        )
+        expect(cctInitializer).toMatchObject({
+          type: ServiceType.AVALANCHE_CCT,
+          avalancheSendTx: mockCctDependencies.avalancheSendTx,
+          getCoreEthAddress: mockCctDependencies.getCoreEthAddress,
+          getAtomicUtxos: mockCctDependencies.getAtomicUtxos,
+          getUtxos: mockCctDependencies.getUtxos,
+          getWalletAddressesForChainAlias:
+            mockCctDependencies.getWalletAddressesForChainAlias,
+          getWalletChangeAddressForChainAlias:
+            mockCctDependencies.getWalletChangeAddressForChainAlias
+        })
+      })
+
+      it('does not register AVALANCHE_CCT when the flag is off', async () => {
+        ;(createTransferManager as jest.Mock).mockResolvedValue(
+          mockManagerFactory()
+        )
+
+        const featureFlags: Partial<FusionServiceFlags> = {
+          'fusion-markr': true,
+          'fusion-avalanche-cct': false
+        }
+
+        await FusionService.initWithFeatureFlags({
+          bitcoinProvider: mockBitcoinProvider,
+          fetch: mockFetch,
+          environment: Environment.PROD,
+          featureFlags: featureFlags as FusionServiceFlags,
+          signers: mockSigners,
+          cctDependencies: mockCctDependencies
+        })
+
+        const call = (createTransferManager as jest.Mock).mock.calls[0][0]
+        const cctInitializer = call.serviceInitializers.find(
+          (s: { type: string }) => s.type === ServiceType.AVALANCHE_CCT
+        )
+        expect(cctInitializer).toBeUndefined()
+      })
     })
   })
 

--- a/packages/core-mobile/app/new/features/swap/services/FusionService.ts
+++ b/packages/core-mobile/app/new/features/swap/services/FusionService.ts
@@ -7,6 +7,7 @@ import type {
   RefundedTransfer
 } from '@avalabs/fusion-sdk'
 import {
+  AvalancheCctInitializer,
   BitcoinFunctions,
   calculatePriceImpactFromQuote as _calculatePriceImpactFromQuote,
   createTransferManager,
@@ -33,6 +34,7 @@ import { MARKR_EVM_PARTNER_ID } from '../consts'
 import { isConcludedTransfer } from '../utils/transferStatus'
 import { fetchMarkrTargetChainAssets } from './fetchMarkrTargetChainAssets'
 import type {
+  FusionCctDependencies,
   FusionConfig,
   FusionServiceFlags,
   FusionSigners,
@@ -74,6 +76,10 @@ class FusionService implements IFusionService {
       services.push(ServiceType.AVALANCHE_EVM)
     }
 
+    if (featureFlags['fusion-avalanche-cct']) {
+      services.push(ServiceType.AVALANCHE_CCT)
+    }
+
     if (featureFlags['fusion-lombard-btc-to-btcb']) {
       services.push(ServiceType.LOMBARD_BTC_TO_BTCB)
     }
@@ -92,12 +98,14 @@ class FusionService implements IFusionService {
     btcFunctions,
     enabledServices,
     signers,
-    disableCrossChainSwaps
+    disableCrossChainSwaps,
+    cctDependencies
   }: {
     btcFunctions: BitcoinFunctions
     enabledServices: ServiceType[]
     signers: FusionSigners
     disableCrossChainSwaps: boolean
+    cctDependencies?: FusionCctDependencies
   }): ServiceInitializer[] {
     const initializers: ServiceInitializer[] = []
     for (const serviceType of enabledServices) {
@@ -119,6 +127,16 @@ class FusionService implements IFusionService {
             type: serviceType,
             evmSigner: signers.evm
           } satisfies EvmServiceInitializer)
+          break
+
+        case ServiceType.AVALANCHE_CCT:
+          if (!cctDependencies) {
+            throw fusionErrors.cctDependenciesMissing()
+          }
+          initializers.push({
+            type: serviceType,
+            ...cctDependencies
+          } satisfies AvalancheCctInitializer)
           break
 
         case ServiceType.LOMBARD_BTC_TO_BTCB:
@@ -150,18 +168,21 @@ class FusionService implements IFusionService {
   async init({
     bitcoinProvider,
     config,
-    signers
+    signers,
+    cctDependencies
   }: {
     bitcoinProvider: BitcoinFunctions
     config: FusionConfig
     signers: FusionSigners
+    cctDependencies?: FusionCctDependencies
   }): Promise<void> {
     try {
       const initializers = this.getServiceInitializers({
         btcFunctions: bitcoinProvider,
         enabledServices: config.enabledServices,
         signers,
-        disableCrossChainSwaps: config.disableCrossChainSwaps ?? false
+        disableCrossChainSwaps: config.disableCrossChainSwaps ?? false,
+        cctDependencies
       })
 
       // Ensure at least one service is enabled
@@ -209,13 +230,15 @@ class FusionService implements IFusionService {
     fetch,
     environment,
     featureFlags,
-    signers
+    signers,
+    cctDependencies
   }: {
     bitcoinProvider: BitcoinFunctions
     fetch: Fetch
     environment: Environment
     featureFlags: FusionServiceFlags
     signers: FusionSigners
+    cctDependencies?: FusionCctDependencies
   }): Promise<void> {
     const enabledServices = this.getEnabledServices(featureFlags)
     const disableCrossChainSwaps =
@@ -224,7 +247,8 @@ class FusionService implements IFusionService {
     return this.init({
       bitcoinProvider,
       config: { environment, enabledServices, fetch, disableCrossChainSwaps },
-      signers
+      signers,
+      cctDependencies
     })
   }
 

--- a/packages/core-mobile/app/new/features/swap/services/FusionService.ts
+++ b/packages/core-mobile/app/new/features/swap/services/FusionService.ts
@@ -1,4 +1,5 @@
 import type {
+  AvalancheCctInitializer,
   CompletedTransfer,
   FailedTransfer,
   GasSettings,
@@ -7,7 +8,6 @@ import type {
   RefundedTransfer
 } from '@avalabs/fusion-sdk'
 import {
-  AvalancheCctInitializer,
   BitcoinFunctions,
   calculatePriceImpactFromQuote as _calculatePriceImpactFromQuote,
   createTransferManager,

--- a/packages/core-mobile/app/new/features/swap/services/cct/buildCctDependencies.ts
+++ b/packages/core-mobile/app/new/features/swap/services/cct/buildCctDependencies.ts
@@ -3,7 +3,6 @@ import { selectActiveAccount } from 'store/account/slice'
 import type { XPAddressDictionary } from 'store/account/types'
 import { selectIsDeveloperMode } from 'store/settings/advanced/slice'
 import { selectWalletById } from 'store/wallet/slice'
-import { WalletType } from 'services/wallet/types'
 import type { AppListenerEffectAPI } from 'store/types'
 import { createCctCallbacks } from './createCctCallbacks'
 
@@ -43,7 +42,7 @@ export const buildCctDependencies = (
       if (!wallet) return EMPTY_XP_ADDRESSES
       return getCachedXPAddresses({
         walletId: wallet.id,
-        walletType: wallet.type as WalletType,
+        walletType: wallet.type,
         account,
         isDeveloperMode: selectIsDeveloperMode(state)
       })

--- a/packages/core-mobile/app/new/features/swap/services/cct/buildCctDependencies.ts
+++ b/packages/core-mobile/app/new/features/swap/services/cct/buildCctDependencies.ts
@@ -1,0 +1,51 @@
+import { getCachedXPAddresses } from 'hooks/useXPAddresses/useXPAddresses'
+import { selectActiveAccount } from 'store/account/slice'
+import type { XPAddressDictionary } from 'store/account/types'
+import { selectIsDeveloperMode } from 'store/settings/advanced/slice'
+import { selectWalletById } from 'store/wallet/slice'
+import { WalletType } from 'services/wallet/types'
+import type { AppListenerEffectAPI } from 'store/types'
+import { createCctCallbacks } from './createCctCallbacks'
+
+const EMPTY_XP_ADDRESSES = {
+  xpAddresses: [] as string[],
+  xpAddressDictionary: {} as XPAddressDictionary
+}
+
+/**
+ * Builds the CCT callbacks against live Redux + React Query state so that
+ * each invocation observes the latest account / wallet / xpAddresses. The
+ * TransferManager doesn't need to be recreated when those change.
+ *
+ * `getXpAddresses` uses `getCachedXPAddresses` rather than a raw cache read
+ * so that a cold cache fetches on demand — a cold-start swap flow with no
+ * prior portfolio mount must not produce empty addresses (that would cause
+ * `getInternalExternalAddrs` to return empty indices and break signing).
+ */
+export const buildCctDependencies = (
+  listenerApi: AppListenerEffectAPI
+): ReturnType<typeof createCctCallbacks> =>
+  createCctCallbacks({
+    getActiveAccount: () => selectActiveAccount(listenerApi.getState()),
+    getIsDeveloperMode: () => selectIsDeveloperMode(listenerApi.getState()),
+    getWallet: () => {
+      const state = listenerApi.getState()
+      const account = selectActiveAccount(state)
+      if (!account) return undefined
+      const wallet = selectWalletById(account.walletId)(state)
+      return wallet ? { id: wallet.id, type: wallet.type } : undefined
+    },
+    getXpAddresses: async () => {
+      const state = listenerApi.getState()
+      const account = selectActiveAccount(state)
+      if (!account) return EMPTY_XP_ADDRESSES
+      const wallet = selectWalletById(account.walletId)(state)
+      if (!wallet) return EMPTY_XP_ADDRESSES
+      return getCachedXPAddresses({
+        walletId: wallet.id,
+        walletType: wallet.type as WalletType,
+        account,
+        isDeveloperMode: selectIsDeveloperMode(state)
+      })
+    }
+  })

--- a/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.test.ts
+++ b/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.test.ts
@@ -1,0 +1,298 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { UnsignedTx } from '@avalabs/avalanchejs'
+import AvalancheWalletService from 'services/wallet/AvalancheWalletService'
+import NetworkService from 'services/network/NetworkService'
+import WalletService from 'services/wallet/WalletService'
+import { WalletType } from 'services/wallet/types'
+import { getInternalExternalAddrs } from 'common/hooks/send/utils/getInternalExternalAddrs'
+import { createCctCallbacks, type CctCallbackDeps } from './createCctCallbacks'
+
+jest.mock('services/wallet/AvalancheWalletService', () => ({
+  __esModule: true,
+  default: { getReadOnlySigner: jest.fn() }
+}))
+
+jest.mock('services/network/NetworkService', () => ({
+  __esModule: true,
+  default: {
+    getAvalancheNetworkP: jest.fn(),
+    getAvalancheNetworkX: jest.fn(),
+    sendTransaction: jest.fn()
+  }
+}))
+
+jest.mock('services/wallet/WalletService', () => ({
+  __esModule: true,
+  default: { sign: jest.fn() }
+}))
+
+jest.mock('common/hooks/send/utils/getInternalExternalAddrs', () => ({
+  getInternalExternalAddrs: jest.fn()
+}))
+
+jest.mock('@avalabs/avalanchejs', () => ({
+  UnsignedTx: { fromJSON: jest.fn() }
+}))
+
+const P_NETWORK = { name: 'P-network' }
+const X_NETWORK = { name: 'X-network' }
+
+const mockedGetReadOnlySigner =
+  AvalancheWalletService.getReadOnlySigner as jest.Mock
+const mockedGetAvalancheNetworkP =
+  NetworkService.getAvalancheNetworkP as jest.Mock
+const mockedGetAvalancheNetworkX =
+  NetworkService.getAvalancheNetworkX as jest.Mock
+const mockedSendTransaction = NetworkService.sendTransaction as jest.Mock
+const mockedWalletSign = WalletService.sign as jest.Mock
+const mockedGetInternalExternalAddrs = getInternalExternalAddrs as jest.Mock
+const mockedUnsignedTxFromJSON = UnsignedTx.fromJSON as jest.Mock
+
+const makeAccount = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: 'account-1',
+    index: 0,
+    walletId: 'wallet-1',
+    addressC: '0xcaddress',
+    addressCoreEth: 'C-fuji1xxx',
+    addressPVM: 'P-fuji1xxx',
+    addressAVM: 'X-fuji1xxx',
+    ...overrides
+  } as any)
+
+const makeDeps = (
+  overrides: Partial<CctCallbackDeps> = {}
+): CctCallbackDeps => {
+  const account = makeAccount()
+  return {
+    getActiveAccount: () => account,
+    getIsDeveloperMode: () => false,
+    getWallet: () => ({ id: account.walletId, type: WalletType.MNEMONIC }),
+    getXpAddresses: async () => ({
+      xpAddresses: ['fuji1aaa', 'fuji1bbb'],
+      xpAddressDictionary: {} as any
+    }),
+    ...overrides
+  }
+}
+
+describe('createCctCallbacks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedGetAvalancheNetworkP.mockReturnValue(P_NETWORK)
+    mockedGetAvalancheNetworkX.mockReturnValue(X_NETWORK)
+  })
+
+  describe('getCoreEthAddress', () => {
+    it('returns the active account Coreth bech32 address', () => {
+      const { getCoreEthAddress } = createCctCallbacks(makeDeps())
+      expect(getCoreEthAddress('0xabc' as any)).toBe('C-fuji1xxx')
+    })
+
+    it('throws when no active account', () => {
+      const { getCoreEthAddress } = createCctCallbacks(
+        makeDeps({ getActiveAccount: () => undefined })
+      )
+      expect(() => getCoreEthAddress('0xabc' as any)).toThrow(
+        /no active account/
+      )
+    })
+  })
+
+  describe('UTXO and address callbacks', () => {
+    const signer = {
+      getAtomicUTXOs: jest.fn(),
+      getUTXOs: jest.fn(),
+      getAddresses: jest.fn(),
+      getChangeAddress: jest.fn()
+    }
+
+    beforeEach(() => {
+      mockedGetReadOnlySigner.mockResolvedValue(signer)
+      signer.getAtomicUTXOs.mockResolvedValue('atomic-utxos')
+      signer.getUTXOs.mockResolvedValue('utxos')
+      signer.getAddresses.mockReturnValue(['P-fuji1xxx', 'P-fuji1yyy'])
+      signer.getChangeAddress.mockReturnValue('P-fuji1change')
+    })
+
+    it('getAtomicUtxos delegates to signer.getAtomicUTXOs(dst, src)', async () => {
+      const { getAtomicUtxos } = createCctCallbacks(makeDeps())
+      const result = await getAtomicUtxos('P', 'C')
+      expect(signer.getAtomicUTXOs).toHaveBeenCalledWith('P', 'C')
+      expect(result).toBe('atomic-utxos')
+    })
+
+    it('getUtxos delegates to signer.getUTXOs(chainAlias)', async () => {
+      const { getUtxos } = createCctCallbacks(makeDeps())
+      const result = await getUtxos('P')
+      expect(signer.getUTXOs).toHaveBeenCalledWith('P')
+      expect(result).toBe('utxos')
+    })
+
+    it('getWalletAddressesForChainAlias delegates to signer.getAddresses', async () => {
+      const { getWalletAddressesForChainAlias } = createCctCallbacks(makeDeps())
+      const result = await getWalletAddressesForChainAlias('P')
+      expect(signer.getAddresses).toHaveBeenCalledWith('P')
+      expect(result).toEqual(['P-fuji1xxx', 'P-fuji1yyy'])
+    })
+
+    it('getWalletChangeAddressForChainAlias delegates to signer.getChangeAddress', async () => {
+      const { getWalletChangeAddressForChainAlias } = createCctCallbacks(
+        makeDeps()
+      )
+      const result = await getWalletChangeAddressForChainAlias('P')
+      expect(signer.getChangeAddress).toHaveBeenCalledWith('P')
+      expect(result).toBe('P-fuji1change')
+    })
+
+    it('reads the latest account on every call (live state)', async () => {
+      let account = makeAccount({ id: 'account-1' })
+      const { getAtomicUtxos } = createCctCallbacks(
+        makeDeps({ getActiveAccount: () => account })
+      )
+      await getAtomicUtxos('P', 'C')
+      account = makeAccount({ id: 'account-2' })
+      await getAtomicUtxos('P', 'C')
+
+      expect(mockedGetReadOnlySigner).toHaveBeenCalledTimes(2)
+      expect(mockedGetReadOnlySigner.mock.calls[0]?.[0].account.id).toBe(
+        'account-1'
+      )
+      expect(mockedGetReadOnlySigner.mock.calls[1]?.[0].account.id).toBe(
+        'account-2'
+      )
+    })
+
+    it('throws when no active account', async () => {
+      const { getAtomicUtxos } = createCctCallbacks(
+        makeDeps({ getActiveAccount: () => undefined })
+      )
+      await expect(getAtomicUtxos('P', 'C')).rejects.toThrow(
+        /no active account/
+      )
+    })
+  })
+
+  describe('avalancheSendTx', () => {
+    const fakeSignedTx = { signedTx: 'bytes' }
+    const fakeUnsignedTx = { utxos: ['utxo-a', 'utxo-b'] } as any
+
+    beforeEach(() => {
+      mockedWalletSign.mockResolvedValue('{"signed":"json"}')
+      mockedUnsignedTxFromJSON.mockReturnValue({
+        getSignedTx: () => fakeSignedTx
+      })
+      mockedSendTransaction.mockResolvedValue('0xTXHASH')
+      mockedGetInternalExternalAddrs.mockReturnValue({
+        externalIndices: [0],
+        internalIndices: [1]
+      })
+    })
+
+    it('signs and broadcasts via the P network for chainAlias=P', async () => {
+      const { avalancheSendTx } = createCctCallbacks(makeDeps())
+
+      const txHash = await avalancheSendTx({
+        baseFeeInNanoAvax: 25n,
+        chainAlias: 'P',
+        txType: 'import',
+        unsignedTx: fakeUnsignedTx
+      })
+
+      expect(mockedGetAvalancheNetworkP).toHaveBeenCalledWith(false)
+      expect(mockedGetAvalancheNetworkX).not.toHaveBeenCalled()
+
+      expect(mockedWalletSign).toHaveBeenCalledWith(
+        expect.objectContaining({
+          walletId: 'wallet-1',
+          walletType: WalletType.MNEMONIC,
+          accountIndex: 0,
+          network: P_NETWORK,
+          transaction: expect.objectContaining({
+            tx: fakeUnsignedTx,
+            externalIndices: [0],
+            internalIndices: [1]
+          })
+        })
+      )
+
+      expect(mockedSendTransaction).toHaveBeenCalledWith({
+        signedTx: fakeSignedTx,
+        network: P_NETWORK
+      })
+      expect(txHash).toBe('0xTXHASH')
+    })
+
+    it('uses the X network for chainAlias=X', async () => {
+      const { avalancheSendTx } = createCctCallbacks(makeDeps())
+
+      await avalancheSendTx({
+        baseFeeInNanoAvax: 25n,
+        chainAlias: 'X',
+        txType: 'export',
+        unsignedTx: fakeUnsignedTx
+      })
+
+      expect(mockedGetAvalancheNetworkX).toHaveBeenCalledWith(false)
+      expect(mockedWalletSign.mock.calls[0]?.[0].network).toBe(X_NETWORK)
+      expect(mockedSendTransaction.mock.calls[0]?.[0].network).toBe(X_NETWORK)
+    })
+
+    it('uses the P network for chainAlias=C (atomic gateway is on the XP RPC)', async () => {
+      const { avalancheSendTx } = createCctCallbacks(makeDeps())
+
+      await avalancheSendTx({
+        baseFeeInNanoAvax: 25n,
+        chainAlias: 'C',
+        txType: 'export',
+        unsignedTx: fakeUnsignedTx
+      })
+
+      expect(mockedGetAvalancheNetworkP).toHaveBeenCalledWith(false)
+      expect(mockedGetAvalancheNetworkX).not.toHaveBeenCalled()
+    })
+
+    it('passes isTestnet through to the network selector', async () => {
+      const { avalancheSendTx } = createCctCallbacks(
+        makeDeps({ getIsDeveloperMode: () => true })
+      )
+
+      await avalancheSendTx({
+        baseFeeInNanoAvax: 1n,
+        chainAlias: 'P',
+        txType: 'import',
+        unsignedTx: fakeUnsignedTx
+      })
+
+      expect(mockedGetAvalancheNetworkP).toHaveBeenCalledWith(true)
+    })
+
+    it('throws when no active wallet', async () => {
+      const { avalancheSendTx } = createCctCallbacks(
+        makeDeps({ getWallet: () => undefined })
+      )
+      await expect(
+        avalancheSendTx({
+          baseFeeInNanoAvax: 1n,
+          chainAlias: 'P',
+          txType: 'import',
+          unsignedTx: fakeUnsignedTx
+        })
+      ).rejects.toThrow(/no active wallet/)
+    })
+
+    it('throws when no active account', async () => {
+      const { avalancheSendTx } = createCctCallbacks(
+        makeDeps({ getActiveAccount: () => undefined })
+      )
+      await expect(
+        avalancheSendTx({
+          baseFeeInNanoAvax: 1n,
+          chainAlias: 'P',
+          txType: 'import',
+          unsignedTx: fakeUnsignedTx
+        })
+      ).rejects.toThrow(/no active account/)
+    })
+  })
+})

--- a/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.test.ts
+++ b/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.test.ts
@@ -100,6 +100,17 @@ describe('createCctCallbacks', () => {
         /no active account/
       )
     })
+
+    it('throws when addressCoreEth is empty (avoid handing the SDK an empty string)', () => {
+      const { getCoreEthAddress } = createCctCallbacks(
+        makeDeps({
+          getActiveAccount: () => makeAccount({ addressCoreEth: '' })
+        })
+      )
+      expect(() => getCoreEthAddress('0xabc' as any)).toThrow(
+        /addressCoreEth empty/
+      )
+    })
   })
 
   describe('UTXO and address callbacks', () => {

--- a/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.test.ts
+++ b/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.test.ts
@@ -70,7 +70,10 @@ const makeDeps = (
     getWallet: () => ({ id: account.walletId, type: WalletType.MNEMONIC }),
     getXpAddresses: async () => ({
       xpAddresses: ['fuji1aaa', 'fuji1bbb'],
-      xpAddressDictionary: {} as any
+      xpAddressDictionary: {
+        fuji1aaa: { space: 'e', index: 0 },
+        fuji1bbb: { space: 'i', index: 0 }
+      } as any
     }),
     ...overrides
   }
@@ -169,6 +172,22 @@ describe('createCctCallbacks', () => {
       )
       await expect(getAtomicUtxos('P', 'C')).rejects.toThrow(
         /no active account/
+      )
+    })
+
+    it('throws when xpAddresses is empty (refuses to build a signer with no XP addresses)', async () => {
+      const { getAtomicUtxos } = createCctCallbacks(
+        makeDeps({
+          getXpAddresses: async () => ({
+            xpAddresses: [],
+            xpAddressDictionary: {
+              fuji1aaa: { space: 'e', index: 0 }
+            } as any
+          })
+        })
+      )
+      await expect(getAtomicUtxos('P', 'C')).rejects.toThrow(
+        /xpAddresses empty/
       )
     })
   })
@@ -293,6 +312,26 @@ describe('createCctCallbacks', () => {
           unsignedTx: fakeUnsignedTx
         })
       ).rejects.toThrow(/no active account/)
+    })
+
+    it('throws when xpAddressDictionary is empty (would otherwise produce invalid signing indices)', async () => {
+      const { avalancheSendTx } = createCctCallbacks(
+        makeDeps({
+          getXpAddresses: async () => ({
+            xpAddresses: ['fuji1aaa'],
+            xpAddressDictionary: {} as any
+          })
+        })
+      )
+      await expect(
+        avalancheSendTx({
+          baseFeeInNanoAvax: 1n,
+          chainAlias: 'P',
+          txType: 'import',
+          unsignedTx: fakeUnsignedTx
+        })
+      ).rejects.toThrow(/xpAddressDictionary empty/)
+      expect(mockedWalletSign).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.ts
+++ b/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.ts
@@ -75,6 +75,14 @@ export const createCctCallbacks = (deps: CctCallbackDeps): CctCallbacks => {
     const account = getRequiredAccount()
     const isTestnet = deps.getIsDeveloperMode()
     const { xpAddresses } = await deps.getXpAddresses()
+    if (xpAddresses.length === 0) {
+      // Defensive: getCachedXPAddresses normally fetches on a cold cache, so
+      // an empty list here means address derivation failed for this wallet
+      // (e.g. Keystone non-primary account). Refuse to build the wallet
+      // rather than silently producing an Avalanche.AddressWallet with no
+      // X/P addresses, which would return empty UTXOs and empty addresses.
+      throw new Error('[cctCallbacks] xpAddresses empty for active account')
+    }
     return AvalancheWalletService.getReadOnlySigner({
       account,
       isTestnet,
@@ -90,6 +98,15 @@ export const createCctCallbacks = (deps: CctCallbackDeps): CctCallbacks => {
     const wallet = getRequiredWallet()
     const isTestnet = deps.getIsDeveloperMode()
     const { xpAddressDictionary } = await deps.getXpAddresses()
+    if (Object.keys(xpAddressDictionary).length === 0) {
+      // Defensive: an empty dictionary would make getInternalExternalAddrs
+      // return empty signing indices, and the wallet's signer could then
+      // fall back to default derivation paths and produce a signature that
+      // doesn't match the UTXO output owners. Fail fast.
+      throw new Error(
+        '[cctCallbacks] xpAddressDictionary empty for active account'
+      )
+    }
 
     // The Avalanche XP provider handles atomic txs for C, P, and X chains —
     // this matches the existing earn flow's network resolution. For X-only

--- a/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.ts
+++ b/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.ts
@@ -1,0 +1,159 @@
+import type {
+  AvalancheCctInitializer,
+  AvalancheSendTxParams
+} from '@avalabs/fusion-sdk'
+import { UnsignedTx } from '@avalabs/avalanchejs'
+import { Avalanche } from '@avalabs/core-wallets-sdk'
+import { getInternalExternalAddrs } from 'common/hooks/send/utils/getInternalExternalAddrs'
+import AvalancheWalletService from 'services/wallet/AvalancheWalletService'
+import NetworkService from 'services/network/NetworkService'
+import WalletService from 'services/wallet/WalletService'
+import { AvalancheTransactionRequest, WalletType } from 'services/wallet/types'
+import { Account, XPAddressDictionary } from 'store/account/types'
+
+/**
+ * Live state accessors the callbacks need at invocation time. Each is read on
+ * every call so callbacks observe the latest account / wallet / xpAddresses
+ * without needing to recreate the TransferManager when state changes.
+ */
+export type CctCallbackDeps = {
+  getActiveAccount: () => Account | undefined
+  getIsDeveloperMode: () => boolean
+  getWallet: () => { id: string; type: WalletType } | undefined
+  /**
+   * Returns the active account's X/P addresses + signing dictionary. Async so
+   * the implementation can fetch on a cold cache (the SDK signing path needs
+   * accurate addresses; falling back to empty would produce invalid signatures).
+   */
+  getXpAddresses: () => Promise<{
+    xpAddresses: string[]
+    xpAddressDictionary: XPAddressDictionary
+  }>
+}
+
+export type CctCallbacks = Pick<
+  AvalancheCctInitializer,
+  | 'avalancheSendTx'
+  | 'getCoreEthAddress'
+  | 'getAtomicUtxos'
+  | 'getUtxos'
+  | 'getWalletAddressesForChainAlias'
+  | 'getWalletChangeAddressForChainAlias'
+>
+
+/**
+ * Builds the six callbacks required by the Fusion SDK's
+ * `AvalancheCctInitializer` from mobile's existing wallet/network primitives.
+ *
+ * - `avalancheSendTx` signs the SDK-built export/import tx via `WalletService`
+ *   and broadcasts it via the Avalanche XP provider (same path the earn flow
+ *   uses for staking exports/imports).
+ * - The address callbacks read from the live wallet via
+ *   `AvalancheWalletService.getReadOnlySigner` (which wraps
+ *   `Avalanche.AddressWallet` from core-wallets-sdk).
+ * - The UTXO callbacks delegate to the same wallet's `getUTXOs` /
+ *   `getAtomicUTXOs` methods.
+ *
+ * All callbacks throw if the active account / wallet / xpAddresses aren't
+ * available at call time — the consumer should gate enablement on those being
+ * present before initializing the service.
+ */
+export const createCctCallbacks = (deps: CctCallbackDeps): CctCallbacks => {
+  const getRequiredAccount = (): Account => {
+    const account = deps.getActiveAccount()
+    if (!account) throw new Error('[cctCallbacks] no active account')
+    return account
+  }
+
+  const getRequiredWallet = (): { id: string; type: WalletType } => {
+    const wallet = deps.getWallet()
+    if (!wallet) throw new Error('[cctCallbacks] no active wallet')
+    return wallet
+  }
+
+  const getReadOnlySigner = async (): Promise<Avalanche.AddressWallet> => {
+    const account = getRequiredAccount()
+    const isTestnet = deps.getIsDeveloperMode()
+    const { xpAddresses } = await deps.getXpAddresses()
+    return AvalancheWalletService.getReadOnlySigner({
+      account,
+      isTestnet,
+      xpAddresses
+    })
+  }
+
+  const avalancheSendTx: CctCallbacks['avalancheSendTx'] = async ({
+    chainAlias,
+    unsignedTx
+  }: AvalancheSendTxParams) => {
+    const account = getRequiredAccount()
+    const wallet = getRequiredWallet()
+    const isTestnet = deps.getIsDeveloperMode()
+    const { xpAddressDictionary } = await deps.getXpAddresses()
+
+    // The Avalanche XP provider handles atomic txs for C, P, and X chains —
+    // this matches the existing earn flow's network resolution. For X-only
+    // (non-atomic) calls we use the X network, otherwise stay on P.
+    const network =
+      chainAlias === 'X'
+        ? NetworkService.getAvalancheNetworkX(isTestnet)
+        : NetworkService.getAvalancheNetworkP(isTestnet)
+
+    const signedTxJson = await WalletService.sign({
+      walletId: wallet.id,
+      walletType: wallet.type,
+      transaction: {
+        tx: unsignedTx,
+        ...getInternalExternalAddrs({
+          utxos: unsignedTx.utxos,
+          xpAddressDict: xpAddressDictionary,
+          isTestnet
+        })
+      } as AvalancheTransactionRequest,
+      accountIndex: account.index,
+      network
+    })
+
+    const signedTx = UnsignedTx.fromJSON(signedTxJson).getSignedTx()
+
+    return NetworkService.sendTransaction({ signedTx, network })
+  }
+
+  const getCoreEthAddress: CctCallbacks['getCoreEthAddress'] = () => {
+    return getRequiredAccount().addressCoreEth
+  }
+
+  const getAtomicUtxos: CctCallbacks['getAtomicUtxos'] = async (
+    destinationChain,
+    sourceChain
+  ) => {
+    const signer = await getReadOnlySigner()
+    return signer.getAtomicUTXOs(destinationChain, sourceChain)
+  }
+
+  const getUtxos: CctCallbacks['getUtxos'] = async chainAlias => {
+    const signer = await getReadOnlySigner()
+    return signer.getUTXOs(chainAlias)
+  }
+
+  const getWalletAddressesForChainAlias: CctCallbacks['getWalletAddressesForChainAlias'] =
+    async chainAlias => {
+      const signer = await getReadOnlySigner()
+      return signer.getAddresses(chainAlias)
+    }
+
+  const getWalletChangeAddressForChainAlias: CctCallbacks['getWalletChangeAddressForChainAlias'] =
+    async chainAlias => {
+      const signer = await getReadOnlySigner()
+      return signer.getChangeAddress(chainAlias)
+    }
+
+  return {
+    avalancheSendTx,
+    getCoreEthAddress,
+    getAtomicUtxos,
+    getUtxos,
+    getWalletAddressesForChainAlias,
+    getWalletChangeAddressForChainAlias
+  }
+}

--- a/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.ts
+++ b/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.ts
@@ -54,9 +54,11 @@ export type CctCallbacks = Pick<
  * - The UTXO callbacks delegate to the same wallet's `getUTXOs` /
  *   `getAtomicUTXOs` methods.
  *
- * All callbacks throw if the active account / wallet / xpAddresses aren't
- * available at call time — the consumer should gate enablement on those being
- * present before initializing the service.
+ * All callbacks throw if the active account isn't available at call time, or
+ * if the underlying XP addresses can't be derived (empty list / empty signing
+ * dictionary). `avalancheSendTx` additionally throws if no active wallet is
+ * available. The consumer should gate enablement on those being present
+ * before initializing the service.
  */
 export const createCctCallbacks = (deps: CctCallbackDeps): CctCallbacks => {
   const getRequiredAccount = (): Account => {
@@ -137,7 +139,15 @@ export const createCctCallbacks = (deps: CctCallbackDeps): CctCallbacks => {
   }
 
   const getCoreEthAddress: CctCallbacks['getCoreEthAddress'] = () => {
-    return getRequiredAccount().addressCoreEth
+    const { addressCoreEth } = getRequiredAccount()
+    if (!addressCoreEth) {
+      // Defensive: addressCoreEth is typed `string` on Account but can be
+      // empty for wallets that don't derive a Coreth bech32 address (some
+      // Ledger paths). Returning '' would only surface as an opaque SDK
+      // failure later — fail fast instead.
+      throw new Error('[cctCallbacks] addressCoreEth empty for active account')
+    }
+    return addressCoreEth
   }
 
   const getAtomicUtxos: CctCallbacks['getAtomicUtxos'] = async (

--- a/packages/core-mobile/app/new/features/swap/services/types.ts
+++ b/packages/core-mobile/app/new/features/swap/services/types.ts
@@ -17,6 +17,7 @@ import type {
   Fetch,
   SolanaSigner
 } from '@avalabs/fusion-sdk'
+import type { CctCallbacks } from './cct/createCctCallbacks'
 
 /**
  * The subset of PostHog feature flags consumed by FusionService.
@@ -25,6 +26,7 @@ export type FusionServiceFlags = Pick<
   FeatureFlags,
   | FeatureGates.FUSION_MARKR
   | FeatureGates.FUSION_AVALANCHE_EVM
+  | FeatureGates.FUSION_AVALANCHE_CCT
   | FeatureGates.FUSION_LOMBARD_BTC_TO_BTCB
   | FeatureGates.FUSION_LOMBARD_BTCB_TO_BTC
   | FeatureGates.FUSION_DISABLE_CROSS_CHAIN_SWAPS
@@ -50,6 +52,12 @@ export interface FusionSigners {
 }
 
 /**
+ * Optional dependencies required only when the `AVALANCHE_CCT` service is
+ * enabled (the six callbacks the SDK's `AvalancheCctInitializer` consumes).
+ */
+export type FusionCctDependencies = CctCallbacks
+
+/**
  * Parameters for creating a Quoter instance
  * Extracts the parameter type from TransferManager's getQuoter method
  */
@@ -65,11 +73,13 @@ export interface IFusionService {
   init({
     bitcoinProvider,
     config,
-    signers
+    signers,
+    cctDependencies
   }: {
     bitcoinProvider: BitcoinFunctions
     config: FusionConfig
     signers: FusionSigners
+    cctDependencies?: FusionCctDependencies
   }): Promise<void>
 
   /**

--- a/packages/core-mobile/app/new/features/swap/store/listeners.test.ts
+++ b/packages/core-mobile/app/new/features/swap/store/listeners.test.ts
@@ -6,6 +6,7 @@ import {
   selectIsFusionEnabled,
   selectIsFusionMarkrEnabled,
   selectIsFusionAvalancheEvmEnabled,
+  selectIsFusionAvalancheCctEnabled,
   selectIsFusionLombardBtcToBtcbEnabled,
   selectIsFusionLombardBtcbToBtcEnabled,
   selectFusionDisableCrossChainSwaps
@@ -45,6 +46,7 @@ jest.mock('store/posthog/slice', () => ({
   selectIsFusionEnabled: jest.fn(),
   selectIsFusionMarkrEnabled: jest.fn(),
   selectIsFusionAvalancheEvmEnabled: jest.fn(),
+  selectIsFusionAvalancheCctEnabled: jest.fn(),
   selectIsFusionLombardBtcToBtcbEnabled: jest.fn(),
   selectIsFusionLombardBtcbToBtcEnabled: jest.fn(),
   selectFusionDisableCrossChainSwaps: jest.fn(),
@@ -122,6 +124,8 @@ const mockSelectIsFusionEnabled = selectIsFusionEnabled as jest.Mock
 const mockSelectIsFusionMarkrEnabled = selectIsFusionMarkrEnabled as jest.Mock
 const mockSelectIsFusionAvalancheEvmEnabled =
   selectIsFusionAvalancheEvmEnabled as jest.Mock
+const mockSelectIsFusionAvalancheCctEnabled =
+  selectIsFusionAvalancheCctEnabled as jest.Mock
 const mockSelectIsFusionLombardBtcToBtcbEnabled =
   selectIsFusionLombardBtcToBtcbEnabled as jest.Mock
 const mockSelectIsFusionLombardBtcbToBtcEnabled =
@@ -157,6 +161,7 @@ describe('Fusion listeners', () => {
     mockSelectIsFusionEnabled.mockReturnValue(true)
     mockSelectIsFusionMarkrEnabled.mockReturnValue(false)
     mockSelectIsFusionAvalancheEvmEnabled.mockReturnValue(false)
+    mockSelectIsFusionAvalancheCctEnabled.mockReturnValue(false)
     mockSelectIsFusionLombardBtcToBtcbEnabled.mockReturnValue(false)
     mockSelectIsFusionLombardBtcbToBtcEnabled.mockReturnValue(false)
     mockSelectFusionDisableCrossChainSwaps.mockReturnValue(false)
@@ -211,6 +216,7 @@ describe('Fusion listeners', () => {
           featureFlags: {
             'fusion-markr': true,
             'fusion-avalanche-evm': true,
+            'fusion-avalanche-cct': false,
             'fusion-lombard-btc-to-btcb': false,
             'fusion-lombard-btcb-to-btc': false,
             'fusion-disable-cross-chain-swaps': false

--- a/packages/core-mobile/app/new/features/swap/store/listeners.ts
+++ b/packages/core-mobile/app/new/features/swap/store/listeners.ts
@@ -11,6 +11,7 @@ import {
   selectIsFusionEnabled,
   selectIsFusionMarkrEnabled,
   selectIsFusionAvalancheEvmEnabled,
+  selectIsFusionAvalancheCctEnabled,
   selectIsFusionLombardBtcToBtcbEnabled,
   selectIsFusionLombardBtcbToBtcEnabled,
   selectFusionDisableCrossChainSwaps,
@@ -39,6 +40,7 @@ import { getFusionEnvironment } from '../consts'
 import { createEvmSigner } from '../services/signers/EvmSigner'
 import { createBtcSigner } from '../services/signers/BtcSigner'
 import { createSvmSigner } from '../services/signers/SvmSigner'
+import { buildCctDependencies } from '../services/cct/buildCctDependencies'
 import {
   useIsFusionServiceReady,
   useFusionServiceInitError,
@@ -58,6 +60,7 @@ const getFusionFeatureStates = (
   isFusionEnabled: boolean
   isFusionMarkrEnabled: boolean
   isFusionAvalancheEvmEnabled: boolean
+  isFusionAvalancheCctEnabled: boolean
   isFusionLombardBtcToBtcbEnabled: boolean
   isFusionLombardBtcbToBtcEnabled: boolean
   isFusionDisableCrossChainSwaps: boolean
@@ -66,6 +69,7 @@ const getFusionFeatureStates = (
   isFusionEnabled: selectIsFusionEnabled(state),
   isFusionMarkrEnabled: selectIsFusionMarkrEnabled(state),
   isFusionAvalancheEvmEnabled: selectIsFusionAvalancheEvmEnabled(state),
+  isFusionAvalancheCctEnabled: selectIsFusionAvalancheCctEnabled(state),
   isFusionLombardBtcToBtcbEnabled: selectIsFusionLombardBtcToBtcbEnabled(state),
   isFusionLombardBtcbToBtcEnabled: selectIsFusionLombardBtcbToBtcEnabled(state),
   isFusionDisableCrossChainSwaps: selectFusionDisableCrossChainSwaps(state),
@@ -205,6 +209,7 @@ export const initFusionService = async (
     const featureFlags = {
       'fusion-markr': featureStates.isFusionMarkrEnabled,
       'fusion-avalanche-evm': featureStates.isFusionAvalancheEvmEnabled,
+      'fusion-avalanche-cct': featureStates.isFusionAvalancheCctEnabled,
       'fusion-lombard-btc-to-btcb':
         featureStates.isFusionLombardBtcToBtcbEnabled,
       'fusion-lombard-btcb-to-btc':
@@ -217,6 +222,13 @@ export const initFusionService = async (
       featureStates.isDeveloperMode
     )
 
+    // CCT callbacks read live Redux + React Query state on each invocation so
+    // they always see the latest account / wallet / xpAddresses. The
+    // TransferManager doesn't need to be recreated when those change.
+    const cctDependencies = featureStates.isFusionAvalancheCctEnabled
+      ? buildCctDependencies(listenerApi)
+      : undefined
+
     // Initialize the service
     await FusionService.initWithFeatureFlags({
       bitcoinProvider,
@@ -227,7 +239,8 @@ export const initFusionService = async (
         evm: evmSigner,
         btc: btcSigner,
         svm: svmSigner
-      }
+      },
+      cctDependencies
     })
 
     // Mark as ready after successful init

--- a/packages/core-mobile/app/new/features/swap/store/listeners.ts
+++ b/packages/core-mobile/app/new/features/swap/store/listeners.ts
@@ -94,6 +94,8 @@ const shouldReinitializeFusion = (
       currentFeatures.isFusionMarkrEnabled ||
     prevFeatures.isFusionAvalancheEvmEnabled !==
       currentFeatures.isFusionAvalancheEvmEnabled ||
+    prevFeatures.isFusionAvalancheCctEnabled !==
+      currentFeatures.isFusionAvalancheCctEnabled ||
     prevFeatures.isFusionLombardBtcToBtcbEnabled !==
       currentFeatures.isFusionLombardBtcToBtcbEnabled ||
     prevFeatures.isFusionLombardBtcbToBtcEnabled !==

--- a/packages/core-mobile/app/new/features/swap/utils/fusionErrors.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/fusionErrors.ts
@@ -49,6 +49,11 @@ export const fusionErrors = {
   unknownServiceType(serviceType: string): FusionQuoteError {
     return new FusionQuoteError(`Unknown service type: ${serviceType}`)
   },
+  cctDependenciesMissing(): FusionQuoteError {
+    return new FusionQuoteError(
+      'AVALANCHE_CCT enabled but cctDependencies not provided'
+    )
+  },
 
   // Type-conversion / validation errors
   erc721Unsupported(): FusionQuoteError {

--- a/packages/core-mobile/app/services/posthog/types.ts
+++ b/packages/core-mobile/app/services/posthog/types.ts
@@ -35,6 +35,7 @@ export enum FeatureGates {
   FUSION = 'fusion',
   FUSION_MARKR = 'fusion-markr',
   FUSION_AVALANCHE_EVM = 'fusion-avalanche-evm',
+  FUSION_AVALANCHE_CCT = 'fusion-avalanche-cct',
   FUSION_LOMBARD_BTC_TO_BTCB = 'fusion-lombard-btc-to-btcb',
   FUSION_LOMBARD_BTCB_TO_BTC = 'fusion-lombard-btcb-to-btc',
   FUSION_DISABLE_CROSS_CHAIN_SWAPS = 'fusion-disable-cross-chain-swaps',

--- a/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
+++ b/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
@@ -476,7 +476,7 @@ class AvalancheWalletService {
     })
   }
 
-  private async getReadOnlySigner({
+  public async getReadOnlySigner({
     account,
     isTestnet,
     xpAddresses

--- a/packages/core-mobile/app/store/posthog/slice.ts
+++ b/packages/core-mobile/app/store/posthog/slice.ts
@@ -558,6 +558,16 @@ export const selectIsFusionAvalancheEvmEnabled = (
   )
 }
 
+export const selectIsFusionAvalancheCctEnabled = (
+  state: RootState
+): boolean => {
+  const { featureFlags } = state.posthog
+  return (
+    featureFlags[FeatureGates.FUSION_AVALANCHE_CCT] === true &&
+    featureFlags[FeatureGates.EVERYTHING] === true
+  )
+}
+
 export const selectIsFusionLombardBtcToBtcbEnabled = (
   state: RootState
 ): boolean => {


### PR DESCRIPTION
## Description

**Ticket: [CP-14361](https://ava-labs.atlassian.net/browse/CP-14361)**

Backend plumbing for the next step in the CCT epic ([CP-14356](https://ava-labs.atlassian.net/browse/CP-14356)) — register the fusion-sdk's `AVALANCHE_CCT` service in our `FusionService` and provide the six callbacks the SDK's `AvalancheCctInitializer` needs. Behind a new `fusion-avalanche-cct` PostHog flag, so it's a no-op until we flip it. No user-facing UI yet — that's CP-14362, which is also where we'll enable the flag and validate the end-to-end transfer across all four wallet types.

The `avalancheSendTx` callback routes through `WalletService.sign` + `NetworkService.sendTransaction` (the same path the earn flow already uses for staking export/import) and picks the X network for `chainAlias='X'`, P network for C/P (matching the existing XP-atomic-gateway convention). The address/UTXO callbacks delegate to the `Avalanche.AddressWallet` built via `AvalancheWalletService.getReadOnlySigner`. `getXpAddresses` uses `getCachedXPAddresses` (`queryClient.fetchQuery`) so a cold cache fetches on demand rather than producing empty addresses and breaking signing.

## Screenshots/Videos

_N/A — no UI changes in this PR._

## Testing

This PR is gated behind `fusion-avalanche-cct` (off by default) so the app behavior is identical to `main`. The flag-on path + 6-direction transfer matrix across the four wallet types will be exercised in CP-14362 when the UI lands.

**Dev Testing**

- Confirm the app behaves identically to `main`. CCT does not register, existing services (Markr, Lombard, Avalanche EVM, Wrap/Unwrap) work as before.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14361]: https://ava-labs.atlassian.net/browse/CP-14361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-14356]: https://ava-labs.atlassian.net/browse/CP-14356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ