### PR TITLE
CP-14428: fix CircularDial value drifting after a fast swipe-release

### DIFF
--- a/packages/k2-alpine/src/components/CircularDial/CircularDial.tsx
+++ b/packages/k2-alpine/src/components/CircularDial/CircularDial.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useMemo, useRef } from 'react'
+import React, { FC, useCallback, useEffect, useMemo, useRef } from 'react'
 import type { LayoutChangeEvent } from 'react-native'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import {
@@ -236,6 +236,16 @@ export const CircularDial: FC<CircularDialProps> = ({
       }, SETTLE_WINDOW_MS)
     },
     [isSettling, settleToken]
+  )
+
+  // Cancel a pending settle timer on unmount so it can't fire ~250ms later
+  // and write to shared values after the component is gone (mirrors the rAF
+  // cleanup in DialReadout).
+  useEffect(
+    () => () => {
+      if (settleTimerRef.current !== null) clearTimeout(settleTimerRef.current)
+    },
+    []
   )
 
   // manualActivation + direction-based commit: once total motion

--- a/packages/k2-alpine/src/components/CircularDial/CircularDial.tsx
+++ b/packages/k2-alpine/src/components/CircularDial/CircularDial.tsx
@@ -219,13 +219,19 @@ export const CircularDial: FC<CircularDialProps> = ({
 
   const readoutRef = useRef<DialReadoutHandle>(null)
 
-  // Clears the settling guard once the post-release window elapses, but
-  // only if no newer interaction has opened its own window since (token
-  // check) — otherwise a stale timer from an earlier swipe could reopen
-  // prop sync mid-settle and let an echo through.
+  // Pending settle-window timer, so rapid repeated swipes cancel the prior
+  // one instead of piling up dozens of timeouts that all wake to no-op.
+  const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Clears the settling guard once the post-release window elapses. Cancels
+  // any in-flight window first; the token check is a belt-and-suspenders
+  // against a stale timer reopening prop sync mid-settle and letting an
+  // echo through.
   const clearSettlingSoon = useCallback(
     (token: number) => {
-      setTimeout(() => {
+      if (settleTimerRef.current !== null) clearTimeout(settleTimerRef.current)
+      settleTimerRef.current = setTimeout(() => {
+        settleTimerRef.current = null
         if (settleToken.value === token) isSettling.value = false
       }, SETTLE_WINDOW_MS)
     },
@@ -341,11 +347,13 @@ export const CircularDial: FC<CircularDialProps> = ({
     })
 
   // Emit onChange on step crossings while the dial is active so consumers —
-  // and the readout text/caption, driven by the parent's controlled
-  // `value` — track the value live. Throttled on the UI thread to
-  // EMIT_THROTTLE_MS via a leading-edge time gate (no trailing timer, so
-  // nothing is queued to fire after release); onEnd always emits the final
-  // snapped value, so throttled-away crossings are never lost.
+  // and parent-derived UI such as the fiat caption — track the value live.
+  // (The readout number itself is now driven by progressSv on the UI thread
+  // in DialReadout, so it no longer depends on this round-trip.) Throttled
+  // on the UI thread to EMIT_THROTTLE_MS via a leading-edge time gate (no
+  // trailing timer, so nothing is queued to fire after release); onEnd
+  // always emits the final snapped value, so throttled-away crossings are
+  // never lost.
   useAnimatedReaction(
     () => {
       const raw = progressSv.value * vMax

--- a/packages/k2-alpine/src/components/CircularDial/CircularDial.tsx
+++ b/packages/k2-alpine/src/components/CircularDial/CircularDial.tsx
@@ -55,6 +55,18 @@ const ACTIVATION_TAN = Math.tan((ACTIVATION_HALF_ANGLE_DEG * Math.PI) / 180)
 // visible knob (KNOB_RADIUS=11) for a comfortable touch target.
 const KNOB_HIT_RADIUS = 32
 
+// Cap on how often the dial emits onChange to the parent during a drag.
+// A fast swipe crosses a step every frame; emitting each one floods the
+// JS thread faster than the parent can render and builds a backlog that
+// drains *after* the finger lifts — making the value keep changing on its
+// own. ~80ms (≈12/s) is live enough for a readout/caption yet slow enough
+// that the parent keeps up and nothing is left queued to fire post-lift.
+const EMIT_THROTTLE_MS = 80
+
+// How long after release to keep blocking prop→progressSv sync, covering
+// the last in-flight throttled onChange echo as it drains on the JS thread.
+const SETTLE_WINDOW_MS = 250
+
 export const CircularDial: FC<CircularDialProps> = ({
   value,
   onChange,
@@ -144,12 +156,20 @@ export const CircularDial: FC<CircularDialProps> = ({
     [presets]
   )
 
-  const { progressSv, isActive } = useDialValue({
+  const { progressSv, isActive, isSettling } = useDialValue({
     value,
     max: vMax,
     step: vStep
   })
   const isDragging = useSharedValue(false)
+
+  // UI-thread timestamp of the last throttled onChange emission; gates the
+  // step-crossing reaction to EMIT_THROTTLE_MS. Reset on each gesture start.
+  const lastEmitMs = useSharedValue(0)
+  // Monotonic token so only the most recent settle window clears
+  // isSettling — during rapid repeated swipes an older timer must not cut a
+  // newer window short.
+  const settleToken = useSharedValue(0)
 
   // Track translation deltas from this anchor so tapping anywhere
   // doesn't snap the knob — the knob only moves with finger motion
@@ -198,6 +218,19 @@ export const CircularDial: FC<CircularDialProps> = ({
   const TAP_SLOP = 10
 
   const readoutRef = useRef<DialReadoutHandle>(null)
+
+  // Clears the settling guard once the post-release window elapses, but
+  // only if no newer interaction has opened its own window since (token
+  // check) — otherwise a stale timer from an earlier swipe could reopen
+  // prop sync mid-settle and let an echo through.
+  const clearSettlingSoon = useCallback(
+    (token: number) => {
+      setTimeout(() => {
+        if (settleToken.value === token) isSettling.value = false
+      }, SETTLE_WINDOW_MS)
+    },
+    [isSettling, settleToken]
+  )
 
   // manualActivation + direction-based commit: once total motion
   // exceeds TAP_SLOP, activate as a pan iff horizontal motion
@@ -261,6 +294,9 @@ export const CircularDial: FC<CircularDialProps> = ({
       'worklet'
       isActive.value = true
       isDragging.value = true
+      // Zero so the first step crossing of this drag emits immediately
+      // rather than waiting out a throttle window left over from before.
+      lastEmitMs.value = 0
       gestureStartProgress.value = progressSv.value
       const startAngle = Math.PI + progressSv.value * Math.PI
       startTangentY.value = Math.cos(startAngle)
@@ -284,6 +320,12 @@ export const CircularDial: FC<CircularDialProps> = ({
       const raw = progressSv.value * vMax
       const snapped = snapToStep(raw, vStep, vMax)
       progressSv.value = snapped / vMax
+      // Open a settle window: isActive just flipped false, but the last
+      // throttled onChange echo may still be draining on the JS thread and
+      // would otherwise be re-synced back into progressSv, jerking the arc.
+      isSettling.value = true
+      settleToken.value += 1
+      scheduleOnRN(clearSettlingSoon, settleToken.value)
       scheduleOnRN(stableOnChange, snapped)
       scheduleOnRN(stableOnCommit, snapped)
     })
@@ -298,8 +340,12 @@ export const CircularDial: FC<CircularDialProps> = ({
       scheduleOnRN(handleTap)
     })
 
-  // Emit onChange on every step crossing while the dial is active so the
-  // readout text (driven by the parent's controlled `value`) updates live.
+  // Emit onChange on step crossings while the dial is active so consumers —
+  // and the readout text/caption, driven by the parent's controlled
+  // `value` — track the value live. Throttled on the UI thread to
+  // EMIT_THROTTLE_MS via a leading-edge time gate (no trailing timer, so
+  // nothing is queued to fire after release); onEnd always emits the final
+  // snapped value, so throttled-away crossings are never lost.
   useAnimatedReaction(
     () => {
       const raw = progressSv.value * vMax
@@ -309,8 +355,10 @@ export const CircularDial: FC<CircularDialProps> = ({
     (stepIdx, prev) => {
       if (prev === null || stepIdx === prev) return
       if (!isActive.value) return
-      const snapped = stepIdx * vStep
-      scheduleOnRN(stableOnChange, snapped)
+      const now = Date.now()
+      if (now - lastEmitMs.value < EMIT_THROTTLE_MS) return
+      lastEmitMs.value = now
+      scheduleOnRN(stableOnChange, stepIdx * vStep)
     }
   )
 
@@ -362,12 +410,20 @@ export const CircularDial: FC<CircularDialProps> = ({
           // ownership of `isActive`.
           if (!finished) return
           isActive.value = false
+          // Same post-commit settle window as a drag release, so the
+          // preset's own onChange echo can't bounce back into progressSv.
+          isSettling.value = true
+          settleToken.value += 1
+          scheduleOnRN(clearSettlingSoon, settleToken.value)
           scheduleOnRN(stableOnChange, snapped)
           scheduleOnRN(stableOnCommit, snapped)
         }
       )
     },
     [
+      clearSettlingSoon,
+      isSettling,
+      settleToken,
       hapticsEnabled,
       isActive,
       progressSv,
@@ -426,6 +482,7 @@ export const CircularDial: FC<CircularDialProps> = ({
                 labelSx={labelSx}
                 value={value}
                 max={vMax}
+                step={vStep}
                 decimals={vDecimals}
                 maxDecimals={maxDecimals}
                 label={label}

--- a/packages/k2-alpine/src/components/CircularDial/DialReadout.tsx
+++ b/packages/k2-alpine/src/components/CircularDial/DialReadout.tsx
@@ -13,6 +13,7 @@ import { TextInput } from 'react-native'
 import Animated, {
   cancelAnimation,
   SharedValue,
+  useAnimatedProps,
   useAnimatedStyle,
   useSharedValue,
   withTiming
@@ -22,7 +23,9 @@ import { alpha, clamp } from '../../utils'
 import { Text, View } from '../Primitives'
 import {
   commitDraftText,
+  formatNatural,
   sanitizeDecimalInput,
+  snapToStep,
   valueToProgress
 } from './helpers'
 
@@ -68,6 +71,8 @@ export type DialReadoutHandle = {
 type DialReadoutProps = {
   value: number
   max: number
+  /** Step the live (drag) display snaps to, matching committed values. */
+  step: number
   decimals: number
   /** Cap on the number of decimal places the user can type. */
   maxDecimals?: number
@@ -102,6 +107,7 @@ export const DialReadout = forwardRef<DialReadoutHandle, DialReadoutProps>(
     {
       value,
       max,
+      step,
       decimals,
       maxDecimals,
       label,
@@ -125,6 +131,13 @@ export const DialReadout = forwardRef<DialReadoutHandle, DialReadoutProps>(
     const [draft, setDraft] = useState<string | null>(null)
     const inputRef = useRef<TextInput>(null)
     const isEditing = draft !== null
+
+    // UI-thread mirror of `isEditing` so the display worklet can step aside
+    // and let the controlled draft own the text while the user types.
+    const isEditingSv = useSharedValue(false)
+    useEffect(() => {
+      isEditingSv.value = isEditing
+    }, [isEditing, isEditingSv])
 
     // Wider than step-derived `decimals` so typed precision beyond step
     // (e.g. `9999.42` with step=10) survives a blur. `naturalDigits`
@@ -154,6 +167,25 @@ export const DialReadout = forwardRef<DialReadoutHandle, DialReadoutProps>(
       const clamped = value < 0 ? 0 : value > max ? max : value
       return naturalDigits(clamped, displayDecimals)
     }, [draft, value, max, displayDecimals])
+
+    // Drive the visible number from progressSv on the UI thread whenever the
+    // dial isn't being manually edited. This decouples the readout from the
+    // parent's controlled `value` round-trip, so a fast swipe-and-release
+    // lands on the final value instantly instead of lagging behind it or
+    // drifting as queued onChange echoes drain on the JS thread. While
+    // editing, return {} so the controlled draft owns the text.
+    const displayAnimatedProps = useAnimatedProps(() => {
+      if (isEditingSv.value) {
+        return {} as { text?: string; defaultValue?: string }
+      }
+      const raw = progressSv.value * max
+      // Snap to step only mid-drag so the live value ticks in clean step
+      // increments; idle / committed / manually-typed values are shown
+      // exactly (progressSv already holds the precise committed value).
+      const shown = isActive.value ? snapToStep(raw, step, max) : raw
+      const text = formatNatural(shown, displayDecimals)
+      return { text, defaultValue: text }
+    })
 
     // Re-measure only when text length changes — most drag updates
     // don't, and skipping the measurement avoids per-frame wobble.
@@ -377,7 +409,13 @@ export const DialReadout = forwardRef<DialReadoutHandle, DialReadoutProps>(
           pointerEvents={isEditing ? 'box-none' : 'none'}>
           <AnimatedTextInput
             ref={inputRef}
-            value={currentText}
+            // Controlled by the draft only while editing; otherwise left
+            // uncontrolled so `displayAnimatedProps` can drive the text on
+            // the UI thread without the parent's controlled `value` fighting
+            // it on every re-render. `defaultValue` seeds the first paint.
+            value={isEditing ? currentText : undefined}
+            defaultValue={currentText}
+            animatedProps={displayAnimatedProps}
             placeholder={placeholder ?? '0'}
             placeholderTextColor={alpha(colors.$textPrimary, 0.3)}
             onChangeText={handleChangeText}

--- a/packages/k2-alpine/src/components/CircularDial/DialReadout.tsx
+++ b/packages/k2-alpine/src/components/CircularDial/DialReadout.tsx
@@ -132,12 +132,13 @@ export const DialReadout = forwardRef<DialReadoutHandle, DialReadoutProps>(
     const inputRef = useRef<TextInput>(null)
     const isEditing = draft !== null
 
-    // UI-thread mirror of `isEditing` so the display worklet can step aside
-    // and let the controlled draft own the text while the user types.
+    // UI-thread mirror of editing state so the display worklet can step aside
+    // and let the controlled draft own the text while the user types. Set
+    // synchronously at the enter/exit points (startEdit / handleBlur) rather
+    // than via an effect — an effect trails `isEditing` by a frame, briefly
+    // letting both the controlled value and the animated text drive the input
+    // at the boundary.
     const isEditingSv = useSharedValue(false)
-    useEffect(() => {
-      isEditingSv.value = isEditing
-    }, [isEditing, isEditingSv])
 
     // Wider than step-derived `decimals` so typed precision beyond step
     // (e.g. `9999.42` with step=10) survives a blur. `naturalDigits`
@@ -216,6 +217,7 @@ export const DialReadout = forwardRef<DialReadoutHandle, DialReadoutProps>(
       // typing and clobber the draft.
       cancelAnimation(progressSv)
       const initial = naturalDigits(clamp(value, 0, max), displayDecimals)
+      isEditingSv.value = true
       setDraft(initial)
     }, [
       enableManualInput,
@@ -224,6 +226,7 @@ export const DialReadout = forwardRef<DialReadoutHandle, DialReadoutProps>(
       max,
       displayDecimals,
       isActive,
+      isEditingSv,
       progressSv
     ])
 
@@ -314,8 +317,9 @@ export const DialReadout = forwardRef<DialReadoutHandle, DialReadoutProps>(
           progressSv.value = valueToProgress(clamp(value, 0, max), max)
         }
       }
+      isEditingSv.value = false
       setDraft(null)
-    }, [draft, progressSv, onChange, onCommit, max, value])
+    }, [draft, progressSv, onChange, onCommit, max, value, isEditingSv])
 
     // While editing, roll external `value` changes into the draft
     // (covers drag/preset-while-editing). Skip when the draft

--- a/packages/k2-alpine/src/components/CircularDial/helpers.test.ts
+++ b/packages/k2-alpine/src/components/CircularDial/helpers.test.ts
@@ -2,6 +2,7 @@ import { clamp } from '../../utils/clamp'
 import { getStepDecimals } from '../../utils/getStepDecimals'
 import {
   commitDraftText,
+  formatNatural,
   progressToPoint,
   sanitizeDecimalInput,
   shouldSyncExternalValue,
@@ -9,6 +10,14 @@ import {
   validateRange,
   valueToProgress
 } from './helpers'
+
+// Reference implementation the live display must agree with (DialReadout's
+// JS-thread formatter), so the progress-driven text never visually diverges
+// from the controlled-value text at the drag/idle handoff.
+const naturalDigitsRef = (v: number, decimals: number): string => {
+  if (decimals <= 0) return `${Math.round(v)}`
+  return v.toFixed(decimals).replace(/\.?0+$/, '')
+}
 
 describe('clamp', () => {
   it('returns the value when within range', () => {
@@ -69,6 +78,34 @@ describe('snapToStep', () => {
   })
   it('clamps negative inputs to 0', () => {
     expect(snapToStep(-5, 0.5, 100)).toBe(0)
+  })
+})
+
+describe('formatNatural', () => {
+  it('rounds to an integer when decimals <= 0', () => {
+    expect(formatNatural(5, 0)).toBe('5')
+    expect(formatNatural(5.4, 0)).toBe('5')
+    expect(formatNatural(5.6, 0)).toBe('6')
+  })
+  it('strips trailing zeros and a dangling dot', () => {
+    expect(formatNatural(5, 2)).toBe('5')
+    expect(formatNatural(5.5, 2)).toBe('5.5')
+    expect(formatNatural(5.05, 2)).toBe('5.05')
+    expect(formatNatural(0, 2)).toBe('0')
+  })
+  it('matches the reference naturalDigits formatter', () => {
+    const cases: [number, number][] = [
+      [0, 2],
+      [5, 2],
+      [5.5, 2],
+      [9999.42, 8],
+      [100, 0],
+      [0.1, 1],
+      [42.5, 0]
+    ]
+    cases.forEach(([v, d]) => {
+      expect(formatNatural(v, d)).toBe(naturalDigitsRef(v, d))
+    })
   })
 })
 
@@ -165,6 +202,31 @@ describe('shouldSyncExternalValue', () => {
       value: 80,
       currentValue: 10,
       isActive: false
+    })
+    expect(r).toEqual({ sync: true, target: 80 })
+  })
+  it('skips while settling, even when the value differs by more than a step', () => {
+    // Reproduces the post-release bug: after a fast swipe the dial flips
+    // isActive false on lift while stale onChange echoes are still draining
+    // on the JS thread. Those echoes differ from the snapped final by more
+    // than a step, so without a settling guard they'd be re-synced into
+    // progressSv and visibly jerk the arc on their own.
+    const r = shouldSyncExternalValue({
+      ...base,
+      value: 80,
+      currentValue: 10,
+      isActive: false,
+      isSettling: true
+    })
+    expect(r.sync).toBe(false)
+  })
+  it('resumes syncing once settling ends', () => {
+    const r = shouldSyncExternalValue({
+      ...base,
+      value: 80,
+      currentValue: 10,
+      isActive: false,
+      isSettling: false
     })
     expect(r).toEqual({ sync: true, target: 80 })
   })

--- a/packages/k2-alpine/src/components/CircularDial/helpers.ts
+++ b/packages/k2-alpine/src/components/CircularDial/helpers.ts
@@ -13,6 +13,20 @@ export const snapToStep = (v: number, step: number, max: number): number => {
   return Number((snapped - step).toFixed(decimals))
 }
 
+// Worklet form of the readout's natural-digit formatting: fixed to
+// `decimals`, then trailing zeros (and any dangling dot) stripped. No regex
+// so it stays UI-thread safe. Mirrors DialReadout's `naturalDigits` so the
+// progress-driven live display and the controlled-value display agree.
+export const formatNatural = (v: number, decimals: number): string => {
+  'worklet'
+  if (decimals <= 0) return `${Math.round(v)}`
+  const s = v.toFixed(decimals)
+  let end = s.length
+  while (end > 0 && s.charAt(end - 1) === '0') end -= 1
+  if (end > 0 && s.charAt(end - 1) === '.') end -= 1
+  return s.substring(0, end)
+}
+
 // Sweep convention: 180° (9 o'clock) at progress=0, 270° (12 o'clock)
 // at 0.5, 360° (3 o'clock) at progress=1.
 export const progressToPoint = ({
@@ -105,20 +119,29 @@ export const validateRange = ({
 // Skips syncing while a gesture / animation owns the dial, and dampens
 // echoes — when the diff is within one step, the incoming value is
 // likely our own onChange bubbling back as controlled state.
+//
+// `isSettling` extends that skip across the brief window just after a
+// drag releases: `isActive` flips false synchronously on the UI thread at
+// lift, but the JS thread is still draining stale mid-drag onChange echoes.
+// Those echoes differ from the snapped final by more than a step, so
+// without this guard they'd be re-synced into progressSv and jerk the arc
+// on their own after the finger is gone.
 export const shouldSyncExternalValue = ({
   value,
   currentValue,
   max,
   step,
-  isActive
+  isActive,
+  isSettling = false
 }: {
   value: number
   currentValue: number
   max: number
   step: number
   isActive: boolean
+  isSettling?: boolean
 }): { sync: false } | { sync: true; target: number } => {
-  if (isActive) return { sync: false }
+  if (isActive || isSettling) return { sync: false }
   const target = clamp(value, 0, max)
   const diff = Math.abs(currentValue - target)
   if (diff <= step) return { sync: false }

--- a/packages/k2-alpine/src/components/CircularDial/useDialValue.ts
+++ b/packages/k2-alpine/src/components/CircularDial/useDialValue.ts
@@ -13,9 +13,15 @@ export const useDialValue = ({
 }): {
   progressSv: SharedValue<number>
   isActive: SharedValue<boolean>
+  isSettling: SharedValue<boolean>
 } => {
   const progressSv = useSharedValue(valueToProgress(value, max))
   const isActive = useSharedValue(false)
+  // Held true for a short window after a drag releases so stale mid-drag
+  // onChange echoes still draining on the JS thread can't re-sync into
+  // progressSv and jerk the arc once the finger is gone. Owned by the
+  // gesture's onEnd / preset completion in CircularDial.
+  const isSettling = useSharedValue(false)
 
   useEffect(() => {
     const currentValue = progressSv.value * max
@@ -24,7 +30,8 @@ export const useDialValue = ({
       currentValue,
       max,
       step,
-      isActive: isActive.value
+      isActive: isActive.value,
+      isSettling: isSettling.value
     })
     if (decision.sync) {
       progressSv.value = valueToProgress(decision.target, max)
@@ -32,5 +39,5 @@ export const useDialValue = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, max, step])
 
-  return { progressSv, isActive }
+  return { progressSv, isActive, isSettling }
 }


### PR DESCRIPTION
## Description

**Ticket: [CP-14428]**

Fast-swiping the `CircularDial` and lifting the finger left the value (and the arc) continuing to change on its own.

**Root cause:** during a drag the dial emits `onChange` on every step crossing (up to once per frame). A fast swipe produces these faster than the parent can render, building a backlog of stale values that drains on the JS thread *after* the finger lifts. Because the readout number was rendered from the parent's controlled `value` prop, it kept ticking through that backlog; meanwhile stale echoes were re-synced back into the shared progress value, jerking the arc.

**Changes:**
- **Throttle the mid-drag `onChange`** to ~80ms via a leading-edge UI-thread time gate (reset on gesture start). `onEnd` always emits the final snapped value, so no crossing is lost. This keeps the parent — and the live fiat caption — from flooding and removes the backlog.
- **Settling guard** — block prop→progress sync for a short window after release (token-guarded so rapid repeated swipes each get a clean window) so an in-flight echo can't re-sync into the arc.
- **Decouple the readout number from the parent round-trip** — drive the displayed number from the shared progress value on the UI thread via `useAnimatedProps` (uncontrolled while not editing, controlled draft while editing), mirroring the sibling `LeverageDisplay`. The number now lands on the final value instantly on release instead of lagging behind it or drifting.
- Added a `formatNatural` worklet (UI-thread-safe, regex-free) mirroring the readout's `naturalDigits`, with parity unit tests, plus tests for the settling guard.

No new dependencies. Not breaking — `CircularDial`'s public API is unchanged.

**Before**

https://github.com/user-attachments/assets/5c1f8425-62e9-4271-9104-a8489694fdd4


**After** 

https://github.com/user-attachments/assets/d2159d2c-f3b8-4ed9-bba8-033a2f74c4ff


## Testing

iOS - 8815
Android - [8816](https://app.bitrise.io/app/7d7ca5af7066e290/installable-artifacts/74406b12e51ae1b6/public-install-page/a3be3653998cd0812a8690785cc388f4)

**Dev Testing**

Reproduce on the Fast Stake amount screen (or any `CircularDial` consumer):

- Swipe the dial hard left/right repeatedly (stress test), then lift.
  - Expected: the number lands on the final value immediately — no self-ticking or catch-up jump after lift.
  - Expected: the arc/knob does not jump around after release.
- Drag slowly — the fiat caption still updates live (now ~12/s).
- Manual input: tap the value, type, blur to commit — display↔edit handoff works and typed precision is preserved.
- Presets (25% / 50% / Max) animate and commit without post-animation drift.

**QA Testing**

- Acceptance: after any swipe (including a very fast one), releasing the dial leaves the value static at the released amount; no value changes occur without user input.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation



[CP-14428]: https://ava-labs.atlassian.net/browse/CP-14428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ