### PR TITLE
CP-14466: absolute angular tracking for CircularDial (fix inverted swipes)

### DIFF
--- a/packages/k2-alpine/src/components/CircularDial/CircularDial.tsx
+++ b/packages/k2-alpine/src/components/CircularDial/CircularDial.tsx
@@ -27,7 +27,7 @@ import {
 } from './DialArc'
 import { DialPresets } from './DialPresets'
 import { DialReadout, DialReadoutHandle } from './DialReadout'
-import { snapToStep, validateRange } from './helpers'
+import { progressFromCanvasPoint, snapToStep, validateRange } from './helpers'
 import { useDialValue } from './useDialValue'
 import type { CircularDialProps, PresetButton } from './types'
 
@@ -54,6 +54,12 @@ const ACTIVATION_TAN = Math.tan((ACTIVATION_HALF_ANGLE_DEG * Math.PI) / 180)
 // should drive the dial rather than fall through to scroll. ~3× the
 // visible knob (KNOB_RADIUS=11) for a comfortable touch target.
 const KNOB_HIT_RADIUS = 32
+
+// When a drag starts off the knob, the knob has to travel to the finger's
+// angle. Easing that entry (and ongoing tracking) with a short withTiming —
+// the same chase DialReadout uses for typing — avoids a jarring teleport. A
+// knob-grab starts under the finger, so it skips this and tracks 1:1.
+const SNAP_CHASE_MS = 80
 
 export const CircularDial: FC<CircularDialProps> = ({
   value,
@@ -151,21 +157,6 @@ export const CircularDial: FC<CircularDialProps> = ({
   })
   const isDragging = useSharedValue(false)
 
-  // Track translation deltas from this anchor so tapping anywhere
-  // doesn't snap the knob — the knob only moves with finger motion
-  // after the first touch.
-  const gestureStartProgress = useSharedValue(0)
-
-  // Vertical weight of the arc tangent at the gesture's starting
-  // progress = cos θ where θ = π + p·π. At p=0.5 (top) it's 0 — pure
-  // X drives the dial. At p=1 (right edge) it's +1 — down adds
-  // forward. At p=0 (left edge) it's −1 — up adds forward. X is
-  // always full-strength so horizontal swipes feel uniform across
-  // the whole sweep (no "stuck" feeling at the curved ends); Y is
-  // weighted so it only contributes where the arc is actually
-  // moving vertically.
-  const startTangentY = useSharedValue(0)
-
   // First-touch coordinates, captured in onTouchesDown so the
   // direction-based activation logic in onTouchesMove can measure
   // total motion from the touch's true origin.
@@ -261,21 +252,24 @@ export const CircularDial: FC<CircularDialProps> = ({
       'worklet'
       isActive.value = true
       isDragging.value = true
-      gestureStartProgress.value = progressSv.value
-      const startAngle = Math.PI + progressSv.value * Math.PI
-      startTangentY.value = Math.cos(startAngle)
     })
     .onUpdate(event => {
       'worklet'
-      // X drives the dial directly (always 100% efficient); Y is
-      // weighted by the tangent's vertical component so it
-      // contributes only where the arc is moving vertically. 2×
-      // ARC_RADIUS pixels of horizontal motion = full 0→1 sweep,
-      // matching the slider-like feel users expect.
-      const proj = event.translationX + event.translationY * startTangentY.value
-      const deltaProgress = proj / (2 * ARC_RADIUS)
-      const target = gestureStartProgress.value + deltaProgress
-      progressSv.value = target < 0 ? 0 : target > 1 ? 1 : target
+      // Absolute angular tracking: the knob follows the finger's angle around
+      // the arc centre (Apple-dial style), so there's no swipe-direction →
+      // value mapping that could invert between the two halves. event.x/y are
+      // view-relative (the pan is on the outer container); convert to canvas
+      // space the same way onTouchesDown does, then offset from the centre.
+      const canvasX = event.x - (outerWidth.value - CANVAS_WIDTH) / 2
+      const canvasY = event.y - canvasPadding
+      const target = progressFromCanvasPoint(canvasX - ARC_CX, canvasY - ARC_CY)
+      // Knob-grab tracks 1:1 for precision; an off-knob grab eases to the
+      // finger's angle so it doesn't teleport. Re-targeted each frame.
+      if (startedOnKnob.value) {
+        progressSv.value = target
+      } else {
+        progressSv.value = withTiming(target, { duration: SNAP_CHASE_MS })
+      }
     })
     .onEnd(() => {
       'worklet'

--- a/packages/k2-alpine/src/components/CircularDial/CircularDial.tsx
+++ b/packages/k2-alpine/src/components/CircularDial/CircularDial.tsx
@@ -255,6 +255,10 @@ export const CircularDial: FC<CircularDialProps> = ({
     })
     .onUpdate(event => {
       'worklet'
+      // Without a measured outer width the canvas-space conversion is wrong, so
+      // skip until onLayout has run (same guard onTouchesDown uses) rather than
+      // jump the dial to a bogus angle.
+      if (outerWidth.value <= 0) return
       // Absolute angular tracking: the knob follows the finger's angle around
       // the arc centre (Apple-dial style), so there's no swipe-direction →
       // value mapping that could invert between the two halves. event.x/y are

--- a/packages/k2-alpine/src/components/CircularDial/helpers.test.ts
+++ b/packages/k2-alpine/src/components/CircularDial/helpers.test.ts
@@ -2,6 +2,7 @@ import { clamp } from '../../utils/clamp'
 import { getStepDecimals } from '../../utils/getStepDecimals'
 import {
   commitDraftText,
+  progressFromCanvasPoint,
   progressToPoint,
   sanitizeDecimalInput,
   shouldSyncExternalValue,
@@ -88,6 +89,33 @@ describe('progressToPoint', () => {
     const { x, y } = progressToPoint({ ...arc, progress: 1 })
     expect(x).toBeCloseTo(150)
     expect(y).toBeCloseTo(100)
+  })
+})
+
+describe('progressFromCanvasPoint', () => {
+  const r = 50
+  it('maps the arc ends and top', () => {
+    expect(progressFromCanvasPoint(-r, 0)).toBe(0) // left, 9 o'clock
+    expect(progressFromCanvasPoint(0, -r)).toBeCloseTo(0.5) // top, 12 o'clock
+    expect(progressFromCanvasPoint(r, 0)).toBe(1) // right, 3 o'clock
+  })
+  it('maps upper-semicircle points monotonically', () => {
+    // progress 0.25 sits at θ = 1.25π → (−0.707r, −0.707r)
+    expect(progressFromCanvasPoint(-0.707 * r, -0.707 * r)).toBeCloseTo(0.25, 2)
+    // progress 0.75 sits at θ = 1.75π → (0.707r, −0.707r)
+    expect(progressFromCanvasPoint(0.707 * r, -0.707 * r)).toBeCloseTo(0.75, 2)
+  })
+  it('pins points below the diameter to the nearer end (no atan2 seam jump)', () => {
+    expect(progressFromCanvasPoint(-r, r)).toBe(0) // below-left
+    expect(progressFromCanvasPoint(r, r)).toBe(1) // below-right
+    expect(progressFromCanvasPoint(-1, 5)).toBe(0)
+    expect(progressFromCanvasPoint(1, 5)).toBe(1)
+  })
+  it('is independent of distance from centre (angle only)', () => {
+    expect(progressFromCanvasPoint(-2 * r, -2 * r)).toBeCloseTo(
+      progressFromCanvasPoint(-0.1 * r, -0.1 * r),
+      5
+    )
   })
 })
 

--- a/packages/k2-alpine/src/components/CircularDial/helpers.ts
+++ b/packages/k2-alpine/src/components/CircularDial/helpers.ts
@@ -41,6 +41,20 @@ export const valueToProgress = (value: number, max: number): number => {
   return clamp(value / max, 0, 1)
 }
 
+// Maps a finger offset from the arc centre (dx, dy in canvas space, screen
+// y-down) to progress 0..1 along the upper semicircle: left end (−r, 0) → 0,
+// top (0, −r) → 0.5, right end (r, 0) → 1. The dial tracks the finger's angle
+// (Apple-dial style) rather than a swipe direction, so there is no up/down
+// mapping left to invert. Points on or below the horizontal diameter sit off
+// the arc and pin to the nearer end — `dy >= 0` (not `> 0`) so the exact left
+// end doesn't land on the +π side of the atan2 seam and jump to the far end.
+export const progressFromCanvasPoint = (dx: number, dy: number): number => {
+  'worklet'
+  if (dy >= 0) return dx < 0 ? 0 : 1
+  const progress = (Math.atan2(dy, dx) + Math.PI) / Math.PI
+  return progress < 0 ? 0 : progress > 1 ? 1 : progress
+}
+
 // Never clamps the lower bound — users may still be typing their way
 // toward a valid value (e.g. `"0.0…"`).
 export const sanitizeDecimalInput = (text: string, max: number): string => {

--- a/packages/k2-alpine/src/components/CircularDial/helpers.ts
+++ b/packages/k2-alpine/src/components/CircularDial/helpers.ts
@@ -51,8 +51,7 @@ export const valueToProgress = (value: number, max: number): number => {
 export const progressFromCanvasPoint = (dx: number, dy: number): number => {
   'worklet'
   if (dy >= 0) return dx < 0 ? 0 : 1
-  const progress = (Math.atan2(dy, dx) + Math.PI) / Math.PI
-  return progress < 0 ? 0 : progress > 1 ? 1 : progress
+  return clamp((Math.atan2(dy, dx) + Math.PI) / Math.PI, 0, 1)
 }
 
 // Never clamps the lower bound — users may still be typing their way


### PR DESCRIPTION
## Description

**Ticket: [CP-14466](https://ava-labs.atlassian.net/browse/CP-14466)**

Dragging the `CircularDial` vertically felt inverted depending on where you grabbed it: on the left half a swipe up increased the value, on the right half a swipe up decreased it.

**Root cause:** `onUpdate` mapped the gesture by projecting translation deltas onto the arc tangent captured at the touch's start (`startTangentY = cos(π + progress·π)`), which is −1 at the left end, 0 at the top, +1 at the right end. So the vertical contribution flips sign across the halfway point. This is geometrically correct "knob-follows-the-track" behavior, but the flip is what reads as inverted — and it's inherent to *any* swipe-direction→value mapping on an arc (the top is the middle of the range, both ends sit at the bottom).

**Fix — absolute angular tracking (Apple-dial style):** the knob now follows the finger's **angle around the arc centre**, so there's no swipe-direction→value mapping left to invert. Behaviour is uniform across the whole arc.

**Changes:**
- New `progressFromCanvasPoint(dx, dy)` worklet in `helpers.ts`: maps a finger offset from the arc centre to progress (left→0, top→0.5, right→1). Uses `dy >= 0` for the off-arc clamp so the exact left end doesn't land on the `+π` side of the `atan2` seam and jump to the far end; points below the diameter pin to the nearer end.
- `onUpdate` converts `event.x/y` to canvas space (same conversion `onTouchesDown` already uses for knob hit-testing) and calls the helper. Removed the now-unused `gestureStartProgress` and `startTangentY` anchors and the tangent-projection math.
- **Eased off-knob snap:** "swipe anywhere" is kept (large hit area); to avoid a jarring teleport when a drag starts away from the knob, `onUpdate` eases `progressSv` toward the finger angle with a short `withTiming` (`SNAP_CHASE_MS = 80`, re-targeted each frame — the same chase `DialReadout` uses for typing). A knob-grab (`startedOnKnob`) skips the easing and tracks 1:1 for precision.
- Activation logic (knob-grab bypass + horizontal wedge so vertical scroll escapes), step-snap + haptics on release, presets, and tap-to-edit are all unchanged.

No new dependencies. Not breaking — `CircularDial`'s public API is unchanged.

## Screenshots/Videos

https://github.com/user-attachments/assets/a81ba600-b626-4bed-90fd-1928cefa644a


## Testing

iOS - 8838
Android - 8839

**Dev Testing**

- Drag around the arc from **both halves** — the value tracks the finger's angle; no direction feels inverted.
- **Off-knob** horizontal swipe — the knob glides smoothly to the finger and tracks (no teleport).
- **Knob-grab** — tracks 1:1, feels crisp.
- **Tap** (no drag) still opens the keypad and does not move the knob.
- A predominantly **vertical** swipe over the dial (not on the knob) still lets the parent scroll.
- Release snaps to the nearest step with the usual haptic.
- **Android specifically:** verify the knob sits under the finger while dragging (coordinate alignment) and that the eased glide / knob-grab both feel right.

**QA Testing**

- Acceptance: a vertical swipe behaves consistently regardless of which half of the dial you start on; the knob follows your finger's position around the arc with no inverted direction.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation



[CP-14466]: https://ava-labs.atlassian.net/browse/CP-14466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ