### PR TITLE
QA - fix missing FF on AWS testing & fire and forget scheduling on bitrise 

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -770,10 +770,13 @@ workflows:
     - IS_DEVICEFARM_RUN: "true"
       opts:
         is_expand: false
+    - WAIT_FOR_COMPLETION: "false"
+      opts:
+        is_expand: false
     steps:
     - path::./packages/core-mobile/scripts/bitrise/devicefarm/step:
         title: AWS Device Farm — upload & schedule run
-        no_output_timeout: 1800
+        no_output_timeout: 600
     - share-pipeline-variable@1:
         inputs:
         - variables: |-
@@ -815,10 +818,13 @@ workflows:
     - IOS_CONFIGURATION: Release
       opts:
         is_expand: false
+    - WAIT_FOR_COMPLETION: "false"
+      opts:
+        is_expand: false
     steps:
     - path::./packages/core-mobile/scripts/bitrise/devicefarm/step:
         title: AWS Device Farm — upload & schedule run
-        no_output_timeout: 1800
+        no_output_timeout: 600
     - share-pipeline-variable@1:
         inputs:
         - variables: |-

--- a/packages/core-mobile/app/services/posthog/PostHogService.ts
+++ b/packages/core-mobile/app/services/posthog/PostHogService.ts
@@ -175,7 +175,7 @@ class PostHogService implements PostHogServiceInterface {
       return sanitizeFeatureFlags(
         responseJson,
         appVersion,
-        Config.E2E === 'true'
+        Config.E2E_MNEMONIC !== undefined
       )
     } catch (e) {
       Logger.error('failed to fetch feature flags', e)

--- a/packages/core-mobile/e2e-appium/pages/settings.page.ts
+++ b/packages/core-mobile/e2e-appium/pages/settings.page.ts
@@ -461,9 +461,7 @@ class Settings {
 
   async tapWalletByName(walletName = 'Wallet 2', accountName = 'Account 1') {
     await actions.tap(this.manageAccountsWalletName(walletName))
-    await actions.isVisible(
-      this.manageAccountsAccountName(walletName, accountName)
-    )
+    await this.verifyMyWalletsAccountName(accountName, walletName)
   }
 
   async verifyAccountDetail(
@@ -777,6 +775,15 @@ class Settings {
     walletName = 'Wallet 1'
   ) {
     await actions.waitFor(
+      this.manageAccountsAccountName(walletName, accountName)
+    )
+  }
+
+  async verifyMywalletsAccountNameNotVisible(
+    accountName = 'Account 1',
+    walletName = 'Wallet 1'
+  ) {
+    await actions.waitForNotVisible(
       this.manageAccountsAccountName(walletName, accountName)
     )
   }

--- a/packages/core-mobile/e2e-appium/pages/transactions.page.ts
+++ b/packages/core-mobile/e2e-appium/pages/transactions.page.ts
@@ -334,7 +334,7 @@ class TransactionsPage {
     await this.selectDuration(duration)
     await this.tapNext()
     await this.tapConfirmStake()
-    await actions.waitForNotVisible(this.reviewStakeTitle)
+    await actions.waitForNotVisible(this.reviewStakeTitle, 40000)
   }
 
   async claim() {

--- a/packages/core-mobile/e2e-appium/specs/portfolioTab/assets/ownedTokenDetail.spec.ts
+++ b/packages/core-mobile/e2e-appium/specs/portfolioTab/assets/ownedTokenDetail.spec.ts
@@ -43,16 +43,28 @@ describe('Portfolio Assets', () => {
 
   it('ETH owned token detail', async () => {
     await commonElsPage.filter(commonElsLoc.ethereum)
-    await portfolioPage.verifyOwnedTokenDetail('Ethereum', tokens.eth)
+    try {
+      await portfolioPage.verifyOwnedTokenDetail('Ethereum', tokens.eth)
+    } catch (error) {
+      await portfolioPage.verifyOwnedTokenDetail('ETH', tokens.eth)
+    }
   })
 
   it('Ethereum ERC20 owned token detail', async () => {
-    await portfolioPage.verifyOwnedTokenDetail('USDC', tokens.usdcETH)
+    try {
+      await portfolioPage.verifyOwnedTokenDetail('USDC', tokens.usdcETH)
+    } catch (error) {
+      await portfolioPage.verifyOwnedTokenDetail('USD Coin', tokens.usdcETH)
+    }
   })
 
   it('SOL owned token detail', async () => {
     await commonElsPage.filter(commonElsLoc.solana)
-    await portfolioPage.verifyOwnedTokenDetail('Solana', tokens.sol)
+    try {
+      await portfolioPage.verifyOwnedTokenDetail('Solana', tokens.sol)
+    } catch (error) {
+      await portfolioPage.verifyOwnedTokenDetail('SOL Wormhole', tokens.sol)
+    }
   })
 
   it('Solana SPL owned token detail', async () => {

--- a/packages/core-mobile/e2e-appium/specs/settings/importWallet.spec.ts
+++ b/packages/core-mobile/e2e-appium/specs/settings/importWallet.spec.ts
@@ -36,9 +36,7 @@ describe('Settings', () => {
 
   it('Import wallet - Seed Phrase wallet can add an account', async () => {
     await settings.tapAddAccountBtn('Wallet 2')
-    await actions.waitFor(
-      settings.manageAccountsAccountName('Wallet 2', 'Account 2')
-    )
+    await settings.verifyMyWalletsAccountName('Account 2', 'Wallet 2')
   })
 
   it('Import wallet - Seed Phrase wallet can get a private key', async () => {
@@ -50,9 +48,7 @@ describe('Settings', () => {
 
   it('Import wallet - Seed Phrase wallet can remove an account', async () => {
     await settings.tapRemoveAccount()
-    await actions.waitForNotVisible(
-      settings.manageAccountsAccountName('Wallet 2', 'Account 2')
-    )
+    await settings.verifyMywalletsAccountNameNotVisible('Account 2', 'Wallet 2')
   })
 
   it('Import wallet - Seed Phrase wallet can be removed', async () => {

--- a/packages/core-mobile/e2e-appium/specs/transactions/cChain/stakeTestnet.spec.ts
+++ b/packages/core-mobile/e2e-appium/specs/transactions/cChain/stakeTestnet.spec.ts
@@ -3,7 +3,7 @@ import txPage from '../../../pages/transactions.page'
 import settingsPage from '../../../pages/settings.page'
 import bottomTabsPage from '../../../pages/bottomTabs.page'
 
-describe('[Smoke] Stake on Testnet', () => {
+describe('Stake on Testnet', () => {
   it('should stake your AVAX', async () => {
     await warmup()
     await settingsPage.switchToTestnet()

--- a/packages/core-mobile/e2e-appium/wdio.conf.ts
+++ b/packages/core-mobile/e2e-appium/wdio.conf.ts
@@ -39,7 +39,7 @@ const iosLocalPath = process.env.E2E_LOCAL_PATH
   ? '/Users/eunji.song/Downloads/AvaxWalletInternal.app'
   : './ios/build/Debug-iphonesimulator/AvaxWalletInternal.app'
 const androidLocalPath = process.env.E2E_LOCAL_PATH
-  ? '/Users/eunji.song/Downloads/app-internal-e2e-bitrise-signed.apk'
+  ? '/Users/eunji.song/Downloads/app-external-e2e-bitrise-signed.apk'
   : './android/app/build/outputs/apk/internal/debug/app-internal-debug.apk'
 
 const iosAppPath = rawAppPath || path.resolve(iosLocalPath)

--- a/packages/core-mobile/scripts/bitrise/devicefarm/android/androidDeviceFarmRegression.sh
+++ b/packages/core-mobile/scripts/bitrise/devicefarm/android/androidDeviceFarmRegression.sh
@@ -36,9 +36,10 @@ export WAIT_FOR_COMPLETION="${WAIT_FOR_COMPLETION:-true}"
 
 # 4. Extract only needed vars from env file
 if [ -f "$CORE_MOBILE_DIR/.env.production.e2e" ]; then
+  E2E_PK=$(grep '^E2E_PK=' "$CORE_MOBILE_DIR/.env.production.e2e" | cut -d'=' -f2-)
   E2E_MNEMONIC=$(grep '^E2E_MNEMONIC=' "$CORE_MOBILE_DIR/.env.production.e2e" | cut -d'=' -f2-)
   E2E_METAMASK_MNEMONIC=$(grep '^E2E_METAMASK_MNEMONIC=' "$CORE_MOBILE_DIR/.env.production.e2e" | cut -d'=' -f2-)
-  export E2E_MNEMONIC E2E_METAMASK_MNEMONIC
+  export E2E_PK E2E_MNEMONIC E2E_METAMASK_MNEMONIC
 fi
 
 # 5. Finally trigger test run

--- a/packages/core-mobile/scripts/bitrise/devicefarm/ios/iosDeviceFarmRegression.sh
+++ b/packages/core-mobile/scripts/bitrise/devicefarm/ios/iosDeviceFarmRegression.sh
@@ -38,9 +38,10 @@ export WAIT_FOR_COMPLETION="${WAIT_FOR_COMPLETION:-true}"
 
 # 4. Extract only needed vars from env file
 if [ -f "$CORE_MOBILE_DIR/.env.production.e2e" ]; then
+  E2E_PK=$(grep '^E2E_PK=' "$CORE_MOBILE_DIR/.env.production.e2e" | cut -d'=' -f2-)
   E2E_MNEMONIC=$(grep '^E2E_MNEMONIC=' "$CORE_MOBILE_DIR/.env.production.e2e" | cut -d'=' -f2-)
   E2E_METAMASK_MNEMONIC=$(grep '^E2E_METAMASK_MNEMONIC=' "$CORE_MOBILE_DIR/.env.production.e2e" | cut -d'=' -f2-)
-  export E2E_MNEMONIC E2E_METAMASK_MNEMONIC
+  export E2E_PK E2E_MNEMONIC E2E_METAMASK_MNEMONIC
 fi
 
 # 5. Finally trigger test run


### PR DESCRIPTION
## Description
- add `WAIT_FOR_COMPLETION` to fire and forget scheduling on Bitrise. This will save a lot of Bitrise credits 
- Fix missing FF on the AWS external build testing. 
- Small changes to the testing files. 