### PR TITLE
CP-14377: scroll to reveal Account performance accordion on PerpetualsBalanceScreen

### DIFF
--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -6,7 +6,7 @@ import {
 } from '@avalabs/k2-alpine'
 import { useEffectiveHeaderHeight } from 'common/hooks/useEffectiveHeaderHeight'
 import { useFadingHeaderNavigation } from 'common/hooks/useFadingHeaderNavigation'
-import React, { useCallback, useRef, useState } from 'react'
+import React, { forwardRef, useCallback, useRef, useState } from 'react'
 import {
   LayoutChangeEvent,
   LayoutRectangle,
@@ -93,349 +93,390 @@ const KeyboardScrollView = Animated.createAnimatedComponent(
   KeyboardAwareScrollView
 )
 
-export const ScrollScreen = ({
-  title,
-  titleSx,
-  subtitle,
-  children,
-  hasParent,
-  isModal,
-  navigationTitle,
-  shouldAvoidKeyboard,
-  disableStickyFooter,
-  showNavigationHeaderTitle = true,
-  hideHeaderBackground,
-  headerCenterOverlay,
-  headerStyle,
-  testID = 'bottom_sheet',
-  renderHeader,
-  renderFooter,
-  renderHeaderRight,
-  onScrolledToEnd,
-  ...props
-}: ScrollScreenProps): JSX.Element => {
-  const insets = useSafeAreaInsets()
-  const headerHeight = useEffectiveHeaderHeight()
+export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
+  function ScrollScreen(
+    {
+      title,
+      titleSx,
+      subtitle,
+      children,
+      hasParent,
+      isModal,
+      navigationTitle,
+      shouldAvoidKeyboard,
+      disableStickyFooter,
+      showNavigationHeaderTitle = true,
+      hideHeaderBackground,
+      headerCenterOverlay,
+      headerStyle,
+      testID = 'bottom_sheet',
+      renderHeader,
+      renderFooter,
+      renderHeaderRight,
+      onScrolledToEnd,
+      ...props
+    },
+    ref
+  ): JSX.Element {
+    const insets = useSafeAreaInsets()
+    const headerHeight = useEffectiveHeaderHeight()
 
-  // scroll to end tracking
-  const scrollContentHeight = useRef(0)
-  const scrollViewHeight = useRef(0)
-  const hasReachedEndRef = useRef(false)
+    // scroll to end tracking
+    const scrollContentHeight = useRef(0)
+    const scrollViewHeight = useRef(0)
+    const hasReachedEndRef = useRef(false)
 
-  const SCROLL_END_THRESHOLD = 20
+    const SCROLL_END_THRESHOLD = 20
 
-  const checkScrolledToEnd = useCallback(
-    (contentOffsetY: number) => {
-      if (!onScrolledToEnd || hasReachedEndRef.current) return
+    const checkScrolledToEnd = useCallback(
+      (contentOffsetY: number) => {
+        if (!onScrolledToEnd || hasReachedEndRef.current) return
+
+        const maxScroll = scrollContentHeight.current - scrollViewHeight.current
+        const isAtEnd =
+          maxScroll <= 0 || contentOffsetY >= maxScroll - SCROLL_END_THRESHOLD
+
+        if (isAtEnd) {
+          hasReachedEndRef.current = true
+          onScrolledToEnd(true)
+        }
+      },
+      [onScrolledToEnd]
+    )
+
+    const checkScrollableAfterLayout = useCallback(() => {
+      if (!onScrolledToEnd) return
 
       const maxScroll = scrollContentHeight.current - scrollViewHeight.current
-      const isAtEnd =
-        maxScroll <= 0 || contentOffsetY >= maxScroll - SCROLL_END_THRESHOLD
-
-      if (isAtEnd) {
+      if (maxScroll <= 0 && scrollContentHeight.current > 0) {
+        // content doesn't require scroll
         hasReachedEndRef.current = true
         onScrolledToEnd(true)
       }
-    },
-    [onScrolledToEnd]
-  )
+    }, [onScrolledToEnd])
 
-  const checkScrollableAfterLayout = useCallback(() => {
-    if (!onScrolledToEnd) return
+    const handleContentSizeChange = useCallback(
+      (_w: number, h: number) => {
+        const prevHeight = scrollContentHeight.current
+        scrollContentHeight.current = h
 
-    const maxScroll = scrollContentHeight.current - scrollViewHeight.current
-    if (maxScroll <= 0 && scrollContentHeight.current > 0) {
-      // content doesn't require scroll
-      hasReachedEndRef.current = true
-      onScrolledToEnd(true)
-    }
-  }, [onScrolledToEnd])
+        if (!onScrolledToEnd) return
 
-  const handleContentSizeChange = useCallback(
-    (_w: number, h: number) => {
-      const prevHeight = scrollContentHeight.current
-      scrollContentHeight.current = h
-
-      if (!onScrolledToEnd) return
-
-      if (Math.abs(h - prevHeight) > 1) {
-        hasReachedEndRef.current = false
-        onScrolledToEnd(false)
-        checkScrollableAfterLayout()
-      }
-    },
-    [onScrolledToEnd, checkScrollableAfterLayout]
-  )
-
-  const handleScrollViewLayout = useCallback(
-    (e: LayoutChangeEvent) => {
-      scrollViewHeight.current = e.nativeEvent.layout.height
-      checkScrollableAfterLayout()
-    },
-    [checkScrollableAfterLayout]
-  )
-  const [headerLayout, setHeaderLayout] = useState<
-    LayoutRectangle | undefined
-  >()
-
-  const [footerLayout, setFooterLayout] = useState<
-    LayoutRectangle | undefined
-  >()
-
-  const headerRef = useRef<View>(null)
-
-  const {
-    onScroll: onFadingScroll,
-    scrollY,
-    targetHiddenProgress
-  } = useFadingHeaderNavigation({
-    header: <NavigationTitleHeader title={navigationTitle ?? title ?? ''} />,
-    targetLayout: headerLayout,
-    hasParent,
-    hideHeaderBackground: hideHeaderBackground || isModal,
-    renderHeaderRight,
-    showNavigationHeaderTitle
-  })
-
-  const onScroll = useCallback(
-    (
-      event:
-        | NativeSyntheticEvent<NativeScrollEvent>
-        | NativeScrollEvent
-        | number
-    ) => {
-      onFadingScroll(event)
-
-      if (onScrolledToEnd) {
-        let offsetY = 0
-        if (typeof event === 'number') {
-          offsetY = event
-        } else if ('nativeEvent' in event) {
-          offsetY = event.nativeEvent.contentOffset.y
-        } else {
-          offsetY = event.contentOffset.y
+        if (Math.abs(h - prevHeight) > 1) {
+          hasReachedEndRef.current = false
+          onScrolledToEnd(false)
+          checkScrollableAfterLayout()
         }
-        checkScrolledToEnd(offsetY)
-      }
-    },
-    [onFadingScroll, onScrolledToEnd, checkScrolledToEnd]
-  )
-
-  const animatedHeaderStyle = useAnimatedStyle(() => {
-    const scale = interpolate(
-      scrollY.value,
-      [-headerHeight, 0, headerHeight],
-      [0.95, 1, 0.95]
+      },
+      [onScrolledToEnd, checkScrollableAfterLayout]
     )
-    return {
-      opacity: 1 - targetHiddenProgress.value * 2,
-      transform: [{ scale }],
-      transformOrigin: 'bottom left'
-    }
-  })
 
-  const handleHeaderLayout = useCallback((event: LayoutChangeEvent) => {
-    const { x, y, width, height } = event.nativeEvent.layout
-    setHeaderLayout({ x, y, width, height })
-  }, [])
+    const handleScrollViewLayout = useCallback(
+      (e: LayoutChangeEvent) => {
+        scrollViewHeight.current = e.nativeEvent.layout.height
+        checkScrollableAfterLayout()
+      },
+      [checkScrollableAfterLayout]
+    )
+    const [headerLayout, setHeaderLayout] = useState<
+      LayoutRectangle | undefined
+    >()
 
-  const handleFooterLayout = useCallback((event: LayoutChangeEvent) => {
-    const { x, y, width, height } = event.nativeEvent.layout
-    setFooterLayout({ x, y, width, height })
-  }, [])
+    const [footerLayout, setFooterLayout] = useState<
+      LayoutRectangle | undefined
+    >()
 
-  const animatedBorderStyle = useAnimatedStyle(() => {
-    const opacity = interpolate(scrollY.value, [0, headerHeight], [0, 1])
-    return {
-      opacity
-    }
-  })
+    const headerRef = useRef<View>(null)
 
-  const renderHeaderContent = useCallback(() => {
-    if (title || subtitle || renderHeader) {
-      const hasTitle = Boolean(title || subtitle)
-      return (
-        <View collapsable={false}>
+    const {
+      onScroll: onFadingScroll,
+      scrollY,
+      targetHiddenProgress
+    } = useFadingHeaderNavigation({
+      header: <NavigationTitleHeader title={navigationTitle ?? title ?? ''} />,
+      targetLayout: headerLayout,
+      hasParent,
+      hideHeaderBackground: hideHeaderBackground || isModal,
+      renderHeaderRight,
+      showNavigationHeaderTitle
+    })
+
+    const onScroll = useCallback(
+      (
+        event:
+          | NativeSyntheticEvent<NativeScrollEvent>
+          | NativeScrollEvent
+          | number
+      ) => {
+        onFadingScroll(event)
+
+        if (onScrolledToEnd) {
+          let offsetY = 0
+          if (typeof event === 'number') {
+            offsetY = event
+          } else if ('nativeEvent' in event) {
+            offsetY = event.nativeEvent.contentOffset.y
+          } else {
+            offsetY = event.contentOffset.y
+          }
+          checkScrolledToEnd(offsetY)
+        }
+      },
+      [onFadingScroll, onScrolledToEnd, checkScrolledToEnd]
+    )
+
+    const animatedHeaderStyle = useAnimatedStyle(() => {
+      const scale = interpolate(
+        scrollY.value,
+        [-headerHeight, 0, headerHeight],
+        [0.95, 1, 0.95]
+      )
+      return {
+        opacity: 1 - targetHiddenProgress.value * 2,
+        transform: [{ scale }],
+        transformOrigin: 'bottom left'
+      }
+    })
+
+    const handleHeaderLayout = useCallback((event: LayoutChangeEvent) => {
+      const { x, y, width, height } = event.nativeEvent.layout
+      setHeaderLayout({ x, y, width, height })
+    }, [])
+
+    const handleFooterLayout = useCallback((event: LayoutChangeEvent) => {
+      const { x, y, width, height } = event.nativeEvent.layout
+      setFooterLayout({ x, y, width, height })
+    }, [])
+
+    const animatedBorderStyle = useAnimatedStyle(() => {
+      const opacity = interpolate(scrollY.value, [0, headerHeight], [0, 1])
+      return {
+        opacity
+      }
+    })
+
+    const renderHeaderContent = useCallback(() => {
+      if (title || subtitle || renderHeader) {
+        const hasTitle = Boolean(title || subtitle)
+        return (
+          <View collapsable={false}>
+            <View
+              ref={headerRef}
+              collapsable={false}
+              onLayout={handleHeaderLayout}
+              style={[headerStyle, hasTitle ? { gap: 4 } : undefined]}>
+              {hasTitle ? (
+                <Animated.View style={[animatedHeaderStyle]}>
+                  <ScreenHeader
+                    title={title ?? ''}
+                    titleSx={titleSx}
+                    titleNumberOfLines={4}
+                    description={subtitle}
+                  />
+                </Animated.View>
+              ) : null}
+
+              {!hasTitle && renderHeader?.()}
+            </View>
+
+            {hasTitle && renderHeader?.()}
+          </View>
+        )
+      } else {
+        // If we don't have a title or subtitle, we need to render an empty header
+        // so that the header height is not undefined
+        return (
           <View
             ref={headerRef}
             collapsable={false}
             onLayout={handleHeaderLayout}
-            style={[headerStyle, hasTitle ? { gap: 4 } : undefined]}>
-            {hasTitle ? (
-              <Animated.View style={[animatedHeaderStyle]}>
-                <ScreenHeader
-                  title={title ?? ''}
-                  titleSx={titleSx}
-                  titleNumberOfLines={4}
-                  description={subtitle}
-                />
-              </Animated.View>
-            ) : null}
-
-            {!hasTitle && renderHeader?.()}
-          </View>
-
-          {hasTitle && renderHeader?.()}
-        </View>
-      )
-    } else {
-      // If we don't have a title or subtitle, we need to render an empty header
-      // so that the header height is not undefined
-      return (
-        <View
-          ref={headerRef}
-          collapsable={false}
-          onLayout={handleHeaderLayout}
-          style={[
-            headerStyle,
-            {
-              position: 'absolute',
-              minHeight: headerHeight,
-              pointerEvents: 'none'
-            }
-          ]}
-        />
-      )
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    headerRef,
-    headerHeight,
-    headerStyle,
-    handleHeaderLayout,
-    renderHeader,
-    subtitle,
-    title,
-    titleSx
-  ])
-
-  const renderFooterContent = useCallback(() => {
-    if (renderFooter) {
-      const footer = renderFooter()
-      if (footer) {
-        // Visual content only — sizes to its own height (not absolutely
-        // positioned), so whatever wraps it gets a real, non-zero height.
-        const footerContent = (
-          <LinearGradientBottomWrapper>
-            <View
-              style={{
-                paddingHorizontal: 16,
-                paddingBottom: insets.bottom + 16
-              }}>
-              <View onLayout={handleFooterLayout}>{footer}</View>
-            </View>
-          </LinearGradientBottomWrapper>
-        )
-
-        if (shouldAvoidKeyboard) {
-          return (
-            <KeyboardStickyView
-              enabled={!disableStickyFooter}
-              offset={{
-                opened: insets.bottom
-              }}
-              style={{ position: 'absolute', bottom: 0, left: 0, right: 0 }}>
-              {footerContent}
-            </KeyboardStickyView>
-          )
-        }
-
-        return (
-          <View
-            collapsable={false}
-            style={{
-              position: 'absolute',
-              bottom: 0,
-              left: 0,
-              right: 0
-            }}>
-            {footerContent}
-          </View>
+            style={[
+              headerStyle,
+              {
+                position: 'absolute',
+                minHeight: headerHeight,
+                pointerEvents: 'none'
+              }
+            ]}
+          />
         )
       }
-    }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+      headerRef,
+      headerHeight,
+      headerStyle,
+      handleHeaderLayout,
+      renderHeader,
+      subtitle,
+      title,
+      titleSx
+    ])
 
-    return null
-  }, [
-    renderFooter,
-    insets.bottom,
-    handleFooterLayout,
-    shouldAvoidKeyboard,
-    disableStickyFooter
-  ])
+    const renderFooterContent = useCallback(() => {
+      if (renderFooter) {
+        const footer = renderFooter()
+        if (footer) {
+          // Visual content only — sizes to its own height (not absolutely
+          // positioned), so whatever wraps it gets a real, non-zero height.
+          const footerContent = (
+            <LinearGradientBottomWrapper>
+              <View
+                style={{
+                  paddingHorizontal: 16,
+                  paddingBottom: insets.bottom + 16
+                }}>
+                <View onLayout={handleFooterLayout}>{footer}</View>
+              </View>
+            </LinearGradientBottomWrapper>
+          )
 
-  const renderGrabber = useCallback(() => {
-    if (isModal)
+          if (shouldAvoidKeyboard) {
+            return (
+              <KeyboardStickyView
+                enabled={!disableStickyFooter}
+                offset={{
+                  opened: insets.bottom
+                }}
+                style={{ position: 'absolute', bottom: 0, left: 0, right: 0 }}>
+                {footerContent}
+              </KeyboardStickyView>
+            )
+          }
+
+          return (
+            <View
+              collapsable={false}
+              style={{
+                position: 'absolute',
+                bottom: 0,
+                left: 0,
+                right: 0
+              }}>
+              {footerContent}
+            </View>
+          )
+        }
+      }
+
+      return null
+    }, [
+      renderFooter,
+      insets.bottom,
+      handleFooterLayout,
+      shouldAvoidKeyboard,
+      disableStickyFooter
+    ])
+
+    const renderGrabber = useCallback(() => {
+      if (isModal)
+        return (
+          <View
+            style={{
+              position: 'absolute',
+              top: Platform.OS === 'android' ? insets.top - 2 : 9,
+              left: 0,
+              right: 0,
+              zIndex: 1000
+            }}>
+            <Grabber />
+          </View>
+        )
+    }, [insets.top, isModal])
+
+    const renderHeaderBackground = useCallback(() => {
+      if (hideHeaderBackground) return null
       return (
         <View
+          pointerEvents="none"
           style={{
             position: 'absolute',
-            top: Platform.OS === 'android' ? insets.top - 2 : 9,
+            top: 0,
             left: 0,
             right: 0,
-            zIndex: 1000
+            bottom: 0,
+            height: headerHeight
           }}>
-          <Grabber />
+          <BlurViewWithFallback
+            style={{
+              flex: 1
+            }}
+          />
+          <Animated.View
+            style={[
+              animatedBorderStyle,
+              {
+                position: 'absolute',
+                bottom: 0,
+                left: 0,
+                right: 0
+              }
+            ]}>
+            <Separator />
+          </Animated.View>
         </View>
       )
-  }, [insets.top, isModal])
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [headerHeight, hideHeaderBackground])
 
-  const renderHeaderBackground = useCallback(() => {
-    if (hideHeaderBackground) return null
-    return (
-      <View
-        pointerEvents="none"
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          height: headerHeight
-        }}>
-        <BlurViewWithFallback
-          style={{
-            flex: 1
-          }}
-        />
-        <Animated.View
-          style={[
-            animatedBorderStyle,
-            {
-              position: 'absolute',
-              bottom: 0,
-              left: 0,
-              right: 0
+    // 90% of our screens reuse this component but only some need keyboard avoiding
+    // If you have an input on the screen, you need to enable this prop
+    if (shouldAvoidKeyboard) {
+      return (
+        <View style={{ flex: 1 }} collapsable={false}>
+          <KeyboardScrollView
+            ref={ref as never}
+            testID={testID}
+            extraKeyboardSpace={disableStickyFooter ? -insets.bottom : 0}
+            keyboardDismissMode="interactive"
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+            {...props}
+            style={{
+              flex: 1
+            }}
+            contentContainerStyle={[
+              props?.contentContainerStyle,
+              {
+                paddingBottom: disableStickyFooter
+                  ? insets.bottom + 32
+                  : (footerLayout?.height ?? 0) + 32,
+                paddingTop: headerHeight
+              }
+            ]}
+            onScroll={onScroll}
+            onContentSizeChange={
+              onScrolledToEnd ? handleContentSizeChange : undefined
             }
-          ]}>
-          <Separator />
-        </Animated.View>
-      </View>
-    )
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [headerHeight, hideHeaderBackground])
+            onLayout={onScrolledToEnd ? handleScrollViewLayout : undefined}>
+            {renderHeaderContent()}
+            {children}
+          </KeyboardScrollView>
 
-  // 90% of our screens reuse this component but only some need keyboard avoiding
-  // If you have an input on the screen, you need to enable this prop
-  if (shouldAvoidKeyboard) {
+          {renderFooterContent()}
+          {renderHeaderBackground()}
+          {headerCenterOverlay}
+          {renderGrabber()}
+        </View>
+      )
+    }
+
+    // All of our screens have to be scrollable
+    // If we don't have an input on the screen then we should not enable keyboard avoiding
     return (
-      <View style={{ flex: 1 }} collapsable={false}>
-        <KeyboardScrollView
+      <View style={[{ flex: 1 }, props.style]} collapsable={false}>
+        <ScrollView
+          ref={ref}
           testID={testID}
-          extraKeyboardSpace={disableStickyFooter ? -insets.bottom : 0}
+          style={{ flex: 1 }}
+          showsVerticalScrollIndicator={false}
           keyboardDismissMode="interactive"
           keyboardShouldPersistTaps="handled"
-          showsVerticalScrollIndicator={false}
           {...props}
-          style={{
-            flex: 1
-          }}
           contentContainerStyle={[
             props?.contentContainerStyle,
             {
-              paddingBottom: disableStickyFooter
-                ? insets.bottom + 32
-                : (footerLayout?.height ?? 0) + 32,
+              paddingBottom: (footerLayout?.height ?? 0) + insets.bottom + 48,
               paddingTop: headerHeight
             }
           ]}
@@ -446,7 +487,7 @@ export const ScrollScreen = ({
           onLayout={onScrolledToEnd ? handleScrollViewLayout : undefined}>
           {renderHeaderContent()}
           {children}
-        </KeyboardScrollView>
+        </ScrollView>
 
         {renderFooterContent()}
         {renderHeaderBackground()}
@@ -455,38 +496,6 @@ export const ScrollScreen = ({
       </View>
     )
   }
+)
 
-  // All of our screens have to be scrollable
-  // If we don't have an input on the screen then we should not enable keyboard avoiding
-  return (
-    <View style={[{ flex: 1 }, props.style]} collapsable={false}>
-      <ScrollView
-        testID={testID}
-        style={{ flex: 1 }}
-        showsVerticalScrollIndicator={false}
-        keyboardDismissMode="interactive"
-        keyboardShouldPersistTaps="handled"
-        {...props}
-        contentContainerStyle={[
-          props?.contentContainerStyle,
-          {
-            paddingBottom: (footerLayout?.height ?? 0) + insets.bottom + 48,
-            paddingTop: headerHeight
-          }
-        ]}
-        onScroll={onScroll}
-        onContentSizeChange={
-          onScrolledToEnd ? handleContentSizeChange : undefined
-        }
-        onLayout={onScrolledToEnd ? handleScrollViewLayout : undefined}>
-        {renderHeaderContent()}
-        {children}
-      </ScrollView>
-
-      {renderFooterContent()}
-      {renderHeaderBackground()}
-      {headerCenterOverlay}
-      {renderGrabber()}
-    </View>
-  )
-}
+ScrollScreen.displayName = 'ScrollScreen'

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsBalanceScreen.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsBalanceScreen.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   GroupList,
   GroupListItem,
+  Icons,
   Text,
   useTheme,
   View
@@ -10,7 +11,8 @@ import {
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import { useRouter } from 'expo-router'
-import React, { useCallback, useEffect, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef } from 'react'
+import { ScrollView } from 'react-native-gesture-handler'
 import AnalyticsService from 'services/analytics/AnalyticsService'
 
 const HERO_VALUE = 1234.45
@@ -23,14 +25,25 @@ const TOTAL_DEPOSITED = 2344.56
 const TOTAL_WITHDRAWN = 500.0
 const NET_DEPOSITS = 1844.56
 const NET_PNL = 418.43
+const ACCORDION_EXPAND_DURATION = 350
 
 export const PerpetualsBalanceScreen = (): JSX.Element => {
   const { theme } = useTheme()
   const { formatCurrency } = useFormatCurrency()
   const router = useRouter()
+  const scrollViewRef = useRef<ScrollView>(null)
 
   useEffect(() => {
     AnalyticsService.capture('PerpetualsBalanceViewed')
+  }, [])
+
+  const handlePerformanceToggle = useCallback((expanded: boolean) => {
+    if (expanded) {
+      setTimeout(
+        () => scrollViewRef.current?.scrollToEnd({ animated: true }),
+        ACCORDION_EXPAND_DURATION
+      )
+    }
   }, [])
 
   const handlePositionsPress = useCallback(() => {
@@ -62,6 +75,12 @@ export const PerpetualsBalanceScreen = (): JSX.Element => {
         title: 'In active positions',
         subtitle: '3 positions',
         value: formatCurrency({ amount: IN_POSITIONS }),
+        accessory: (
+          <Icons.Navigation.ChevronRight
+            color={theme.colors.$textSecondary}
+            style={{ marginRight: -8 }}
+          />
+        ),
         onPress: handlePositionsPress
       },
       {
@@ -70,7 +89,7 @@ export const PerpetualsBalanceScreen = (): JSX.Element => {
         value: formatCurrency({ amount: PENDING })
       }
     ],
-    [formatCurrency, handlePositionsPress]
+    [formatCurrency, handlePositionsPress, theme.colors.$textSecondary]
   )
 
   const performanceBreakdown = useMemo<GroupListItem[]>(
@@ -100,6 +119,7 @@ export const PerpetualsBalanceScreen = (): JSX.Element => {
       {
         title: 'Account performance',
         subtitle: 'All-time performance',
+        onAccordionToggle: handlePerformanceToggle,
         accordion: (
           <GroupList
             data={performanceBreakdown}
@@ -109,7 +129,7 @@ export const PerpetualsBalanceScreen = (): JSX.Element => {
         )
       }
     ],
-    [performanceBreakdown]
+    [performanceBreakdown, handlePerformanceToggle]
   )
 
   const handleWithdraw = useCallback(() => {
@@ -144,6 +164,7 @@ export const PerpetualsBalanceScreen = (): JSX.Element => {
 
   return (
     <ScrollScreen
+      ref={scrollViewRef}
       isModal
       title="Available balance"
       subtitle="An overview of your Hyperliquid account"

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsBalanceScreen.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsBalanceScreen.tsx
@@ -32,7 +32,7 @@ export const PerpetualsBalanceScreen = (): JSX.Element => {
   const { formatCurrency } = useFormatCurrency()
   const router = useRouter()
   const scrollViewRef = useRef<ScrollView>(null)
-  const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
+  const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     AnalyticsService.capture('PerpetualsBalanceViewed')

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsBalanceScreen.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsBalanceScreen.tsx
@@ -32,14 +32,24 @@ export const PerpetualsBalanceScreen = (): JSX.Element => {
   const { formatCurrency } = useFormatCurrency()
   const router = useRouter()
   const scrollViewRef = useRef<ScrollView>(null)
+  const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
 
   useEffect(() => {
     AnalyticsService.capture('PerpetualsBalanceViewed')
   }, [])
 
+  // Clear any pending scroll on unmount so it can't fire after teardown.
+  useEffect(() => {
+    return () => {
+      if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current)
+    }
+  }, [])
+
   const handlePerformanceToggle = useCallback((expanded: boolean) => {
+    // Cancel any pending scroll (e.g. a quick collapse) before scheduling.
+    if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current)
     if (expanded) {
-      setTimeout(
+      scrollTimeoutRef.current = setTimeout(
         () => scrollViewRef.current?.scrollToEnd({ animated: true }),
         ACCORDION_EXPAND_DURATION
       )

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsBalanceScreen.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsBalanceScreen.tsx
@@ -12,7 +12,7 @@ import { ScrollScreen } from 'common/components/ScrollScreen'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import { useRouter } from 'expo-router'
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
-import { ScrollView } from 'react-native-gesture-handler'
+import type { ScrollView } from 'react-native-gesture-handler'
 import AnalyticsService from 'services/analytics/AnalyticsService'
 
 const HERO_VALUE = 1234.45

--- a/packages/k2-alpine/src/components/GroupList/GroupList.tsx
+++ b/packages/k2-alpine/src/components/GroupList/GroupList.tsx
@@ -54,11 +54,11 @@ export const GroupList = ({
 
   const handlePress = (item: GroupListItem, index: number): void => {
     if (item.accordion) {
-      const nextExpanded = !(expandedStates[index] ?? false)
-      setExpandedStates(prev =>
-        prev.map((value, i) => (i === index ? nextExpanded : value))
-      )
-      item.onAccordionToggle?.(nextExpanded)
+      setExpandedStates(prev => {
+        const nextExpanded = !(prev[index] ?? false)
+        item.onAccordionToggle?.(nextExpanded)
+        return prev.map((value, i) => (i === index ? nextExpanded : value))
+      })
     } else {
       item.onPress?.()
     }

--- a/packages/k2-alpine/src/components/GroupList/GroupList.tsx
+++ b/packages/k2-alpine/src/components/GroupList/GroupList.tsx
@@ -1,5 +1,5 @@
 import { SxProp } from 'dripsy'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { LayoutChangeEvent, StyleProp, ViewStyle } from 'react-native'
 import Animated, {
   Easing,
@@ -47,6 +47,21 @@ export const GroupList = ({
   const [expandedStates, setExpandedStates] = useState<boolean[]>(
     data.map(i => i.expanded ?? false)
   )
+  const prevExpandedStatesRef = useRef(expandedStates)
+
+  // Emit onAccordionToggle after the state change is committed rather than from
+  // inside the state updater. The updater must stay pure (React may re-run it
+  // under concurrent rendering / StrictMode), so side effects belong here. We
+  // diff against the previously committed values, so the callback fires exactly
+  // once per actual toggle and never on mount.
+  useEffect(() => {
+    expandedStates.forEach((expanded, index) => {
+      if (expanded !== prevExpandedStatesRef.current[index]) {
+        data[index]?.onAccordionToggle?.(expanded)
+      }
+    })
+    prevExpandedStatesRef.current = expandedStates
+  }, [expandedStates, data])
 
   const handleLayout = (event: LayoutChangeEvent): void => {
     setTextMarginLeft(event.nativeEvent.layout.x)
@@ -54,11 +69,10 @@ export const GroupList = ({
 
   const handlePress = (item: GroupListItem, index: number): void => {
     if (item.accordion) {
-      setExpandedStates(prev => {
-        const nextExpanded = !(prev[index] ?? false)
-        item.onAccordionToggle?.(nextExpanded)
-        return prev.map((value, i) => (i === index ? nextExpanded : value))
-      })
+      // Pure updater: derive next state from prev, no side effects here.
+      setExpandedStates(prev =>
+        prev.map((value, i) => (i === index ? !(prev[index] ?? false) : value))
+      )
     } else {
       item.onPress?.()
     }

--- a/packages/k2-alpine/src/components/GroupList/GroupList.tsx
+++ b/packages/k2-alpine/src/components/GroupList/GroupList.tsx
@@ -54,9 +54,11 @@ export const GroupList = ({
 
   const handlePress = (item: GroupListItem, index: number): void => {
     if (item.accordion) {
+      const nextExpanded = !(expandedStates[index] ?? false)
       setExpandedStates(prev =>
-        prev.map((value, i) => (i === index ? !value : value))
+        prev.map((value, i) => (i === index ? nextExpanded : value))
       )
+      item.onAccordionToggle?.(nextExpanded)
     } else {
       item.onPress?.()
     }
@@ -264,6 +266,8 @@ export type GroupListItem = {
   bottomAccessory?: JSX.Element
   accordion?: JSX.Element
   expanded?: boolean
+  /** Called when an accordion row is toggled, with the resulting expanded state. */
+  onAccordionToggle?: (expanded: boolean) => void
   containerSx?: SxProp
   hideSeparator?: boolean
   /** When true, sets accessible={false} on the row so child testIDs (e.g. Toggle) are findable by Appium */


### PR DESCRIPTION
## Description

**Ticket: [CP-14377](https://ava-labs.atlassian.net/browse/CP-14377)**

Make the screen scroll to reveal the **Account performance** breakdown when its accordion is expanded on `PerpetualsBalanceScreen`.

**Summary of changes**

- **`GroupList` (k2-alpine):** added an optional `onAccordionToggle?(expanded)` callback, fired on toggle with the resulting expanded state. Additive — no behavior change for existing callers.
- **`ScrollScreen` (core-mobile):** converted to `forwardRef`, forwarding the ref to its inner `ScrollView` (both the keyboard-aware and standard branches) so callers can drive scrolling programmatically. Kept as a PascalCase named function so it stays recognized as a React component by the `sonarjs/cognitive-complexity` lint rule.
- **`PerpetualsBalanceScreen`:** holds a `scrollViewRef`, passes it to `ScrollScreen`, and on expand calls `scrollToEnd({ animated: true })` after the accordion's expand animation settles, revealing the breakdown rows (which otherwise land below the fold / behind the sticky footer). Collapsing does nothing.


## Screenshots/Videos

https://github.com/user-attachments/assets/07b2334e-98c6-424c-a00b-22b95ded706e

iOS - 8907
Android - 8908

## Testing

**Dev Testing**

- Open the Perpetuals **Available balance** screen.
- Tap the **Account performance** row to expand the accordion.
- Expected: the screen scrolls to the end so the full performance breakdown is visible above the footer.
- Tap again to collapse — no scroll should occur.
- Verify on both iOS and Android (Android won't scroll if content already fits the viewport, which is expected).

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14377]: https://ava-labs.atlassian.net/browse/CP-14377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ