### PR TITLE
CP-14375: hide auto-added iOS "More" navigation bar when 6+ tabs are visible

### DIFF
--- a/packages/core-mobile/patches/react-native-bottom-tabs+1.1.0.patch
+++ b/packages/core-mobile/patches/react-native-bottom-tabs+1.1.0.patch
@@ -99,3 +99,22 @@ index d699315..2484cc4 100644
  @available(iOS 26.0, *)
  struct BottomAccessoryRepresentableView: PlatformViewRepresentable {
    @Environment(\.tabViewBottomAccessoryPlacement) var tabViewBottomAccessoryPlacement
+diff --git a/node_modules/react-native-bottom-tabs/ios/TabViewImpl.swift b/node_modules/react-native-bottom-tabs/ios/TabViewImpl.swift
+index 72938be..a5d4290 100644
+--- a/node_modules/react-native-bottom-tabs/ios/TabViewImpl.swift
++++ b/node_modules/react-native-bottom-tabs/ios/TabViewImpl.swift
+@@ -64,6 +64,14 @@ struct TabViewImpl: View {
+ #if !os(macOS)
+         tabController.view.backgroundColor = .clear
+         tabController.viewControllers?.forEach { $0.view.backgroundColor = .clear }
++#endif
++#if os(iOS)
++        // When more than 5 tabs are present, UIKit moves the overflow into an
++        // auto-generated "More" UINavigationController, which renders a navigation
++        // bar with a back button on top of the tab's content. The app already
++        // provides its own custom tab bar that navigates directly to every tab,
++        // so this system bar is unwanted chrome. Hide it.
++        tabController.moreNavigationController.isNavigationBarHidden = true
+ #endif
+         #if os(macOS)
+           tabBar = tabController


### PR DESCRIPTION
## Description

**Ticket: [CP-14375](https://ava-labs.atlassian.net/browse/CP-14375)**

When more than 5 tabs are visible, iOS's native `UITabBarController` automatically moves the overflow tab into a system-generated "More" `UINavigationController`. That controller renders its own navigation bar with a back button on top of the tab's content — which showed up as unwanted chrome above the Perps/Trade screen (e.g. when Portfolio, Track, Stake, Earn, Browser, and Trade are all visible).

The app already provides its own custom JS tab bar that navigates directly to every tab, so this system "More" navigation bar is never needed.

**Changes**
- Extend the existing `patches/react-native-bottom-tabs+1.1.0.patch` with a one-line hook in the native `TabViewImpl.swift` introspect closure that sets `tabController.moreNavigationController.isNavigationBarHidden = true` (guarded by `#if os(iOS)`).

**Notes**
- iOS only — Android has no equivalent overflow behavior.
- No new dependencies. No JS/TS changes — native patch only, so it requires a native rebuild to take effect.
- No breaking changes / migration steps.

## Screenshots/Videos

https://github.com/user-attachments/assets/8bc5086e-8d5e-48d4-a02f-aa9e15deb6bd


## Testing

iOS - 8919
Android - [8920](https://app.bitrise.io/app/7d7ca5af7066e290/installable-artifacts/1cdacd3fc8d74b2b/public-install-page/cf0c5f6e63aaabd6a04d5594012debc5)

**Dev Testing**

- Use a wallet/config that surfaces 6 visible tabs (`hasXpAddresses` + in-app DeFi enabled + perpetuals enabled → Portfolio, Track, Stake, Earn, Browser, Trade).
- Open the Trade tab on iOS and confirm there is **no** extra navigation bar / back button above the screen content.
- Verify tabs with ≤ 5 visible items are unaffected.
- Confirm Android is unchanged.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14375]: https://ava-labs.atlassian.net/browse/CP-14375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ