### PR TITLE
CP-14518: Keystone wallets load no accounts (infinite portfolio spinner)

### DIFF
--- a/packages/core-mobile/app/new/features/keystone/services/KeystoneService.test.ts
+++ b/packages/core-mobile/app/new/features/keystone/services/KeystoneService.test.ts
@@ -1,0 +1,68 @@
+import { UR } from '@ngraveio/bc-ur'
+
+const mockParseMultiAccounts = jest.fn()
+
+jest.mock('features/keystone/storage/KeystoneDataStorage', () => ({
+  KeystoneDataStorage: { save: jest.fn() }
+}))
+
+jest.mock('@keystonehq/keystone-sdk', () => ({
+  __esModule: true,
+  default: jest
+    .fn()
+    .mockImplementation(() => ({ parseMultiAccounts: mockParseMultiAccounts }))
+}))
+
+jest.mock('utils/bip32', () => ({
+  extendedPublicKeyToXpub: jest.fn(
+    (publicKey: string, chainCode: string) => `xpub(${publicKey},${chainCode})`
+  )
+}))
+
+// KeystoneService is a default-exported singleton whose private walletInfo
+// persists across tests. Reset modules before each test so every case starts
+// from a fresh (empty walletInfo) instance, keeping the tests order-independent.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let KeystoneService: any
+let mockedSave: jest.Mock
+
+describe('KeystoneService', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    KeystoneService = require('./KeystoneService').default
+    mockedSave = require('features/keystone/storage/KeystoneDataStorage')
+      .KeystoneDataStorage.save as jest.Mock
+    mockedSave.mockClear()
+    mockParseMultiAccounts.mockReset()
+  })
+
+  describe('save', () => {
+    it('does not overwrite stored keystone data when walletInfo is not populated', async () => {
+      // On a cold relaunch, KeystoneService.walletInfo is empty (init() only runs
+      // during the onboarding QR scan). save() must NOT clobber the real stored
+      // xpubs with empty strings.
+      await KeystoneService.save()
+
+      expect(mockedSave).not.toHaveBeenCalled()
+    })
+
+    it('persists walletInfo once it has been populated by init()', async () => {
+      mockParseMultiAccounts.mockReturnValue({
+        masterFingerprint: 'mfp123',
+        keys: [
+          { chain: 'ETH', publicKey: 'ethPub', chainCode: 'ethCode' },
+          { chain: 'AVAX', publicKey: 'avaxPub', chainCode: 'avaxCode' }
+        ]
+      })
+
+      KeystoneService.init({} as UR)
+      await KeystoneService.save()
+
+      expect(mockedSave).toHaveBeenCalledWith({
+        evm: 'xpub(ethPub,ethCode)',
+        xp: 'xpub(avaxPub,avaxCode)',
+        mfp: 'mfp123'
+      })
+    })
+  })
+})

--- a/packages/core-mobile/app/new/features/keystone/services/KeystoneService.ts
+++ b/packages/core-mobile/app/new/features/keystone/services/KeystoneService.ts
@@ -32,6 +32,12 @@ class KeystoneService {
   }
 
   async save(): Promise<void> {
+    // walletInfo is only populated by init() during the onboarding QR scan and
+    // is not rehydrated from storage. On a cold relaunch it is empty, so guard
+    // against overwriting the real stored xpubs with empty strings.
+    if (!this.walletInfo.evm || !this.walletInfo.xp || !this.walletInfo.mfp) {
+      return
+    }
     await KeystoneDataStorage.save(this.walletInfo)
   }
 }

--- a/packages/core-mobile/app/vmModule/ModuleManager.test.ts
+++ b/packages/core-mobile/app/vmModule/ModuleManager.test.ts
@@ -30,11 +30,14 @@ jest
       [NetworkVMType.CoreEth]: `C-avax${i}`
     }))
   )
-jest
-  .spyOn(SvmModule.prototype, 'deriveAddresses')
-  .mockImplementation(async ({ accountIndices }) =>
-    accountIndices.map((_, i) => ({ [NetworkVMType.SVM]: `svm${i}` }))
-  )
+const mockSvmResolved = (): void => {
+  jest
+    .spyOn(SvmModule.prototype, 'deriveAddresses')
+    .mockImplementation(async ({ accountIndices }) =>
+      accountIndices.map((_, i) => ({ [NetworkVMType.SVM]: `svm${i}` }))
+    )
+}
+mockSvmResolved()
 
 describe('ModuleManager', () => {
   describe('not initialized', () => {
@@ -176,6 +179,51 @@ describe('ModuleManager', () => {
       // `undefined` rather than empty-string addresses so downstream
       // `!addresses` guards engage instead of treating the account as valid.
       expect(result).toEqual([undefined, undefined])
+    })
+
+    describe('Solana exclusion for Keystone', () => {
+      afterEach(() => {
+        // Restore the default resolving Solana mock so later tests are unaffected.
+        mockSvmResolved()
+      })
+
+      it('still derives a Keystone account when the Solana module rejects', async () => {
+        // Keystone hardware cannot derive Solana (ED25519) addresses, so the
+        // Solana module rejects. This must NOT discard the whole account.
+        jest
+          .spyOn(SvmModule.prototype, 'deriveAddresses')
+          .mockRejectedValue(new Error('ED25519 not supported'))
+
+        const result = await ModuleManager.deriveAllAddresses({
+          walletId: 'w1',
+          walletType: WalletType.KEYSTONE,
+          accountIndices: [0],
+          network: { isTestnet: false } as Network
+        })
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toBeDefined()
+        expect(result[0]?.[NetworkVMType.EVM]).toBe('0xevm0')
+        expect(result[0]?.[NetworkVMType.AVM]).toBe('X-avax0')
+        expect(result[0]?.[NetworkVMType.BITCOIN]).toBe('bc1btc0')
+        // Solana is not derivable for Keystone; the address is simply absent.
+        expect(result[0]?.[NetworkVMType.SVM]).toBeFalsy()
+      })
+
+      it('still fails closed when the Solana module rejects for a non-Keystone wallet', async () => {
+        jest
+          .spyOn(SvmModule.prototype, 'deriveAddresses')
+          .mockRejectedValue(new Error('transient svm failure'))
+
+        const result = await ModuleManager.deriveAllAddresses({
+          walletId: 'w1',
+          walletType: WalletType.MNEMONIC,
+          accountIndices: [0],
+          network: { isTestnet: false } as Network
+        })
+
+        expect(result).toEqual([undefined])
+      })
     })
   })
 })

--- a/packages/core-mobile/app/vmModule/ModuleManager.ts
+++ b/packages/core-mobile/app/vmModule/ModuleManager.ts
@@ -132,8 +132,24 @@ class ModuleManager {
         : DerivationPath.BIP44
     const secretId = JSON.stringify({ walletId, walletType })
 
+    // Keystone hardware wallets only expose secp256k1 xpubs (EVM + Avalanche
+    // X/P); they cannot derive Solana (ED25519) addresses. Asking the Solana
+    // module to derive would reject, and the fail-closed handling below would
+    // then discard the entire account for every index. Exclude Solana for
+    // Keystone so the account is still created from its supported chains — the
+    // empty SVM address is handled at the UI layer (CP-14303).
+    const modules =
+      walletType === WalletType.KEYSTONE
+        ? this.modules.filter(
+            module =>
+              !module
+                .getManifest()
+                ?.network.namespaces.includes(BlockchainNamespace.SOLANA)
+          )
+        : this.modules
+
     const perModuleResults = await Promise.allSettled(
-      this.modules.map(async module =>
+      modules.map(async module =>
         module.deriveAddresses({
           secretId,
           accountIndices,


### PR DESCRIPTION
## What & why

Fixes **CP-14518** — Keystone hardware wallets load **no accounts**; the portfolio page spins forever. Affects new Keystone onboarding and existing Keystone users stuck at 0 accounts.

### Root cause
CP-14230 (#3851) changed vm-module address derivation from fault-tolerant to **fail-closed**: in `ModuleManager.deriveAllAddresses`, if *any* module rejects, the whole account record becomes `undefined`, so `AccountsService.getAddresses` throws and no account is persisted. Keystone hardware only exposes secp256k1 xpubs (EVM + Avalanche X/P) and **cannot derive Solana (ED25519) addresses**, so the Solana module always rejects for Keystone → fail-closed discards the entire account → `selectActiveAccount` is `undefined` → `useAccountBalanceSummary` returns `isBalanceLoaded: false` → infinite spinner.

Because `handleInitAccountsIfNeeded` re-runs `initAccounts` whenever `accounts.length === 0`, every relaunch re-fails — which is why both new and "existing" (post-CP-14230) Keystone users see it. (Users who onboarded *before* CP-14230 kept persisted accounts and took the migrate branch, so this reads as a recent regression.)

## Changes

1. **`ModuleManager.ts` (`deriveAllAddresses`)** — for `WalletType.KEYSTONE`, exclude the Solana module (matched by `BlockchainNamespace.SOLANA`) from the derivation fan-out. The Keystone account is created from its supported chains (EVM/BTC/AVM/PVM) with an empty SVM address (already handled at the UI layer per CP-14303). **Fail-closed behavior is unchanged for every other wallet type and for genuine/transient failures.**

2. **`KeystoneService.ts` (`save()`)** — guard against persisting an empty/partial `walletInfo`. `walletInfo` is only populated by `init()` during the onboarding QR scan and is not rehydrated from storage; on a cold relaunch it is empty, and the previous unconditional `save()` would clobber the real stored xpubs with `''` (reachable only while stuck at 0 accounts). This is a contained safety net independent of change #1.

## Tests
- `ModuleManager.test.ts` — Keystone account is still derived when the Solana module rejects; non-Keystone wallets still fail closed.
- `KeystoneService.test.ts` — `save()` does not overwrite storage when `walletInfo` is empty; persists once populated.
- Local: ModuleManager + AccountsService + account store suites pass (68); new Keystone tests pass (13); `tsc` clean; ESLint clean.

## Scope / recovery
This bug only ever shipped to **internal builds — never a released build**. The only Keystone wallets whose stored xpubs were clobbered are on current internal builds; they recover simply by **re-onboarding** (re-scan QR, which repopulates the xpubs). No production users are affected and no migration/recovery path is needed.

## Dev testing

**Builds:**
iOS: 8939
Android: 8940

**Steps:**
1. Onboard a Keystone wallet (scan QR) → land on portfolio → an account loads with balances (previously: infinite spinner, no account).
2. Existing/stuck Keystone wallet: cold-relaunch the app → account loads (no spinner).
3. Confirm Solana is excluded for the Keystone account (no SVM address / Solana network hidden), and EVM/BTC/AVM/PVM addresses are present and correct.
4. Regression: onboard a mnemonic, seedless, and Ledger wallet → all still onboard and load accounts normally (including Solana for mnemonic/seedless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
