### PR TITLE
CP-14454: change step to 1 on perpetuals place order

### DIFF
--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsPlaceOrderScreen.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsPlaceOrderScreen.tsx
@@ -123,6 +123,7 @@ export const PerpetualsPlaceOrderScreen = (): JSX.Element => {
                 label="USD"
                 enableManualInput
                 testID="perpetuals_place_order_amount"
+                step={1}
               />
             </View>
             <Text


### PR DESCRIPTION
## Description

**Ticket: [CP-14454]**

Sets the `step` on the perpetuals place-order amount dial (`CircularDial`) to `1`, so the USD amount increments/decrements by 1 instead of the component's default step.

## Testing

**Dev Testing**

- Open the Perpetuals → Place Order screen
- Drag/adjust the amount dial and confirm the value changes in increments of 1 USD
- Confirm manual input still works and stays within the available balance

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works


[CP-14454]: https://ava-labs.atlassian.net/browse/CP-14454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ