### PR TITLE
CP-14507: fix C→P CCT swap on Ledger (empty xpAddressDictionary)

### DIFF
--- a/packages/core-mobile/app/hooks/useXPAddresses/transformXPAddresses.test.ts
+++ b/packages/core-mobile/app/hooks/useXPAddresses/transformXPAddresses.test.ts
@@ -79,6 +79,33 @@ describe('transformXPAddresses', () => {
     })
   })
 
+  // CP-14507: a successful lookup can return an empty dictionary (e.g. a Ledger
+  // account with no X/P activity yet). The empty `{}` must NOT be used as-is —
+  // it has to fall back to the account's primary P-chain address, otherwise XP
+  // signing yields no indices and C->P CCT swaps fail.
+  describe('when queryData.xpAddressDictionary is an empty object', () => {
+    it('falls back to account.addressPVM for the dictionary', () => {
+      const queryData = {
+        xpAddresses: [],
+        xpAddressDictionary: {}
+      }
+      const account = createMockAccount({
+        addressPVM: 'P-avax1fallback'
+      })
+
+      const result = transformXPAddresses(queryData, account)
+
+      expect(result.xpAddresses).toEqual(['avax1fallback'])
+      expect(result.xpAddressDictionary).toEqual({
+        avax1fallback: {
+          space: 'e',
+          index: 0,
+          hasActivity: false
+        }
+      })
+    })
+  })
+
   describe('when queryData.xpAddressDictionary is missing', () => {
     it('falls back to account.addressPVM for dictionary', () => {
       const queryData = {

--- a/packages/core-mobile/app/hooks/useXPAddresses/transformXPAddresses.ts
+++ b/packages/core-mobile/app/hooks/useXPAddresses/transformXPAddresses.ts
@@ -24,9 +24,17 @@ export function transformXPAddresses(
     xpAddresses = [stripAddressPrefix(account.addressPVM)]
   }
 
-  // Derive xpAddressDictionary with fallback
+  // Derive xpAddressDictionary with fallback. Mirror the xpAddresses branch
+  // above and require a non-empty dictionary before using it: a successful
+  // lookup can still return an empty `{}` (e.g. a Ledger account with no X/P
+  // activity yet), and an empty dictionary makes getInternalExternalAddrs yield
+  // no signing indices, which breaks XP signing and blocks C->P CCT swaps. Fall
+  // back to the account's primary P-chain address instead. See CP-14507.
   let xpAddressDictionary: XPAddressDictionary = {}
-  if (queryData?.xpAddressDictionary) {
+  if (
+    queryData?.xpAddressDictionary &&
+    Object.keys(queryData.xpAddressDictionary).length > 0
+  ) {
     xpAddressDictionary = queryData.xpAddressDictionary
   } else if (account?.addressPVM) {
     xpAddressDictionary = {

--- a/packages/core-mobile/app/hooks/useXPAddresses/useXPAddresses.test.ts
+++ b/packages/core-mobile/app/hooks/useXPAddresses/useXPAddresses.test.ts
@@ -1,0 +1,146 @@
+import { CoreAccountType } from '@avalabs/types'
+import { Account } from 'store/account/types'
+import { WalletType } from 'services/wallet/types'
+
+const mockFetchQuery = jest.fn()
+const mockGetAddressesFromXpubXP = jest.fn()
+
+jest.mock('contexts/ReactQueryProvider', () => ({
+  queryClient: {
+    fetchQuery: (...args: unknown[]) => mockFetchQuery(...args)
+  }
+}))
+
+jest.mock('utils/getAddressesFromXpubXP/getAddressesFromXpubXP', () => ({
+  getAddressesFromXpubXP: (...args: unknown[]) =>
+    mockGetAddressesFromXpubXP(...args)
+}))
+
+jest.mock('utils/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    trace: jest.fn()
+  }
+}))
+
+const { getCachedXPAddresses } = require('./useXPAddresses')
+
+const PVM_ADDRESS = 'P-avax1putwtyrvk7vx8zeffmnja8djxku5nnc87au7rj'
+const STRIPPED_PVM_ADDRESS = 'avax1putwtyrvk7vx8zeffmnja8djxku5nnc87au7rj'
+
+const createMockAccount = (overrides?: Partial<Account>): Account =>
+  ({
+    id: 'test-account-id',
+    name: 'Test Account',
+    walletId: 'test-wallet-id',
+    index: 0,
+    type: CoreAccountType.PRIMARY as CoreAccountType.PRIMARY,
+    addressC: '0x066b2322a30d7C5838035112F3b816b46D639bBC',
+    addressCoreEth: '0x066b2322a30d7C5838035112F3b816b46D639bBC',
+    addressBTC: 'bc1qmm9qawklnfau5hhrkt33kqumggxwy7s9raxuxk',
+    addressSVM: '9gQmZ7fTTgv5hVScrr9QqT6SpBs7i4cKLDdj4tuae3sW',
+    addressAVM: 'X-avax1aahxdv3wqxd42rxdalvp2knxs244r06wrxmvlf',
+    addressPVM: PVM_ADDRESS,
+    ...overrides
+  } as Account)
+
+describe('getCachedXPAddresses', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns the resolved addresses when the lookup succeeds', async () => {
+    mockFetchQuery.mockImplementation(({ queryFn }) => queryFn())
+    mockGetAddressesFromXpubXP.mockResolvedValue({
+      xpAddresses: [{ address: `X-${STRIPPED_PVM_ADDRESS}`, index: 0 }],
+      xpAddressDictionary: {
+        [STRIPPED_PVM_ADDRESS]: { space: 'e', index: 0, hasActivity: true }
+      }
+    })
+
+    const result = await getCachedXPAddresses({
+      walletId: 'test-wallet-id',
+      walletType: WalletType.LEDGER,
+      account: createMockAccount(),
+      isDeveloperMode: false
+    })
+
+    expect(result.xpAddresses).toEqual([STRIPPED_PVM_ADDRESS])
+    expect(result.xpAddressDictionary).toEqual({
+      [STRIPPED_PVM_ADDRESS]: { space: 'e', index: 0, hasActivity: true }
+    })
+  })
+
+  // CP-14507: a successful lookup can still return empty results (e.g. a Ledger
+  // account with no X/P activity yet). It must fall back to the account's
+  // primary P-chain address rather than returning an empty dictionary.
+  it('falls back to the account primary P-chain address when the lookup returns empty', async () => {
+    mockFetchQuery.mockImplementation(({ queryFn }) => queryFn())
+    mockGetAddressesFromXpubXP.mockResolvedValue({
+      xpAddresses: [],
+      xpAddressDictionary: {}
+    })
+
+    const result = await getCachedXPAddresses({
+      walletId: 'test-wallet-id',
+      walletType: WalletType.LEDGER,
+      account: createMockAccount(),
+      isDeveloperMode: false
+    })
+
+    expect(result.xpAddresses).toEqual([STRIPPED_PVM_ADDRESS])
+    expect(result.xpAddressDictionary).toEqual({
+      [STRIPPED_PVM_ADDRESS]: { space: 'e', index: 0, hasActivity: false }
+    })
+  })
+
+  // CP-14507: a Ledger wallet whose Avalanche xpub can't be derived makes the
+  // lookup throw. Instead of returning an empty dictionary (which breaks XP
+  // signing and blocks C->P CCT swaps), it must fall back to the account's
+  // primary P-chain address — mirroring the useXPAddresses hook.
+  it('falls back to the account primary P-chain address when the lookup throws', async () => {
+    mockFetchQuery.mockRejectedValue(new Error('No xpub stored for account'))
+
+    const result = await getCachedXPAddresses({
+      walletId: 'test-wallet-id',
+      walletType: WalletType.LEDGER,
+      account: createMockAccount(),
+      isDeveloperMode: false
+    })
+
+    expect(result.xpAddresses).toEqual([STRIPPED_PVM_ADDRESS])
+    expect(result.xpAddressDictionary).toEqual({
+      [STRIPPED_PVM_ADDRESS]: { space: 'e', index: 0, hasActivity: false }
+    })
+  })
+
+  it('returns empty when the lookup throws and the account has no P-chain address', async () => {
+    mockFetchQuery.mockRejectedValue(new Error('No xpub stored for account'))
+
+    const result = await getCachedXPAddresses({
+      walletId: 'test-wallet-id',
+      walletType: WalletType.LEDGER,
+      account: createMockAccount({ addressPVM: '' }),
+      isDeveloperMode: false
+    })
+
+    expect(result.xpAddresses).toEqual([])
+    expect(result.xpAddressDictionary).toEqual({})
+  })
+
+  it('returns empty for non-primary Keystone accounts without hitting the lookup', async () => {
+    const result = await getCachedXPAddresses({
+      walletId: 'test-wallet-id',
+      walletType: WalletType.KEYSTONE,
+      account: createMockAccount({ index: 1 }),
+      isDeveloperMode: false
+    })
+
+    expect(result.xpAddresses).toEqual([])
+    expect(result.xpAddressDictionary).toEqual({})
+    expect(mockFetchQuery).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core-mobile/app/hooks/useXPAddresses/useXPAddresses.ts
+++ b/packages/core-mobile/app/hooks/useXPAddresses/useXPAddresses.ts
@@ -142,9 +142,13 @@ export async function getCachedXPAddresses({
     return transformXPAddresses(result, account)
   } catch (error) {
     Logger.error('getCachedXPAddresses failed', error)
-    return {
-      xpAddresses: [],
-      xpAddressDictionary: {}
-    }
+    // Mirror the useXPAddresses hook: when the address lookup throws (e.g. a
+    // Ledger wallet whose Avalanche xpub can't be derived), fall back to the
+    // account's primary P-chain address rather than returning an empty
+    // dictionary. An empty dictionary makes getInternalExternalAddrs yield no
+    // signing indices, which breaks XP signing and blocks C->P CCT swaps on
+    // Ledger. transformXPAddresses(undefined, account) applies the same
+    // addressPVM fallback the hook already uses on a failed query. See CP-14507.
+    return transformXPAddresses(undefined, account)
   }
 }

--- a/packages/core-mobile/app/new/features/swap/services/cct/consts.ts
+++ b/packages/core-mobile/app/new/features/swap/services/cct/consts.ts
@@ -1,0 +1,7 @@
+/**
+ * Prefix shared by every error the CCT callbacks throw. The swap error mapper
+ * (`getSwapErrorMessage`) matches on this tag to surface a clear, user-facing
+ * message instead of the raw internal guard string. Keep producer
+ * (`createCctCallbacks`) and consumer (`fusionErrors`) in sync via this const.
+ */
+export const CCT_CALLBACKS_ERROR_TAG = '[cctCallbacks]'

--- a/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.ts
+++ b/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.ts
@@ -13,6 +13,7 @@ import { Account, XPAddressDictionary } from 'store/account/types'
 import { Request } from 'store/rpc/utils/createInAppRequest'
 import { RequestContext } from 'store/rpc/types'
 import { getAvalancheChainAliasCaip2 } from '../../utils/getAvalancheChainAliasCaip2'
+import { CCT_CALLBACKS_ERROR_TAG } from './consts'
 
 /**
  * Live state accessors the callbacks need at invocation time. Each is read on
@@ -73,7 +74,8 @@ export type CctCallbacks = Pick<
 export const createCctCallbacks = (deps: CctCallbackDeps): CctCallbacks => {
   const getRequiredAccount = (): Account => {
     const account = deps.getActiveAccount()
-    if (!account) throw new Error('[cctCallbacks] no active account')
+    if (!account)
+      throw new Error(`${CCT_CALLBACKS_ERROR_TAG} no active account`)
     return account
   }
 
@@ -87,7 +89,9 @@ export const createCctCallbacks = (deps: CctCallbackDeps): CctCallbacks => {
       // (e.g. Keystone non-primary account). Refuse to build the wallet
       // rather than silently producing an Avalanche.AddressWallet with no
       // X/P addresses, which would return empty UTXOs and empty addresses.
-      throw new Error('[cctCallbacks] xpAddresses empty for active account')
+      throw new Error(
+        `${CCT_CALLBACKS_ERROR_TAG} xpAddresses empty for active account`
+      )
     }
     return AvalancheWalletService.getReadOnlySigner({
       account,
@@ -109,7 +113,7 @@ export const createCctCallbacks = (deps: CctCallbackDeps): CctCallbacks => {
       // fall back to default derivation paths and produce a signature that
       // doesn't match the UTXO output owners. Fail fast.
       throw new Error(
-        '[cctCallbacks] xpAddressDictionary empty for active account'
+        `${CCT_CALLBACKS_ERROR_TAG} xpAddressDictionary empty for active account`
       )
     }
 
@@ -162,7 +166,9 @@ export const createCctCallbacks = (deps: CctCallbackDeps): CctCallbacks => {
       // empty for wallets that don't derive a Coreth bech32 address (some
       // Ledger paths). Returning '' would only surface as an opaque SDK
       // failure later — fail fast instead.
-      throw new Error('[cctCallbacks] addressCoreEth empty for active account')
+      throw new Error(
+        `${CCT_CALLBACKS_ERROR_TAG} addressCoreEth empty for active account`
+      )
     }
     return addressCoreEth
   }

--- a/packages/core-mobile/app/new/features/swap/utils/fusionErrors.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/fusionErrors.test.ts
@@ -338,6 +338,23 @@ describe('getSwapErrorMessage', () => {
     )
   })
 
+  it('should return a clear message for cctCallbacks xp-address errors', () => {
+    expect(
+      getSwapErrorMessage(
+        new Error('[cctCallbacks] xpAddressDictionary empty for active account')
+      )
+    ).toBe(
+      "This account isn't set up for cross-chain swaps. Please try a different account."
+    )
+    expect(
+      getSwapErrorMessage(
+        new Error('[cctCallbacks] xpAddresses empty for active account')
+      )
+    ).toBe(
+      "This account isn't set up for cross-chain swaps. Please try a different account."
+    )
+  })
+
   it('should return original message for unrecognized errors', () => {
     expect(getSwapErrorMessage(new Error('something unexpected'))).toBe(
       'something unexpected'

--- a/packages/core-mobile/app/new/features/swap/utils/fusionErrors.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/fusionErrors.ts
@@ -1,5 +1,6 @@
 import { isEstimateNativeFeeError, isSdkError } from '@avalabs/fusion-sdk'
 import type { QuoterDoneReason } from '@avalabs/fusion-sdk'
+import { CCT_CALLBACKS_ERROR_TAG } from '../services/cct/consts'
 
 export type FusionQuoteErrorKind =
   | 'network-fee-only' // gas alone exceeds balance; no bridge fee involved
@@ -253,6 +254,13 @@ export function getSwapErrorMessage(error: unknown): string {
   }
 
   const message = actualError?.message ?? error.message
+
+  // CCT swap couldn't resolve the active account's X/P addresses (e.g. a Ledger
+  // wallet with no derivable Avalanche address). Surface a clear message instead
+  // of the raw internal guard string. See CP-14507.
+  if (message.includes(CCT_CALLBACKS_ERROR_TAG)) {
+    return "This account isn't set up for cross-chain swaps. Please try a different account."
+  }
 
   // Common error patterns
   if (message.includes('insufficient funds')) {


### PR DESCRIPTION
## Description

**Ticket: [CP-14507](https://ava-labs.atlassian.net/browse/CP-14507)**

A C → P cross-chain transfer (CCT) swap failed on Ledger wallets. The handler logged `[cctCallbacks] xpAddressDictionary empty for active account`, so no X/P signing indices could be derived and the swap couldn't proceed.

**Root cause**

The CCT swap resolves the active account's X/P addresses through `transformXPAddresses`. Its dictionary branch only checked `if (queryData?.xpAddressDictionary)`. A successful address lookup can still return an empty `{}` (e.g. a Ledger account with no X/P activity yet, which is the normal state for the P-chain destination of a C → P swap). An empty object is truthy, so the code kept it and never fell back to the account's primary P-chain address. The `xpAddresses` branch right above it already falls back on an empty list, so the two branches were inconsistent. The empty dictionary made `getInternalExternalAddrs` return no signing indices, which surfaced the error above.

**Changes**

- `transformXPAddresses`: require a non-empty dictionary before using it; otherwise fall back to the account's primary P-chain address (`addressPVM`). This mirrors the existing `xpAddresses` branch and core-web's `createXpAddressDictionary`.
- `getCachedXPAddresses`: on a failed lookup, fall back via `transformXPAddresses(undefined, account)` instead of returning empty. Covers the Ledger Live case where the Avalanche xpub can't be derived (the lookup throws rather than returns empty).
- `getSwapErrorMessage`: map the `[cctCallbacks]` guard errors to a clear user-facing message instead of the raw internal string, as a safety net for the rare case an account genuinely has no P-chain address. The shared tag is extracted into a `CCT_CALLBACKS_ERROR_TAG` constant referenced by both the producer (`createCctCallbacks`) and consumer (`fusionErrors`).

No dependencies introduced. No breaking changes.

## Screenshots/Videos
C->P CCT swap
https://github.com/user-attachments/assets/59a9e3b9-71bb-41ef-82e2-39e8191a176a

Error
<img width="350" alt="15395" src="https://github.com/user-attachments/assets/3c8dab96-117b-43b1-b26e-939657c73cee" />

## Testing
**iOS: 0.0.0.8963
Android: 0.0.0.8964**

1. Connect a Ledger wallet (via ledger live).
2. Start a swap from C-Chain to P-Chain (CCT).
3. Approve the export and import legs on the device.
4. Confirm the swap completes and the funds land on the P-chain (previously it failed with no progress).

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14507]: https://ava-labs.atlassian.net/browse/CP-14507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ