### PR TITLE
CP-13954: route Ledger EVM signing on Avalanche L1s to the Avalanche app

### DIFF
--- a/packages/core-mobile/app/new/features/ledger/utils/index.test.ts
+++ b/packages/core-mobile/app/new/features/ledger/utils/index.test.ts
@@ -6,12 +6,14 @@ import {
   WalletSecretOperation
 } from 'services/ledger/types'
 import { Curve } from 'utils/publicKeys'
+import { ChainId, Network, NetworkVMType } from '@avalabs/core-chains-sdk'
 import {
   isBitcoinCompatibleApp,
   isVersionExceeding,
   getFormattedAddresses,
   buildKeysFromMultiIndex,
   buildLedgerWalletSecret,
+  getLedgerAppName,
   LedgerWalletSecretSchema
 } from './index'
 
@@ -136,6 +138,33 @@ describe('isBitcoinCompatibleApp', () => {
     it('Unknown app is not compatible', () => {
       expect(isBitcoinCompatibleApp(LedgerAppType.UNKNOWN, '1.0.0')).toBe(false)
     })
+  })
+})
+
+describe('getLedgerAppName', () => {
+  it('routes local Avalanche C-Chain (43112) to the Avalanche app', () => {
+    const network = {
+      chainId: ChainId.AVALANCHE_LOCAL_ID,
+      vmName: NetworkVMType.EVM
+    } as Network
+
+    expect(getLedgerAppName(network)).toBe(LedgerAppType.AVALANCHE)
+  })
+
+  it('routes an Avalanche L1 (EVM chain with a subnetId) to the Avalanche app', () => {
+    const network = {
+      chainId: 1510,
+      vmName: NetworkVMType.EVM,
+      subnetId: 'orange-subnet'
+    } as Network
+
+    expect(getLedgerAppName(network)).toBe(LedgerAppType.AVALANCHE)
+  })
+
+  it('routes a foreign EVM chain (no subnetId) to the Ethereum app', () => {
+    const network = { chainId: 1, vmName: NetworkVMType.EVM } as Network
+
+    expect(getLedgerAppName(network)).toBe(LedgerAppType.ETHEREUM)
   })
 })
 

--- a/packages/core-mobile/app/new/features/ledger/utils/index.ts
+++ b/packages/core-mobile/app/new/features/ledger/utils/index.ts
@@ -51,7 +51,8 @@ export const getLedgerAppName = (network?: Network): LedgerAppType => {
 
   const isAvalancheChain =
     network.chainId === ChainId.AVALANCHE_MAINNET_ID ||
-    network.chainId === ChainId.AVALANCHE_TESTNET_ID
+    network.chainId === ChainId.AVALANCHE_TESTNET_ID ||
+    network.chainId === ChainId.AVALANCHE_LOCAL_ID
 
   const isAvalancheVM = [NetworkVMType.AVM, NetworkVMType.PVM].includes(
     network.vmName

--- a/packages/core-mobile/app/services/wallet/LedgerWallet.test.ts
+++ b/packages/core-mobile/app/services/wallet/LedgerWallet.test.ts
@@ -1053,7 +1053,7 @@ describe('LedgerWallet', () => {
       await ledgerWallet.signEvmTransaction({
         accountIndex: 0,
         transaction: { ...baseTransaction, chainId: 43114 },
-        network: { chainId: 43114 } as Network,
+        network: { chainId: 43114, vmName: NetworkVMType.EVM } as Network,
         provider: mockProvider
       })
 
@@ -2149,8 +2149,11 @@ describe('LedgerWallet', () => {
 
     describe('handleSignedTypedData', () => {
       const derivationPath = "m/44'/60'/0'/0/0"
-      const ethNetwork = { chainId: 1 } as Network
-      const avaxNetwork = { chainId: 43114 } as Network
+      const ethNetwork = { chainId: 1, vmName: NetworkVMType.EVM } as Network
+      const avaxNetwork = {
+        chainId: 43114,
+        vmName: NetworkVMType.EVM
+      } as Network
 
       const validTypedData = {
         domain: { name: 'Test App', version: '1' },

--- a/packages/core-mobile/app/services/wallet/LedgerWallet.test.ts
+++ b/packages/core-mobile/app/services/wallet/LedgerWallet.test.ts
@@ -159,17 +159,13 @@ jest.mock('@avalabs/core-wallets-sdk', () => ({
   }))
 }))
 
-// Mock isAvalancheChainId to control Avalanche vs Ethereum app selection
-jest.mock('services/network/utils/isAvalancheNetwork', () => ({
-  isAvalancheChainId: jest.fn().mockReturnValue(false)
-}))
-
-// Import after mocking
+// Import after mocking. App selection (Avalanche vs Ethereum) is driven by the
+// real getLedgerAppName(network) helper, so tests control it via the network
+// object they pass rather than by mocking a predicate.
 import { Transaction } from 'ethers'
 import LedgerService from 'services/ledger/LedgerService'
 import { bip32 } from 'utils/bip32'
 import { getBitcoinProvider } from 'services/network/utils/providerUtils'
-import { isAvalancheChainId } from 'services/network/utils/isAvalancheNetwork'
 import { AvalancheTransactionRequest } from './types'
 import { LedgerWallet } from './LedgerWallet'
 import { BitcoinWalletPolicyService } from './BitcoinWalletPolicyService'
@@ -245,7 +241,6 @@ describe('LedgerWallet', () => {
     ;(bip32.fromPublicKey as jest.Mock).mockReturnValue({
       toBase58: jest.fn().mockReturnValue('mock-xpub')
     })
-    ;(isAvalancheChainId as jest.Mock).mockReturnValue(false)
 
     // Create wallet instance with correct constructor signature
     ledgerWallet = new LedgerWallet({
@@ -982,7 +977,6 @@ describe('LedgerWallet', () => {
     const mockSignature = { r: 'aaaa', s: 'bbbb', v: '1c' }
 
     beforeEach(() => {
-      ;(isAvalancheChainId as jest.Mock).mockReturnValue(false)
       mockEthGetAddress.mockResolvedValue({ address: '0xabc' })
       mockEthSignTransaction.mockResolvedValue(mockSignature)
     })
@@ -1041,8 +1035,6 @@ describe('LedgerWallet', () => {
     })
 
     it('uses getEvmSignature (Ethereum app) for non-Avalanche chains', async () => {
-      ;(isAvalancheChainId as jest.Mock).mockReturnValue(false)
-
       await ledgerWallet.signEvmTransaction({
         accountIndex: 0,
         transaction: { ...baseTransaction, chainId: 1 },
@@ -1055,14 +1047,33 @@ describe('LedgerWallet', () => {
     })
 
     it('uses getCChainSignature (Avalanche app) for Avalanche chains', async () => {
-      ;(isAvalancheChainId as jest.Mock).mockReturnValue(true)
       mockGetETHAddress.mockResolvedValue({ address: '0xabc' })
       mockSignEVMTransaction.mockResolvedValue(mockSignature)
 
       await ledgerWallet.signEvmTransaction({
         accountIndex: 0,
         transaction: { ...baseTransaction, chainId: 43114 },
-        network: mockNetwork,
+        network: { chainId: 43114 } as Network,
+        provider: mockProvider
+      })
+
+      expect(mockSignEVMTransaction).toHaveBeenCalledTimes(1)
+      expect(mockEthSignTransaction).not.toHaveBeenCalled()
+    })
+
+    it('uses getCChainSignature (Avalanche app) for Avalanche L1 networks (EVM + subnetId)', async () => {
+      mockGetETHAddress.mockResolvedValue({ address: '0xabc' })
+      mockSignEVMTransaction.mockResolvedValue(mockSignature)
+      const l1Network = {
+        chainId: 1510,
+        vmName: NetworkVMType.EVM,
+        subnetId: 'orange-subnet'
+      } as Network
+
+      await ledgerWallet.signEvmTransaction({
+        accountIndex: 0,
+        transaction: { ...baseTransaction, chainId: 1510 },
+        network: l1Network,
         provider: mockProvider
       })
 
@@ -2120,12 +2131,26 @@ describe('LedgerWallet', () => {
           })
         ).rejects.toThrow('No device')
       })
+
+      it('opens the Avalanche app for Avalanche L1 networks (EVM + subnetId)', async () => {
+        await (ledgerWallet as any).handleEthAndPersonalSign({
+          data: 'hello world',
+          derivationPath,
+          network: {
+            chainId: 1510,
+            vmName: NetworkVMType.EVM,
+            subnetId: 'orange-subnet'
+          } as Network
+        })
+
+        expect(mockOpenApp).toHaveBeenCalledWith(LedgerAppType.AVALANCHE)
+      })
     })
 
     describe('handleSignedTypedData', () => {
       const derivationPath = "m/44'/60'/0'/0/0"
-      const ethChainId = 1
-      const avaxChainId = 43114
+      const ethNetwork = { chainId: 1 } as Network
+      const avaxNetwork = { chainId: 43114 } as Network
 
       const validTypedData = {
         domain: { name: 'Test App', version: '1' },
@@ -2159,7 +2184,7 @@ describe('LedgerWallet', () => {
             data: [{ name: 'test', type: 'string', value: 'hello' }],
             rpcMethod: RpcMethod.SIGN_TYPED_DATA,
             derivationPath,
-            chainId: ethChainId
+            network: ethNetwork
           })
         ).rejects.toThrow(
           'eth_signTypedData v1 is not supported on Ledger devices.'
@@ -2172,7 +2197,7 @@ describe('LedgerWallet', () => {
             data: '[{"name":"test","type":"string","value":"hello"}]',
             rpcMethod: RpcMethod.SIGN_TYPED_DATA,
             derivationPath,
-            chainId: ethChainId
+            network: ethNetwork
           })
         ).rejects.toThrow(
           'eth_signTypedData v1 is not supported on Ledger devices.'
@@ -2185,7 +2210,7 @@ describe('LedgerWallet', () => {
             data: validTypedData,
             rpcMethod: RpcMethod.SIGN_TYPED_DATA_V1,
             derivationPath,
-            chainId: ethChainId
+            network: ethNetwork
           })
         ).rejects.toThrow(
           'eth_signTypedData v1 is not supported on Ledger devices.'
@@ -2197,7 +2222,7 @@ describe('LedgerWallet', () => {
           data: validTypedData,
           rpcMethod: RpcMethod.SIGN_TYPED_DATA_V4,
           derivationPath,
-          chainId: ethChainId
+          network: ethNetwork
         })
 
         expect(mockEthSignEIP712Message).toHaveBeenCalledWith(
@@ -2212,7 +2237,7 @@ describe('LedgerWallet', () => {
           data: JSON.stringify(validTypedData),
           rpcMethod: RpcMethod.SIGN_TYPED_DATA_V4,
           derivationPath,
-          chainId: ethChainId
+          network: ethNetwork
         })
 
         expect(mockEthSignEIP712Message).toHaveBeenCalled()
@@ -2225,7 +2250,7 @@ describe('LedgerWallet', () => {
             data: 'not-valid-json',
             rpcMethod: RpcMethod.SIGN_TYPED_DATA_V4,
             derivationPath,
-            chainId: ethChainId
+            network: ethNetwork
           })
         ).rejects.toThrow(
           'Invalid typed data format: expected JSON string or object'
@@ -2239,7 +2264,7 @@ describe('LedgerWallet', () => {
             data: dataWithoutDomain,
             rpcMethod: RpcMethod.SIGN_TYPED_DATA_V4,
             derivationPath,
-            chainId: ethChainId
+            network: ethNetwork
           })
         ).rejects.toThrow('TypedData missing required field: domain')
       })
@@ -2251,7 +2276,7 @@ describe('LedgerWallet', () => {
             data: dataWithoutTypes,
             rpcMethod: RpcMethod.SIGN_TYPED_DATA_V4,
             derivationPath,
-            chainId: ethChainId
+            network: ethNetwork
           })
         ).rejects.toThrow('TypedData missing required field: types')
       })
@@ -2264,7 +2289,7 @@ describe('LedgerWallet', () => {
             data: dataWithoutPrimary,
             rpcMethod: RpcMethod.SIGN_TYPED_DATA_V4,
             derivationPath,
-            chainId: ethChainId
+            network: ethNetwork
           })
         ).rejects.toThrow('TypedData missing required field: primaryType')
       })
@@ -2276,19 +2301,17 @@ describe('LedgerWallet', () => {
             data: dataWithoutMessage,
             rpcMethod: RpcMethod.SIGN_TYPED_DATA_V4,
             derivationPath,
-            chainId: ethChainId
+            network: ethNetwork
           })
         ).rejects.toThrow('TypedData missing required field: message')
       })
 
       it('should use Avalanche app for Avalanche chain IDs', async () => {
-        ;(isAvalancheChainId as jest.Mock).mockReturnValue(true)
-
         await (ledgerWallet as any).handleSignedTypedData({
           data: validTypedData,
           rpcMethod: RpcMethod.SIGN_TYPED_DATA_V4,
           derivationPath,
-          chainId: avaxChainId
+          network: avaxNetwork
         })
 
         expect(mockAvaxSignEIP712Message).toHaveBeenCalledWith(
@@ -2303,11 +2326,30 @@ describe('LedgerWallet', () => {
           data: validTypedData,
           rpcMethod: RpcMethod.SIGN_TYPED_DATA_V4,
           derivationPath,
-          chainId: ethChainId
+          network: ethNetwork
         })
 
         expect(mockEthSignEIP712Message).toHaveBeenCalled()
         expect(mockAvaxSignEIP712Message).not.toHaveBeenCalled()
+      })
+
+      it('should use Avalanche app for Avalanche L1 networks (EVM + subnetId)', async () => {
+        await (ledgerWallet as any).handleSignedTypedData({
+          data: validTypedData,
+          rpcMethod: RpcMethod.SIGN_TYPED_DATA_V4,
+          derivationPath,
+          network: {
+            chainId: 1510,
+            vmName: NetworkVMType.EVM,
+            subnetId: 'orange-subnet'
+          } as Network
+        })
+
+        expect(mockAvaxSignEIP712Message).toHaveBeenCalledWith(
+          derivationPath,
+          expect.objectContaining({ primaryType: 'Message' })
+        )
+        expect(mockEthSignEIP712Message).not.toHaveBeenCalled()
       })
     })
   })

--- a/packages/core-mobile/app/services/wallet/LedgerWallet.ts
+++ b/packages/core-mobile/app/services/wallet/LedgerWallet.ts
@@ -59,7 +59,7 @@ import {
 import { Account } from 'store/account'
 import { uuid } from 'utils/uuid'
 import { CoreAccountType } from '@avalabs/types'
-import { isAvalancheChainId } from 'services/network/utils/isAvalancheNetwork'
+import { getLedgerAppName } from 'features/ledger/utils'
 import LedgerTrustedNameService from 'services/ledger/LedgerTrustedNameService'
 import { toSegments } from 'utils/toSegments'
 import { BitcoinWalletPolicyService } from './BitcoinWalletPolicyService'
@@ -661,6 +661,16 @@ export class LedgerWallet implements Wallet {
     }
   }
 
+  /**
+   * Whether EVM signing for this network should use the Ledger Avalanche app
+   * (C-Chain or an Avalanche L1) rather than the Ethereum app. Shares
+   * getLedgerAppName with the approval UI so the app we prompt for and the app
+   * we sign with can never disagree.
+   */
+  private usesAvalancheApp(network?: Network): boolean {
+    return getLedgerAppName(network) === LedgerAppType.AVALANCHE
+  }
+
   public async signEvmTransaction({
     accountIndex,
     transaction,
@@ -674,9 +684,12 @@ export class LedgerWallet implements Wallet {
   }): Promise<string> {
     Logger.info('signEvmTransaction called')
 
-    // Determine chain type and required app
+    // Determine chain type and required app.
+    // Route C-Chain and Avalanche L1s (EVM chains with a subnetId) to the
+    // Avalanche app; all other EVM chains use the Ethereum app. getLedgerAppName
+    // is the single source of truth shared with the approval UI.
     const chainId = transaction.chainId ? Number(transaction.chainId) : 43114
-    const isAvalanche = isAvalancheChainId(chainId)
+    const isAvalanche = this.usesAvalancheApp(network)
     const appType = isAvalanche
       ? LedgerAppType.AVALANCHE
       : LedgerAppType.ETHEREUM
@@ -1216,19 +1229,20 @@ export class LedgerWallet implements Wallet {
     data,
     rpcMethod,
     derivationPath,
-    chainId
+    network
   }: {
     data: string | TypedDataV1 | TypedData<MessageTypes>
     rpcMethod: RpcMethod
     derivationPath: string
-    chainId: number
+    network: Network
   }): Promise<string> {
-    const appType = isAvalancheChainId(chainId)
+    const isAvalanche = this.usesAvalancheApp(network)
+    const appType = isAvalanche
       ? LedgerAppType.AVALANCHE
       : LedgerAppType.ETHEREUM
     // Get transport and create Ethereum app instance
     const transport = await this.handleAppConnection(appType)
-    const app = isAvalancheChainId(chainId)
+    const app = isAvalanche
       ? new AppAvax(transport as Transport)
       : new Eth(transport as Transport)
 
@@ -1304,16 +1318,17 @@ export class LedgerWallet implements Wallet {
   private async handleEthAndPersonalSign({
     data,
     derivationPath,
-    chainId
+    network
   }: {
     data: string | TypedDataV1 | TypedData<MessageTypes>
     derivationPath: string
-    chainId: number
+    network: Network
   }): Promise<string> {
-    // Use the Avalanche app when on an Avalanche chain — the Avalanche Ledger
-    // app exposes EVM signing through the same transport, so we can create an
-    // Eth instance without switching apps (matches core-web/extension behavior).
-    const appType = isAvalancheChainId(chainId)
+    // Use the Avalanche app when on an Avalanche chain (C-Chain or an L1) — the
+    // Avalanche Ledger app exposes EVM signing through the same transport, so we
+    // can create an Eth instance without switching apps (matches
+    // core-web/extension behavior).
+    const appType = this.usesAvalancheApp(network)
       ? LedgerAppType.AVALANCHE
       : LedgerAppType.ETHEREUM
     const transport = await this.handleAppConnection(appType)
@@ -1363,7 +1378,7 @@ export class LedgerWallet implements Wallet {
           data,
           rpcMethod,
           derivationPath,
-          chainId: network.chainId
+          network
         })
       } else if (
         rpcMethod === RpcMethod.ETH_SIGN ||
@@ -1372,7 +1387,7 @@ export class LedgerWallet implements Wallet {
         return this.handleEthAndPersonalSign({
           data,
           derivationPath,
-          chainId: network.chainId
+          network
         })
       } else {
         throw new Error('This function is not supported on your wallet')

--- a/packages/core-mobile/app/services/wallet/LedgerWallet.ts
+++ b/packages/core-mobile/app/services/wallet/LedgerWallet.ts
@@ -662,10 +662,11 @@ export class LedgerWallet implements Wallet {
   }
 
   /**
-   * Whether EVM signing for this network should use the Ledger Avalanche app
-   * (C-Chain or an Avalanche L1) rather than the Ethereum app. Shares
-   * getLedgerAppName with the approval UI so the app we prompt for and the app
-   * we sign with can never disagree.
+   * For the EVM signing flows, whether to use the Ledger Avalanche app rather
+   * than the Ethereum app. Mirrors the approval UI by delegating to
+   * getLedgerAppName(network) — which for EVM networks resolves to the Avalanche
+   * app on C-Chain and Avalanche L1s — so the app we prompt for and the app we
+   * sign with can never disagree.
    */
   private usesAvalancheApp(network?: Network): boolean {
     return getLedgerAppName(network) === LedgerAppType.AVALANCHE
@@ -688,7 +689,9 @@ export class LedgerWallet implements Wallet {
     // Route C-Chain and Avalanche L1s (EVM chains with a subnetId) to the
     // Avalanche app; all other EVM chains use the Ethereum app. getLedgerAppName
     // is the single source of truth shared with the approval UI.
-    const chainId = transaction.chainId ? Number(transaction.chainId) : 43114
+    const chainId = transaction.chainId
+      ? Number(transaction.chainId)
+      : network.chainId
     const isAvalanche = this.usesAvalancheApp(network)
     const appType = isAvalanche
       ? LedgerAppType.AVALANCHE


### PR DESCRIPTION
## What

Routes Ledger **EVM** signing on Avalanche C-Chain and Avalanche L1s (EVM subnets) to the Ledger **Avalanche** app instead of the Ethereum app.

Previously `LedgerWallet` picked the signing app via `isAvalancheChainId(chainId)`, which only matches C-Chain by chain ID. Avalanche L1s (EVM chains with a `subnetId`) fell through to the Ethereum app, so the app the approval UI prompted for could disagree with the app actually used to sign.

This change makes `LedgerWallet` defer to `getLedgerAppName(network)` — the same function the approval UI already uses — as the single source of truth, via a small `usesAvalancheApp(network)` helper. The full `Network` object is now threaded through `signEvmTransaction`, the typed-data path, and `handleEthAndPersonalSign` (replacing the bare `chainId`). Also adds `ChainId.AVALANCHE_LOCAL_ID` to the Avalanche-chain check in `getLedgerAppName`.

Matches core-web / extension behavior (the Avalanche Ledger app exposes EVM signing over the same transport, so no app switch is needed).

Jira: https://ava-labs.atlassian.net/browse/CP-13954

## Why it matters

The app prompted in the approval sheet and the app used to sign can no longer drift apart on Avalanche L1s — they are now computed from one function.

## Dev testing

Bitrise builds:
- iOS: 8972
- Android: 8973

**Verified locally** on a physical Pixel 8 Pro with a real Ledger (BLE), using the Avalanche RPC playground (https://ava-labs.github.io/extension-avalanche-playground/rpc-calls):
- **Avalanche L1** (EVM chain with `subnetId`): `eth_sendTransaction`, `personal_sign`, `eth_signTypedData_v4` → all prompt and sign with the **Avalanche** Ledger app ✅ (previously routed to the Ethereum app)
- **C-Chain** → **Avalanche** app ✅
- **Ethereum / non-Avalanche EVM** → **Ethereum** app ✅ (unchanged)

Steps for reviewers (Ledger device required):
1. Pair a Ledger over BLE and add a Ledger account.
2. Open the Avalanche RPC playground (or any EVM dApp) with the wallet's active network set to an **Avalanche L1** (EVM subnet).
3. Fire `eth_sendTransaction`, `personal_sign`, and `eth_signTypedData_v4`.
   - Expected: approval sheet prompts for the **Avalanche** app, and signing completes on the Avalanche app (no Ethereum-app prompt, no mismatch).
4. Repeat on **C-Chain** → Avalanche app.
5. Repeat on **Ethereum / a non-Avalanche EVM chain** → Ethereum app.

## Notes
- Logic test `ledger/utils/index.test.ts` passes (63 tests, includes new L1-routing cases).
- `LedgerWallet.test.ts` currently fails to *run* on `main` due to a pre-existing zod-v4 module-init error (unrelated to this diff; reproduces on clean `main`).
- Optional review follow-ups (not blocking): a clarifying comment that `chainId` in `signEvmTransaction` is now serialization-only, and an explicit signing-path negative test for an EVM chain without `subnetId`.
