### PR TITLE
CP-14594: allow Keystone EVM/BTC signing when X/P xpub is missing

### DIFF
--- a/packages/core-mobile/app/new/features/keystone/storage/KeystoneDataStorage.test.ts
+++ b/packages/core-mobile/app/new/features/keystone/storage/KeystoneDataStorage.test.ts
@@ -1,0 +1,57 @@
+import SecureStorageService from 'security/SecureStorageService'
+import { KeystoneDataStorage } from './KeystoneDataStorage'
+
+jest.mock('security/SecureStorageService', () => ({
+  __esModule: true,
+  default: {
+    store: jest.fn(),
+    load: jest.fn()
+  },
+  KeySlot: { KeystoneData: 'KeystoneData' }
+}))
+
+const mockedLoad = SecureStorageService.load as jest.Mock
+
+describe('KeystoneDataStorage.retrieve', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // reset the module-level cache between tests
+    // @ts-expect-error - private static cache, reset for test isolation
+    KeystoneDataStorage.cache = undefined
+  })
+
+  it('returns stored data when all keys are present', async () => {
+    mockedLoad.mockResolvedValueOnce({
+      mfp: 'fp',
+      xp: 'xpubXP',
+      evm: 'xpubEvm'
+    })
+
+    const result = await KeystoneDataStorage.retrieve()
+
+    expect(result).toEqual({ mfp: 'fp', xp: 'xpubXP', evm: 'xpubEvm' })
+  })
+
+  it('resolves when xp is missing so EVM signing is not blocked', async () => {
+    // A Keystone wallet whose X/P xpub was never imported (e.g. account created
+    // while the device was disconnected) must still load so EVM/BTC can sign.
+    // X/P operations fail later via the lazy xpubXP getter, not here.
+    mockedLoad.mockResolvedValueOnce({ mfp: 'fp', evm: 'xpubEvm' })
+
+    const result = await KeystoneDataStorage.retrieve()
+
+    expect(result).toEqual({ mfp: 'fp', evm: 'xpubEvm' })
+  })
+
+  it('still throws when the EVM xpub is missing', async () => {
+    mockedLoad.mockResolvedValueOnce({ mfp: 'fp', xp: 'xpubXP' })
+
+    await expect(KeystoneDataStorage.retrieve()).rejects.toThrow('no evm found')
+  })
+
+  it('still throws when the master fingerprint is missing', async () => {
+    mockedLoad.mockResolvedValueOnce({ xp: 'xpubXP', evm: 'xpubEvm' })
+
+    await expect(KeystoneDataStorage.retrieve()).rejects.toThrow('no mfp found')
+  })
+})

--- a/packages/core-mobile/app/new/features/keystone/storage/KeystoneDataStorage.ts
+++ b/packages/core-mobile/app/new/features/keystone/storage/KeystoneDataStorage.ts
@@ -3,7 +3,11 @@ import { assertNotUndefined } from 'utils/assertions'
 
 export type KeystoneDataStorageType = {
   evm: string
-  xp: string
+  // X/P xpub is optional: a Keystone wallet can be onboarded (or an account
+  // created) without X/P data — e.g. while the device is disconnected, pending
+  // the on-demand X/P enabler (CP-13335). EVM/BTC signing must still work; only
+  // X/P operations require it, enforced lazily via KeystoneWallet's xpubXP getter.
+  xp?: string
   mfp: string
 }
 
@@ -17,15 +21,17 @@ export class KeystoneDataStorage {
   }
 
   static async retrieve(): Promise<KeystoneDataStorageType> {
-    if (this.cache?.mfp && this.cache?.xp && this.cache?.evm) {
+    if (this.cache?.mfp && this.cache?.evm) {
       return this.cache
     }
 
     const walletInfo = await SecureStorageService.load<KeystoneDataStorageType>(
       KeySlot.KeystoneData
     )
+    // Only mfp + evm are required to construct a usable signer. xp (X/P xpub) is
+    // intentionally NOT asserted here so EVM/BTC signing works for Keystone
+    // wallets without X/P data; X/P access throws lazily via the xpubXP getter.
     assertNotUndefined(walletInfo.mfp, 'no mfp found')
-    assertNotUndefined(walletInfo.xp, 'no xp found')
     assertNotUndefined(walletInfo.evm, 'no evm found')
 
     return walletInfo

--- a/packages/core-mobile/app/services/wallet/KeystoneWallet/KeystoneWallet.test.ts
+++ b/packages/core-mobile/app/services/wallet/KeystoneWallet/KeystoneWallet.test.ts
@@ -39,6 +39,26 @@ describe('KeystoneWallet', () => {
     expect(wallet.mfp).toEqual(MockedKeystoneData.mfp)
   })
 
+  it('throws when the X/P xpub is absent (undefined)', () => {
+    const walletWithoutXp = new KeystoneWallet({
+      evm: MockedKeystoneData.evm,
+      mfp: MockedKeystoneData.mfp
+    })
+    expect(() => walletWithoutXp.xpubXP).toThrow(
+      'no public key (xpubXP) available'
+    )
+  })
+
+  it('throws when the X/P xpub is an empty string (fails closed)', () => {
+    const walletWithEmptyXp = new KeystoneWallet({
+      ...MockedKeystoneData,
+      xp: ''
+    })
+    expect(() => walletWithEmptyXp.xpubXP).toThrow(
+      'no public key (xpubXP) available'
+    )
+  })
+
   it('should have returned the correct public key', async () => {
     const evmPublicKey = await wallet.getPublicKeyFor({
       derivationPath: `m/44'/60'/0'/0/1`,
@@ -65,6 +85,7 @@ describe('KeystoneWallet', () => {
       const result = await wallet.signBtcTransaction({
         accountIndex: 0,
         transaction: { inputs: [], outputs: [] },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         network: { vmName: 'BITCOIN' } as any,
         provider: new BitcoinProvider()
       })

--- a/packages/core-mobile/app/services/wallet/KeystoneWallet/KeystoneWallet.test.ts
+++ b/packages/core-mobile/app/services/wallet/KeystoneWallet/KeystoneWallet.test.ts
@@ -20,6 +20,20 @@ jest.mock('./keystoneSigner.ts', () => ({
   signer: jest.fn().mockImplementation(async () => '0xmockedsignature')
 }))
 
+// Stub the Keystone QR codec so EVM signing runs end-to-end through the real
+// tx-building + mfp path (the `DataType` enum is otherwise undefined under jest).
+// The mocked `signer` above resolves the signature, so the codec internals are
+// not exercised — this keeps the EVM-without-xp regression test focused.
+jest.mock('@keystonehq/bc-ur-registry-eth', () => ({
+  DataType: { transaction: 1, typedTransaction: 2 },
+  RegistryTypes: {},
+  CryptoPSBT: jest.fn(),
+  ETHSignature: { fromCBOR: jest.fn() },
+  EthSignRequest: {
+    constructETHRequest: jest.fn(() => ({ toUR: jest.fn(() => ({})) }))
+  }
+}))
+
 describe('KeystoneWallet', () => {
   let wallet: KeystoneWallet
 
@@ -57,6 +71,30 @@ describe('KeystoneWallet', () => {
     expect(() => walletWithEmptyXp.xpubXP).toThrow(
       'no public key (xpubXP) available'
     )
+  })
+
+  it('signs an EVM transaction when the X/P xpub is absent (regression: EVM must not depend on xp)', async () => {
+    const walletWithoutXp = new KeystoneWallet({
+      evm: MockedKeystoneData.evm,
+      mfp: MockedKeystoneData.mfp
+    })
+    const evmTx = {
+      chainId: 43114,
+      nonce: 0,
+      to: '0x45A62B090DF48243F12A21897e7ed91863E2c86b',
+      value: '0x0',
+      data: '0x',
+      gasLimit: '0x5208',
+      maxFeePerGas: '0x6fc23ac00',
+      maxPriorityFeePerGas: '0x59682f00'
+    }
+
+    const signed = await walletWithoutXp.signEvmTransaction({
+      accountIndex: 0,
+      transaction: evmTx
+    } as unknown as Parameters<KeystoneWallet['signEvmTransaction']>[0])
+
+    expect(signed).toBe('0xmockedsignature')
   })
 
   it('should have returned the correct public key', async () => {

--- a/packages/core-mobile/app/services/wallet/KeystoneWallet/index.ts
+++ b/packages/core-mobile/app/services/wallet/KeystoneWallet/index.ts
@@ -58,7 +58,9 @@ export const AVAX_DERIVATION_PATH = `m/44'/9000'/0'`
 export default class KeystoneWallet implements Wallet {
   #mfp: string
   #xpub: string
-  #xpubXP: string
+  // May be undefined for a Keystone wallet without X/P data; the xpubXP getter
+  // asserts presence, so X/P operations fail clearly while EVM/BTC still sign.
+  #xpubXP: string | undefined
 
   constructor(keystoneData: KeystoneDataStorageType) {
     this.#mfp = keystoneData.mfp
@@ -72,7 +74,12 @@ export default class KeystoneWallet implements Wallet {
   }
 
   public get xpubXP(): string {
-    assertNotUndefined(this.#xpubXP, 'no public key (xpubXP) available')
+    // Fail closed on any falsy value (undefined OR empty string): a Keystone
+    // wallet may legitimately lack X/P data, and we must never feed an empty
+    // xpub into X/P address derivation / signing. EVM/BTC never read this getter.
+    if (!this.#xpubXP) {
+      throw new Error('no public key (xpubXP) available')
+    }
     return this.#xpubXP
   }
 


### PR DESCRIPTION
## What

A Keystone wallet whose stored data is missing the X/P xpub (`xp`) could not sign **any** transaction — including C-Chain **EVM** and **BTC** — failing with `Failed to sign evm transaction` (cause: `no xp found`). This unblocks EVM/BTC signing for those wallets while keeping X/P fail-closed.

Fixes CP-14594.

https://github.com/user-attachments/assets/84480f73-d7a6-4c18-b6cc-e317040a7da9


## Root cause

`KeystoneDataStorage.retrieve()` eagerly asserted **all three** keys (`mfp` + `xp` + `evm`) at wallet *construction*. `WalletService.sign()` calls `WalletFactory.createWallet()` **before** any per-chain branching, so a missing `xp` aborted construction of the signer — even though EVM/BTC signing never use the X/P xpub. A Keystone account can legitimately lack X/P data (e.g. created while the device was disconnected; pending the on-demand X/P enabler, CP-13335).

## Fix (narrow — EVM/BTC unblock only)

- `KeystoneDataStorageType.xp` is now optional; removed the eager `no xp found` assertion in `retrieve()` (still requires `mfp` + `evm`); cache fast-path no longer requires `xp`.
- `KeystoneWallet.#xpubXP` is now `string | undefined`; the `xpubXP` getter **fails closed on any falsy value** (undefined *or* empty string), so X/P operations still error clearly (`no public key (xpubXP) available`) while EVM/BTC sign normally.

**Scope:** intentionally orthogonal to the paused Keystone X/P derivation migration (CP-13335 — the multi-guard / per-account-xpub / architecture A-vs-B work is untouched). Related: CP-14518 (Keystone no-accounts / infinite spinner).

## Why it's safe (adversarially reviewed)

- EVM (`signEvmTransaction`, EVM `signMessage`) and BTC (`signBtcTransaction`) never read `xpubXP` — signatures are byte-identical to before.
- X/P paths read through the asserting getter and **throw** (never silently return empty/zero), so no wrong/zero address can be derived or displayed.
- `KeystoneDataStorage.cache` is only populated by `save()`, which is strictly guarded (`KeystoneService.save()` refuses to persist unless `evm && xp && mfp`) — so a wallet that *has* `xp` can never have it dropped.
- Behavior-preserving for normally-onboarded Keystone wallets (which have `xp`).

## Tests

- New `KeystoneDataStorage.test.ts` (retrieve tolerates missing `xp`; still throws on missing `mfp`/`evm`).
- New `KeystoneWallet` getter tests (`xpubXP` throws on undefined and on empty string).
- `KeystoneWallet.test.ts` + `KeystoneDataStorage.test.ts`: **11/11 pass**. Lint clean.

## Dev testing

**Bitrise builds:**
- Android: 8989
- iOS: 8988

**Local verification:** device-verified on **Pixel 8 Pro (Android)** via Metro on this branch.

**Reviewer steps:**
1. Use a **Keystone** wallet/account that has **no stored X/P xpub** (or a fresh Keystone account created while the device was disconnected). Make it the **active** account.
2. Open a dApp (e.g. `lfj.gg`), connect, and perform a **C-Chain swap** (EVM `eth_sendTransaction`).
   - ✅ Before: `Failed to sign evm transaction` / `no xp found`. After: signs + broadcasts.
3. Also confirm a **BTC** send signs for the same wallet.
4. Confirm an **X/P** (P/X-Chain) operation for that account still fails with a clear error (intended fail-closed behavior — not a regression).
5. Regression: a normally-onboarded Keystone wallet (with X/P data) behaves exactly as before.

📹 **Demo:** _drag `Screen Recording 2026-06-25 at 2.40.53 PM.mov` into this description here_
