### PR TITLE
CP-14421: enum-backed signing classification for the injected router

### DIFF
--- a/packages/core-mobile/app/hooks/browser/injectedProvider/approvalMethods.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/approvalMethods.test.ts
@@ -47,7 +47,11 @@ describe('approvalMethods', () => {
   })
 
   it('neither helper classifies a cross-namespace enum member', () => {
+    const enumValues = Object.values(RpcMethod)
     for (const m of CROSS_NAMESPACE) {
+      // Guard against vacuity: these must be real enum members, otherwise they
+      // would classify as false simply for not being in the enum at all.
+      expect(enumValues).toContain(m)
       expect(isEvmSigningMethod(m)).toBe(false)
       expect(isAvalancheSigningMethod(m)).toBe(false)
     }

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/approvalMethods.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/approvalMethods.test.ts
@@ -60,6 +60,21 @@ describe('approvalMethods', () => {
     }
   })
 
+  it('requires enum membership, not just an eth_/personal_ prefix', () => {
+    // These start with eth_/personal_ but are NOT RpcMethod signing members
+    // (read-only or non-signing) — they must classify as false. Proves the AND
+    // in the matcher: prefix alone is insufficient.
+    for (const m of [
+      'eth_call',
+      'eth_chainId',
+      'eth_getBalance',
+      'eth_blockNumber',
+      'personal_ecRecover'
+    ]) {
+      expect(isEvmSigningMethod(m)).toBe(false)
+    }
+  })
+
   it('is prototype-safe (Object members are not signing methods)', () => {
     for (const m of [
       'toString',
@@ -72,15 +87,22 @@ describe('approvalMethods', () => {
     }
   })
 
-  it('enum-hygiene tripwire: every RpcMethod member is classified or in a known-unhandled namespace', () => {
-    // Namespaces with no injected provider yet. If vm-module-types adds a member
-    // outside these and outside eth_/personal_/avalanche_, this fails — forcing
-    // a conscious decision (the list-free replacement for the old drift guard).
-    const KNOWN_UNHANDLED = ['solana_', 'bitcoin_', 'hvm_']
+  it('enum-hygiene tripwire: every RpcMethod member is classified or an explicitly-known unhandled member', () => {
+    // Frozen list of enum members that have no injected provider yet. A NEW enum
+    // member — even under an existing unhandled namespace — fails this until it
+    // is consciously triaged here (and routed, if it needs an injected provider).
+    // This is the list-free replacement for the old hand-maintained drift guard.
+    const KNOWN_UNHANDLED = [
+      'solana_signTransaction',
+      'solana_signAndSendTransaction',
+      'solana_signMessage',
+      'bitcoin_sendTransaction',
+      'bitcoin_signTransaction',
+      'hvm_signTransaction'
+    ]
     for (const m of Object.values(RpcMethod)) {
       const classified = isEvmSigningMethod(m) || isAvalancheSigningMethod(m)
-      const knownUnhandled = KNOWN_UNHANDLED.some(p => m.startsWith(p))
-      expect(classified || knownUnhandled).toBe(true)
+      expect(classified || KNOWN_UNHANDLED.includes(m)).toBe(true)
     }
   })
 })

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/approvalMethods.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/approvalMethods.test.ts
@@ -1,0 +1,86 @@
+import { RpcMethod } from '@avalabs/vm-module-types'
+import { isEvmSigningMethod, isAvalancheSigningMethod } from './approvalMethods'
+
+describe('approvalMethods', () => {
+  // Frozen snapshot: the exact EVM signing set before the refactor. If the enum
+  // gains a new eth_*/personal_* member, the tripwire below fails and forces a
+  // conscious update here too.
+  const EVM_SIGNING = [
+    'eth_sendTransaction',
+    'eth_sendTransactionBatch',
+    'eth_sign',
+    'eth_signTypedData',
+    'eth_signTypedData_v1',
+    'eth_signTypedData_v3',
+    'eth_signTypedData_v4',
+    'personal_sign'
+  ]
+  const AVALANCHE_SIGNING = [
+    'avalanche_sendTransaction',
+    'avalanche_signTransaction',
+    'avalanche_signMessage'
+  ]
+  const CROSS_NAMESPACE = [
+    'solana_signTransaction',
+    'solana_signAndSendTransaction',
+    'solana_signMessage',
+    'bitcoin_sendTransaction',
+    'bitcoin_signTransaction',
+    'hvm_signTransaction'
+  ]
+  const ACCOUNT_METHODS = [
+    'avalanche_getAccounts',
+    'avalanche_selectAccount',
+    'avalanche_getAccountPubKey'
+  ]
+
+  it('isEvmSigningMethod matches exactly the EVM signing set', () => {
+    const matched = Object.values(RpcMethod).filter(isEvmSigningMethod).sort()
+    expect(matched).toEqual([...EVM_SIGNING].sort())
+  })
+
+  it('isAvalancheSigningMethod matches exactly the avalanche signing set', () => {
+    const matched = Object.values(RpcMethod)
+      .filter(isAvalancheSigningMethod)
+      .sort()
+    expect(matched).toEqual([...AVALANCHE_SIGNING].sort())
+  })
+
+  it('neither helper classifies a cross-namespace enum member', () => {
+    for (const m of CROSS_NAMESPACE) {
+      expect(isEvmSigningMethod(m)).toBe(false)
+      expect(isAvalancheSigningMethod(m)).toBe(false)
+    }
+  })
+
+  it('neither helper classifies the first-party account methods as signing', () => {
+    for (const m of ACCOUNT_METHODS) {
+      expect(isEvmSigningMethod(m)).toBe(false)
+      expect(isAvalancheSigningMethod(m)).toBe(false)
+    }
+  })
+
+  it('is prototype-safe (Object members are not signing methods)', () => {
+    for (const m of [
+      'toString',
+      'constructor',
+      '__proto__',
+      'hasOwnProperty'
+    ]) {
+      expect(isEvmSigningMethod(m)).toBe(false)
+      expect(isAvalancheSigningMethod(m)).toBe(false)
+    }
+  })
+
+  it('enum-hygiene tripwire: every RpcMethod member is classified or in a known-unhandled namespace', () => {
+    // Namespaces with no injected provider yet. If vm-module-types adds a member
+    // outside these and outside eth_/personal_/avalanche_, this fails — forcing
+    // a conscious decision (the list-free replacement for the old drift guard).
+    const KNOWN_UNHANDLED = ['solana_', 'bitcoin_', 'hvm_']
+    for (const m of Object.values(RpcMethod)) {
+      const classified = isEvmSigningMethod(m) || isAvalancheSigningMethod(m)
+      const knownUnhandled = KNOWN_UNHANDLED.some(p => m.startsWith(p))
+      expect(classified || knownUnhandled).toBe(true)
+    }
+  })
+})

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/approvalMethods.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/approvalMethods.ts
@@ -13,9 +13,12 @@ const APPROVAL_METHODS = new Set<string>(Object.values(RpcMethod))
 // etc. are not enum members, so they correctly classify as non-signing. This
 // preserves the property the old `hasOwnProperty` check on the SIGNING_METHODS
 // record provided.
+// Returns a type guard: a true result proves `method` is an `RpcMethod` value
+// (membership in APPROVAL_METHODS == Object.values(RpcMethod)), so callers narrow
+// `method` to `RpcMethod` and avoid downstream `as RpcMethod` assertions.
 const signingMethodMatcher =
   (...prefixes: string[]) =>
-  (method: string): boolean =>
+  (method: string): method is RpcMethod =>
     APPROVAL_METHODS.has(method) && prefixes.some(p => method.startsWith(p))
 
 export const isEvmSigningMethod = signingMethodMatcher('eth_', 'personal_')

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/approvalMethods.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/approvalMethods.ts
@@ -1,0 +1,23 @@
+import { RpcMethod } from '@avalabs/vm-module-types'
+
+// The vm-module RpcMethod enum enumerates exactly the approval/signing methods
+// across all VMs (no read-only members). It is the single source of truth that
+// replaces the per-provider hand-maintained signing lists. CP-14421.
+const APPROVAL_METHODS = new Set<string>(Object.values(RpcMethod))
+
+// Namespace-scoped: a cross-namespace enum member (solana_*, bitcoin_*, hvm_*)
+// must NOT route into the EVM or AVAX signing path of an injected provider that
+// doesn't own it — the prefix filter is mandatory, not cosmetic.
+//
+// `Set.has` is inherently prototype-safe: `toString`, `constructor`, `__proto__`
+// etc. are not enum members, so they correctly classify as non-signing. This
+// preserves the property the old `hasOwnProperty` check on the SIGNING_METHODS
+// record provided.
+const signingMethodMatcher =
+  (...prefixes: string[]) =>
+  (method: string): boolean =>
+    APPROVAL_METHODS.has(method) && prefixes.some(p => method.startsWith(p))
+
+export const isEvmSigningMethod = signingMethodMatcher('eth_', 'personal_')
+
+export const isAvalancheSigningMethod = signingMethodMatcher('avalanche_')

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.test.ts
@@ -1,5 +1,4 @@
 import { NetworkVMType } from '@avalabs/core-chains-sdk'
-import { RpcMethod } from '@avalabs/vm-module-types'
 import { setTabChainId } from 'store/browser/slices/tabs'
 import type { Networks } from 'store/network/types'
 import type { Account } from 'store/account'
@@ -8,7 +7,7 @@ import {
   JSON_RPC_INTERNAL_ERROR_CODE,
   USER_REJECTED_REQUEST_MESSAGE
 } from './errors'
-import { createInjectedProviderRouter, SIGNING_METHODS } from './router'
+import { createInjectedProviderRouter } from './router'
 import { BrowserNetwork, RouterDeps } from './types'
 
 jest.mock('store/browser/slices/tabs', () => ({
@@ -1527,21 +1526,6 @@ describe('createInjectedProviderRouter', () => {
         expect.objectContaining({ method: 'eth_sendTransactionBatch' })
       )
       expect(requestReadOnly).not.toHaveBeenCalled()
-    })
-
-    it('SIGNING_METHODS covers every EVM signing method in the RpcMethod enum (drift guard)', () => {
-      // Source of truth: the vm-module RpcMethod enum. Every eth_*/personal_*
-      // member is an EVM method that requires approval and must take the
-      // signing path; one missing here would silently fall through to the
-      // read-only branch (the drift hazard CP-14384 removed for the read-only
-      // list). If the enum gains a new EVM signing method, this fails until
-      // SIGNING_METHODS is updated.
-      const evmSigningMethods = Object.values(RpcMethod).filter(
-        m => m.startsWith('eth_') || m.startsWith('personal_')
-      )
-      expect(Object.keys(SIGNING_METHODS).sort()).toEqual(
-        [...evmSigningMethods].sort()
-      )
     })
   })
 

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -1,6 +1,7 @@
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors'
 import { NetworkVMType } from '@avalabs/core-chains-sdk'
 import { RpcMethod } from '@avalabs/vm-module-types'
+import { RpcMethod as AppRpcMethod } from 'store/rpc/types'
 import Logger from 'utils/Logger'
 import {
   getEvmCaip2ChainId,
@@ -12,6 +13,7 @@ import { isUserRejectedRpcError } from './errors'
 import { resolveActiveConnectedAccounts } from './resolveGrantedAccounts'
 import { isFirstPartyOrigin } from './firstPartyDomains'
 import { MAX_MESSAGE_SIZE, ProviderRequest, RouterDeps } from './types'
+import { isEvmSigningMethod, isAvalancheSigningMethod } from './approvalMethods'
 
 // avalanche_* methods (X/P account management + signing) are first-party-only.
 // A prefix classifies them: it conservatively covers every current and future
@@ -31,63 +33,17 @@ const isAvalancheMethod = (method: string): boolean =>
 // methods (avalanche_sendTransaction/…) are intentionally NOT here — they need
 // per-request CAIP-2 scope and route separately. CP-13672.
 const AVALANCHE_ACCOUNT_METHODS = new Set<string>([
-  'avalanche_getAccounts',
-  'avalanche_selectAccount',
-  'avalanche_getAccountPubKey'
+  AppRpcMethod.AVALANCHE_GET_ACCOUNTS,
+  AppRpcMethod.AVALANCHE_SELECT_ACCOUNT,
+  AppRpcMethod.AVALANCHE_GET_ACCOUNT_PUB_KEY
 ])
 
 const isAvalancheAccountMethod = (method: string): boolean =>
   AVALANCHE_ACCOUNT_METHODS.has(method)
 
-// The first-party avalanche signing methods. Unlike the account methods, these
-// route to the Avalanche VM module (ModuleManager.loadModule by CAIP-2) and go
-// through the approval screen, with a per-request CAIP-2 scope (D3), NOT the EVM
-// browser network. Param shapes differ by method (see dispatchAvalancheSigning-
-// Request): send/signTransaction carry an object with chainAlias; signMessage is
-// a [message, accountIndex] tuple. Exact case-sensitive match (same reasoning as
-// the account set). CP-13672.
-const AVALANCHE_SIGNING_METHODS = new Set<string>([
-  'avalanche_sendTransaction',
-  'avalanche_signTransaction',
-  'avalanche_signMessage'
-])
-
-const isAvalancheSigningMethod = (method: string): boolean =>
-  AVALANCHE_SIGNING_METHODS.has(method)
-
 // The Avalanche Primary Network chain aliases a signing request may target.
 const isAvalancheChainAlias = (value: unknown): value is 'X' | 'P' | 'C' =>
   value === 'X' || value === 'P' || value === 'C'
-
-// Injected-specific methods (connect / EIP-2255 permissions / chain management)
-// are handled directly in `dispatchMethod`. Signing methods route through
-// `requestSigning`. Everything else is treated as read-only and dispatched to
-// the VM module, which validates it against its manifest — so the read-only
-// allowlist is no longer hand-maintained here (CP-14384).
-//
-// This list must cover every EVM (eth_*/personal_*) method in the vm-module
-// RpcMethod enum: a signing method missing here silently falls through to the
-// read-only branch. A drift guard in router.test.ts cross-checks it against the
-// enum so it can't quietly fall out of sync.
-export const SIGNING_METHODS: Record<string, RpcMethod> = {
-  [RpcMethod.ETH_SEND_TRANSACTION]: RpcMethod.ETH_SEND_TRANSACTION,
-  [RpcMethod.ETH_SEND_TRANSACTION_BATCH]: RpcMethod.ETH_SEND_TRANSACTION_BATCH,
-  [RpcMethod.PERSONAL_SIGN]: RpcMethod.PERSONAL_SIGN,
-  [RpcMethod.ETH_SIGN]: RpcMethod.ETH_SIGN,
-  [RpcMethod.SIGN_TYPED_DATA]: RpcMethod.SIGN_TYPED_DATA,
-  [RpcMethod.SIGN_TYPED_DATA_V1]: RpcMethod.SIGN_TYPED_DATA_V1,
-  [RpcMethod.SIGN_TYPED_DATA_V3]: RpcMethod.SIGN_TYPED_DATA_V3,
-  [RpcMethod.SIGN_TYPED_DATA_V4]: RpcMethod.SIGN_TYPED_DATA_V4
-}
-
-// `method` comes straight from the dApp, so an own-property check is required:
-// `method in SIGNING_METHODS` / `SIGNING_METHODS[method]` walk the prototype
-// chain, so names like `toString`, `constructor`, or `__proto__` would otherwise
-// hit the signing branch and call requestSigning with a non-RPC value.
-const signingMethodFor = (method: string): RpcMethod | undefined =>
-  Object.prototype.hasOwnProperty.call(SIGNING_METHODS, method)
-    ? SIGNING_METHODS[method]
-    : undefined
 
 const isEvmAddress = (value: unknown): value is string =>
   typeof value === 'string' && /^0x[0-9a-fA-F]{40}$/.test(value)
@@ -334,8 +290,7 @@ export function createInjectedProviderRouter(
     method: string,
     params: unknown[]
   ): Promise<void> => {
-    const rpcMethod = signingMethodFor(method)
-    if (!rpcMethod) {
+    if (!isEvmSigningMethod(method)) {
       sendResponse(
         id,
         rpcErrors.methodNotFound(`Method not supported: ${method}`),
@@ -365,7 +320,10 @@ export function createInjectedProviderRouter(
         addr => addr.toLowerCase()
       )
     )
-    const requestedSigners = requestedSignerAddresses(rpcMethod, params)
+    const requestedSigners = requestedSignerAddresses(
+      method as RpcMethod,
+      params
+    )
     const signerAddresses =
       requestedSigners.length > 0
         ? requestedSigners
@@ -390,7 +348,7 @@ export function createInjectedProviderRouter(
 
     try {
       const result = await requestSigning({
-        method: rpcMethod,
+        method: method as RpcMethod,
         params,
         chainId: caip2ChainId,
         peerMeta: getPeerMeta(),
@@ -882,7 +840,7 @@ export function createInjectedProviderRouter(
       // RAW params (NOT safeParams): avalanche signing uses object params whose
       // top-level chainAlias would be lost by the array coercion.
       dispatchAvalancheSigningRequest(id, method, params)
-    } else if (signingMethodFor(method)) {
+    } else if (isEvmSigningMethod(method)) {
       dispatchSigningRequest(id, method, safeParams)
     } else {
       // Anything not injected-specific and not a signing method is treated as

--- a/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
+++ b/packages/core-mobile/app/hooks/browser/injectedProvider/router.ts
@@ -320,10 +320,7 @@ export function createInjectedProviderRouter(
         addr => addr.toLowerCase()
       )
     )
-    const requestedSigners = requestedSignerAddresses(
-      method as RpcMethod,
-      params
-    )
+    const requestedSigners = requestedSignerAddresses(method, params)
     const signerAddresses =
       requestedSigners.length > 0
         ? requestedSigners
@@ -348,7 +345,7 @@ export function createInjectedProviderRouter(
 
     try {
       const result = await requestSigning({
-        method: method as RpcMethod,
+        method,
         params,
         chainId: caip2ChainId,
         peerMeta: getPeerMeta(),


### PR DESCRIPTION
## What

Replaces the injected-provider router's two **hand-maintained** signing-method lists with namespace-scoped helpers derived from the `@avalabs/vm-module-types` `RpcMethod` enum — a single source of truth. Last injected-provider ticket ([CP-14421](https://ava-labs.atlassian.net/browse/CP-14421)).

Before this PR the router maintained `SIGNING_METHODS` (EVM) and — added by the X/P work — `AVALANCHE_SIGNING_METHODS`, each a drift hazard (the EVM one had already drifted once; the avalanche one shipped with no drift guard at all). Each future injected VM provider would add another.

## How

- **New `approvalMethods.ts`** exporting `isEvmSigningMethod` / `isAvalancheSigningMethod` — each a namespace-prefix-filtered membership test over `RpcMethod`. `Set.has` makes them inherently prototype-safe.
- **Router** consumes the helpers and deletes `SIGNING_METHODS`, `signingMethodFor`, and `AVALANCHE_SIGNING_METHODS`. Dispatch-fork ordering and both signing dispatchers are unchanged.
- **Account allowlist** (`avalanche_getAccounts` / `selectAccount` / `getAccountPubKey`) stays explicit — these are Core-proprietary, not in the vm-module enum — but is hardened to use the app-layer `RpcMethod` enum constants instead of raw strings.
- **Tests**: the hand-list drift guard is replaced by enum-hygiene tests in `approvalMethods.test.ts` — frozen snapshots, namespace isolation, prototype safety, an enum-membership negative test, and a member-level tripwire that fails CI when the enum gains an unhandled method.

**Zero runtime behavior change** — verified: the enum-derived sets reproduce both prior lists exactly (8 EVM, 3 avalanche).

## Why this isn't a cross-repo change

The original ticket framed this as exposing a `requiresApproval` API from `core-vm-modules`. Investigation (incl. the v3.9.0 source) confirmed the `RpcMethod` enum already enumerates exactly the approval methods across all VMs, so an in-repo namespace-scoped helper is sufficient and authoritative — no module-API change needed.

## Note on base branch

Stacked on `boyer/CP-13672-xp-injected-provider` (X/P provider, in review) because that branch introduces the second list this PR unifies. Rebase onto `main` once X/P merges.

## Dev testing

This is a pure refactor with **no runtime behavior change**; correctness is enforced by the existing injected-provider suite as the behavior-equivalence net.

- `yarn test app/hooks/browser/injectedProvider` → **136 passing**, lint + tsc clean.
- Reviewer-facing sanity checks (in the in-app browser):
  - Connect a dapp, send an EVM tx / `personal_sign` / `signTypedData_v4` → approval screen still appears (signing path).
  - Read-only calls (`eth_call`, `eth_chainId`, `eth_getBalance`) → still answered with no prompt.
  - On a Core first-party surface, X/P `avalanche_sendTransaction` / `signMessage` → approval screen; `avalanche_getAccounts` → resolves with no prompt.
- Bitrise build: _TBD — to add before marking ready for review._

## Review confidence

Reviewed per task with parallel Claude + Codex adversarial passes, plus a whole-branch review. Codex independently enumerated the installed enum to confirm exact-set equivalence and surfaced two test-robustness gaps, both fixed in `907edbe33`.


[CP-14421]: https://ava-labs.atlassian.net/browse/CP-14421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ