### PR TITLE
CP-14606: create Keystone non-primary accounts with EVM/BTC and empty X/P

### DIFF
--- a/packages/core-mobile/app/services/wallet/KeystoneWallet/KeystoneWallet.test.ts
+++ b/packages/core-mobile/app/services/wallet/KeystoneWallet/KeystoneWallet.test.ts
@@ -2,6 +2,7 @@ import { KeystoneDataStorageType } from 'features/keystone/storage/KeystoneDataS
 import { Curve } from 'utils/publicKeys'
 import { BitcoinProvider } from '@avalabs/core-wallets-sdk'
 import KeystoneWallet from 'services/wallet/KeystoneWallet'
+import { KeystoneErrors } from 'services/wallet/KeystoneWallet/errors'
 
 jest.mock('@avalabs/core-wallets-sdk', () => ({
   ...jest.requireActual('@avalabs/core-wallets-sdk'),
@@ -112,6 +113,32 @@ describe('KeystoneWallet', () => {
     expect(xpPublicKey).toEqual(
       '034814b89f62338b37881a71ffe40cdd29752241560b861a7086ac711fa7a8fe79'
     )
+  })
+
+  it('throws a typed UNSUPPORTED_XP_DERIVATION error for a non-primary X/P path', async () => {
+    // Keystone QR wallets only carry the depth-3 account-0 X/P xpub
+    // (m/44'/9000'/0'), so per-account X/P paths (m/44'/9000'/N'/0/0, N > 0)
+    // cannot be derived. The error must be distinguishable so address
+    // derivation can omit X/P for the account rather than failing closed.
+    await expect(
+      wallet.getPublicKeyFor({
+        derivationPath: `m/44'/9000'/1'/0/0`,
+        curve: Curve.SECP256K1
+      })
+    ).rejects.toMatchObject({
+      name: KeystoneErrors.UNSUPPORTED_XP_DERIVATION
+    })
+  })
+
+  it('still throws a generic error for a truly unknown derivation path', async () => {
+    // Only the AVAX coin type (m/44'/9000'/...) maps to the X/P-unsupported
+    // sentinel; any other unknown path stays a generic failure.
+    await expect(
+      wallet.getPublicKeyFor({
+        derivationPath: `m/44'/1'/0'/0/0`,
+        curve: Curve.SECP256K1
+      })
+    ).rejects.toMatchObject({ name: 'Error' })
   })
 
   describe('getSigner', () => {

--- a/packages/core-mobile/app/services/wallet/KeystoneWallet/errors.ts
+++ b/packages/core-mobile/app/services/wallet/KeystoneWallet/errors.ts
@@ -1,0 +1,24 @@
+import { ErrorBase } from 'errors/ErrorBase'
+
+export enum KeystoneErrors {
+  UNSUPPORTED_XP_DERIVATION = 'UNSUPPORTED_XP_DERIVATION'
+}
+
+export class KeystoneWalletError extends ErrorBase<KeystoneErrors> {}
+
+/**
+ * Keystone QR wallets carry only the depth-3 account-0 X/P xpub
+ * (`m/44'/9000'/0'`), so they cannot derive per-account X/P paths
+ * (`m/44'/9000'/N'/0/0` for N > 0). This predicate flags that specific,
+ * structurally-unsupported case so address derivation can create the account
+ * with empty X/P addresses instead of failing closed (CP-14606).
+ *
+ * Matched by `name` on any error-like object rather than via `instanceof` so
+ * the check still holds if the rejection reason was wrapped, re-thrown, or
+ * serialized into a plain object while crossing the vm-module package boundary.
+ */
+export const isUnsupportedXpDerivationError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  (error as { name?: unknown }).name ===
+    KeystoneErrors.UNSUPPORTED_XP_DERIVATION

--- a/packages/core-mobile/app/services/wallet/KeystoneWallet/index.ts
+++ b/packages/core-mobile/app/services/wallet/KeystoneWallet/index.ts
@@ -9,7 +9,7 @@ import {
   MessageTypes,
   RpcMethod
 } from '@avalabs/vm-module-types'
-import { Curve } from 'utils/publicKeys'
+import { AVALANCHE_DERIVATION_PATH_PREFIX, Curve } from 'utils/publicKeys'
 import { assertNotUndefined } from 'utils/assertions'
 import {
   Avalanche,
@@ -58,10 +58,6 @@ import { SignatureRSV } from '../types'
 
 export const EVM_DERIVATION_PATH = `m/44'/60'/0'`
 export const AVAX_DERIVATION_PATH = `m/44'/9000'/0'`
-// AVAX (X/P) BIP44 coin-type prefix shared by every account; only the primary
-// account (AVAX_DERIVATION_PATH, account 0) is derivable from a Keystone QR
-// wallet's single shared xpub.
-export const AVAX_COIN_TYPE_PATH = `m/44'/9000'/`
 
 export default class KeystoneWallet implements Wallet {
   #mfp: string
@@ -399,7 +395,7 @@ export default class KeystoneWallet implements Wallet {
     // derivation can omit X/P for the non-primary account rather than failing
     // closed (CP-14606). Real per-account X/P support is future work with the
     // Keystone team.
-    if (path.startsWith(AVAX_COIN_TYPE_PATH)) {
+    if (path.startsWith(AVALANCHE_DERIVATION_PATH_PREFIX)) {
       throw new KeystoneWalletError({
         name: KeystoneErrors.UNSUPPORTED_XP_DERIVATION,
         message: `Keystone cannot derive X/P for non-primary account path: ${path}`

--- a/packages/core-mobile/app/services/wallet/KeystoneWallet/index.ts
+++ b/packages/core-mobile/app/services/wallet/KeystoneWallet/index.ts
@@ -50,10 +50,18 @@ import { BN } from 'bn.js'
 import { isTypedData } from '@avalabs/evm-module'
 import { convertTxData, makeBigIntLike } from 'services/wallet/utils'
 import { signer } from 'services/wallet/KeystoneWallet/keystoneSigner'
+import {
+  KeystoneErrors,
+  KeystoneWalletError
+} from 'services/wallet/KeystoneWallet/errors'
 import { SignatureRSV } from '../types'
 
 export const EVM_DERIVATION_PATH = `m/44'/60'/0'`
 export const AVAX_DERIVATION_PATH = `m/44'/9000'/0'`
+// AVAX (X/P) BIP44 coin-type prefix shared by every account; only the primary
+// account (AVAX_DERIVATION_PATH, account 0) is derivable from a Keystone QR
+// wallet's single shared xpub.
+export const AVAX_COIN_TYPE_PATH = `m/44'/9000'/`
 
 export default class KeystoneWallet implements Wallet {
   #mfp: string
@@ -384,6 +392,18 @@ export default class KeystoneWallet implements Wallet {
     }
     if (path.startsWith(AVAX_DERIVATION_PATH)) {
       return Avalanche.getAddressPublicKeyFromXpub(this.xpubXP, accountIndex)
+    }
+    // A Keystone QR wallet only carries the primary account's X/P xpub
+    // (AVAX_DERIVATION_PATH); per-account X/P paths (m/44'/9000'/N'/0/0, N > 0)
+    // are not derivable. Surface this as a distinguishable error so address
+    // derivation can omit X/P for the non-primary account rather than failing
+    // closed (CP-14606). Real per-account X/P support is future work with the
+    // Keystone team.
+    if (path.startsWith(AVAX_COIN_TYPE_PATH)) {
+      throw new KeystoneWalletError({
+        name: KeystoneErrors.UNSUPPORTED_XP_DERIVATION,
+        message: `Keystone cannot derive X/P for non-primary account path: ${path}`
+      })
     }
     throw new Error(`Unknown path: ${path}`)
   }

--- a/packages/core-mobile/app/services/walletconnectv2/utils.test.ts
+++ b/packages/core-mobile/app/services/walletconnectv2/utils.test.ts
@@ -112,4 +112,25 @@ describe('getAddressWithCaip2ChainId', () => {
     })
     expect(result).toBeUndefined()
   })
+
+  it('should return undefined for a non-primary Keystone account with no AVM address', () => {
+    // Keystone non-primary accounts have empty X/P addresses (CP-14606). The
+    // formatter must not emit a malformed "avax:<chain>:" account string with a
+    // trailing colon, which would otherwise be advertised to the dApp.
+    const result = getAddressWithCaip2ChainId({
+      account: { ...mockAccount, index: 1, addressAVM: '', addressPVM: '' },
+      blockchainNamespace: BlockchainNamespace.AVAX,
+      caip2ChainId: AvalancheCaip2ChainId.X
+    })
+    expect(result).toBeUndefined()
+  })
+
+  it('should return undefined for a non-primary Keystone account with no PVM address', () => {
+    const result = getAddressWithCaip2ChainId({
+      account: { ...mockAccount, index: 1, addressAVM: '', addressPVM: '' },
+      blockchainNamespace: BlockchainNamespace.AVAX,
+      caip2ChainId: AvalancheCaip2ChainId.P
+    })
+    expect(result).toBeUndefined()
+  })
 })

--- a/packages/core-mobile/app/services/walletconnectv2/utils.ts
+++ b/packages/core-mobile/app/services/walletconnectv2/utils.ts
@@ -15,16 +15,27 @@ export const getAddressWithCaip2ChainId = ({
 }): string | undefined => {
   let address: string | undefined
 
+  // Resolve the per-chain address first, then guard against an empty/missing
+  // value before building the CAIP-10 account string. Non-primary Keystone
+  // accounts have empty X/P (AVM/PVM) addresses (CP-14606); without this guard
+  // we would advertise a malformed "avax:<chain>:" account (trailing colon, no
+  // address) to the dApp.
+  let resolvedAddress: string | undefined
+
   if (blockchainNamespace === BlockchainNamespace.AVAX) {
-    address = isXChainId(caip2ChainId)
-      ? `${caip2ChainId}:${account.addressAVM}`
+    resolvedAddress = isXChainId(caip2ChainId)
+      ? account.addressAVM
       : isPChainId(caip2ChainId)
-      ? `${caip2ChainId}:${account.addressPVM}`
+      ? account.addressPVM
       : undefined
   } else if (blockchainNamespace === BlockchainNamespace.BIP122) {
-    address = `${caip2ChainId}:${account.addressBTC}`
+    resolvedAddress = account.addressBTC
   } else if (blockchainNamespace === BlockchainNamespace.EIP155) {
-    address = `${caip2ChainId}:${account.addressC}`
+    resolvedAddress = account.addressC
+  }
+
+  if (resolvedAddress && resolvedAddress.trim().length > 0) {
+    address = `${caip2ChainId}:${resolvedAddress}`
   }
 
   return address

--- a/packages/core-mobile/app/vmModule/ModuleManager.test.ts
+++ b/packages/core-mobile/app/vmModule/ModuleManager.test.ts
@@ -5,31 +5,46 @@ import { SvmModule } from '@avalabs/svm-module'
 import { NetworkVMType, Network } from '@avalabs/core-chains-sdk'
 import ModuleManager from 'vmModule/ModuleManager'
 import { WalletType } from 'services/wallet/types'
+import {
+  KeystoneErrors,
+  KeystoneWalletError
+} from 'services/wallet/KeystoneWallet/errors'
 import { VmModuleErrors } from './errors'
 
 // Keep real module instances so chainId/namespace lookups still hit real
 // manifests in the other tests; only stub the derivation pipeline.
-jest
-  .spyOn(EvmModule.prototype, 'deriveAddresses')
-  .mockImplementation(async ({ accountIndices }) =>
-    accountIndices.map((_, i) => ({ [NetworkVMType.EVM]: `0xevm${i}` }))
-  )
-jest
-  .spyOn(BitcoinModule.prototype, 'deriveAddresses')
-  .mockImplementation(async ({ accountIndices, network }) =>
-    accountIndices.map((_, i) => ({
-      [NetworkVMType.BITCOIN]: `${network.isTestnet ? 'tb1' : 'bc1'}btc${i}`
-    }))
-  )
-jest
-  .spyOn(AvalancheModule.prototype, 'deriveAddresses')
-  .mockImplementation(async ({ accountIndices }) =>
-    accountIndices.map((_, i) => ({
-      [NetworkVMType.AVM]: `X-avax${i}`,
-      [NetworkVMType.PVM]: `P-avax${i}`,
-      [NetworkVMType.CoreEth]: `C-avax${i}`
-    }))
-  )
+//
+// The default mocks key addresses off the *batch position* `i`, which the
+// positional-merge tests below rely on. The Keystone tests re-mock by the
+// real `accountIndex` (a single-index batch per index) so per-index
+// assertions are meaningful.
+const mockEvmResolved = (): void => {
+  jest
+    .spyOn(EvmModule.prototype, 'deriveAddresses')
+    .mockImplementation(async ({ accountIndices }) =>
+      accountIndices.map((_, i) => ({ [NetworkVMType.EVM]: `0xevm${i}` }))
+    )
+}
+const mockBtcResolved = (): void => {
+  jest
+    .spyOn(BitcoinModule.prototype, 'deriveAddresses')
+    .mockImplementation(async ({ accountIndices, network }) =>
+      accountIndices.map((_, i) => ({
+        [NetworkVMType.BITCOIN]: `${network.isTestnet ? 'tb1' : 'bc1'}btc${i}`
+      }))
+    )
+}
+const mockAvalancheResolved = (): void => {
+  jest
+    .spyOn(AvalancheModule.prototype, 'deriveAddresses')
+    .mockImplementation(async ({ accountIndices }) =>
+      accountIndices.map((_, i) => ({
+        [NetworkVMType.AVM]: `X-avax${i}`,
+        [NetworkVMType.PVM]: `P-avax${i}`,
+        [NetworkVMType.CoreEth]: `C-avax${i}`
+      }))
+    )
+}
 const mockSvmResolved = (): void => {
   jest
     .spyOn(SvmModule.prototype, 'deriveAddresses')
@@ -37,6 +52,9 @@ const mockSvmResolved = (): void => {
       accountIndices.map((_, i) => ({ [NetworkVMType.SVM]: `svm${i}` }))
     )
 }
+mockEvmResolved()
+mockBtcResolved()
+mockAvalancheResolved()
 mockSvmResolved()
 
 describe('ModuleManager', () => {
@@ -219,6 +237,123 @@ describe('ModuleManager', () => {
           walletId: 'w1',
           walletType: WalletType.MNEMONIC,
           accountIndices: [0],
+          network: { isTestnet: false } as Network
+        })
+
+        expect(result).toEqual([undefined])
+      })
+    })
+
+    describe('Keystone non-primary X/P handling', () => {
+      // Re-mock EVM/BTC/AVM by the real account index (the Keystone path
+      // derives one index per batch) so per-index assertions actually prove
+      // index 1 differs from index 0.
+      const mockByAccountIndex = (): void => {
+        jest
+          .spyOn(EvmModule.prototype, 'deriveAddresses')
+          .mockImplementation(async ({ accountIndices }) =>
+            accountIndices.map(index => ({
+              [NetworkVMType.EVM]: `0xevm${index}`
+            }))
+          )
+        jest
+          .spyOn(BitcoinModule.prototype, 'deriveAddresses')
+          .mockImplementation(async ({ accountIndices, network }) =>
+            accountIndices.map(index => ({
+              [NetworkVMType.BITCOIN]: `${
+                network.isTestnet ? 'tb1' : 'bc1'
+              }btc${index}`
+            }))
+          )
+      }
+
+      // The Avalanche module rejects with the typed Keystone error for any
+      // batch whose account index is non-zero — mirroring
+      // KeystoneWallet.getPublicKey throwing for m/44'/9000'/N'/0/0 (N > 0) —
+      // and resolves index 0 to the primary account's X/P addresses.
+      const mockAvalancheRejectsNonPrimary = (): void => {
+        jest
+          .spyOn(AvalancheModule.prototype, 'deriveAddresses')
+          .mockImplementation(async ({ accountIndices }) => {
+            if (accountIndices.some(index => index > 0)) {
+              throw new KeystoneWalletError({
+                name: KeystoneErrors.UNSUPPORTED_XP_DERIVATION,
+                message: 'Keystone cannot derive X/P for non-primary account'
+              })
+            }
+            return accountIndices.map(index => ({
+              [NetworkVMType.AVM]: `X-avax${index}`,
+              [NetworkVMType.PVM]: `P-avax${index}`,
+              [NetworkVMType.CoreEth]: `C-avax${index}`
+            }))
+          })
+      }
+
+      beforeEach(() => {
+        mockByAccountIndex()
+      })
+
+      afterEach(() => {
+        // Restore the default position-based mocks for the other suites.
+        mockEvmResolved()
+        mockBtcResolved()
+        mockAvalancheResolved()
+        mockSvmResolved()
+      })
+
+      it('creates a non-primary Keystone account with EVM/BTC but empty X/P', async () => {
+        mockAvalancheRejectsNonPrimary()
+
+        const result = await ModuleManager.deriveAllAddresses({
+          walletId: 'w1',
+          walletType: WalletType.KEYSTONE,
+          accountIndices: [1],
+          network: { isTestnet: false } as Network
+        })
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toBeDefined()
+        // EVM + BTC are derivable from the shared account-0 xpub.
+        expect(result[0]?.[NetworkVMType.EVM]).toBe('0xevm1')
+        expect(result[0]?.[NetworkVMType.BITCOIN]).toBe('bc1btc1')
+        // X/P (and Solana) are absent for a non-primary Keystone account.
+        expect(result[0]?.[NetworkVMType.AVM]).toBeFalsy()
+        expect(result[0]?.[NetworkVMType.PVM]).toBeFalsy()
+        expect(result[0]?.[NetworkVMType.CoreEth]).toBeFalsy()
+        expect(result[0]?.[NetworkVMType.SVM]).toBeFalsy()
+      })
+
+      it('keeps X/P for the primary account while omitting it for non-primary accounts in the same batch', async () => {
+        mockAvalancheRejectsNonPrimary()
+
+        const result = await ModuleManager.deriveAllAddresses({
+          walletId: 'w1',
+          walletType: WalletType.KEYSTONE,
+          accountIndices: [0, 1],
+          network: { isTestnet: false } as Network
+        })
+
+        expect(result).toHaveLength(2)
+        // Primary account retains its X/P addresses.
+        expect(result[0]).toBeDefined()
+        expect(result[0]?.[NetworkVMType.AVM]).toBe('X-avax0')
+        expect(result[0]?.[NetworkVMType.EVM]).toBe('0xevm0')
+        // Non-primary account is still created, just without X/P.
+        expect(result[1]).toBeDefined()
+        expect(result[1]?.[NetworkVMType.EVM]).toBe('0xevm1')
+        expect(result[1]?.[NetworkVMType.AVM]).toBeFalsy()
+      })
+
+      it('still fails closed for a Keystone account when the Avalanche module rejects for a genuine reason', async () => {
+        // A non-sentinel rejection (transient/real failure) must NOT be masked.
+        jest
+          .spyOn(AvalancheModule.prototype, 'deriveAddresses')
+          .mockRejectedValue(new Error('transient avalanche failure'))
+
+        const result = await ModuleManager.deriveAllAddresses({
+          walletId: 'w1',
+          walletType: WalletType.KEYSTONE,
+          accountIndices: [1],
           network: { isTestnet: false } as Network
         })
 

--- a/packages/core-mobile/app/vmModule/ModuleManager.ts
+++ b/packages/core-mobile/app/vmModule/ModuleManager.ts
@@ -25,6 +25,7 @@ import { APPLICATION_NAME, APPLICATION_VERSION } from 'utils/api/constants'
 import { DerivationPath } from '@avalabs/core-wallets-sdk'
 import { emptyAddresses } from 'utils/publicKeys'
 import { WalletType } from 'services/wallet/types'
+import { isUnsupportedXpDerivationError } from 'services/wallet/KeystoneWallet/errors'
 import { ModuleErrors, VmModuleErrors } from './errors'
 import { approvalController } from './ApprovalController/ApprovalController'
 
@@ -132,24 +133,24 @@ class ModuleManager {
         : DerivationPath.BIP44
     const secretId = JSON.stringify({ walletId, walletType })
 
-    // Keystone hardware wallets only expose secp256k1 xpubs (EVM + Avalanche
-    // X/P); they cannot derive Solana (ED25519) addresses. Asking the Solana
-    // module to derive would reject, and the fail-closed handling below would
-    // then discard the entire account for every index. Exclude Solana for
-    // Keystone so the account is still created from its supported chains — the
-    // empty SVM address is handled at the UI layer (CP-14303).
-    const modules =
-      walletType === WalletType.KEYSTONE
-        ? this.modules.filter(
-            module =>
-              !module
-                .getManifest()
-                ?.network.namespaces.includes(BlockchainNamespace.SOLANA)
-          )
-        : this.modules
+    // Keystone hardware wallets cannot derive Solana (ED25519) at all, and can
+    // only derive Avalanche X/P for the primary account (index 0) — their QR
+    // payload carries a single depth-3 account-0 X/P xpub (m/44'/9000'/0').
+    // Derive each index independently so those per-account limitations drop only
+    // the affected chains for the affected index instead of failing closed for
+    // the whole batch. Empty X/P / SVM addresses are handled at the UI layer.
+    // See deriveKeystoneAddresses (CP-14303 / CP-14606).
+    if (walletType === WalletType.KEYSTONE) {
+      return this.deriveKeystoneAddresses({
+        secretId,
+        accountIndices,
+        network,
+        derivationPathType
+      })
+    }
 
     const perModuleResults = await Promise.allSettled(
-      modules.map(async module =>
+      this.modules.map(async module =>
         module.deriveAddresses({
           secretId,
           accountIndices,
@@ -191,6 +192,88 @@ class ModuleManager {
       })
       return addresses
     })
+  }
+
+  /**
+   * Derive addresses for a Keystone wallet, one account index at a time.
+   *
+   * Two Keystone-specific limitations are tolerated per index so they don't
+   * fail closed the way a genuine error would:
+   *  - Solana (ED25519) is never derivable, so the Solana module is excluded.
+   *  - Avalanche X/P is only derivable for the primary account (index 0); for
+   *    non-primary accounts the Avalanche module rejects with a typed
+   *    UNSUPPORTED_XP_DERIVATION error, which we treat as "X/P absent for this
+   *    account" and omit (the account is still created from EVM/BTC).
+   *
+   * Any other rejection still fails closed for that index (returns `undefined`)
+   * so a partially-derived account is never persisted. Deriving per index keeps
+   * a non-primary X/P rejection from discarding the primary account's X/P when
+   * several indices are derived in one batch (e.g. account discovery).
+   */
+  private deriveKeystoneAddresses = async ({
+    secretId,
+    accountIndices,
+    network,
+    derivationPathType
+  }: {
+    secretId: string
+    accountIndices: number[]
+    network: Network
+    derivationPathType: DerivationPath
+  }): Promise<(Record<NetworkVMType, string> | undefined)[]> => {
+    const modules = this.modules.filter(
+      module =>
+        !module
+          .getManifest()
+          ?.network.namespaces.includes(BlockchainNamespace.SOLANA)
+    )
+
+    return Promise.all(
+      accountIndices.map(async accountIndex => {
+        const perModuleResults = await Promise.allSettled(
+          modules.map(async module =>
+            module.deriveAddresses({
+              secretId,
+              accountIndices: [accountIndex],
+              network,
+              derivationPathType
+            })
+          )
+        )
+
+        let addresses = emptyAddresses()
+        for (const result of perModuleResults) {
+          if (result.status === 'fulfilled') {
+            const slot = result.value[0]
+            if (slot) {
+              addresses = { ...addresses, ...slot }
+            }
+            continue
+          }
+
+          // Non-primary Keystone accounts simply have no X/P addresses; omit
+          // them and keep the account's EVM/BTC addresses.
+          if (isUnsupportedXpDerivationError(result.reason)) {
+            Logger.info(
+              'Keystone non-primary account has no X/P addresses; deriving EVM/BTC only',
+              { accountIndex }
+            )
+            continue
+          }
+
+          // Genuine/transient failure — fail closed for this index so a
+          // partially derived account is never persisted.
+          Logger.error('Failed to derive addresses for one or more modules', {
+            accountIndex,
+            isTestnet: network.isTestnet,
+            reason: result.reason
+          })
+          return undefined
+        }
+
+        return addresses
+      })
+    )
   }
 
   loadModule = async (chainId: string, method?: string): Promise<Module> => {


### PR DESCRIPTION
## What

Keystone hardware wallets could not derive additional accounts or create a new account ("Unable to add account"). This change creates non-primary Keystone accounts (index > 0) with EVM + BTC addresses and **no X/P** (AVM/PVM/CoreEth) addresses. Account 0 keeps full X/P. Real per-account X/P derivation is deferred to future work with the Keystone team.

https://github.com/user-attachments/assets/0239e224-4ef2-456e-9440-1abc49c112ff


## Root cause

The Avalanche vm-module derives X/P for account N at the per-account BIP44 path `m/44'/9000'/N'/0/0`, but a QR Keystone wallet only holds a single depth-3 account-0 X/P xpub (`m/44'/9000'/0'`). For N > 0 `KeystoneWallet.getPublicKey` threw, and the fail-closed `deriveAllAddresses` discarded the whole account, so add-account and discovery failed.

## Changes

- New `KeystoneWallet/errors.ts`: `KeystoneWalletError` + `UNSUPPORTED_XP_DERIVATION` sentinel (matched by `name` so it survives the vm-module package boundary).
- `KeystoneWallet.getPublicKey` throws the sentinel for non-primary AVAX paths (`m/44'/9000'/N'/...`, N > 0); generic error still for truly unknown paths; account-0 X/P unchanged.
- `ModuleManager.deriveAllAddresses` derives Keystone **per index**, tolerating the sentinel (omit X/P) while still failing closed on genuine/transient errors. Per-index derivation keeps a non-primary rejection from discarding the primary account's X/P during multi-index discovery batches.
- `walletconnectv2/utils.ts`: guard `getAddressWithCaip2ChainId` against empty resolved addresses so a non-primary Keystone account never advertises a malformed `avax:<chain>:` account to dApps.

Builds on CP-14594 (xp-less Keystone support).

## Dev testing

**Bitrise builds:** iOS 9007 · Android 9008

Reviewer steps (Keystone device required):
1. Open/onboard a Keystone wallet → account selector → **Add account**.
   - Before: "Unable to add account". After: account is created successfully.
2. The new (non-primary) account has C-Chain (EVM) + BTC addresses and **no X/P** (X-Chain/P-Chain hidden, no AVM/PVM receive). Account 1 (index 0) still shows full X/P.
3. (Optional) With a non-primary account active, exercise a WalletConnect session that includes Avalanche — no crash, AVAX namespace simply omits the account.

Verified locally on Pixel 8 Pro: add-account now succeeds; non-primary account has EVM/BTC and no X/P. Unit: 40 tests across the KeystoneWallet, ModuleManager, walletconnectv2/utils, and KeystoneDataStorage suites; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)