### PR TITLE
Recurring swap: execution push notifications, Markr per-order floor, first-fill double-approval fix

### DIFF
--- a/packages/core-mobile/app/new/features/notifications/components/NotificationIcon.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/NotificationIcon.tsx
@@ -8,6 +8,7 @@ import {
   AppNotification,
   isPriceAlertNotification,
   isBalanceChangeNotification,
+  isRecurringSwapNotification,
   BalanceChangeEventSchema
 } from '../types'
 
@@ -62,16 +63,28 @@ const NotificationIcon: FC<NotificationIconProps> = ({ notification }) => {
     if (isBalanceChangeNotification(notification)) {
       return renderBalanceChangeIcon()
     }
+    if (isRecurringSwapNotification(notification)) {
+      // The schedules screen uses the same `Compare` glyph for the
+      // (tokenIn → tokenOut) header on each card — reusing it here keeps
+      // the visual link consistent when the user taps through.
+      return <Icons.Custom.Compare color={colors.$textPrimary} />
+    }
     return (
       <Logos.AppIcons.Core color={colors.$textPrimary} width={24} height={7} />
     )
   }
 
-  // Get chain logo for balance change notifications
+  // Chain badge for balance-change + recurring-swap rows. Both carry an
+  // EVM chainId in metadata (recurring-swap's already a number from the
+  // schema coercion, balance-change's a string — `Number(chainId)`
+  // normalises either). News / PriceAlerts have no chain context.
   const renderChainBadge = (): React.JSX.Element | null => {
-    if (!isBalanceChangeNotification(notification)) return null
-    const chainId = notification.data?.chainId
-    if (!chainId) return null
+    const chainId =
+      isBalanceChangeNotification(notification) ||
+      isRecurringSwapNotification(notification)
+        ? notification.data?.chainId
+        : undefined
+    if (chainId === undefined || chainId === '') return null
 
     const network = getNetwork(Number(chainId))
     if (!network) return null

--- a/packages/core-mobile/app/new/features/notifications/components/RecurringSwapItem.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/RecurringSwapItem.tsx
@@ -1,6 +1,10 @@
 import React, { FC, useMemo } from 'react'
 import { Text, useTheme, View } from '@avalabs/k2-alpine'
-import { AppNotification, isRecurringSwapNotification } from '../types'
+import {
+  AppNotification,
+  isRecurringSwapNotification,
+  RecurringSwapMetadata
+} from '../types'
 import NotificationListItem from './NotificationListItem'
 import NotificationIcon from './NotificationIcon'
 
@@ -14,27 +18,39 @@ type RecurringSwapItemProps = {
 // Per Sarp's PR #174 the notification-sender service formats the push
 // envelope's `title` + `body` server-side (e.g. "Recurring swap executed",
 // "Insufficient balance — your recurring swap schedule will be cancelled"),
-// so the row just renders those verbatim. The `data.status` field is used
-// only to drive the colored status badge under the subtitle — that's the
-// one piece of UI we can synthesize client-side without lossy formatting.
+// so the row just renders those verbatim. The machine-readable `data` block
+// drives the colored status badge under the subtitle — the one piece of UI we
+// synthesize client-side without lossy formatting.
 //
-// Status → badge mapping (matches the Figma design):
-//   - 'failed'                → red "Failed"
-//   - 'active' / 'completed'  → green "Completed"   (a fill landed; either a
-//                                                    mid-schedule leg or the
-//                                                    final one — both are
-//                                                    surfaced the same way)
-//   - anything else           → no badge
-type BadgeKind = 'success' | 'failure' | null
+// We read the structured `data` fields (NOT the human-facing copy) to tell a
+// mid-schedule fill apart from the final leg:
+//   - 'failed'                       → red "Failed"
+//   - final leg                      → green "Completed"
+//       (`status === 'completed'`, or — for finite schedules — no fills left)
+//   - other success fill             → green "Executed"
+//       (a mid-schedule leg landed; infinite/DCA schedules never "complete",
+//        so they always read here)
+//   - anything else                  → no badge
+type Badge = { kind: 'success' | 'failure'; label: string } | null
 
-function resolveBadgeKind(status: string | undefined): BadgeKind {
-  if (status === undefined) return null
-  const lower = status.toLowerCase()
-  if (lower === 'failed') return 'failure'
-  if (lower === 'active' || lower === 'completed' || lower === 'executed') {
-    return 'success'
-  }
-  return null
+function resolveBadge(data: RecurringSwapMetadata | undefined): Badge {
+  if (data === undefined) return null
+  const status = data.status.toLowerCase()
+  if (status === 'failed') return { kind: 'failure', label: 'Failed' }
+
+  const isSuccessFill =
+    status === 'active' || status === 'completed' || status === 'executed'
+  if (!isSuccessFill) return null
+
+  // The schedule is finished when the backend marks it completed, or — for
+  // finite schedules — when no fills remain. Infinite/DCA schedules
+  // (numberOfOrders === -1) never reach a completed terminal, so they always
+  // read as a mid-schedule fill.
+  const isFinalLeg =
+    status === 'completed' ||
+    (data.numberOfOrders !== -1 && data.remainingOrders === 0)
+
+  return { kind: 'success', label: isFinalLeg ? 'Completed' : 'Executed' }
 }
 
 const RecurringSwapItem: FC<RecurringSwapItemProps> = ({
@@ -47,10 +63,10 @@ const RecurringSwapItem: FC<RecurringSwapItemProps> = ({
     theme: { colors }
   } = useTheme()
 
-  const badgeKind = useMemo(
+  const badge = useMemo(
     () =>
       isRecurringSwapNotification(notification)
-        ? resolveBadgeKind(notification.data?.status)
+        ? resolveBadge(notification.data)
         : null,
     [notification]
   )
@@ -59,10 +75,9 @@ const RecurringSwapItem: FC<RecurringSwapItemProps> = ({
   // in a View (rather than passing a string) lets NotificationListItem render
   // both lines without us re-implementing its typography defaults.
   const subtitle = useMemo<React.ReactNode>(() => {
-    if (badgeKind === null) return notification.body
+    if (badge === null) return notification.body
     const badgeColor =
-      badgeKind === 'failure' ? colors.$textDanger : colors.$textSuccess
-    const badgeLabel = badgeKind === 'failure' ? 'Failed' : 'Completed'
+      badge.kind === 'failure' ? colors.$textDanger : colors.$textSuccess
     return (
       <View sx={{ gap: 2 }}>
         <Text
@@ -73,11 +88,11 @@ const RecurringSwapItem: FC<RecurringSwapItemProps> = ({
           {notification.body}
         </Text>
         <Text variant="body2" sx={{ color: badgeColor }}>
-          {badgeLabel}
+          {badge.label}
         </Text>
       </View>
     )
-  }, [badgeKind, notification.body, colors.$textDanger, colors.$textSuccess])
+  }, [badge, notification.body, colors.$textDanger, colors.$textSuccess])
 
   return (
     <NotificationListItem

--- a/packages/core-mobile/app/new/features/notifications/components/RecurringSwapItem.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/RecurringSwapItem.tsx
@@ -5,6 +5,7 @@ import {
   isRecurringSwapNotification,
   RecurringSwapMetadata
 } from '../types'
+import { classifyRecurringSwapStatus } from '../utils'
 import NotificationListItem from './NotificationListItem'
 import NotificationIcon from './NotificationIcon'
 
@@ -35,19 +36,21 @@ type Badge = { kind: 'success' | 'failure'; label: string } | null
 
 function resolveBadge(data: RecurringSwapMetadata | undefined): Badge {
   if (data === undefined) return null
-  const status = data.status.toLowerCase()
-  if (status === 'failed') return { kind: 'failure', label: 'Failed' }
+  // Shared classifier (see notifications/utils.ts) so the badge stays in lockstep
+  // with `isTerminalRecurringSwapNotification`'s row-actionability logic.
+  const kind = classifyRecurringSwapStatus(data.status)
+  if (kind === 'failed') return { kind: 'failure', label: 'Failed' }
 
-  const isSuccessFill =
-    status === 'active' || status === 'completed' || status === 'executed'
-  if (!isSuccessFill) return null
+  // Only success fills get a badge; 'cancelled' and unrecognized statuses show
+  // none (a cancelled schedule was deliberately stopped, not a fill event).
+  if (kind !== 'completed' && kind !== 'fill') return null
 
   // The schedule is finished when the backend marks it completed, or — for
   // finite schedules — when no fills remain. Infinite/DCA schedules
   // (numberOfOrders === -1) never reach a completed terminal, so they always
   // read as a mid-schedule fill.
   const isFinalLeg =
-    status === 'completed' ||
+    kind === 'completed' ||
     (data.numberOfOrders !== -1 && data.remainingOrders === 0)
 
   return { kind: 'success', label: isFinalLeg ? 'Completed' : 'Executed' }

--- a/packages/core-mobile/app/new/features/notifications/components/RecurringSwapItem.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/RecurringSwapItem.tsx
@@ -1,0 +1,93 @@
+import React, { FC, useMemo } from 'react'
+import { Text, useTheme, View } from '@avalabs/k2-alpine'
+import { AppNotification, isRecurringSwapNotification } from '../types'
+import NotificationListItem from './NotificationListItem'
+import NotificationIcon from './NotificationIcon'
+
+type RecurringSwapItemProps = {
+  notification: AppNotification
+  showSeparator: boolean
+  accessoryType: 'chevron' | 'none'
+  testID?: string
+}
+
+// Per Sarp's PR #174 the notification-sender service formats the push
+// envelope's `title` + `body` server-side (e.g. "Recurring swap executed",
+// "Insufficient balance — your recurring swap schedule will be cancelled"),
+// so the row just renders those verbatim. The `data.status` field is used
+// only to drive the colored status badge under the subtitle — that's the
+// one piece of UI we can synthesize client-side without lossy formatting.
+//
+// Status → badge mapping (matches the Figma design):
+//   - 'failed'                → red "Failed"
+//   - 'active' / 'completed'  → green "Completed"   (a fill landed; either a
+//                                                    mid-schedule leg or the
+//                                                    final one — both are
+//                                                    surfaced the same way)
+//   - anything else           → no badge
+type BadgeKind = 'success' | 'failure' | null
+
+function resolveBadgeKind(status: string | undefined): BadgeKind {
+  if (status === undefined) return null
+  const lower = status.toLowerCase()
+  if (lower === 'failed') return 'failure'
+  if (lower === 'active' || lower === 'completed') return 'success'
+  return null
+}
+
+const RecurringSwapItem: FC<RecurringSwapItemProps> = ({
+  notification,
+  showSeparator,
+  accessoryType,
+  testID
+}) => {
+  const {
+    theme: { colors }
+  } = useTheme()
+
+  const badgeKind = useMemo(
+    () =>
+      isRecurringSwapNotification(notification)
+        ? resolveBadgeKind(notification.data?.status)
+        : null,
+    [notification]
+  )
+
+  // Subtitle = backend-formatted body + optional colored status line. Wrapping
+  // in a View (rather than passing a string) lets NotificationListItem render
+  // both lines without us re-implementing its typography defaults.
+  const subtitle = useMemo<React.ReactNode>(() => {
+    if (badgeKind === null) return notification.body
+    const badgeColor =
+      badgeKind === 'failure' ? colors.$textDanger : colors.$textSuccess
+    const badgeLabel = badgeKind === 'failure' ? 'Failed' : 'Completed'
+    return (
+      <View sx={{ gap: 2 }}>
+        <Text
+          variant="body2"
+          numberOfLines={2}
+          ellipsizeMode="tail"
+          sx={{ color: '$textSecondary' }}>
+          {notification.body}
+        </Text>
+        <Text variant="body2" sx={{ color: badgeColor }}>
+          {badgeLabel}
+        </Text>
+      </View>
+    )
+  }, [badgeKind, notification.body, colors.$textDanger, colors.$textSuccess])
+
+  return (
+    <NotificationListItem
+      title={notification.title}
+      subtitle={subtitle}
+      icon={<NotificationIcon notification={notification} />}
+      timestamp={notification.timestamp}
+      showSeparator={showSeparator}
+      accessoryType={accessoryType}
+      testID={testID}
+    />
+  )
+}
+
+export default RecurringSwapItem

--- a/packages/core-mobile/app/new/features/notifications/components/RecurringSwapItem.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/RecurringSwapItem.tsx
@@ -51,8 +51,10 @@ function resolveBadge(data: RecurringSwapMetadata | undefined): Badge {
   // read as a mid-schedule fill.
   const isFinalLeg =
     kind === 'completed' ||
-    (data.numberOfOrders !== -1 && data.remainingOrders === 0)
-
+    (data.numberOfOrders !== undefined &&
+      data.remainingOrders !== undefined &&
+      data.numberOfOrders !== -1 &&
+      data.remainingOrders === 0)
   return { kind: 'success', label: isFinalLeg ? 'Completed' : 'Executed' }
 }
 

--- a/packages/core-mobile/app/new/features/notifications/components/RecurringSwapItem.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/RecurringSwapItem.tsx
@@ -31,7 +31,9 @@ function resolveBadgeKind(status: string | undefined): BadgeKind {
   if (status === undefined) return null
   const lower = status.toLowerCase()
   if (lower === 'failed') return 'failure'
-  if (lower === 'active' || lower === 'completed') return 'success'
+  if (lower === 'active' || lower === 'completed' || lower === 'executed') {
+    return 'success'
+  }
   return null
 }
 

--- a/packages/core-mobile/app/new/features/notifications/screens/NotificationsScreen.tsx
+++ b/packages/core-mobile/app/new/features/notifications/screens/NotificationsScreen.tsx
@@ -39,7 +39,11 @@ import {
   isBalanceChangeNotification,
   isRecurringSwapNotification
 } from '../types'
-import { buildAccountLabelMap, isSwapTerminal } from '../utils'
+import {
+  buildAccountLabelMap,
+  isSwapTerminal,
+  isTerminalRecurringSwapNotification
+} from '../utils'
 import { FusionTransferItem } from '../components/FusionTransferItem'
 
 const TITLE = 'Notifications'
@@ -83,6 +87,11 @@ const isBalanceChangeWithData = (notification: AppNotification): boolean => {
  * Check if a notification has an actionable URL (not skipped like core://portfolio)
  */
 const hasActionableUrl = (notification: AppNotification): boolean => {
+  // Terminal / last-leg recurring-swap notifications point at a schedule the
+  // management screen no longer lists (it shows only Active / Paused), so the
+  // row is non-actionable — no chevron, and the press handler no-ops.
+  if (isTerminalRecurringSwapNotification(notification)) return false
+
   const url = notification.deepLinkUrl
   if (!url) return false
 

--- a/packages/core-mobile/app/new/features/notifications/screens/NotificationsScreen.tsx
+++ b/packages/core-mobile/app/new/features/notifications/screens/NotificationsScreen.tsx
@@ -24,6 +24,7 @@ import NotificationEmptyState from '../components/NotificationEmptyState'
 import SwipeableRow from '../components/SwipeableRow'
 import PriceAlertItem from '../components/PriceAlertItem'
 import BalanceChangeItem from '../components/BalanceChangeItem'
+import RecurringSwapItem from '../components/RecurringSwapItem'
 import GenericNotificationItem from '../components/GenericNotificationItem'
 import {
   useNotifications,
@@ -35,7 +36,8 @@ import {
   AppNotification,
   NotificationTab,
   isPriceAlertNotification,
-  isBalanceChangeNotification
+  isBalanceChangeNotification,
+  isRecurringSwapNotification
 } from '../types'
 import { buildAccountLabelMap, isSwapTerminal } from '../utils'
 import { FusionTransferItem } from '../components/FusionTransferItem'
@@ -121,6 +123,15 @@ const renderNotificationItem = (
         {...props}
       />
     )
+  }
+
+  // RecurringSwap rows render even without a parsed `data` payload — the
+  // backend-formatted title / body alone are enough for the user to read the
+  // notification, and the deepLinkUrl still routes to the schedules screen.
+  // (BalanceChange / PriceAlert require `data` for their formatted titles,
+  // hence the `*WithData` predicates above; recurring-swap doesn't.)
+  if (isRecurringSwapNotification(item)) {
+    return <RecurringSwapItem notification={item} {...props} />
   }
 
   return <GenericNotificationItem notification={item} {...props} />

--- a/packages/core-mobile/app/new/features/notifications/services/NotificationCenterService.ts
+++ b/packages/core-mobile/app/new/features/notifications/services/NotificationCenterService.ts
@@ -9,10 +9,121 @@ import {
   BalanceChangesMetadataSchema,
   PriceAlertsMetadataSchema,
   NewsPriceAlertMetadataSchema,
-  NewsMetadataSchema
+  NewsMetadataSchema,
+  RecurringSwapMetadataSchema
 } from './schemas'
 
 const BASE_URL = Config.NOTIFICATION_SENDER_API_URL
+
+// Base fields shared by every variant of `BackendNotification` — extracted so
+// the per-type helpers below can spread it without recomputing.
+type TransformBase = {
+  id: string
+  category: ReturnType<typeof mapTypeToCategory>
+  title: string
+  body: string
+  timestamp: number
+  deepLinkUrl: string | undefined
+}
+
+// Per-type parse helpers. Each safe-parses the metadata against its schema and
+// either returns the typed `data` or `undefined` (logged) so the row still
+// renders with the backend-formatted title / body / category. Extracted from
+// `transformNotification` so the dispatcher itself stays linear and below the
+// sonarjs cognitive-complexity cap (the four sequential case bodies + their
+// safe-parse branches push the inline form over the limit).
+function transformBalanceChanges(
+  base: TransformBase,
+  metadata: unknown
+): BackendNotification {
+  const parsed = BalanceChangesMetadataSchema.safeParse(metadata)
+  if (!parsed.success) {
+    Logger.error(
+      '[NotificationCenterService] BALANCE_CHANGES metadata parse failed; falling back to generic row',
+      parsed.error
+    )
+  }
+  return {
+    ...base,
+    type: 'BALANCE_CHANGES',
+    data: parsed.success ? parsed.data : undefined
+  }
+}
+
+function transformPriceAlerts(
+  base: TransformBase,
+  metadata: unknown
+): BackendNotification {
+  const parsed = PriceAlertsMetadataSchema.safeParse(metadata)
+  if (!parsed.success) {
+    Logger.error(
+      '[NotificationCenterService] PRICE_ALERTS metadata parse failed; falling back to generic row',
+      parsed.error
+    )
+  }
+  return {
+    ...base,
+    type: 'PRICE_ALERTS',
+    data: parsed.success ? parsed.data : undefined
+  }
+}
+
+// NEWS double-shape: the backend wraps price-alerts as `type:"NEWS" +
+// event:"PRICE_ALERTS" + data[]`. Detect that first and re-emit as a
+// PRICE_ALERTS row so the in-app list renders the same `PriceAlertItem`
+// regardless of whether the backend sent the canonical or wrapped form.
+function transformNews(
+  base: TransformBase,
+  metadata: unknown
+): BackendNotification {
+  const priceAlert = NewsPriceAlertMetadataSchema.safeParse(metadata)
+  if (priceAlert.success) {
+    const priceData = priceAlert.data.data[0]!
+    return {
+      ...base,
+      category: mapTypeToCategory('PRICE_ALERTS'),
+      type: 'PRICE_ALERTS' as const,
+      data: {
+        ...priceData,
+        url: priceAlert.data.url
+      }
+    }
+  }
+  const parsed = NewsMetadataSchema.safeParse(metadata)
+  if (!parsed.success) {
+    Logger.error(
+      '[NotificationCenterService] NEWS metadata parse failed; falling back to generic row',
+      parsed.error
+    )
+  }
+  return {
+    ...base,
+    type: 'NEWS',
+    data: parsed.success ? parsed.data : undefined
+  }
+}
+
+function transformRecurringSwap(
+  base: TransformBase,
+  metadata: unknown
+): BackendNotification {
+  // Backend (Sarp PRs #172 / #174) sends order progress fields in the
+  // metadata block. Parse-failures fall back to a generic row — title /
+  // body / category from `base` are still rendered, so the user still
+  // sees the notification even if the schema drifts.
+  const parsed = RecurringSwapMetadataSchema.safeParse(metadata)
+  if (!parsed.success) {
+    Logger.error(
+      '[NotificationCenterService] RECURRING_SWAP metadata parse failed; falling back to generic row',
+      parsed.error
+    )
+  }
+  return {
+    ...base,
+    type: 'RECURRING_SWAP',
+    data: parsed.success ? parsed.data : undefined
+  }
+}
 
 /**
  * Transform API notification response to app notification format
@@ -22,7 +133,7 @@ const BASE_URL = Config.NOTIFICATION_SENDER_API_URL
 function transformNotification(
   response: NotificationResponse
 ): BackendNotification {
-  const base = {
+  const base: TransformBase = {
     id: response.notificationId,
     category: mapTypeToCategory(response.type),
     title: response.title,
@@ -32,65 +143,14 @@ function transformNotification(
   }
 
   switch (response.type) {
-    case 'BALANCE_CHANGES': {
-      const parsed = BalanceChangesMetadataSchema.safeParse(response.metadata)
-      if (!parsed.success) {
-        Logger.error(
-          '[NotificationCenterService] BALANCE_CHANGES metadata parse failed; falling back to generic row',
-          parsed.error
-        )
-      }
-      return {
-        ...base,
-        type: 'BALANCE_CHANGES',
-        data: parsed.success ? parsed.data : undefined
-      }
-    }
-    case 'PRICE_ALERTS': {
-      const parsed = PriceAlertsMetadataSchema.safeParse(response.metadata)
-      if (!parsed.success) {
-        Logger.error(
-          '[NotificationCenterService] PRICE_ALERTS metadata parse failed; falling back to generic row',
-          parsed.error
-        )
-      }
-      return {
-        ...base,
-        type: 'PRICE_ALERTS',
-        data: parsed.success ? parsed.data : undefined
-      }
-    }
-    case 'NEWS': {
-      // Check if this is a NEWS-wrapped price alert (type:"NEWS" + event:"PRICE_ALERTS")
-      const priceAlert = NewsPriceAlertMetadataSchema.safeParse(
-        response.metadata
-      )
-      if (priceAlert.success) {
-        const priceData = priceAlert.data.data[0]!
-        return {
-          ...base,
-          category: mapTypeToCategory('PRICE_ALERTS'),
-          type: 'PRICE_ALERTS' as const,
-          data: {
-            ...priceData,
-            url: priceAlert.data.url
-          }
-        }
-      }
-
-      const parsed = NewsMetadataSchema.safeParse(response.metadata)
-      if (!parsed.success) {
-        Logger.error(
-          '[NotificationCenterService] NEWS metadata parse failed; falling back to generic row',
-          parsed.error
-        )
-      }
-      return {
-        ...base,
-        type: 'NEWS',
-        data: parsed.success ? parsed.data : undefined
-      }
-    }
+    case 'BALANCE_CHANGES':
+      return transformBalanceChanges(base, response.metadata)
+    case 'PRICE_ALERTS':
+      return transformPriceAlerts(base, response.metadata)
+    case 'NEWS':
+      return transformNews(base, response.metadata)
+    case 'RECURRING_SWAP':
+      return transformRecurringSwap(base, response.metadata)
     default: {
       // Exhaustiveness guard: a new NotificationType must add its case above.
       // Unreachable today — `response.type` is validated against the zod enum

--- a/packages/core-mobile/app/new/features/notifications/services/schemas.test.ts
+++ b/packages/core-mobile/app/new/features/notifications/services/schemas.test.ts
@@ -1,0 +1,59 @@
+import { RecurringSwapMetadataSchema } from './schemas'
+
+// The notification-center history API returns raw JSON (numbers stay numbers),
+// while the FCM push stringifies every `data` value. The schema must accept
+// both shapes — most importantly `reasonCode`, which the push sends as a string
+// but history sends as a number. A failed notification ALWAYS carries a
+// reasonCode, so a non-coercing schema drops the entire `data` block on the
+// history path (regression: failure badge + terminal-state detection break).
+describe('RecurringSwapMetadataSchema', () => {
+  const base = {
+    orderId: '0xorder',
+    owner: '0xowner',
+    tokenIn: '0xin',
+    tokenOut: '0xout',
+    amountIn: '1000000',
+    amountOut: '2000000',
+    status: 'failed'
+  }
+
+  it('parses the history-API shape (numeric counts + numeric reasonCode)', () => {
+    const parsed = RecurringSwapMetadataSchema.safeParse({
+      ...base,
+      chainId: 43114,
+      numberOfOrders: 5,
+      executedOrders: 2,
+      remainingOrders: 3,
+      reasonCode: 1
+    })
+    expect(parsed.success).toBe(true)
+    // reasonCode normalizes to a string regardless of the wire shape.
+    expect(parsed.success && parsed.data.reasonCode).toBe('1')
+  })
+
+  it('parses the FCM push shape (all values stringified)', () => {
+    const parsed = RecurringSwapMetadataSchema.safeParse({
+      ...base,
+      chainId: '43114',
+      numberOfOrders: '5',
+      executedOrders: '2',
+      remainingOrders: '3',
+      reasonCode: '1'
+    })
+    expect(parsed.success).toBe(true)
+    expect(parsed.success && parsed.data.reasonCode).toBe('1')
+  })
+
+  it('parses a non-failed update with no reasonCode', () => {
+    const parsed = RecurringSwapMetadataSchema.safeParse({
+      ...base,
+      status: 'active',
+      chainId: 43114,
+      numberOfOrders: 5,
+      executedOrders: 2,
+      remainingOrders: 3
+    })
+    expect(parsed.success).toBe(true)
+    expect(parsed.success && parsed.data.reasonCode).toBeUndefined()
+  })
+})

--- a/packages/core-mobile/app/new/features/notifications/services/schemas.test.ts
+++ b/packages/core-mobile/app/new/features/notifications/services/schemas.test.ts
@@ -56,4 +56,25 @@ describe('RecurringSwapMetadataSchema', () => {
     expect(parsed.success).toBe(true)
     expect(parsed.success && parsed.data.reasonCode).toBeUndefined()
   })
+
+  // Only `status` is required. A parse failure drops the entire `data` block
+  // (→ `data: undefined`), which flips a terminal row back to tappable — the
+  // regression this schema guards against. So a stray missing field from a
+  // field no consumer renders must NOT take the whole block down: anything but
+  // `status` is optional.
+  it('parses a payload carrying only status (all other fields absent)', () => {
+    const parsed = RecurringSwapMetadataSchema.safeParse({ status: 'failed' })
+    expect(parsed.success).toBe(true)
+    expect(parsed.success && parsed.data.status).toBe('failed')
+    expect(parsed.success && parsed.data.numberOfOrders).toBeUndefined()
+    expect(parsed.success && parsed.data.remainingOrders).toBeUndefined()
+  })
+
+  it('still fails when status itself is missing', () => {
+    const parsed = RecurringSwapMetadataSchema.safeParse({
+      orderId: '0xorder',
+      owner: '0xowner'
+    })
+    expect(parsed.success).toBe(false)
+  })
 })

--- a/packages/core-mobile/app/new/features/notifications/services/schemas.ts
+++ b/packages/core-mobile/app/new/features/notifications/services/schemas.ts
@@ -99,10 +99,17 @@ export const NewsMetadataSchema = z.object({
  * Sarp's webhook fans out (PRs #172 / #174 on core-notification-sender):
  * machine-readable progress fields the in-app row uses to format its title /
  * subtitle + a status badge, and the `orderId` the deep link uses to
- * auto-expand the matching schedule. Numeric fields arrive as strings
- * (`z.coerce.number` is intentional — the wire format is plain JSON-string).
- * `reasonCode` is set only on `status === 'failed'`; known codes are
- * documented at the call site, unknown codes are passed through so newer
+ * auto-expand the matching schedule. Numeric fields are coerced because the
+ * two backend channels disagree on shape: the FCM push stringifies every
+ * `data` value, while the notification-center history API returns raw JSON
+ * (numbers stay numbers). `z.coerce` accepts both.
+ *
+ * `reasonCode` is set only on `status === 'failed'`; the push sends it as a
+ * string (`String(reasonCode)`) but history sends the raw number — so it MUST
+ * be coerced too. Without this, every failed notification (which always
+ * carries a reasonCode) fails to parse on the history path, dropping the whole
+ * `data` block and with it the failure badge + terminal-state detection. Known
+ * codes are documented at the call site; unknown codes pass through so newer
  * backend codes don't fail parsing.
  */
 export const RecurringSwapMetadataSchema = z.object({
@@ -117,7 +124,7 @@ export const RecurringSwapMetadataSchema = z.object({
   amountIn: z.string(),
   amountOut: z.string(),
   status: z.string(),
-  reasonCode: z.string().optional()
+  reasonCode: z.coerce.string().optional()
 })
 
 /**

--- a/packages/core-mobile/app/new/features/notifications/services/schemas.ts
+++ b/packages/core-mobile/app/new/features/notifications/services/schemas.ts
@@ -111,19 +111,33 @@ export const NewsMetadataSchema = z.object({
  * `data` block and with it the failure badge + terminal-state detection. Known
  * codes are documented at the call site; unknown codes pass through so newer
  * backend codes don't fail parsing.
+ *
+ * Only `status` is required. Because `safeParse` is all-or-nothing and a parse
+ * failure drops the entire `data` block (→ `data: undefined`), a required field
+ * that no consumer reads becomes a liability: if the backend ever stops sending
+ * it, terminal detection collapses and a finished schedule's row turns tappable
+ * again — deep-linking to a schedule the manage screen filters out, the exact
+ * regression this schema guards against. So every field but `status` is
+ * optional. The only other fields any consumer reads are `numberOfOrders` /
+ * `remainingOrders` (final-leg detection in `RecurringSwapItem` +
+ * `isTerminalRecurringSwapNotification`); when absent they degrade gracefully —
+ * the status-based terminal states (`completed`/`cancelled`/`failed`) and the
+ * failure badge still resolve, only the "Completed" vs "Executed" last-leg
+ * nuance is lost. The remaining fields are unread today and kept only as a
+ * forward-compatible record of the wire shape.
  */
 export const RecurringSwapMetadataSchema = z.object({
-  orderId: z.string(),
-  owner: z.string(),
-  chainId: z.coerce.number(),
-  numberOfOrders: z.coerce.number(),
-  executedOrders: z.coerce.number(),
-  remainingOrders: z.coerce.number(),
-  tokenIn: z.string(),
-  tokenOut: z.string(),
-  amountIn: z.string(),
-  amountOut: z.string(),
   status: z.string(),
+  orderId: z.string().optional(),
+  owner: z.string().optional(),
+  chainId: z.coerce.number().optional(),
+  numberOfOrders: z.coerce.number().optional(),
+  executedOrders: z.coerce.number().optional(),
+  remainingOrders: z.coerce.number().optional(),
+  tokenIn: z.string().optional(),
+  tokenOut: z.string().optional(),
+  amountIn: z.string().optional(),
+  amountOut: z.string().optional(),
   reasonCode: z.coerce.string().optional()
 })
 

--- a/packages/core-mobile/app/new/features/notifications/services/schemas.ts
+++ b/packages/core-mobile/app/new/features/notifications/services/schemas.ts
@@ -6,7 +6,8 @@ import { z } from 'zod'
 export const NotificationTypeSchema = z.enum([
   'BALANCE_CHANGES',
   'PRICE_ALERTS',
-  'NEWS'
+  'NEWS',
+  'RECURRING_SWAP'
 ])
 
 /**
@@ -91,6 +92,32 @@ export const NewsPriceAlertMetadataSchema = z.object({
 export const NewsMetadataSchema = z.object({
   event: z.string(),
   url: z.string()
+})
+
+/**
+ * Recurring swap (DCA) notification metadata. Mirrors the FCM push payload
+ * Sarp's webhook fans out (PRs #172 / #174 on core-notification-sender):
+ * machine-readable progress fields the in-app row uses to format its title /
+ * subtitle + a status badge, and the `orderId` the deep link uses to
+ * auto-expand the matching schedule. Numeric fields arrive as strings
+ * (`z.coerce.number` is intentional — the wire format is plain JSON-string).
+ * `reasonCode` is set only on `status === 'failed'`; known codes are
+ * documented at the call site, unknown codes are passed through so newer
+ * backend codes don't fail parsing.
+ */
+export const RecurringSwapMetadataSchema = z.object({
+  orderId: z.string(),
+  owner: z.string(),
+  chainId: z.coerce.number(),
+  numberOfOrders: z.coerce.number(),
+  executedOrders: z.coerce.number(),
+  remainingOrders: z.coerce.number(),
+  tokenIn: z.string(),
+  tokenOut: z.string(),
+  amountIn: z.string(),
+  amountOut: z.string(),
+  status: z.string(),
+  reasonCode: z.string().optional()
 })
 
 /**

--- a/packages/core-mobile/app/new/features/notifications/types.ts
+++ b/packages/core-mobile/app/new/features/notifications/types.ts
@@ -44,17 +44,16 @@ export type NotificationMetadata =
 /**
  * Notification categories mapping to UI tabs.
  *
- * `RECURRING_SWAP` lives under the same category bucket as transaction-style
- * notifications: a fill is an on-chain event the user cares about alongside
- * balance changes, and the Figma list groups them together. Tabs filter on
- * `category` so a user on the Transactions tab sees recurring-swap fills /
- * completions / failures without needing a separate sub-tab.
+ * There is intentionally no `RECURRING_SWAP` category. Recurring-swap fills /
+ * completions / failures are on-chain transaction-like events, so
+ * `mapTypeToCategory` folds the `RECURRING_SWAP` notification *type* into the
+ * `TRANSACTION` bucket — they surface on the Transactions tab alongside
+ * balance changes (matching the Figma list) without needing a dedicated tab.
  */
 export enum NotificationCategory {
   TRANSACTION = 'TRANSACTION',
   PRICE_UPDATE = 'PRICE_UPDATE',
-  NEWS = 'NEWS',
-  RECURRING_SWAP = 'RECURRING_SWAP'
+  NEWS = 'NEWS'
 }
 
 /**

--- a/packages/core-mobile/app/new/features/notifications/types.ts
+++ b/packages/core-mobile/app/new/features/notifications/types.ts
@@ -8,7 +8,8 @@ import {
   BalanceChangesTransferSchema,
   BalanceChangesMetadataSchema,
   PriceAlertsMetadataSchema,
-  NewsMetadataSchema
+  NewsMetadataSchema,
+  RecurringSwapMetadataSchema
 } from './services/schemas'
 
 /**
@@ -27,6 +28,7 @@ export type BalanceChangesMetadata = z.infer<
 >
 export type PriceAlertsMetadata = z.infer<typeof PriceAlertsMetadataSchema>
 export type NewsMetadata = z.infer<typeof NewsMetadataSchema>
+export type RecurringSwapMetadata = z.infer<typeof RecurringSwapMetadataSchema>
 
 export { BalanceChangeEventSchema }
 
@@ -37,14 +39,22 @@ export type NotificationMetadata =
   | BalanceChangesMetadata
   | PriceAlertsMetadata
   | NewsMetadata
+  | RecurringSwapMetadata
 
 /**
- * Notification categories mapping to UI tabs
+ * Notification categories mapping to UI tabs.
+ *
+ * `RECURRING_SWAP` lives under the same category bucket as transaction-style
+ * notifications: a fill is an on-chain event the user cares about alongside
+ * balance changes, and the Figma list groups them together. Tabs filter on
+ * `category` so a user on the Transactions tab sees recurring-swap fills /
+ * completions / failures without needing a separate sub-tab.
  */
 export enum NotificationCategory {
   TRANSACTION = 'TRANSACTION',
   PRICE_UPDATE = 'PRICE_UPDATE',
-  NEWS = 'NEWS'
+  NEWS = 'NEWS',
+  RECURRING_SWAP = 'RECURRING_SWAP'
 }
 
 /**
@@ -84,6 +94,10 @@ export type BackendNotification =
       type: 'NEWS'
       data?: NewsMetadata
     })
+  | (BaseNotification & {
+      type: 'RECURRING_SWAP'
+      data?: RecurringSwapMetadata
+    })
 
 /**
  * Union type for all notifications (used in UI)
@@ -91,7 +105,14 @@ export type BackendNotification =
 export type AppNotification = BackendNotification
 
 /**
- * Type guard for price alert notifications
+ * Type guard for price alert notifications.
+ *
+ * Also matches NEWS-wrapped price alerts (`category === 'NEWS'` +
+ * `data.event === 'PRICE_ALERTS'`). The `'event' in data` runtime check is
+ * load-bearing now that the `data` union includes RecurringSwapMetadata
+ * (which has no `event` field) — a direct `.event` access would fail at
+ * compile time. Semantics are unchanged: the in-check is true exactly
+ * when `data` carries the News/Balance/PriceAlerts shape.
  */
 export function isPriceAlertNotification(
   notification: AppNotification
@@ -99,11 +120,10 @@ export function isPriceAlertNotification(
   type: 'PRICE_ALERTS'
   data?: PriceAlertsMetadata
 } {
-  return (
-    notification.type === 'PRICE_ALERTS' ||
-    (notification.category === 'NEWS' &&
-      notification.data?.event === 'PRICE_ALERTS')
-  )
+  if (notification.type === 'PRICE_ALERTS') return true
+  if (notification.category !== 'NEWS') return false
+  const data = notification.data
+  return data !== undefined && 'event' in data && data.event === 'PRICE_ALERTS'
 }
 
 /**
@@ -116,6 +136,20 @@ export function isBalanceChangeNotification(
   data?: BalanceChangesMetadata
 } {
   return notification.type === 'BALANCE_CHANGES'
+}
+
+/**
+ * Type guard for recurring-swap notifications. Used by the notifications-list
+ * renderer + the `RecurringSwapItem` row component to derive title / subtitle
+ * / status badge from the metadata.
+ */
+export function isRecurringSwapNotification(
+  notification: AppNotification
+): notification is BaseNotification & {
+  type: 'RECURRING_SWAP'
+  data?: RecurringSwapMetadata
+} {
+  return notification.type === 'RECURRING_SWAP'
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/core-mobile/app/new/features/notifications/utils.test.ts
+++ b/packages/core-mobile/app/new/features/notifications/utils.test.ts
@@ -402,8 +402,7 @@ const makeRecurringNotification = (
           }
         }
       : {})
-  } as Partial<AppNotification> &
-    Pick<AppNotification, 'type' | 'category'>)
+  } as Partial<AppNotification> & Pick<AppNotification, 'type' | 'category'>)
 
 describe('isTerminalRecurringSwapNotification', () => {
   it('returns false for a non-recurring notification', () => {
@@ -411,9 +410,9 @@ describe('isTerminalRecurringSwapNotification', () => {
   })
 
   it('returns false for a recurring notification without a data payload', () => {
-    expect(isTerminalRecurringSwapNotification(makeRecurringNotification())).toBe(
-      false
-    )
+    expect(
+      isTerminalRecurringSwapNotification(makeRecurringNotification())
+    ).toBe(false)
   })
 
   it.each([['active'], ['paused'], ['executed']])(

--- a/packages/core-mobile/app/new/features/notifications/utils.test.ts
+++ b/packages/core-mobile/app/new/features/notifications/utils.test.ts
@@ -7,6 +7,7 @@ import {
 } from './types'
 import {
   buildAccountLabelMap,
+  classifyRecurringSwapStatus,
   filterByTab,
   isSwapTerminal,
   isTerminalRecurringSwapNotification,
@@ -367,6 +368,32 @@ describe('mapTransferToTargetChainStatus', () => {
           makeTransfer(status as Transfer['status'])
         )
       ).toBe(NotificationSwapStatus.InProgress)
+    }
+  )
+})
+
+// ─── classifyRecurringSwapStatus ─────────────────────────────────────────────
+
+describe('classifyRecurringSwapStatus', () => {
+  it.each([
+    ['failed', 'failed'],
+    ['cancelled', 'cancelled'],
+    ['completed', 'completed'],
+    ['active', 'fill'],
+    ['executed', 'fill']
+  ])('classifies "%s" as %s', (raw, expected) => {
+    expect(classifyRecurringSwapStatus(raw)).toBe(expected)
+  })
+
+  it('is case-insensitive', () => {
+    expect(classifyRecurringSwapStatus('FAILED')).toBe('failed')
+    expect(classifyRecurringSwapStatus('Executed')).toBe('fill')
+  })
+
+  it.each([['paused'], ['source-pending'], ['']])(
+    'classifies unrecognized status "%s" as unknown',
+    raw => {
+      expect(classifyRecurringSwapStatus(raw)).toBe('unknown')
     }
   )
 })

--- a/packages/core-mobile/app/new/features/notifications/utils.test.ts
+++ b/packages/core-mobile/app/new/features/notifications/utils.test.ts
@@ -9,6 +9,7 @@ import {
   buildAccountLabelMap,
   filterByTab,
   isSwapTerminal,
+  isTerminalRecurringSwapNotification,
   mapTransferToSourceChainStatus,
   mapTransferToSwapStatus,
   mapTransferToTargetChainStatus,
@@ -368,4 +369,98 @@ describe('mapTransferToTargetChainStatus', () => {
       ).toBe(NotificationSwapStatus.InProgress)
     }
   )
+})
+
+// ─── isTerminalRecurringSwapNotification ──────────────────────────────────────
+
+const makeRecurringNotification = (
+  data?: Partial<{
+    status: string
+    numberOfOrders: number
+    executedOrders: number
+    remainingOrders: number
+  }>
+): AppNotification =>
+  makeNotification({
+    type: 'RECURRING_SWAP',
+    category: NotificationCategory.TRANSACTION,
+    ...(data
+      ? {
+          data: {
+            orderId: '0xorder',
+            owner: '0xowner',
+            chainId: 43114,
+            tokenIn: '0xin',
+            tokenOut: '0xout',
+            amountIn: '1',
+            amountOut: '2',
+            status: 'active',
+            numberOfOrders: 5,
+            executedOrders: 1,
+            remainingOrders: 4,
+            ...data
+          }
+        }
+      : {})
+  } as Partial<AppNotification> &
+    Pick<AppNotification, 'type' | 'category'>)
+
+describe('isTerminalRecurringSwapNotification', () => {
+  it('returns false for a non-recurring notification', () => {
+    expect(isTerminalRecurringSwapNotification(balanceChange)).toBe(false)
+  })
+
+  it('returns false for a recurring notification without a data payload', () => {
+    expect(isTerminalRecurringSwapNotification(makeRecurringNotification())).toBe(
+      false
+    )
+  })
+
+  it.each([['active'], ['paused'], ['executed']])(
+    'returns false for an ongoing fill (status "%s", fills remaining)',
+    status => {
+      expect(
+        isTerminalRecurringSwapNotification(
+          makeRecurringNotification({ status, remainingOrders: 3 })
+        )
+      ).toBe(false)
+    }
+  )
+
+  it.each([['completed'], ['cancelled'], ['failed']])(
+    'returns true for terminal status "%s"',
+    status => {
+      expect(
+        isTerminalRecurringSwapNotification(
+          makeRecurringNotification({ status, remainingOrders: 2 })
+        )
+      ).toBe(true)
+    }
+  )
+
+  it('returns true for the final leg of a finite schedule (no fills remain)', () => {
+    expect(
+      isTerminalRecurringSwapNotification(
+        makeRecurringNotification({
+          status: 'active',
+          numberOfOrders: 3,
+          executedOrders: 3,
+          remainingOrders: 0
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('returns false for an infinite/DCA schedule even with remainingOrders 0', () => {
+    // numberOfOrders === -1 never reaches a "no fills remain" terminal.
+    expect(
+      isTerminalRecurringSwapNotification(
+        makeRecurringNotification({
+          status: 'active',
+          numberOfOrders: -1,
+          remainingOrders: 0
+        })
+      )
+    ).toBe(false)
+  })
 })

--- a/packages/core-mobile/app/new/features/notifications/utils.ts
+++ b/packages/core-mobile/app/new/features/notifications/utils.ts
@@ -6,7 +6,8 @@ import {
   NotificationCategory,
   NotificationTab,
   NotificationType,
-  NotificationSwapStatus
+  NotificationSwapStatus,
+  isRecurringSwapNotification
 } from './types'
 
 /**
@@ -82,6 +83,40 @@ export function mapTransferToTargetChainStatus(
 
   // source-pending, source-completed, target-pending → target not done yet
   return NotificationSwapStatus.InProgress
+}
+
+/**
+ * A recurring-swap notification is "terminal" when its schedule will no longer
+ * appear on the management screen — which lists only Active / Paused schedules
+ * (`RecurringSchedulesScreen` filters out Cancelled / Completed). Such a
+ * notification deep-links to a schedule the user can't see, so the row is
+ * rendered non-actionable (no chevron, no navigation) by `hasActionableUrl`.
+ *
+ * Read off the structured `data` block (NOT the human-facing copy):
+ *   - status is a terminal / failed event ('completed' | 'cancelled' | 'failed'), or
+ *   - it's the final leg of a finite schedule (`numberOfOrders !== -1` and no
+ *     fills remain). Infinite / DCA schedules (`numberOfOrders === -1`) never
+ *     reach this state.
+ *
+ * Note: 'failed' is a per-fill event, not a `RecurringOrderStatus` — a failed
+ * fill can occur on a schedule that stays Active. We still treat it as
+ * non-actionable per product intent (failures generally precede auto-cancel);
+ * if a still-Active schedule's failure should remain tappable, drop 'failed'
+ * from the terminal set here.
+ */
+export function isTerminalRecurringSwapNotification(
+  notification: AppNotification
+): boolean {
+  if (!isRecurringSwapNotification(notification)) return false
+  const data = notification.data
+  if (!data) return false
+
+  const status = data.status.toLowerCase()
+  if (status === 'completed' || status === 'cancelled' || status === 'failed') {
+    return true
+  }
+  // Final leg of a finite schedule — no fills left to run.
+  return data.numberOfOrders !== -1 && data.remainingOrders === 0
 }
 
 /**

--- a/packages/core-mobile/app/new/features/notifications/utils.ts
+++ b/packages/core-mobile/app/new/features/notifications/utils.ts
@@ -160,7 +160,12 @@ export function isTerminalRecurringSwapNotification(
     return true
   }
   // Final leg of a finite schedule — no fills left to run.
-  return data.numberOfOrders !== -1 && data.remainingOrders === 0
+  return (
+    data.numberOfOrders !== undefined &&
+    data.remainingOrders !== undefined &&
+    data.numberOfOrders !== -1 &&
+    data.remainingOrders === 0
+  )
 }
 
 /**

--- a/packages/core-mobile/app/new/features/notifications/utils.ts
+++ b/packages/core-mobile/app/new/features/notifications/utils.ts
@@ -86,6 +86,48 @@ export function mapTransferToTargetChainStatus(
 }
 
 /**
+ * Semantic bucket for a recurring-swap `data.status` string. This is the single
+ * source of truth for the raw-status vocabulary, shared by the two places that
+ * branch on it: `isTerminalRecurringSwapNotification` here (row actionability)
+ * and `resolveBadge` in `RecurringSwapItem.tsx` (the colored status badge).
+ * Both read the same backend strings and must agree on what each one means, so
+ * route every new status through this classifier rather than re-listing literals
+ * at the call site.
+ *
+ *   - 'failed'    → a fill failed (red badge; terminal / non-actionable)
+ *   - 'cancelled' → schedule was stopped (terminal / non-actionable, but no badge)
+ *   - 'completed' → the schedule's final leg landed (green "Completed"; terminal)
+ *   - 'fill'      → a mid-schedule leg landed ('active' / 'executed'; green
+ *                   "Executed"; NOT terminal on its own — a finite final leg is
+ *                   detected separately via remainingOrders)
+ *   - 'unknown'   → unrecognized status (no badge; not terminal on its own)
+ */
+export type RecurringSwapStatusKind =
+  | 'failed'
+  | 'cancelled'
+  | 'completed'
+  | 'fill'
+  | 'unknown'
+
+export function classifyRecurringSwapStatus(
+  rawStatus: string
+): RecurringSwapStatusKind {
+  switch (rawStatus.toLowerCase()) {
+    case 'failed':
+      return 'failed'
+    case 'cancelled':
+      return 'cancelled'
+    case 'completed':
+      return 'completed'
+    case 'active':
+    case 'executed':
+      return 'fill'
+    default:
+      return 'unknown'
+  }
+}
+
+/**
  * A recurring-swap notification is "terminal" when its schedule will no longer
  * appear on the management screen — which lists only Active / Paused schedules
  * (`RecurringSchedulesScreen` filters out Cancelled / Completed). Such a
@@ -93,7 +135,8 @@ export function mapTransferToTargetChainStatus(
  * rendered non-actionable (no chevron, no navigation) by `hasActionableUrl`.
  *
  * Read off the structured `data` block (NOT the human-facing copy):
- *   - status is a terminal / failed event ('completed' | 'cancelled' | 'failed'), or
+ *   - status classifies as a terminal event ('completed' | 'cancelled' |
+ *     'failed'), or
  *   - it's the final leg of a finite schedule (`numberOfOrders !== -1` and no
  *     fills remain). Infinite / DCA schedules (`numberOfOrders === -1`) never
  *     reach this state.
@@ -101,8 +144,9 @@ export function mapTransferToTargetChainStatus(
  * Note: 'failed' is a per-fill event, not a `RecurringOrderStatus` — a failed
  * fill can occur on a schedule that stays Active. We still treat it as
  * non-actionable per product intent (failures generally precede auto-cancel);
- * if a still-Active schedule's failure should remain tappable, drop 'failed'
- * from the terminal set here.
+ * if a still-Active schedule's failure should remain tappable, remap 'failed'
+ * in `classifyRecurringSwapStatus` (it also drives the red badge) or special-case
+ * it here.
  */
 export function isTerminalRecurringSwapNotification(
   notification: AppNotification
@@ -111,8 +155,8 @@ export function isTerminalRecurringSwapNotification(
   const data = notification.data
   if (!data) return false
 
-  const status = data.status.toLowerCase()
-  if (status === 'completed' || status === 'cancelled' || status === 'failed') {
+  const kind = classifyRecurringSwapStatus(data.status)
+  if (kind === 'completed' || kind === 'cancelled' || kind === 'failed') {
     return true
   }
   // Final leg of a finite schedule — no fills left to run.

--- a/packages/core-mobile/app/new/features/notifications/utils.ts
+++ b/packages/core-mobile/app/new/features/notifications/utils.ts
@@ -95,6 +95,12 @@ export function mapTypeToCategory(
       return NotificationCategory.TRANSACTION
     case 'PRICE_ALERTS':
       return NotificationCategory.PRICE_UPDATE
+    case 'RECURRING_SWAP':
+      // Recurring-swap fills / completions / failures are on-chain
+      // transaction-like events the user cares about alongside balance
+      // changes. Sharing the TRANSACTION bucket means they land on the
+      // Transactions tab without needing a dedicated tab.
+      return NotificationCategory.TRANSACTION
     case 'NEWS':
     default:
       return NotificationCategory.NEWS

--- a/packages/core-mobile/app/new/features/recurringSwap/components/RecurringDetailsRows.test.tsx
+++ b/packages/core-mobile/app/new/features/recurringSwap/components/RecurringDetailsRows.test.tsx
@@ -113,7 +113,10 @@ jest.mock('../contexts/RecurringSwapContext', () => ({
 
 // Import after mocks are registered.
 
-import { RecurringDetailsRows } from './RecurringDetailsRows'
+import {
+  RecurringDetailsRows,
+  ordersChipsForToken
+} from './RecurringDetailsRows'
 
 /** Walk the rendered tree and collect all string leaf values. */
 function collectText(
@@ -265,5 +268,23 @@ describe('<RecurringDetailsRows />', () => {
 
     expect(containsText(json, 'Unlimited')).toBe(true)
     expect(containsText(json, 'Estimated total spend')).toBe(false)
+  })
+})
+
+describe('ordersChipsForToken', () => {
+  it('includes the Unlimited chip for non-native (ERC-20) source tokens', () => {
+    const ids = ordersChipsForToken(false).map(chip => chip.id)
+    expect(ids).toContain('unlimited')
+  })
+
+  it('omits the Unlimited chip for native source tokens', () => {
+    // Native-input recurring pre-wraps the full schedule total, so an unbounded
+    // (Unlimited) schedule 400s on Markr's /recurring/quote — hide the option.
+    const ids = ordersChipsForToken(true).map(chip => chip.id)
+    expect(ids).not.toContain('unlimited')
+    // The finite presets + custom remain selectable.
+    expect(ids).toEqual(
+      expect.arrayContaining(['5', '10', '15', '20', 'custom'])
+    )
   })
 })

--- a/packages/core-mobile/app/new/features/recurringSwap/components/RecurringDetailsRows.tsx
+++ b/packages/core-mobile/app/new/features/recurringSwap/components/RecurringDetailsRows.tsx
@@ -22,6 +22,7 @@ import {
   RECURRING_FREQUENCY_VALUE_MAX,
   validateFrequency
 } from '@avalabs/fusion-sdk'
+import { TokenType } from '@avalabs/vm-module-types'
 import { useSelector } from 'react-redux'
 import { selectActiveAccount } from 'store/account'
 import { useSwapContext } from 'features/swap/contexts/SwapContext'
@@ -136,6 +137,21 @@ const MIN_ORDERS = 2
 const DEFAULT_CUSTOM_ORDERS = 5
 const ORDERS_INPUT_KEY = 'orders_value'
 
+// Native-input recurring can't express an "Unlimited" schedule: the first fill
+// pre-wraps the whole schedule's worth (numberOfOrders × amountPerOrder) into
+// the wrapped-native token, and an unbounded schedule has no finite total to
+// wrap — Markr's `/recurring/quote` returns HTTP 400 for native + unlimited.
+// Hide the Unlimited chip for native source tokens so the user can't pick a
+// combination that would otherwise dead-end with a disabled "Next" and no
+// explanation (the recurring-quote error isn't surfaced in the UI).
+export function ordersChipsForToken(
+  isNativeFromToken: boolean
+): ChipOption<OrdersChipId>[] {
+  return isNativeFromToken
+    ? ORDERS_CHIPS.filter(chip => chip.id !== 'unlimited')
+    : ORDERS_CHIPS
+}
+
 function ordersToChipId(
   n: NumberOfOrders | undefined
 ): OrdersChipId | undefined {
@@ -176,6 +192,23 @@ export function RecurringDetailsRows({
   const { fromToken, toToken } = useSwapContext()
   const activeAccount = useSelector(selectActiveAccount)
   const evmAddress = activeAccount?.addressC
+
+  // Unlimited isn't valid for a native source token (see `ordersChipsForToken`).
+  const isNativeFromToken = fromToken?.type === TokenType.NATIVE
+  const ordersChips = useMemo(
+    () => ordersChipsForToken(isNativeFromToken),
+    [isNativeFromToken]
+  )
+
+  // If the source switches to native while Unlimited is selected, clear the
+  // selection — the chip is now hidden and the combination would 400 on quote.
+  // Cleared to `undefined` so the user makes an explicit valid choice rather
+  // than us silently picking a count for them.
+  useEffect(() => {
+    if (isNativeFromToken && numberOfOrders === UNLIMITED_ORDERS) {
+      setNumberOfOrders(undefined)
+    }
+  }, [isNativeFromToken, numberOfOrders, setNumberOfOrders])
 
   const eligibility = useRecurringEligibility(fromToken, toToken, evmAddress)
   const minIntervalSeconds = eligibility.eligible
@@ -446,7 +479,7 @@ export function RecurringDetailsRows({
         testID="recurring_row__orders">
         <View sx={{ padding: 16 }}>
           <RecurrenceChips
-            options={ORDERS_CHIPS}
+            options={ordersChips}
             selectedId={selectedOrdersChip}
             onSelect={handleSelectOrdersChip}
             testID="orders_chips"

--- a/packages/core-mobile/app/new/features/recurringSwap/hooks/_makeOrderActionHook.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/hooks/_makeOrderActionHook.ts
@@ -9,6 +9,7 @@ import { isHttpError } from '@avalabs/fusion-sdk'
 import type { Network } from '@avalabs/core-chains-sdk'
 import { showSnackbar } from 'common/utils/toast'
 import FusionService from 'features/swap/services/FusionService'
+import { isUserRejectionError } from 'features/swap/utils/fusionErrors'
 import AnalyticsService from 'services/analytics/AnalyticsService'
 import Logger from 'utils/Logger'
 import { useNetworks } from 'hooks/networks/useNetworks'
@@ -372,17 +373,6 @@ export function makeOrderActionHook(
       [isPending, mutate, run]
     )
   }
-}
-
-// Matches the user-rejection detector in SwapScreen.submitRecurring. The
-// underlying signer throws an Error whose message starts with
-// "User rejected" / "User cancelled" / "User canceled" when the user taps
-// Reject (or closes the modal) on the in-app approval sheet. These aren't
-// failures we should surface — they're the user's deliberate action.
-function isUserRejectionError(err: unknown): boolean {
-  const message =
-    err instanceof Error ? err.message : typeof err === 'string' ? err : ''
-  return /User (rejected|cancel(l|led))/i.test(message)
 }
 
 function showOrderActionErrorSnackbar(

--- a/packages/core-mobile/app/new/features/recurringSwap/hooks/useRecurringEligibility.test.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/hooks/useRecurringEligibility.test.ts
@@ -58,7 +58,6 @@ describe('useRecurringEligibility', () => {
   it('delegates to SDK checkEligibility and returns its result for a supported same-chain pair', () => {
     mockCheckEligibility.mockReturnValue({
       eligible: true,
-      minimumAmount: '1000000',
       minIntervalSeconds: 300
     })
 
@@ -78,7 +77,6 @@ describe('useRecurringEligibility', () => {
     )
     expect(result.current).toEqual({
       eligible: true,
-      minimumAmount: '1000000',
       minIntervalSeconds: 300
     })
   })
@@ -146,23 +144,4 @@ describe('useRecurringEligibility', () => {
     })
   })
 
-  it('passes the optional amount through to checkEligibility', () => {
-    mockCheckEligibility.mockReturnValue({
-      eligible: false,
-      reason: 'amount-below-minimum'
-    })
-    renderHook(() =>
-      useRecurringEligibility(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        usdc as any,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        wavax as any,
-        '0xabc',
-        500_000n
-      )
-    )
-    expect(mockCheckEligibility).toHaveBeenCalledWith(
-      expect.objectContaining({ amount: 500_000n })
-    )
-  })
 })

--- a/packages/core-mobile/app/new/features/recurringSwap/hooks/useRecurringEligibility.test.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/hooks/useRecurringEligibility.test.ts
@@ -143,5 +143,4 @@ describe('useRecurringEligibility', () => {
       reason: 'cross-chain'
     })
   })
-
 })

--- a/packages/core-mobile/app/new/features/recurringSwap/hooks/useRecurringEligibility.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/hooks/useRecurringEligibility.ts
@@ -12,8 +12,9 @@ import { resolveRecurringTokenAddress } from '../types'
  * Recurring-swap eligibility for a candidate `(fromToken, toToken, owner)` triple.
  *
  * The SDK's `markr.recurring.checkEligibility(...)` is the source of truth — it
- * encodes Markr's cross-chain / unsupported-token / amount-below-minimum rules
- * against the cached `/info/chains` payload. This hook is a thin React adapter:
+ * encodes Markr's cross-chain / unsupported-token / native-to-wrapped-native
+ * rules against the cached `/info/chains` payload. This hook is a thin React
+ * adapter:
  *
  * - returns `{ eligible: false, reason: 'unsupported-source-chain' }` while
  *   `FusionService` is initialising (caches not loaded yet); re-renders when
@@ -21,15 +22,14 @@ import { resolveRecurringTokenAddress } from '../types'
  * - projects mobile's `LocalTokenWithBalance` shape onto the SDK's `Address`
  *   inputs (the SDK's branded type — cast at the boundary)
  *
- * @param amount — per-order input amount in `tokenIn`'s smallest unit. When set,
- *   the SDK additionally surfaces the `amount-below-minimum` reason. UI passes
- *   it from the live input box; pass `undefined` to skip the amount check.
+ * Markr no longer publishes a per-chain supported-token list, so eligibility is
+ * a pure chain + same-chain + native/wrapped check — every ERC-20 (and the
+ * native asset) is recurring-eligible. There is no per-order minimum to surface.
  */
 export function useRecurringEligibility(
   fromToken: LocalTokenWithBalance | undefined,
   toToken: LocalTokenWithBalance | undefined,
-  ownerAddress: string | undefined,
-  amount?: bigint
+  ownerAddress: string | undefined
 ): RecurringEligibility {
   const [isFusionServiceReady] = useIsFusionServiceReady()
 
@@ -89,8 +89,7 @@ export function useRecurringEligibility(
         // boundary, the SDK validates the address against its chain-info map.
         fromTokenAddress: fromTokenAddress as Address,
         toTokenAddress: toTokenAddress as Address,
-        ownerAddress: ownerAddress as Address,
-        amount
+        ownerAddress: ownerAddress as Address
       })
     } catch (err) {
       Logger.info(
@@ -109,7 +108,6 @@ export function useRecurringEligibility(
     fromToken?.localId,
     toToken?.networkChainId,
     toToken?.localId,
-    ownerAddress,
-    amount
+    ownerAddress
   ])
 }

--- a/packages/core-mobile/app/new/features/recurringSwap/screens/RecurringSchedulesScreen.tsx
+++ b/packages/core-mobile/app/new/features/recurringSwap/screens/RecurringSchedulesScreen.tsx
@@ -527,6 +527,9 @@ export function RecurringSchedulesScreen({
    *  the user lands directly on the order the notification was about. */
   initialExpandedOrderId?: string
 } = {}): JSX.Element {
+  const {
+    theme: { colors }
+  } = useTheme()
   const activeAccount = useSelector(selectActiveAccount)
   const activeNetwork = useSelector(selectActiveNetwork)
   const chainId = activeNetwork?.chainId
@@ -808,7 +811,7 @@ export function RecurringSchedulesScreen({
         isModal
         contentContainerStyle={{ flexGrow: 1, padding: 16 }}>
         <View sx={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-          <ActivityIndicator size="large" color="#3C3C4399" />
+          <ActivityIndicator size="large" color={colors.$textPrimary} />
         </View>
       </ScrollScreen>
     )

--- a/packages/core-mobile/app/new/features/recurringSwap/screens/RecurringSchedulesScreen.tsx
+++ b/packages/core-mobile/app/new/features/recurringSwap/screens/RecurringSchedulesScreen.tsx
@@ -799,6 +799,21 @@ export function RecurringSchedulesScreen({
   const title = `${manageableCount} recurring\n${swapWord} scheduled`
   const navigationTitle = `${manageableCount} recurring ${swapWord} scheduled`
 
+  // While the first fetch is in flight we have no real count yet — rendering the
+  // "{N} recurring swaps scheduled" header would flash a misleading "0 …". Per
+  // design, show only a centered spinner over the modal until data resolves.
+  if (isLoading) {
+    return (
+      <ScrollScreen
+        isModal
+        contentContainerStyle={{ flexGrow: 1, padding: 16 }}>
+        <View sx={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+          <ActivityIndicator size="large" color="#3C3C4399" />
+        </View>
+      </ScrollScreen>
+    )
+  }
+
   return (
     <ScrollScreen
       ref={scrollRef}
@@ -806,18 +821,11 @@ export function RecurringSchedulesScreen({
       navigationTitle={navigationTitle}
       isModal
       contentContainerStyle={{ padding: 16 }}>
-      {isLoading && (
-        <View sx={{ alignItems: 'center', paddingTop: 32 }}>
-          <Text variant="body2" sx={{ color: '$textSecondary' }}>
-            Loading…
-          </Text>
-        </View>
-      )}
       {/* Distinguish "Markr fetch failed with no cached data" from "fetch
           succeeded and you have zero schedules". The previous render
           collapsed both into the empty state, which made a server
           outage look like "your schedules disappeared". */}
-      {!isLoading && isError && manageableSchedules.length === 0 && (
+      {isError && manageableSchedules.length === 0 && (
         <View sx={{ alignItems: 'center', paddingTop: 32, gap: 12 }}>
           <Text variant="body2" sx={{ color: '$textSecondary' }}>
             Couldn’t load recurring swaps.
@@ -827,7 +835,7 @@ export function RecurringSchedulesScreen({
           </Button>
         </View>
       )}
-      {!isLoading && !isError && manageableSchedules.length === 0 && (
+      {!isError && manageableSchedules.length === 0 && (
         <View sx={{ alignItems: 'center', paddingTop: 32 }}>
           <Text variant="body2" sx={{ color: '$textSecondary' }}>
             No recurring swaps found.

--- a/packages/core-mobile/app/new/features/recurringSwap/services/recurringSignerContext.test.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/services/recurringSignerContext.test.ts
@@ -3,6 +3,7 @@ import {
   type TransferStepDetails
 } from '@avalabs/fusion-sdk'
 import {
+  isRecurringOrderActionSignatureReason,
   isRecurringTransferSignatureReason,
   readRecurringSignerContext
 } from './recurringSignerContext'
@@ -55,6 +56,35 @@ describe('isRecurringTransferSignatureReason', () => {
     TransferSignatureReason.HyperliquidAuthorize
   ])('does NOT match non-recurring reason %s', reason => {
     expect(isRecurringTransferSignatureReason(reason)).toBe(false)
+  })
+})
+
+describe('isRecurringOrderActionSignatureReason', () => {
+  // Cancel / pause / resume are the schedule-management actions EvmSigner
+  // suppresses the success confetti for.
+  it.each([
+    TransferSignatureReason.CancelRecurringSwap,
+    TransferSignatureReason.PauseRecurringSwap,
+    TransferSignatureReason.ResumeRecurringSwap
+  ])('matches %s', reason => {
+    expect(isRecurringOrderActionSignatureReason(reason)).toBe(true)
+  })
+
+  // Creating a schedule is NOT an order action — it keeps its normal
+  // confetti, so it must not match.
+  it('does NOT match ScheduleRecurringSwap', () => {
+    expect(
+      isRecurringOrderActionSignatureReason(
+        TransferSignatureReason.ScheduleRecurringSwap
+      )
+    ).toBe(false)
+  })
+
+  it.each([
+    TransferSignatureReason.TokensTransfer,
+    TransferSignatureReason.AllowanceApproval
+  ])('does NOT match non-recurring reason %s', reason => {
+    expect(isRecurringOrderActionSignatureReason(reason)).toBe(false)
   })
 })
 

--- a/packages/core-mobile/app/new/features/recurringSwap/services/recurringSignerContext.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/services/recurringSignerContext.ts
@@ -56,6 +56,18 @@ export function isRecurringTransferSignatureReason(
 ): boolean {
   return (
     reason === TransferSignatureReason.ScheduleRecurringSwap ||
+    isRecurringOrderActionSignatureReason(reason)
+  )
+}
+
+// Cancel / pause / resume are schedule-management actions, not a completed
+// swap or a new schedule. `EvmSigner.signOne` uses this to suppress the
+// success confetti for these three (`ScheduleRecurringSwap` — creating a
+// schedule — and recurring fills keep their normal feedback).
+export function isRecurringOrderActionSignatureReason(
+  reason: TransferSignatureReason
+): boolean {
+  return (
     reason === TransferSignatureReason.CancelRecurringSwap ||
     reason === TransferSignatureReason.PauseRecurringSwap ||
     reason === TransferSignatureReason.ResumeRecurringSwap

--- a/packages/core-mobile/app/new/features/recurringSwap/services/recurringSwapNotifications.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/services/recurringSwapNotifications.ts
@@ -1,5 +1,4 @@
 import Config from 'react-native-config'
-import { registerAndGetDeviceArn } from 'services/notifications/registerDeviceToNotificationSender'
 import { appCheckPostJson } from 'utils/api/common/appCheckFetch'
 
 // Backend (core-notification-sender): see Sarp's PR
@@ -17,17 +16,21 @@ const RECURRING_SWAP_SUBSCRIBE_PATH = '/v1/push/recurring-swaps/subscribe'
 
 type RecurringSwapNotificationSubscription = {
   orderId: string
+  // Resolved once per batch by the caller (`ensureOrderSubscriptions`) and
+  // reused across orders, mirroring the balance-change subscribe flow — so a
+  // multi-order snapshot triggers one `/v1/push/register`, not one per order.
+  deviceArn: string
 }
 
 export async function subscribeRecurringSwapNotifications(
   subscription: RecurringSwapNotificationSubscription
 ): Promise<void> {
-  const deviceArn = await registerAndGetDeviceArn()
+  const { deviceArn, orderId } = subscription
   const response = await appCheckPostJson(
     Config.NOTIFICATION_SENDER_API_URL + RECURRING_SWAP_SUBSCRIBE_PATH,
     JSON.stringify({
       deviceArn,
-      orderId: subscription.orderId
+      orderId
     })
   )
 

--- a/packages/core-mobile/app/new/features/recurringSwap/services/recurringSwapNotifications.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/services/recurringSwapNotifications.ts
@@ -1,0 +1,37 @@
+import Config from 'react-native-config'
+import { registerAndGetDeviceArn } from 'services/notifications/registerDeviceToNotificationSender'
+import { appCheckPostJson } from 'utils/api/common/appCheckFetch'
+
+// Backend (core-notification-sender): see Sarp's PR
+// https://github.com/ava-labs/core-notification-sender-service/pull/172
+//   - Subscription is per (orderId, deviceArn). Re-subscribing the same
+//     device is an idempotent reactivation, so retries on app restart /
+//     network blip are safe.
+//   - No client-side unsubscribe — teardown is event-driven (terminal
+//     status / executedOrders ≥ numberOfOrders / dead device endpoint),
+//     owned by the webhook.
+//   - AppCheck-authed, matches the balance-changes subscribe endpoint
+//     pattern so the auth + retry semantics align with the rest of the
+//     notification-sender clients.
+const RECURRING_SWAP_SUBSCRIBE_PATH = '/v1/push/recurring-swaps/subscribe'
+
+type RecurringSwapNotificationSubscription = {
+  orderId: string
+}
+
+export async function subscribeRecurringSwapNotifications(
+  subscription: RecurringSwapNotificationSubscription
+): Promise<void> {
+  const deviceArn = await registerAndGetDeviceArn()
+  const response = await appCheckPostJson(
+    Config.NOTIFICATION_SENDER_API_URL + RECURRING_SWAP_SUBSCRIBE_PATH,
+    JSON.stringify({
+      deviceArn,
+      orderId: subscription.orderId
+    })
+  )
+
+  if (!response.ok) {
+    throw new Error(`${response.status}:${response.statusText}`)
+  }
+}

--- a/packages/core-mobile/app/new/features/recurringSwap/store/listeners.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/store/listeners.ts
@@ -2,9 +2,12 @@ import { queryClient } from 'contexts/ReactQueryProvider'
 import { showSnackbar } from 'common/utils/toast'
 import Logger from 'utils/Logger'
 import { TransferSignatureReason } from '@avalabs/fusion-sdk'
+import { isAnyOf } from '@reduxjs/toolkit'
 import type { QueryCacheNotifyEvent } from '@tanstack/react-query'
-import { onAppUnlocked } from 'store/app/slice'
+import { onAppUnlocked, onLogOut } from 'store/app/slice'
+import { onFcmTokenChange } from 'store/notifications/slice'
 import type { AppStartListening } from 'store/types'
+import { registerAndGetDeviceArn } from 'services/notifications/registerDeviceToNotificationSender'
 import { RECURRING_SCHEDULES_QK } from '../hooks/useRecurringSchedules'
 import { RecurringOrderStatus } from '../types'
 import type { RecurringOrder } from '../types'
@@ -34,6 +37,22 @@ import {
 // so a duplicate that slips through is harmless — this set is purely a
 // network-traffic optimization.
 const subscribeInFlight = new Set<string>()
+
+// Session-scoped memo for the deviceArn used by the recurring-swap subscribe
+// flow. `ensureOrderSubscriptions` already resolves the ARN once per batch,
+// but every snapshot that surfaces a fresh subscribable order (new order
+// created, 30s poll, banner mount, unlock invalidate, focus) re-hits
+// `/v1/push/register` for a result we already received earlier in the
+// session — this cache collapses that across batches.
+//
+// Invalidated on:
+//   - subscribe failure inside the loop (ARN may have been retired backend-side;
+//     drop it so the next batch re-registers and the live ARN gets reused)
+//   - `onFcmTokenChange` (the SNS endpoint mapping is stale until /v1/push/register
+//     posts the new FCM token, so we MUST force a fresh register or push
+//     deliveries will dead-letter against the old token)
+//   - `onLogOut` (a fresh sign-in may use a different device identity)
+let cachedDeviceArn: string | null = null
 
 // The SDK now signs and broadcasts internally for fill /
 // cancel / pause / resume, so the old Redux listeners that watched for
@@ -159,15 +178,45 @@ async function ensureOrderSubscriptions(
 ): Promise<void> {
   const ownerLower = ownerAddress.toLowerCase()
   const subscribed = loadSubscribedOrders(ownerAddress, chainId)
-  for (const schedule of schedules) {
-    if (!isSubscribableStatus(schedule.status)) continue
+
+  // Orders from this snapshot that still need a subscription. Filtering up
+  // front lets us resolve the deviceArn exactly once for the whole batch —
+  // and skip the register call entirely in the steady state (every order
+  // already subscribed, the common case on the 30s poll).
+  const pending = schedules.filter(
+    schedule =>
+      isSubscribableStatus(schedule.status) &&
+      !subscribed.has(schedule.orderId) &&
+      !subscribeInFlight.has(`${ownerLower}:${chainId}:${schedule.orderId}`)
+  )
+  if (pending.length === 0) return
+
+  // Resolve the deviceArn for this batch, reusing the session-cached value
+  // when present and falling back to /v1/push/register otherwise. Bail on
+  // failure rather than retrying register once per order; the next listOrders
+  // refetch retries the whole batch.
+  let deviceArn: string
+  if (cachedDeviceArn) {
+    deviceArn = cachedDeviceArn
+  } else {
+    try {
+      deviceArn = await registerAndGetDeviceArn()
+      cachedDeviceArn = deviceArn
+    } catch (err) {
+      Logger.error('[RecurringSwap] deviceArn registration failed', err)
+      return
+    }
+  }
+
+  for (const schedule of pending) {
     const orderId = schedule.orderId
-    if (subscribed.has(orderId)) continue
     const inFlightKey = `${ownerLower}:${chainId}:${orderId}`
+    // Re-check in-flight: a concurrent ensureOrderSubscriptions run may have
+    // claimed this order while we awaited the deviceArn above.
     if (subscribeInFlight.has(inFlightKey)) continue
     subscribeInFlight.add(inFlightKey)
     try {
-      await subscribeRecurringSwapNotifications({ orderId })
+      await subscribeRecurringSwapNotifications({ orderId, deviceArn })
       subscribed.add(orderId)
       // Save after each success so a mid-batch interruption (app kill,
       // network drop on the next iteration) preserves the work done so far.
@@ -179,6 +228,10 @@ async function ensureOrderSubscriptions(
       ])
       saveSubscribedOrders(ownerAddress, chainId, merged)
     } catch (err) {
+      // The ARN may have been retired backend-side (e.g. dead-endpoint
+      // cleanup); drop the cached value so the next batch re-registers
+      // against a live ARN before reusing it across the rest of the loop.
+      cachedDeviceArn = null
       Logger.error('[RecurringSwap] order subscribe failed', {
         orderId,
         err
@@ -391,6 +444,17 @@ export function addRecurringSwapListeners(
     actionCreator: onAppUnlocked,
     effect: () => {
       queryClient.invalidateQueries({ queryKey: RECURRING_SCHEDULES_QK })
+    }
+  })
+
+  // Drop the session-cached deviceArn whenever the underlying device identity
+  // can shift out from under it — FCM token rotation invalidates the SNS
+  // endpoint mapping (must re-register to refresh server-side), and logout
+  // may swap to a different account on the next sign-in.
+  startListening({
+    matcher: isAnyOf(onFcmTokenChange, onLogOut),
+    effect: () => {
+      cachedDeviceArn = null
     }
   })
 

--- a/packages/core-mobile/app/new/features/recurringSwap/store/listeners.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/store/listeners.ts
@@ -171,10 +171,13 @@ async function ensureOrderSubscriptions(
       subscribed.add(orderId)
       // Save after each success so a mid-batch interruption (app kill,
       // network drop on the next iteration) preserves the work done so far.
-      // `loadSubscribedOrders` re-reads from MMKV at the start of each
-      // refetch, so a sibling subscriber's writes (different chain, same
-      // session) don't get clobbered.
-      saveSubscribedOrders(ownerAddress, chainId, subscribed)
+      // Merge with the latest persisted set to avoid clobbering concurrent
+      // ensureOrderSubscriptions runs for the same (owner, chain).
+      const merged = new Set([
+        ...loadSubscribedOrders(ownerAddress, chainId),
+        ...subscribed
+      ])
+      saveSubscribedOrders(ownerAddress, chainId, merged)
     } catch (err) {
       Logger.error('[RecurringSwap] order subscribe failed', {
         orderId,
@@ -296,7 +299,9 @@ function reconcilePendingActions(
  * (see `useRecurringSchedules`). We pluck both out so the seen-failures
  * persistence can be scoped per (account, chain).
  */
-async function handleQueryCacheEvent(event: QueryCacheNotifyEvent): Promise<void> {
+async function handleQueryCacheEvent(
+  event: QueryCacheNotifyEvent
+): Promise<void> {
   if (
     event.query.queryKey?.[0] !== RECURRING_SCHEDULES_QK[0] ||
     event.type !== 'updated' ||

--- a/packages/core-mobile/app/new/features/recurringSwap/store/listeners.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/store/listeners.ts
@@ -2,11 +2,10 @@ import { queryClient } from 'contexts/ReactQueryProvider'
 import { showSnackbar } from 'common/utils/toast'
 import Logger from 'utils/Logger'
 import { TransferSignatureReason } from '@avalabs/fusion-sdk'
-import { isAnyOf } from '@reduxjs/toolkit'
 import type { QueryCacheNotifyEvent } from '@tanstack/react-query'
-import { onAppUnlocked, onLogOut } from 'store/app/slice'
-import { onFcmTokenChange } from 'store/notifications/slice'
+import { onAppUnlocked } from 'store/app/slice'
 import type { AppStartListening } from 'store/types'
+import { commonStorage, CommonStorageKeys } from 'utils/mmkv'
 import { registerAndGetDeviceArn } from 'services/notifications/registerDeviceToNotificationSender'
 import { RECURRING_SCHEDULES_QK } from '../hooks/useRecurringSchedules'
 import { RecurringOrderStatus } from '../types'
@@ -21,7 +20,7 @@ import {
   loadSubscribedOrders,
   saveSubscribedOrders
 } from '../utils/subscribedOrders'
-import { subscribeRecurringSwapNotifications } from '../services/recurringSwapNotifications'
+import { subscribeForRecurringSwap } from 'services/notifications/recurringSwap/subscribeForRecurringSwap'
 import {
   pendingActionStore,
   type PendingActionEntry
@@ -37,22 +36,6 @@ import {
 // so a duplicate that slips through is harmless — this set is purely a
 // network-traffic optimization.
 const subscribeInFlight = new Set<string>()
-
-// Session-scoped memo for the deviceArn used by the recurring-swap subscribe
-// flow. `ensureOrderSubscriptions` already resolves the ARN once per batch,
-// but every snapshot that surfaces a fresh subscribable order (new order
-// created, 30s poll, banner mount, unlock invalidate, focus) re-hits
-// `/v1/push/register` for a result we already received earlier in the
-// session — this cache collapses that across batches.
-//
-// Invalidated on:
-//   - subscribe failure inside the loop (ARN may have been retired backend-side;
-//     drop it so the next batch re-registers and the live ARN gets reused)
-//   - `onFcmTokenChange` (the SNS endpoint mapping is stale until /v1/push/register
-//     posts the new FCM token, so we MUST force a fresh register or push
-//     deliveries will dead-letter against the old token)
-//   - `onLogOut` (a fresh sign-in may use a different device identity)
-let cachedDeviceArn: string | null = null
 
 // The SDK now signs and broadcasts internally for fill /
 // cancel / pause / resume, so the old Redux listeners that watched for
@@ -191,17 +174,21 @@ async function ensureOrderSubscriptions(
   )
   if (pending.length === 0) return
 
-  // Resolve the deviceArn for this batch, reusing the session-cached value
-  // when present and falling back to /v1/push/register otherwise. Bail on
-  // failure rather than retrying register once per order; the next listOrders
-  // refetch retries the whole batch.
-  let deviceArn: string
-  if (cachedDeviceArn) {
-    deviceArn = cachedDeviceArn
-  } else {
+  // Resolve the deviceArn for this batch. `registerDeviceToNotificationSender`
+  // persists the ARN in commonStorage, and the global notification flow keeps
+  // that key fresh — re-registered on FCM token rotation (`onFcmTokenChange`
+  // drives the balance-change / news / price-alert subscribes), wiped by
+  // logout's `clearAll()`. So reading the persisted key gives the same
+  // freshness as a session-scoped memo with none of the invalidation
+  // machinery, and it survives cold start. Fall back to /v1/push/register only
+  // when the key is empty. Bail on failure rather than retrying register once
+  // per order; the next listOrders refetch retries the whole batch.
+  let deviceArn = commonStorage.getString(
+    CommonStorageKeys.NOTIFICATIONS_OPTIMIZATION
+  )
+  if (!deviceArn) {
     try {
       deviceArn = await registerAndGetDeviceArn()
-      cachedDeviceArn = deviceArn
     } catch (err) {
       Logger.error('[RecurringSwap] deviceArn registration failed', err)
       return
@@ -216,7 +203,7 @@ async function ensureOrderSubscriptions(
     if (subscribeInFlight.has(inFlightKey)) continue
     subscribeInFlight.add(inFlightKey)
     try {
-      await subscribeRecurringSwapNotifications({ orderId, deviceArn })
+      await subscribeForRecurringSwap({ orderId, deviceArn })
       subscribed.add(orderId)
       // Save after each success so a mid-batch interruption (app kill,
       // network drop on the next iteration) preserves the work done so far.
@@ -228,14 +215,24 @@ async function ensureOrderSubscriptions(
       ])
       saveSubscribedOrders(ownerAddress, chainId, merged)
     } catch (err) {
-      // The ARN may have been retired backend-side (e.g. dead-endpoint
-      // cleanup); drop the cached value so the next batch re-registers
-      // against a live ARN before reusing it across the rest of the loop.
-      cachedDeviceArn = null
       Logger.error('[RecurringSwap] order subscribe failed', {
         orderId,
         err
       })
+      // The ARN may have been retired backend-side (e.g. dead-endpoint
+      // cleanup). Re-reading the persisted key would just hand back the same
+      // dead ARN, so force a fresh /v1/push/register and reuse the live ARN
+      // for the remaining orders in this loop. Bail if the re-register itself
+      // fails — the next listOrders refetch retries the whole batch.
+      try {
+        deviceArn = await registerAndGetDeviceArn()
+      } catch (registerErr) {
+        Logger.error(
+          '[RecurringSwap] deviceArn re-registration failed',
+          registerErr
+        )
+        return
+      }
     } finally {
       subscribeInFlight.delete(inFlightKey)
     }
@@ -444,17 +441,6 @@ export function addRecurringSwapListeners(
     actionCreator: onAppUnlocked,
     effect: () => {
       queryClient.invalidateQueries({ queryKey: RECURRING_SCHEDULES_QK })
-    }
-  })
-
-  // Drop the session-cached deviceArn whenever the underlying device identity
-  // can shift out from under it — FCM token rotation invalidates the SNS
-  // endpoint mapping (must re-register to refresh server-side), and logout
-  // may swap to a different account on the next sign-in.
-  startListening({
-    matcher: isAnyOf(onFcmTokenChange, onLogOut),
-    effect: () => {
-      cachedDeviceArn = null
     }
   })
 

--- a/packages/core-mobile/app/new/features/recurringSwap/store/listeners.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/store/listeners.ts
@@ -15,9 +15,25 @@ import {
   makeFailureKey
 } from '../utils/seenFailures'
 import {
+  loadSubscribedOrders,
+  saveSubscribedOrders
+} from '../utils/subscribedOrders'
+import { subscribeRecurringSwapNotifications } from '../services/recurringSwapNotifications'
+import {
   pendingActionStore,
   type PendingActionEntry
 } from './pendingActionStore'
+
+// In-flight subscribe dedupe. Keyed by `${ownerLower}:${chainId}:${orderId}`
+// so concurrent refetches (banner + manage-screen mount + 30s poll + focus +
+// unlock invalidate) don't all fire the same subscribe call. Module-scoped
+// because the React Query cache subscriber is a singleton — multiple
+// concurrent firings of `handleQueryCacheEvent` share this set.
+//
+// The backend treats re-subscribes as idempotent reactivations (Sarp's PR #172),
+// so a duplicate that slips through is harmless — this set is purely a
+// network-traffic optimization.
+const subscribeInFlight = new Set<string>()
 
 // The SDK now signs and broadcasts internally for fill /
 // cancel / pause / resume, so the old Redux listeners that watched for
@@ -109,6 +125,65 @@ function processAllSchedules(
 
   if (failuresDirty) saveSeenFailures(ownerAddress, chainId, seenFailures)
   if (anyNewFailure) showSnackbar('Recurring swap execution failed')
+}
+
+// ─── Notification subscription ────────────────────────────────────────────────
+
+// Active and Paused are the only statuses that can fire future fills (Paused
+// can be resumed). Cancelled / Completed are terminal — the backend webhook
+// deactivates the subscription on those transitions anyway (per Sarp's PR
+// #172), so subscribing them client-side would be a wasted round-trip.
+function isSubscribableStatus(status: RecurringOrderStatus): boolean {
+  return (
+    status === RecurringOrderStatus.Active ||
+    status === RecurringOrderStatus.Paused
+  )
+}
+
+/**
+ * Subscribe this device to push notifications for any new orders that
+ * appeared in the latest listOrders snapshot and aren't already tracked
+ * locally. Fire-and-forget — sequential per-order with a per-success save
+ * so a mid-batch app kill leaves a coherent persisted set instead of
+ * orphaning the surviving subscriptions.
+ *
+ * Failure handling: log + skip. The next listOrders refetch (banner mount,
+ * 30s poll, unlock invalidate, etc.) retries any unsubscribed order — and
+ * the backend treats re-subscribes as idempotent reactivations, so the
+ * worst case is a one-refetch delay before push notifications start.
+ */
+async function ensureOrderSubscriptions(
+  ownerAddress: string,
+  chainId: number,
+  schedules: readonly RecurringOrder[]
+): Promise<void> {
+  const ownerLower = ownerAddress.toLowerCase()
+  const subscribed = loadSubscribedOrders(ownerAddress, chainId)
+  for (const schedule of schedules) {
+    if (!isSubscribableStatus(schedule.status)) continue
+    const orderId = schedule.orderId
+    if (subscribed.has(orderId)) continue
+    const inFlightKey = `${ownerLower}:${chainId}:${orderId}`
+    if (subscribeInFlight.has(inFlightKey)) continue
+    subscribeInFlight.add(inFlightKey)
+    try {
+      await subscribeRecurringSwapNotifications({ orderId })
+      subscribed.add(orderId)
+      // Save after each success so a mid-batch interruption (app kill,
+      // network drop on the next iteration) preserves the work done so far.
+      // `loadSubscribedOrders` re-reads from MMKV at the start of each
+      // refetch, so a sibling subscriber's writes (different chain, same
+      // session) don't get clobbered.
+      saveSubscribedOrders(ownerAddress, chainId, subscribed)
+    } catch (err) {
+      Logger.error('[RecurringSwap] order subscribe failed', {
+        orderId,
+        err
+      })
+    } finally {
+      subscribeInFlight.delete(inFlightKey)
+    }
+  }
 }
 
 /**
@@ -221,7 +296,7 @@ function reconcilePendingActions(
  * (see `useRecurringSchedules`). We pluck both out so the seen-failures
  * persistence can be scoped per (account, chain).
  */
-function handleQueryCacheEvent(event: QueryCacheNotifyEvent): void {
+async function handleQueryCacheEvent(event: QueryCacheNotifyEvent): Promise<void> {
   if (
     event.query.queryKey?.[0] !== RECURRING_SCHEDULES_QK[0] ||
     event.type !== 'updated' ||
@@ -258,6 +333,18 @@ function handleQueryCacheEvent(event: QueryCacheNotifyEvent): void {
     // is initialised once — subsequent refetches then hit the new-failure
     // path normally.
     processAllSchedules(ownerAddress, chainId, schedules ?? [])
+
+    // Fire-and-forget the per-order push subscription pass. Async to keep
+    // the cache subscriber callback non-blocking; failures inside the
+    // function are logged but never bubble up — the next refetch retries
+    // any order that didn't make it into the persisted subscribed-set.
+    await ensureOrderSubscriptions(
+      ownerAddress,
+      chainId,
+      schedules ?? []
+    ).catch(err => {
+      Logger.error('[RecurringSwap] ensureOrderSubscriptions threw', err)
+    })
   } catch (err) {
     Logger.error('[RecurringSwap] Failure watcher error', err)
   }

--- a/packages/core-mobile/app/new/features/recurringSwap/store/listeners.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/store/listeners.ts
@@ -339,17 +339,15 @@ async function handleQueryCacheEvent(
     // path normally.
     processAllSchedules(ownerAddress, chainId, schedules ?? [])
 
-    // Fire-and-forget the per-order push subscription pass. Async to keep
-    // the cache subscriber callback non-blocking; failures inside the
-    // function are logged but never bubble up — the next refetch retries
-    // any order that didn't make it into the persisted subscribed-set.
-    await ensureOrderSubscriptions(
-      ownerAddress,
-      chainId,
-      schedules ?? []
-    ).catch(err => {
-      Logger.error('[RecurringSwap] ensureOrderSubscriptions threw', err)
-    })
+    // Fire-and-forget the per-order push subscription pass. Kept out of the
+    // synchronous cache-subscriber call path; failures inside the function are
+    // logged but never bubble up — the next refetch retries any order that
+    // didn't make it into the persisted subscribed-set.
+    void ensureOrderSubscriptions(ownerAddress, chainId, schedules ?? []).catch(
+      err => {
+        Logger.error('[RecurringSwap] ensureOrderSubscriptions threw', err)
+      }
+    )
   } catch (err) {
     Logger.error('[RecurringSwap] Failure watcher error', err)
   }

--- a/packages/core-mobile/app/new/features/recurringSwap/store/listeners.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/store/listeners.ts
@@ -299,9 +299,7 @@ function reconcilePendingActions(
  * (see `useRecurringSchedules`). We pluck both out so the seen-failures
  * persistence can be scoped per (account, chain).
  */
-async function handleQueryCacheEvent(
-  event: QueryCacheNotifyEvent
-): Promise<void> {
+function handleQueryCacheEvent(event: QueryCacheNotifyEvent): void {
   if (
     event.query.queryKey?.[0] !== RECURRING_SCHEDULES_QK[0] ||
     event.type !== 'updated' ||

--- a/packages/core-mobile/app/new/features/recurringSwap/store/listeners.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/store/listeners.ts
@@ -7,6 +7,7 @@ import { onAppUnlocked } from 'store/app/slice'
 import type { AppStartListening } from 'store/types'
 import { commonStorage, CommonStorageKeys } from 'utils/mmkv'
 import { registerAndGetDeviceArn } from 'services/notifications/registerDeviceToNotificationSender'
+import { subscribeForRecurringSwap } from 'services/notifications/recurringSwap/subscribeForRecurringSwap'
 import { RECURRING_SCHEDULES_QK } from '../hooks/useRecurringSchedules'
 import { RecurringOrderStatus } from '../types'
 import type { RecurringOrder } from '../types'
@@ -20,7 +21,6 @@ import {
   loadSubscribedOrders,
   saveSubscribedOrders
 } from '../utils/subscribedOrders'
-import { subscribeForRecurringSwap } from 'services/notifications/recurringSwap/subscribeForRecurringSwap'
 import {
   pendingActionStore,
   type PendingActionEntry

--- a/packages/core-mobile/app/new/features/recurringSwap/utils/seenFailures.test.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/utils/seenFailures.test.ts
@@ -135,7 +135,6 @@ describe('seenFailures', () => {
   // letting it through would mean the next refetch re-enters the silent-
   // seed path and suppresses snackbars for genuinely new failures.
   it('swallows and logs an init-flag MMKV write failure (does not propagate)', () => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const Logger = require('utils/Logger').default as {
       error: jest.Mock
     }

--- a/packages/core-mobile/app/new/features/recurringSwap/utils/submitRecurringSwap.test.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/utils/submitRecurringSwap.test.ts
@@ -114,8 +114,16 @@ describe('submitRecurringSwap', () => {
       quote: QUOTE,
       fromAddress: FROM_ADDR,
       sourceChain: SOURCE_CHAIN,
-      // Match `transferAsset`'s graceful one-click → sequential fallback.
-      fallbackToDefaultOnBatchFailure: true,
+      // MUST be false for recurring. Mobile's `signBatch` is NOT atomic for
+      // recurring — `EvmSigner.signBatch` routes recurring straight to
+      // `signEachManually`, which signs and broadcasts wrap/approve/swap
+      // sequentially. The SDK attempts `signBatch` first (it's defined), and
+      // with `fallbackToDefaultOnBatchFailure: true` it silently re-runs the
+      // whole wrap→approve→swap sequence on ANY throw — but the intermediate
+      // txs were already broadcast, so the user gets a SECOND spend-limit
+      // approval and a spurious "User rejected the request." from a superseded
+      // sheet. `false` surfaces a real failure once, with no double-execution.
+      fallbackToDefaultOnBatchFailure: false,
       // The SDK forwards this verbatim onto `step.signerContext`, where
       // EvmSigner.signOne tags it with the action type derived from
       // `step.currentSignatureReason` (ScheduleRecurringSwap /

--- a/packages/core-mobile/app/new/features/recurringSwap/utils/submitRecurringSwap.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/utils/submitRecurringSwap.ts
@@ -191,15 +191,28 @@ export async function submitRecurringSwap(
 
   let result: { txHash: Hex }
   try {
-    // `fallbackToDefaultOnBatchFailure: true` matches `transferAsset`'s UX —
-    // try the one-click approve+swap batch first, and if the wallet rejects
-    // the batch (Ledger, certain WalletConnect peers), fall back to two
-    // sequential signatures rather than bubbling the batch error.
+    // `fallbackToDefaultOnBatchFailure` MUST be false for recurring.
+    //
+    // The SDK's `executeFirstFill` attempts `signBatch` first (it's defined on
+    // mobile's signer) and, when this flag is true, silently re-runs the whole
+    // wrap→approve→swap sequence on ANY throw from that attempt. That fallback
+    // is only safe when `signBatch` is atomic (a true `eth_sendTransactionBatch`
+    // where a throw means nothing was signed). Mobile's `signBatch` is NOT
+    // atomic for recurring: `EvmSigner.signBatch` routes recurring straight to
+    // `signEachManually`, which signs and BROADCASTS wrap + approve before the
+    // swap step. So a partway throw leaves those txs on-chain, and the SDK's
+    // re-run prompts a SECOND spend-limit approval and surfaces a spurious
+    // "User rejected the request." from a superseded approval sheet.
+    //
+    // With `false`, mobile's sequential `signBatch` is the single execution
+    // path; a real failure propagates once. Ledger/WC peers are unaffected —
+    // recurring never issues a true atomic batch, so there is no batch
+    // rejection for the SDK fallback to recover from.
     result = await markrRecurring.executeFirstFill({
       quote,
       fromAddress: fromAddress as `0x${string}`,
       sourceChain,
-      fallbackToDefaultOnBatchFailure: true,
+      fallbackToDefaultOnBatchFailure: false,
       signerContext
     })
   } catch (err) {

--- a/packages/core-mobile/app/new/features/recurringSwap/utils/subscribedOrders.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/utils/subscribedOrders.ts
@@ -1,0 +1,49 @@
+import { loadArrayFromStorage, saveArrayToStorage } from 'utils/mmkv/utils'
+import { commonStorage } from 'utils/mmkv/storages'
+
+// Persisted set of order IDs this device has already subscribed to for
+// push notifications, scoped per (ownerAddress, chainId). The auto-subscribe
+// listener (`recurringSwap/store/listeners.ts`) uses this to avoid re-issuing
+// `/v1/push/recurring-swaps/subscribe` on every listOrders refetch — Sarp's
+// backend treats re-subscribes as idempotent reactivations, but skipping
+// the redundant call is cheaper and clearer in network logs.
+//
+// Bound persisted size so the key cannot grow without limit for heavy users.
+// 2000 = ~30 years of daily orders, well past any realistic usage; entries
+// past the bound are dropped oldest-first so the most recent state is
+// preserved (the listener will re-subscribe any evicted order the next time
+// it appears in a listOrders response).
+const MAX_SUBSCRIBED_ORDERS = 2000
+
+const entriesKeyFor = (ownerAddress: string, chainId: number): string =>
+  `recurringSwap.subscribedOrders.${ownerAddress.toLowerCase()}.${chainId}`
+
+export function loadSubscribedOrders(
+  ownerAddress: string,
+  chainId: number
+): Set<string> {
+  const raw = loadArrayFromStorage<unknown>(
+    commonStorage,
+    entriesKeyFor(ownerAddress, chainId)
+  )
+  if (!Array.isArray(raw)) return new Set()
+  return new Set(raw.filter((v): v is string => typeof v === 'string'))
+}
+
+export function saveSubscribedOrders(
+  ownerAddress: string,
+  chainId: number,
+  keys: Set<string>
+): void {
+  const arr = Array.from(keys)
+  const trimmed =
+    arr.length > MAX_SUBSCRIBED_ORDERS
+      ? arr.slice(arr.length - MAX_SUBSCRIBED_ORDERS)
+      : arr
+
+  saveArrayToStorage(
+    commonStorage,
+    entriesKeyFor(ownerAddress, chainId),
+    trimmed
+  )
+}

--- a/packages/core-mobile/app/new/features/swap/hooks/useMinimumTransferAmount.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useMinimumTransferAmount.ts
@@ -1,5 +1,5 @@
 import { skipToken, useQuery } from '@tanstack/react-query'
-import type { Caip2ChainId } from '@avalabs/fusion-sdk'
+import type { Caip2ChainId, ServiceType } from '@avalabs/fusion-sdk'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import { LocalTokenWithBalance } from 'store/balance'
 import { getCaip2ChainId } from 'utils/caip2ChainIds'
@@ -11,7 +11,8 @@ import { useIsFusionServiceReady } from './useZustandStore'
 
 const fetchMinimumTransferAmount = async (
   fromToken: LocalTokenWithBalance,
-  toToken: LocalTokenWithBalance
+  toToken: LocalTokenWithBalance,
+  serviceType?: ServiceType
 ): Promise<bigint | null> => {
   try {
     const result = await FusionService.getMinimumTransferAmount({
@@ -22,6 +23,13 @@ const fetchMinimumTransferAmount = async (
     })
 
     if (!result) return null
+
+    // When a specific service is requested, pin its floor. Recurring swaps are
+    // Markr-only, so blending in a lower non-Markr floor (e.g. the gas-based
+    // avalanche-evm one) would under-floor the per-order amount and let a
+    // sub-fillable schedule through — the Markr fee/decimals floor is the
+    // relevant one. Returns null when that service doesn't support the route.
+    if (serviceType) return result[serviceType] ?? null
 
     const values = Object.values(result).filter(v => v !== undefined)
 
@@ -42,10 +50,14 @@ const fetchMinimumTransferAmount = async (
 
 export const useMinimumTransferAmount = ({
   fromToken,
-  toToken
+  toToken,
+  serviceType
 }: {
   fromToken: LocalTokenWithBalance | undefined
   toToken: LocalTokenWithBalance | undefined
+  // When set, return that service's minimum instead of the lowest across all
+  // services. Used by the recurring path to pin the Markr floor.
+  serviceType?: ServiceType
 }): bigint | null | undefined => {
   const [isFusionServiceReady] = useIsFusionServiceReady()
 
@@ -54,11 +66,12 @@ export const useMinimumTransferAmount = ({
     queryKey: [
       ReactQueryKeys.FUSION_MINIMUM_TRANSFER_AMOUNT,
       fromToken ? getTokenKey(fromToken) : undefined,
-      toToken ? getTokenKey(toToken) : undefined
+      toToken ? getTokenKey(toToken) : undefined,
+      serviceType
     ],
     queryFn:
       isFusionServiceReady && fromToken && toToken
-        ? () => fetchMinimumTransferAmount(fromToken, toToken)
+        ? () => fetchMinimumTransferAmount(fromToken, toToken, serviceType)
         : skipToken,
     staleTime: 30_000
   })

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -417,21 +417,12 @@ export const SwapScreen = (): JSX.Element => {
     isRecurringBlocked ? undefined : toToken,
     isRecurringBlocked ? undefined : evmAddress
   )
-  // Recurring per-token minimum sourced from `/info/chains` (via SDK eligibility
-  // check, which keys on the source token address). Available whenever the pair
-  // is supported, even before the user enters an amount.
-  const recurringMinimumTransferAmount = useMemo<bigint | null>(() => {
-    if (!eligibility.eligible) return null
-    try {
-      return BigInt(eligibility.minimumAmount)
-    } catch {
-      return null
-    }
-  }, [eligibility])
-  // Recurring on → validate against the supportedTokens minimum.
-  // Recurring off → validate against the active quote's one-shot minimum.
+  // Markr dropped the per-chain recurring supported-token list (and with it the
+  // per-order minimum), so recurring swaps no longer carry their own floor.
+  // Recurring on → no minimum check. Recurring off → validate against the
+  // active quote's one-shot minimum.
   const effectiveMinimumTransferAmount = recurring.isRecurring
-    ? recurringMinimumTransferAmount
+    ? null
     : minimumTransferAmount
   // Toggle stays hidden until the user enters a non-zero amount (matches Figma
   // "Recurring OFF" frame — the toggle row only appears beneath a populated
@@ -1218,16 +1209,12 @@ export const SwapScreen = (): JSX.Element => {
     quote: activeQuote
   })
 
-  // Submit-gate logic lives in `recurringSubmitGate` so the recurring
-  // below-minimum guard is unit testable without the whole screen. It mirrors
-  // the one-shot `canSwap` gate: a blocking (non-warning) validation error must
-  // disable Next. Most importantly this covers below-minimum, which
-  // `computeValidationError` evaluates against the recurring per-token minimum
-  // (`effectiveMinimumTransferAmount`). Without it the below-minimum error was
-  // displayed but never reached `canSubmit`, and because the recurring quote
-  // succeeds below the minimum (`useRecurringQuote` only gates on a non-zero
-  // amount, and `/recurring/quote` doesn't enforce the per-order minimum), a
-  // sub-minimum `amountPerOrder` could be submitted. Warnings (e.g.
+  // Submit-gate logic lives in `recurringSubmitGate` so it is unit testable
+  // without the whole screen. It mirrors the one-shot `canSwap` gate: a
+  // blocking (non-warning) validation error must disable Next. Recurring no
+  // longer carries a per-order minimum (Markr dropped the supported-token
+  // list), so `effectiveMinimumTransferAmount` is null when recurring is on and
+  // the below-minimum branch is inert for recurring. Warnings (e.g.
   // gas-estimation) are tolerated, matching `canSwap`'s `isWarning` allowance.
   const canSubmit = computeCanSubmit({
     isRecurring: recurring.isRecurring,

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -1290,6 +1290,11 @@ export const SwapScreen = (): JSX.Element => {
     hasRecurringQuote: !!recurringQuote.data,
     recurringSubmitting,
     validationError,
+    // `undefined` = the Markr per-order minimum query is still loading; gate
+    // Next until it settles (a value or null) so a sub-minimum per-order amount
+    // can't slip through the window where the recurring quote has resolved but
+    // the floor hasn't (the below-minimum check is skipped while it's unknown).
+    isRecurringMinimumReady: markrMinimumTransferAmount !== undefined,
     canSwap
   })
 

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -417,14 +417,6 @@ export const SwapScreen = (): JSX.Element => {
   const [validationError, setValidationError] =
     useState<FusionQuoteError | null>(null)
   const minimumTransferAmount = useMinimumTransferAmount({ fromToken, toToken })
-  // Recurring is Markr-only, so its per-order floor is Markr's minimum
-  // specifically — not the blended "lowest across services" value, which could
-  // pin a lower non-Markr floor and let a sub-fillable per-order amount through.
-  const markrMinimumTransferAmount = useMinimumTransferAmount({
-    fromToken,
-    toToken,
-    serviceType: ServiceType.MARKR
-  })
 
   const {
     debounced: debouncedFromTokenValue,
@@ -450,6 +442,22 @@ export const SwapScreen = (): JSX.Element => {
 
   const isRecurringBlocked = useSelector(selectIsRecurringSwapsBlocked)
   const recurring = useRecurringSwapContext()
+
+  // Recurring is Markr-only, so its per-order floor is Markr's minimum
+  // specifically — not the blended "lowest across services" value, which could
+  // pin a lower non-Markr floor and let a sub-fillable per-order amount through.
+  // Only pin the Markr floor when recurring is on. When it's off, leave
+  // serviceType undefined so this collapses onto the blended query key
+  // (`minimumTransferAmount`) and React Query dedupes them, instead of firing a
+  // second, unread getMinimumTransferAmount round trip on every one-shot swap.
+  // The recurring minimum-ready gate tolerates the brief loading window on
+  // toggle-on (Next stays disabled until this settles).
+  const markrMinimumTransferAmount = useMinimumTransferAmount({
+    fromToken,
+    toToken,
+    serviceType: recurring.isRecurring ? ServiceType.MARKR : undefined
+  })
+
   const evmAddress = activeAccount?.addressC
   const eligibility = useRecurringEligibility(
     isRecurringBlocked ? undefined : fromToken,

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -386,6 +386,14 @@ export const SwapScreen = (): JSX.Element => {
   const [validationError, setValidationError] =
     useState<FusionQuoteError | null>(null)
   const minimumTransferAmount = useMinimumTransferAmount({ fromToken, toToken })
+  // Recurring is Markr-only, so its per-order floor is Markr's minimum
+  // specifically — not the blended "lowest across services" value, which could
+  // pin a lower non-Markr floor and let a sub-fillable per-order amount through.
+  const markrMinimumTransferAmount = useMinimumTransferAmount({
+    fromToken,
+    toToken,
+    serviceType: ServiceType.MARKR
+  })
 
   const {
     debounced: debouncedFromTokenValue,
@@ -417,13 +425,13 @@ export const SwapScreen = (): JSX.Element => {
     isRecurringBlocked ? undefined : toToken,
     isRecurringBlocked ? undefined : evmAddress
   )
-  // Markr dropped the per-chain recurring supported-token list (and with it the
-  // per-order minimum), so recurring swaps no longer carry their own floor.
-  // Recurring on → no minimum check. Recurring off → validate against the
-  // active quote's one-shot minimum.
+
+  // Recurring on → validate the per-order amount against Markr's floor.
+  // Recurring off → validate against the blended one-shot minimum.
   const effectiveMinimumTransferAmount = recurring.isRecurring
-    ? null
+    ? markrMinimumTransferAmount
     : minimumTransferAmount
+
   // Toggle stays hidden until the user enters a non-zero amount (matches Figma
   // "Recurring OFF" frame — the toggle row only appears beneath a populated
   // swap card). The recurring flag itself is preserved when the amount is
@@ -1211,10 +1219,10 @@ export const SwapScreen = (): JSX.Element => {
 
   // Submit-gate logic lives in `recurringSubmitGate` so it is unit testable
   // without the whole screen. It mirrors the one-shot `canSwap` gate: a
-  // blocking (non-warning) validation error must disable Next. Recurring no
-  // longer carries a per-order minimum (Markr dropped the supported-token
-  // list), so `effectiveMinimumTransferAmount` is null when recurring is on and
-  // the below-minimum branch is inert for recurring. Warnings (e.g.
+  // blocking (non-warning) validation error must disable Next. Recurring
+  // validates the per-order amount against Markr's floor
+  // (`effectiveMinimumTransferAmount`), so a per-order amount below that floor
+  // surfaces a blocking validation error here and disables Next. Warnings (e.g.
   // gas-estimation) are tolerated, matching `canSwap`'s `isWarning` allowance.
   const canSubmit = computeCanSubmit({
     isRecurring: recurring.isRecurring,

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -70,6 +70,7 @@ import { useRecurringQuote } from 'features/recurringSwap/hooks/useRecurringQuot
 import { RecurringDetailsRows } from 'features/recurringSwap/components/RecurringDetailsRows'
 import { RecurringSchedulesBanner } from 'features/recurringSwap/components/RecurringSchedulesBanner'
 import { submitRecurringSwap } from 'features/recurringSwap/utils/submitRecurringSwap'
+import type { NumberOfOrders } from 'features/recurringSwap/types'
 import { AdditiveFeesNotice } from '../components/AdditiveFeesNotice'
 import { FeeDebugTable } from '../components/FeeDebugTable'
 import { useFusionTokenLookup } from '../hooks/useFusionTokenLookup'
@@ -93,6 +94,7 @@ import { useSwapRate } from '../hooks/useSwapRate'
 import { useSupportedChains } from '../hooks/useSupportedChains'
 import { getDisplaySlippageValue } from '../utils/getDisplaySlippageValue'
 import { computeCanSubmit } from '../utils/recurringSubmitGate'
+import { computeRecurringBalanceError } from '../utils/recurringBalanceGate'
 import { ServiceType } from '../types'
 import { usePriceImpact } from '../hooks/usePriceImpact'
 import {
@@ -191,17 +193,42 @@ function computeValidationError({
   debouncedFromTokenValue,
   minimumTransferAmount,
   fromToken,
-  feeValidationError
+  feeValidationError,
+  isRecurring,
+  numberOfOrders,
+  recurringTotalAmountIn,
+  recurringAdditiveNativeFee,
+  nativeFromToken
 }: {
   fromTokenValue: bigint | undefined
   debouncedFromTokenValue: bigint | undefined
   minimumTransferAmount: bigint | null | undefined
   fromToken: LocalTokenWithBalance | undefined
   feeValidationError: FusionQuoteError | null | undefined
+  isRecurring: boolean
+  numberOfOrders: NumberOfOrders | undefined
+  recurringTotalAmountIn: bigint | undefined
+  recurringAdditiveNativeFee: bigint
+  nativeFromToken: LocalTokenWithBalance | undefined
 }): FusionQuoteError | null {
   if (fromTokenValue === undefined) return null
   if (debouncedFromTokenValue !== undefined && debouncedFromTokenValue === 0n) {
     return fusionErrors.enterAmount()
+  }
+  // Recurring: validate the full schedule commitment (principal + additive
+  // native fees) up front so an under-funded schedule is caught here with a
+  // clear message instead of reverting on-chain at estimateGas (which surfaces
+  // as a generic "Recurring swap failed" toast). Stricter than the per-order
+  // balance guard below, so it runs first.
+  if (isRecurring && fromToken !== undefined) {
+    const recurringError = computeRecurringBalanceError({
+      numberOfOrders,
+      totalAmountIn: recurringTotalAmountIn,
+      additiveNativeFee: recurringAdditiveNativeFee,
+      fromToken,
+      nativeFromToken
+    })
+    if (recurringError) return recurringError
   }
   if (
     minimumTransferAmount != null &&
@@ -601,6 +628,21 @@ export const SwapScreen = (): JSX.Element => {
     updateMissingTokenPrice(toToken)
   }, [toToken, updateMissingTokenPrice])
 
+  // Sum the recurring quote's *additive* fees (SDK marks the one-time native
+  // schedule fee with `fee.extra` truthy and documents it as
+  // "balance-check separately"). These are native-denominated and must be
+  // reserved on top of the principal. Estimated gas (type 'gas', not `extra`)
+  // is intentionally excluded — the quote reports it in gas units, not a wei
+  // cost — and is left to the SDK's own estimateGas guard.
+  const recurringAdditiveNativeFee = useMemo(
+    () =>
+      (recurringQuote.data?.fees ?? []).reduce<bigint>(
+        (sum, fee) => (fee.extra ? sum + fee.amount : sum),
+        0n
+      ),
+    [recurringQuote.data?.fees]
+  )
+
   const validateInputs = useCallback(() => {
     // fromTokenValue drives the reset — if it's undefined (token just changed),
     // clear any error immediately without waiting for the debounce to settle.
@@ -610,7 +652,12 @@ export const SwapScreen = (): JSX.Element => {
         debouncedFromTokenValue,
         minimumTransferAmount: effectiveMinimumTransferAmount,
         fromToken,
-        feeValidationError
+        feeValidationError,
+        isRecurring: recurring.isRecurring,
+        numberOfOrders: recurring.numberOfOrders,
+        recurringTotalAmountIn: recurringQuote.data?.totalAmountIn,
+        recurringAdditiveNativeFee,
+        nativeFromToken
       })
     )
   }, [
@@ -618,7 +665,12 @@ export const SwapScreen = (): JSX.Element => {
     debouncedFromTokenValue,
     effectiveMinimumTransferAmount,
     fromToken,
-    feeValidationError
+    feeValidationError,
+    recurring.isRecurring,
+    recurring.numberOfOrders,
+    recurringQuote.data?.totalAmountIn,
+    recurringAdditiveNativeFee,
+    nativeFromToken
   ])
 
   const applyQuote = useCallback(() => {

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -78,7 +78,11 @@ import {
   fusionTransfersStore,
   useFusionServiceInitError
 } from '../hooks/useZustandStore'
-import { FusionQuoteError, fusionErrors } from '../utils/fusionErrors'
+import {
+  FusionQuoteError,
+  fusionErrors,
+  isUserRejectionError
+} from '../utils/fusionErrors'
 import { clampToNAvax } from '../utils/clampToNAvax'
 import {
   isAvalancheCctRoute,
@@ -1289,12 +1293,18 @@ export const SwapScreen = (): JSX.Element => {
       dismissAll()
       return true
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
       // User-rejection errors from the signer bubble up untouched. They're
       // not a bug — they're the user explicitly tapping Reject. Suppress
       // both the failure toast AND the Logger.error (which pipes to
       // Sentry) so rejections don't pollute the error telemetry.
-      if (/User (rejected|cancel(l|led))/i.test(message)) {
+      //
+      // Detect via `isUserRejectionError`, which checks the EIP-1193 code
+      // (4001) and the message across Error instances AND plain JSON-RPC
+      // error objects. The signer rejection crosses the VM-module boundary as
+      // a serialized `{ code, message }` object — not an `Error` — so the old
+      // inline `err.message` regex missed it and showed the generic "failed"
+      // toast on a deliberate reject.
+      if (isUserRejectionError(err)) {
         Logger.info('[RecurringSwap] submitRecurringSwap user-rejected')
       } else if (isInvalidParamsError(err)) {
         // Quote expired / sourceChain mismatch — surface a recoverable

--- a/packages/core-mobile/app/new/features/swap/services/signers/EvmSigner.ts
+++ b/packages/core-mobile/app/new/features/swap/services/signers/EvmSigner.ts
@@ -15,6 +15,7 @@ import Logger from 'utils/Logger'
 import { RequestContext, type SwapAutoApproveContext } from 'store/rpc/types'
 import type { QuickSwapMaxBuy } from 'store/settings/advanced/types'
 import {
+  isRecurringOrderActionSignatureReason,
   isRecurringTransferSignatureReason,
   readRecurringSignerContext
 } from 'features/recurringSwap/services/recurringSignerContext'
@@ -293,10 +294,19 @@ export function createEvmSigner(
     const recurringActive = isRecurring
       ? readRecurringSignerContext(stepDetails)
       : undefined
+    // Cancel / pause / resume are schedule-management actions, not a
+    // completed swap — suppress the success confetti (schedule creation and
+    // recurring fills keep their normal feedback).
+    const isRecurringOrderAction = isRecurringOrderActionSignatureReason(
+      stepDetails.currentSignatureReason
+    )
     const requestContext = recurringActive
       ? {
           ...contextWithManualReview,
-          [RequestContext.RECURRING_SWAP]: recurringActive
+          [RequestContext.RECURRING_SWAP]: recurringActive,
+          ...(isRecurringOrderAction
+            ? { [RequestContext.CONFETTI_DISABLED]: true }
+            : {})
         }
       : contextWithManualReview
 

--- a/packages/core-mobile/app/new/features/swap/utils/fusionErrors.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/fusionErrors.test.ts
@@ -144,9 +144,29 @@ describe('isUserRejectionError', () => {
     expect(isUserRejectionError(new Error(''))).toBe(false)
   })
 
-  it('should return false for non-Error values', () => {
-    expect(isUserRejectionError('user rejected')).toBe(false)
-    expect(isUserRejectionError({ message: 'user rejected' })).toBe(false)
+  it('should return true for the EIP-1193 user-rejected code (4001), regardless of message', () => {
+    // The rejection can reach us as a plain JSON-RPC error object (not an
+    // Error instance) after crossing the VM-module boundary — e.g.
+    // `providerErrors.userRejectedRequest()` serialized to `{ code, message }`.
+    // The standard 4001 code is the reliable signal; the message may be
+    // absent, wrapped, or "[object Object]"-ified by callers.
+    expect(isUserRejectionError({ code: 4001 })).toBe(true)
+    expect(
+      isUserRejectionError({ code: 4001, message: 'Internal JSON-RPC error.' })
+    ).toBe(true)
+  })
+
+  it('should match the rejection message on plain objects and strings too', () => {
+    expect(isUserRejectionError({ message: 'User rejected the request.' })).toBe(
+      true
+    )
+    expect(isUserRejectionError('User cancelled')).toBe(true)
+  })
+
+  it('should return false for unrelated non-Error values', () => {
+    expect(isUserRejectionError({ code: -32603 })).toBe(false)
+    expect(isUserRejectionError({ message: 'insufficient funds' })).toBe(false)
+    expect(isUserRejectionError('boom')).toBe(false)
     expect(isUserRejectionError(null)).toBe(false)
     expect(isUserRejectionError(undefined)).toBe(false)
     expect(isUserRejectionError(42)).toBe(false)

--- a/packages/core-mobile/app/new/features/swap/utils/fusionErrors.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/fusionErrors.test.ts
@@ -157,9 +157,9 @@ describe('isUserRejectionError', () => {
   })
 
   it('should match the rejection message on plain objects and strings too', () => {
-    expect(isUserRejectionError({ message: 'User rejected the request.' })).toBe(
-      true
-    )
+    expect(
+      isUserRejectionError({ message: 'User rejected the request.' })
+    ).toBe(true)
     expect(isUserRejectionError('User cancelled')).toBe(true)
   })
 

--- a/packages/core-mobile/app/new/features/swap/utils/fusionErrors.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/fusionErrors.ts
@@ -94,6 +94,40 @@ export const fusionErrors = {
   belowMinimumAmount(formattedMin: string): FusionQuoteError {
     return new FusionQuoteError(`Minimum amount is ${formattedMin}.`)
   },
+  // Recurring: the full schedule total (amountPerOrder × numberOfOrders) must be
+  // funded up front. For native source tokens the first fill pre-wraps the whole
+  // total to WAVAX in one tx (the schedule can't pull native per order), so a
+  // total above balance reverts on-chain at estimateGas with INSUFFICIENT_FUNDS
+  // and surfaces as a generic "Recurring swap failed" toast. Block at input time
+  // instead. ERC-20 schedules also need the total to satisfy every future fill,
+  // so the same guard applies. Skipped for Unlimited (no finite total).
+  recurringTotalExceedsBalance(
+    numberOfOrders: number,
+    formattedTotal: string
+  ): FusionQuoteError {
+    return new FusionQuoteError(
+      `Insufficient balance — ${numberOfOrders} orders require ${formattedTotal}.`
+    )
+  },
+  // ERC-20 source: token balance covers the principal but the native balance
+  // can't cover the one-time recurring schedule fee (charged in the gas token).
+  recurringScheduleFeeExceedsNativeBalance(
+    formattedFee: string
+  ): FusionQuoteError {
+    return new FusionQuoteError(
+      `Insufficient balance — needs ${formattedFee} for the schedule fee.`
+    )
+  },
+  // ERC-20 source: neither the token balance (principal) nor the native balance
+  // (schedule fee) is sufficient — surface both shortfalls in one message.
+  recurringInsufficientForTotalAndFee(
+    formattedTotal: string,
+    formattedFee: string
+  ): FusionQuoteError {
+    return new FusionQuoteError(
+      `Insufficient balance — needs ${formattedTotal} and ${formattedFee} for the schedule fee.`
+    )
+  },
   // Native token: gas alone exceeds balance (no bridge fee)
   networkFeeExceedsBalance(formattedFee: string): FusionQuoteError {
     return new FusionQuoteError(

--- a/packages/core-mobile/app/new/features/swap/utils/fusionErrors.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/fusionErrors.ts
@@ -194,14 +194,33 @@ export function isGasOnlyNetworkFeeError(error: FusionQuoteError): boolean {
   return error.kind === 'network-fee-only'
 }
 
+// EIP-1193 standard code for a user-rejected request. The rejection can reach
+// us either as an Error instance OR as a plain JSON-RPC error object — e.g.
+// `providerErrors.userRejectedRequest()` serialized to `{ code, message }`
+// after crossing the VM-module boundary. A plain object is NOT `instanceof
+// Error`, so a message-only check on `Error` lets it through to the generic
+// "failed" path. The 4001 code survives serialization on both shapes and is
+// the reliable signal; we keep the message check as a fallback.
+const USER_REJECTED_REQUEST_CODE = 4001
+const USER_REJECTION_MESSAGE_PATTERN = /user (rejected|cancel(l|led))/i
+
 /**
- * Check if error is user rejection (user cancelled transaction)
- * Don't show error toast for these - user intentionally cancelled
+ * Check if error is a user rejection (user cancelled the transaction).
+ * Don't show an error toast for these — the user intentionally cancelled.
+ *
+ * Robust to the three shapes a rejection arrives in: an `Error` instance, a
+ * plain JSON-RPC error object (`{ code, message }`), and a bare string.
  */
 export function isUserRejectionError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false
-
-  return error.message.toLowerCase().includes('user rejected')
+  if (typeof error === 'string') {
+    return USER_REJECTION_MESSAGE_PATTERN.test(error)
+  }
+  if (!error || typeof error !== 'object') return false
+  const { code, message } = error as { code?: unknown; message?: unknown }
+  if (code === USER_REJECTED_REQUEST_CODE) return true
+  return (
+    typeof message === 'string' && USER_REJECTION_MESSAGE_PATTERN.test(message)
+  )
 }
 
 // The SDK has updated its error phrasing across versions, so the checkers

--- a/packages/core-mobile/app/new/features/swap/utils/recurringBalanceGate.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/recurringBalanceGate.test.ts
@@ -1,0 +1,224 @@
+import { formatTokenAmount } from 'utils/Utils'
+import { bigintToBig } from '@avalabs/core-utils-sdk'
+import { TokenType } from '@avalabs/vm-module-types'
+import type { LocalTokenWithBalance } from 'store/balance'
+import { UNLIMITED_ORDERS } from 'features/recurringSwap/types'
+import {
+  computeRecurringBalanceError,
+  type RecurringBalanceGateParams
+} from './recurringBalanceGate'
+
+const AVAX_DECIMALS = 18
+const USDC_DECIMALS = 6
+
+// Round, human-readable amounts so the assertions read clearly.
+const AVAX = (whole: number, fraction = 0n): bigint =>
+  BigInt(whole) * 10n ** 18n + fraction
+const USDC = (whole: number): bigint => BigInt(whole) * 10n ** 6n
+
+const SCHEDULE_FEE = 50_000_000_000_000_000n // 0.05 AVAX
+const FIVE_AVAX = AVAX(5)
+const FIVE_AVAX_PLUS_FEE = FIVE_AVAX + SCHEDULE_FEE // 5.05 AVAX
+const FIVE_USDC = USDC(5)
+
+const makeToken = (cfg: {
+  type: TokenType
+  balance: bigint
+  decimals: number
+  symbol: string
+}): LocalTokenWithBalance =>
+  ({
+    ...cfg,
+    address: cfg.type === TokenType.NATIVE ? '' : '0xtoken'
+  } as unknown as LocalTokenWithBalance)
+
+const nativeToken = (balance: bigint): LocalTokenWithBalance =>
+  makeToken({
+    type: TokenType.NATIVE,
+    balance,
+    decimals: AVAX_DECIMALS,
+    symbol: 'AVAX'
+  })
+const erc20Token = (balance: bigint): LocalTokenWithBalance =>
+  makeToken({
+    type: TokenType.ERC20,
+    balance,
+    decimals: USDC_DECIMALS,
+    symbol: 'USDC'
+  })
+
+// Mirror the gate's own formatting so assertions verify the *amount* passed
+// (principal vs principal+fee) without hard-coding formatTokenAmount's output.
+const fmt = (amount: bigint, decimals: number, symbol: string): string =>
+  `${formatTokenAmount(bigintToBig(amount, decimals), decimals)} ${symbol}`
+
+const params = (
+  overrides: Partial<RecurringBalanceGateParams>
+): RecurringBalanceGateParams => ({
+  numberOfOrders: 5,
+  totalAmountIn: FIVE_AVAX,
+  additiveNativeFee: SCHEDULE_FEE,
+  fromToken: nativeToken(AVAX(10)),
+  nativeFromToken: nativeToken(AVAX(10)),
+  ...overrides
+})
+
+describe('computeRecurringBalanceError — guards', () => {
+  it('returns null until the quote total is known', () => {
+    expect(
+      computeRecurringBalanceError(params({ totalAmountIn: undefined }))
+    ).toBeNull()
+  })
+
+  it('returns null when the order count is undefined', () => {
+    expect(
+      computeRecurringBalanceError(params({ numberOfOrders: undefined }))
+    ).toBeNull()
+  })
+
+  it('returns null for Unlimited orders (no finite total to check)', () => {
+    // Even with a balance far below the total, Unlimited can't be range-checked.
+    expect(
+      computeRecurringBalanceError(
+        params({
+          numberOfOrders: UNLIMITED_ORDERS,
+          fromToken: nativeToken(AVAX(0))
+        })
+      )
+    ).toBeNull()
+  })
+})
+
+describe('computeRecurringBalanceError — native source', () => {
+  it('is null when the native balance covers principal + schedule fee', () => {
+    expect(
+      computeRecurringBalanceError(
+        params({ fromToken: nativeToken(FIVE_AVAX_PLUS_FEE) })
+      )
+    ).toBeNull()
+  })
+
+  it('errors when balance covers the principal but not principal + fee', () => {
+    const err = computeRecurringBalanceError(
+      params({ fromToken: nativeToken(FIVE_AVAX) }) // exactly 5 AVAX, need 5.05
+    )
+    // Quotes the FULL requirement (principal + fee), not just the principal.
+    expect(err?.message).toBe(
+      `Insufficient balance — 5 orders require ${fmt(
+        FIVE_AVAX_PLUS_FEE,
+        AVAX_DECIMALS,
+        'AVAX'
+      )}.`
+    )
+  })
+
+  it('errors when the native balance is below the principal', () => {
+    const err = computeRecurringBalanceError(
+      params({ fromToken: nativeToken(AVAX(1, 830_000_000_000_000_000n)) }) // 1.83
+    )
+    expect(err?.message).toBe(
+      `Insufficient balance — 5 orders require ${fmt(
+        FIVE_AVAX_PLUS_FEE,
+        AVAX_DECIMALS,
+        'AVAX'
+      )}.`
+    )
+  })
+
+  it('does not block on a warning (the error is a blocking FusionQuoteError)', () => {
+    const err = computeRecurringBalanceError(
+      params({ fromToken: nativeToken(AVAX(0)) })
+    )
+    expect(err?.isWarning).toBeUndefined()
+  })
+})
+
+describe('computeRecurringBalanceError — ERC-20 source', () => {
+  const erc20Params = (
+    overrides: Partial<RecurringBalanceGateParams>
+  ): RecurringBalanceGateParams =>
+    params({
+      totalAmountIn: FIVE_USDC,
+      fromToken: erc20Token(USDC(10)),
+      nativeFromToken: nativeToken(AVAX(10)),
+      ...overrides
+    })
+
+  it('is null when both balances are sufficient', () => {
+    expect(computeRecurringBalanceError(erc20Params({}))).toBeNull()
+  })
+
+  it('token short, native enough → principal-only message', () => {
+    const err = computeRecurringBalanceError(
+      erc20Params({ fromToken: erc20Token(USDC(1)) })
+    )
+    expect(err?.message).toBe(
+      `Insufficient balance — 5 orders require ${fmt(
+        FIVE_USDC,
+        USDC_DECIMALS,
+        'USDC'
+      )}.`
+    )
+  })
+
+  it('token enough, native short → schedule-fee message', () => {
+    const err = computeRecurringBalanceError(
+      erc20Params({ nativeFromToken: nativeToken(AVAX(0)) })
+    )
+    expect(err?.message).toBe(
+      `Insufficient balance — needs ${fmt(
+        SCHEDULE_FEE,
+        AVAX_DECIMALS,
+        'AVAX'
+      )} for the schedule fee.`
+    )
+  })
+
+  it('both short → combined message', () => {
+    const err = computeRecurringBalanceError(
+      erc20Params({
+        fromToken: erc20Token(USDC(1)),
+        nativeFromToken: nativeToken(AVAX(0))
+      })
+    )
+    expect(err?.message).toBe(
+      `Insufficient balance — needs ${fmt(
+        FIVE_USDC,
+        USDC_DECIMALS,
+        'USDC'
+      )} and ${fmt(SCHEDULE_FEE, AVAX_DECIMALS, 'AVAX')} for the schedule fee.`
+    )
+  })
+
+  it('no schedule fee (additiveNativeFee = 0) → fee branch is skipped', () => {
+    expect(
+      computeRecurringBalanceError(
+        erc20Params({
+          additiveNativeFee: 0n,
+          nativeFromToken: nativeToken(AVAX(0))
+        })
+      )
+    ).toBeNull()
+  })
+
+  it('native token unresolved → fee can not be checked, principal still can', () => {
+    // nativeFromToken undefined: skip the fee check entirely.
+    expect(
+      computeRecurringBalanceError(erc20Params({ nativeFromToken: undefined }))
+    ).toBeNull()
+    // ...but a principal shortfall still surfaces (not the combined message).
+    const err = computeRecurringBalanceError(
+      erc20Params({
+        fromToken: erc20Token(USDC(1)),
+        nativeFromToken: undefined
+      })
+    )
+    expect(err?.message).toBe(
+      `Insufficient balance — 5 orders require ${fmt(
+        FIVE_USDC,
+        USDC_DECIMALS,
+        'USDC'
+      )}.`
+    )
+  })
+})

--- a/packages/core-mobile/app/new/features/swap/utils/recurringBalanceGate.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/recurringBalanceGate.ts
@@ -1,0 +1,108 @@
+// Pure balance-gate logic for the recurring-swap "Next" button, extracted from
+// SwapScreen so the native / ERC-20 / combined shortfall branches are unit
+// testable without standing up the whole screen. Returns a `FusionQuoteError`
+// (or null) that the screen feeds into `validationError`, which both renders
+// inline and disables submission via `isRecurringReady`.
+
+import { formatTokenAmount } from 'utils/Utils'
+import { bigintToBig } from '@avalabs/core-utils-sdk'
+import { TokenType } from '@avalabs/vm-module-types'
+import type { LocalTokenWithBalance } from 'store/balance'
+import type { NumberOfOrders } from 'features/recurringSwap/types'
+import { fusionErrors, type FusionQuoteError } from './fusionErrors'
+
+const formatTokenWithSymbol = (
+  amount: bigint,
+  token: LocalTokenWithBalance
+): string =>
+  'decimals' in token
+    ? `${formatTokenAmount(
+        bigintToBig(amount, token.decimals),
+        token.decimals
+      )} ${token.symbol}`
+    : `${amount}`
+
+export type RecurringBalanceGateParams = {
+  numberOfOrders: NumberOfOrders | undefined
+  /** Authoritative principal from the recurring quote (`amount × orders`). */
+  totalAmountIn: bigint | undefined
+  /**
+   * Sum of the quote's *additive* fees (`fee.extra` truthy) — the one-time
+   * native schedule fee the SDK documents as "balance-check separately".
+   * Native-denominated; estimated gas is excluded (left to the SDK).
+   */
+  additiveNativeFee: bigint
+  /** Selected source token (drives native vs ERC-20 branch). */
+  fromToken: LocalTokenWithBalance
+  /** Native gas token for `fromToken`'s chain — funds the schedule fee when
+   *  the source is an ERC-20. Undefined when it can't be resolved. */
+  nativeFromToken: LocalTokenWithBalance | undefined
+}
+
+/**
+ * Recurring schedules must fund the WHOLE commitment up front, not just one
+ * order. The first fill for a NATIVE source wraps the entire `totalAmountIn`
+ * (per-order × order count) to WAVAX in a single tx, and the SDK flags the
+ * one-time schedule fee (`fee.extra` truthy, native-denominated) as
+ * "balance-check separately" — so the real native requirement is
+ * `totalAmountIn + additive native fees`. For an ERC-20 source the principal is
+ * drawn from the token balance while the native schedule fee is drawn from the
+ * native balance, so the two are checked independently (and surfaced together
+ * when both fail). Estimated *gas* is left to the SDK's own estimateGas — the
+ * quote reports it in gas units, not a wei cost we can safely reserve here.
+ * Returns null for Unlimited (no finite total) and until the quote's
+ * `totalAmountIn` is known (the submit gate already blocks on a missing quote).
+ */
+export function computeRecurringBalanceError({
+  numberOfOrders,
+  totalAmountIn,
+  additiveNativeFee,
+  fromToken,
+  nativeFromToken
+}: RecurringBalanceGateParams): FusionQuoteError | null {
+  if (totalAmountIn === undefined) return null
+  if (numberOfOrders === undefined || !Number.isFinite(numberOfOrders)) {
+    return null
+  }
+
+  if (fromToken.type === TokenType.NATIVE) {
+    // Principal + native schedule fee both come out of the native balance.
+    const required = totalAmountIn + additiveNativeFee
+    if (required > fromToken.balance) {
+      return fusionErrors.recurringTotalExceedsBalance(
+        numberOfOrders,
+        formatTokenWithSymbol(required, fromToken)
+      )
+    }
+    return null
+  }
+
+  // ERC-20 source: principal is drawn from the token balance, the native
+  // schedule fee from the native balance — independent shortfalls. Surface both
+  // in one message when both fail so the user isn't asked to fix one, then
+  // discover the other.
+  const principalShort = totalAmountIn > fromToken.balance
+  const feeShort =
+    additiveNativeFee > 0n &&
+    nativeFromToken !== undefined &&
+    additiveNativeFee > nativeFromToken.balance
+
+  if (principalShort && feeShort && nativeFromToken !== undefined) {
+    return fusionErrors.recurringInsufficientForTotalAndFee(
+      formatTokenWithSymbol(totalAmountIn, fromToken),
+      formatTokenWithSymbol(additiveNativeFee, nativeFromToken)
+    )
+  }
+  if (principalShort) {
+    return fusionErrors.recurringTotalExceedsBalance(
+      numberOfOrders,
+      formatTokenWithSymbol(totalAmountIn, fromToken)
+    )
+  }
+  if (feeShort && nativeFromToken !== undefined) {
+    return fusionErrors.recurringScheduleFeeExceedsNativeBalance(
+      formatTokenWithSymbol(additiveNativeFee, nativeFromToken)
+    )
+  }
+  return null
+}

--- a/packages/core-mobile/app/new/features/swap/utils/recurringBalanceGate.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/recurringBalanceGate.ts
@@ -14,13 +14,24 @@ import { fusionErrors, type FusionQuoteError } from './fusionErrors'
 const formatTokenWithSymbol = (
   amount: bigint,
   token: LocalTokenWithBalance
-): string =>
-  'decimals' in token
-    ? `${formatTokenAmount(
-        bigintToBig(amount, token.decimals),
-        token.decimals
-      )} ${token.symbol}`
-    : `${amount}`
+): string => {
+  // `LocalTokenWithBalance` is a union whose NFT member omits `decimals`, so the
+  // guard is real at the type level — but the gate only ever receives a swap
+  // source or its native gas token, never an NFT, so `decimals` is always here.
+  // Assert that invariant rather than fall back to a bare wei value: a wei
+  // amount with no symbol would land verbatim in a user-facing "Insufficient
+  // balance" string, and a silent fallback invites the next reader to trust it.
+  if (!('decimals' in token)) {
+    throw new Error(
+      `formatTokenWithSymbol: token "${token.symbol}" has no decimals — ` +
+        'a non-fungible token reached the recurring balance gate'
+    )
+  }
+  return `${formatTokenAmount(
+    bigintToBig(amount, token.decimals),
+    token.decimals
+  )} ${token.symbol}`
+}
 
 export type RecurringBalanceGateParams = {
   numberOfOrders: NumberOfOrders | undefined

--- a/packages/core-mobile/app/new/features/swap/utils/recurringSubmitGate.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/recurringSubmitGate.test.ts
@@ -17,7 +17,8 @@ const READY: RecurringSubmitGateParams = {
   hasFromTokenValue: true,
   hasRecurringQuote: true,
   recurringSubmitting: false,
-  validationError: null
+  validationError: null,
+  isRecurringMinimumReady: true
 }
 
 describe('hasBlockingValidationError', () => {
@@ -74,6 +75,24 @@ describe('isRecurringReady', () => {
   it('is false while a submit is already in flight', () => {
     expect(isRecurringReady({ ...READY, recurringSubmitting: true })).toBe(
       false
+    )
+  })
+
+  // Race guard: the recurring quote can resolve before the Markr per-order
+  // minimum query settles. While the minimum is unknown the below-minimum
+  // validation check is skipped, so readiness must stay false until it settles
+  // — otherwise a quick tap could submit a sub-minimum per-order amount.
+  it('is false while the Markr minimum query has not settled', () => {
+    expect(isRecurringReady({ ...READY, isRecurringMinimumReady: false })).toBe(
+      false
+    )
+  })
+
+  it('is ready once the minimum query has settled (even with no floor)', () => {
+    // A settled "no minimum" (null) still counts as ready — the flag only
+    // tracks that the query is no longer in flight.
+    expect(isRecurringReady({ ...READY, isRecurringMinimumReady: true })).toBe(
+      true
     )
   })
 })

--- a/packages/core-mobile/app/new/features/swap/utils/recurringSubmitGate.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/recurringSubmitGate.ts
@@ -31,13 +31,22 @@ export type RecurringSubmitGateParams = {
   hasRecurringQuote: boolean
   recurringSubmitting: boolean
   validationError: ValidationErrorLike | null
+  /**
+   * True once the Markr per-order minimum query has *settled* (a value or a
+   * resolved "no minimum"), false while it's still loading. The below-minimum
+   * check is skipped while the minimum is unknown, so without this gate a user
+   * who taps quickly — recurring quote already resolved, minimum query still in
+   * flight — could submit a sub-minimum per-order amount the floor would have
+   * rejected. Gating readiness on the settled query closes that race.
+   */
+  isRecurringMinimumReady: boolean
 }
 
 /**
  * The recurring "Next" button is enabled only when the schedule is fully
  * configured (frequency + order count), both tokens and an amount are present,
- * a recurring quote is in hand, no submit is already in flight, and there's no
- * blocking validation error.
+ * a recurring quote is in hand, the per-order minimum query has settled, no
+ * submit is already in flight, and there's no blocking validation error.
  */
 export function isRecurringReady(p: RecurringSubmitGateParams): boolean {
   return (
@@ -48,6 +57,7 @@ export function isRecurringReady(p: RecurringSubmitGateParams): boolean {
     p.hasToToken &&
     p.hasFromTokenValue &&
     p.hasRecurringQuote &&
+    p.isRecurringMinimumReady &&
     !p.recurringSubmitting &&
     !hasBlockingValidationError(p.validationError)
   )

--- a/packages/core-mobile/app/services/fcm/FCMService.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.ts
@@ -116,11 +116,10 @@ class FCMService {
     // RECURRING_SWAP payloads carry only machine-readable progress fields
     // (orderId / status / token addresses) — no `title` or `body`, since
     // those live on the envelope. The Android data-only path can't
-    // construct a user-visible notification from them; the backend always
-    // sends a populated `notification` envelope for RECURRING_SWAP per
-    // Sarp's PR #174, so this branch should never fire in practice. Throw
-    // loudly so a misconfigured payload surfaces in logs instead of
-    // silently emitting a blank toast.
+    // construct a user-visible notification from them. The schema now rejects
+    // data-only RECURRING_SWAP payloads (NotificationPayloadSchema.superRefine),
+    // but keep this fallback so a regression still shows something reasonable
+    // and is surfaced in logs rather than rendering a blank notification.
     if (fcmData.type === NotificationTypes.RECURRING_SWAP) {
       Logger.error(
         '[FCMService] RECURRING_SWAP arrived data-only; expected title/body in `notification` envelope'

--- a/packages/core-mobile/app/services/fcm/FCMService.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.ts
@@ -155,7 +155,7 @@ class FCMService {
     const fallbackChannelId =
       fcm.data.type === NotificationTypes.RECURRING_SWAP
         ? DEFAULT_ANDROID_CHANNEL
-        : EVENT_TO_CH_ID[fcm.data.event]
+        : EVENT_TO_CH_ID[fcm.data.event] ?? DEFAULT_ANDROID_CHANNEL
     return {
       channelId: fcm.notification.android?.channelId ?? fallbackChannelId,
       title: fcm.notification.title,

--- a/packages/core-mobile/app/services/fcm/FCMService.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.ts
@@ -199,7 +199,7 @@ class FCMService {
       return {
         // TODO: remove urlV2 after backend is updated to send just url for NEWS notifications
         url: fcmData.urlV2 ?? fcmData.url ?? '',
-        channelId: EVENT_TO_CH_ID[fcmData.event] as string,
+        channelId: EVENT_TO_CH_ID[fcmData.event] ?? DEFAULT_ANDROID_CHANNEL,
         event: fcmData.event
       }
     } else if (fcmData.type === NotificationTypes.RECURRING_SWAP) {

--- a/packages/core-mobile/app/services/fcm/FCMService.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.ts
@@ -111,6 +111,8 @@ class FCMService {
   #prepareDataOnlyNotificationData = (
     fcmData: BalanceChangeData | NewsData | RecurringSwapData
   ): DisplayNotificationParams => {
+    const data = this.#extractDeepLinkData(fcmData)
+
     // RECURRING_SWAP payloads carry only machine-readable progress fields
     // (orderId / status / token addresses) — no `title` or `body`, since
     // those live on the envelope. The Android data-only path can't
@@ -120,12 +122,17 @@ class FCMService {
     // loudly so a misconfigured payload surfaces in logs instead of
     // silently emitting a blank toast.
     if (fcmData.type === NotificationTypes.RECURRING_SWAP) {
-      throw Error(
-        'RECURRING_SWAP arrived data-only — backend must send title/body in `notification`'
+      Logger.error(
+        '[FCMService] RECURRING_SWAP arrived data-only; expected title/body in `notification` envelope'
       )
+      return {
+        channelId: DEFAULT_ANDROID_CHANNEL,
+        title: 'Recurring swap update',
+        body: 'Tap to view your recurring swap schedule.',
+        data
+      }
     }
     if (!fcmData.title) throw Error('No notification title')
-    const data = this.#extractDeepLinkData(fcmData)
     return {
       channelId: EVENT_TO_CH_ID[fcmData.event] ?? DEFAULT_ANDROID_CHANNEL,
       title: fcmData.title,

--- a/packages/core-mobile/app/services/fcm/FCMService.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.ts
@@ -17,7 +17,8 @@ import {
   NewsData,
   NotificationPayload,
   NotificationPayloadSchema,
-  NotificationTypes
+  NotificationTypes,
+  RecurringSwapData
 } from 'services/fcm/types'
 import {
   ChannelId,
@@ -72,11 +73,16 @@ class FCMService {
         })
         .catch(Logger.error)
 
+      // Skip user-originated balance changes (spent / transferred between own
+      // accounts) — they're already visible in the app's own flows and would
+      // be noisy. The skip is balance-change-specific; other notification
+      // types (News / RecurringSwap) have no `event` field, so gate the
+      // access on the discriminator.
       if (
-        result.data.data.event === BalanceChangeEvents.BALANCES_SPENT ||
-        result.data.data.event === BalanceChangeEvents.BALANCES_TRANSFERRED
+        result.data.data.type === NotificationTypes.BALANCE_CHANGES &&
+        (result.data.data.event === BalanceChangeEvents.BALANCES_SPENT ||
+          result.data.data.event === BalanceChangeEvents.BALANCES_TRANSFERRED)
       ) {
-        // skip showing notification if user just spent balance in app, or transferred balance between user's own accounts
         return
       }
 
@@ -103,8 +109,21 @@ class FCMService {
   }
 
   #prepareDataOnlyNotificationData = (
-    fcmData: BalanceChangeData | NewsData
+    fcmData: BalanceChangeData | NewsData | RecurringSwapData
   ): DisplayNotificationParams => {
+    // RECURRING_SWAP payloads carry only machine-readable progress fields
+    // (orderId / status / token addresses) — no `title` or `body`, since
+    // those live on the envelope. The Android data-only path can't
+    // construct a user-visible notification from them; the backend always
+    // sends a populated `notification` envelope for RECURRING_SWAP per
+    // Sarp's PR #174, so this branch should never fire in practice. Throw
+    // loudly so a misconfigured payload surfaces in logs instead of
+    // silently emitting a blank toast.
+    if (fcmData.type === NotificationTypes.RECURRING_SWAP) {
+      throw Error(
+        'RECURRING_SWAP arrived data-only — backend must send title/body in `notification`'
+      )
+    }
     if (!fcmData.title) throw Error('No notification title')
     const data = this.#extractDeepLinkData(fcmData)
     return {
@@ -120,10 +139,19 @@ class FCMService {
   ): DisplayNotificationParams => {
     if (!fcm.notification) throw Error('No notification payload')
     const data = this.#extractDeepLinkData(fcm.data)
-
+    // EVENT_TO_CH_ID is keyed by BalanceChange / News event values; RECURRING_SWAP
+    // has no `event` field, so fall back to the platform default channel when
+    // the backend doesn't supply `android.channelId` on the envelope. We
+    // intentionally don't introduce a dedicated RECURRING_SWAP channel —
+    // these pushes are already gated behind the device's balance-notification
+    // preference (per Sarp's PR #174) and reusing the default channel keeps
+    // the channel-management UX surface aligned with that gating.
+    const fallbackChannelId =
+      fcm.data.type === NotificationTypes.RECURRING_SWAP
+        ? DEFAULT_ANDROID_CHANNEL
+        : EVENT_TO_CH_ID[fcm.data.event]
     return {
-      channelId:
-        fcm.notification.android?.channelId ?? EVENT_TO_CH_ID[fcm.data.event],
+      channelId: fcm.notification.android?.channelId ?? fallbackChannelId,
       title: fcm.notification.title,
       body: fcm.notification.body,
       sound: fcm.notification.sound,
@@ -132,7 +160,7 @@ class FCMService {
   }
 
   #extractDeepLinkData = (
-    fcmData: BalanceChangeData | NewsData
+    fcmData: BalanceChangeData | NewsData | RecurringSwapData
   ):
     | {
         accountAddress: string
@@ -167,6 +195,22 @@ class FCMService {
         url: fcmData.urlV2 ?? fcmData.url ?? '',
         channelId: EVENT_TO_CH_ID[fcmData.event] as string,
         event: fcmData.event
+      }
+    } else if (fcmData.type === NotificationTypes.RECURRING_SWAP) {
+      // Deep-link a notification tap to the schedules screen, parameterized
+      // by orderId so `RecurringSchedulesScreen` auto-expands + scrolls the
+      // matching card into view (`initialExpandedOrderId` prop — already
+      // wired on main). The `event` field carries the type discriminator so
+      // `resolveChannelId` can classify the press consistently across cold-
+      // start and warm-background paths without needing a dedicated channel.
+      return {
+        url: `${
+          PROTOCOLS.CORE
+        }://recurringSwapSchedules?orderId=${encodeURIComponent(
+          fcmData.orderId
+        )}`,
+        channelId: DEFAULT_ANDROID_CHANNEL,
+        event: NotificationTypes.RECURRING_SWAP
       }
     }
   }
@@ -208,9 +252,16 @@ class FCMService {
       // and walletconnect taps are no longer dropped. Channel-id resolution
       // is centralized in `resolveChannelId` to keep precedence consistent
       // with the cold-start and warm-background paths.
+      // RECURRING_SWAP payloads have no `event` field — pass undefined for
+      // that variant; `resolveChannelId` already handles the missing
+      // fallback (the `data.channelId` we stamped in `#extractDeepLinkData`
+      // is the primary signal, fallbackEvent is the secondary).
       const channelId = resolveChannelId({
         data,
-        fallbackEvent: result.data.data.event
+        fallbackEvent:
+          result.data.data.type === NotificationTypes.RECURRING_SWAP
+            ? undefined
+            : result.data.data.event
       })
       AnalyticsService.capture('PushNotificationPressed', {
         channelId,

--- a/packages/core-mobile/app/services/fcm/types.test.ts
+++ b/packages/core-mobile/app/services/fcm/types.test.ts
@@ -360,3 +360,39 @@ describe('NewsDataSchema', () => {
     expect(result.success).toBe(true)
   })
 })
+
+describe('NotificationPayloadSchema — RECURRING_SWAP envelope requirement', () => {
+  const recurringData = {
+    type: NotificationTypes.RECURRING_SWAP,
+    orderId: 'order-123',
+    owner: '0xabc0000000000000000000000000000000000001',
+    chainId: '43114',
+    numberOfOrders: '12',
+    executedOrders: '1',
+    remainingOrders: '11',
+    tokenIn: '0x0000000000000000000000000000000000000001',
+    tokenOut: '0x0000000000000000000000000000000000000002',
+    amountIn: '1000000000000000000',
+    amountOut: '2000000',
+    status: 'executed'
+  }
+
+  it('rejects a data-only RECURRING_SWAP payload (missing notification envelope)', () => {
+    // RecurringSwapDataSchema omits title/body, so without the envelope there
+    // is nothing to display. The refine must fail validation so the FCM
+    // handlers log + drop it rather than trying to render it at runtime.
+    const result = NotificationPayloadSchema.safeParse({ data: recurringData })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a RECURRING_SWAP payload that includes a notification envelope', () => {
+    const result = NotificationPayloadSchema.safeParse({
+      data: recurringData,
+      notification: {
+        title: 'Recurring swap executed',
+        body: 'Order 1 of 12 completed'
+      }
+    })
+    expect(result.success).toBe(true)
+  })
+})

--- a/packages/core-mobile/app/services/fcm/types.ts
+++ b/packages/core-mobile/app/services/fcm/types.ts
@@ -105,6 +105,26 @@ export const NotificationPayloadSchema = object({
         'Legacy field for UNKNOWN-classified SNS endpoints.'
       )
   }).optional()
+}).superRefine((payload, ctx) => {
+  // BALANCE_CHANGES / NEWS carry their own `title` / `body` in the data block,
+  // so they render on the Android data-only path without an envelope. A
+  // RECURRING_SWAP data block intentionally omits title/body — those live only
+  // on the `notification` envelope — so a data-only RECURRING_SWAP would pass
+  // the shape check yet have nothing to display, failing at runtime in
+  // FCMService. Require the envelope here so a misconfigured payload (backend/
+  // config regression) fails `safeParse` and is logged + dropped by the
+  // handlers' existing guard rather than reaching the display layer.
+  if (
+    payload.data.type === NotificationTypes.RECURRING_SWAP &&
+    !payload.notification
+  ) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['notification'],
+      message:
+        'RECURRING_SWAP payloads must include a `notification` envelope (title/body).'
+    })
+  }
 })
 
 export type NotificationPayload = z.infer<typeof NotificationPayloadSchema>

--- a/packages/core-mobile/app/services/fcm/types.ts
+++ b/packages/core-mobile/app/services/fcm/types.ts
@@ -3,7 +3,13 @@ import { ChannelId } from 'services/notifications/channels'
 
 export enum NotificationTypes {
   BALANCE_CHANGES = 'BALANCE_CHANGES',
-  NEWS = 'NEWS'
+  NEWS = 'NEWS',
+  // Recurring swap (DCA) per-order progress. Subscribed via
+  // `subscribeRecurringSwapNotifications`; payload shape comes from the
+  // notification-sender webhook fanout (Sarp's PR #172 / #174). Backend
+  // gates these behind the device's balance-notification preference and
+  // owns subscription teardown — no client-side unsubscribe path.
+  RECURRING_SWAP = 'RECURRING_SWAP'
 }
 
 export enum NewsEvents {
@@ -32,6 +38,38 @@ export const BalanceChangeDataSchema = object({
   url: string() // we need this url to deeplink to in-app browser or screens.
 })
 
+// Recurring swap execution / completion / failure notification. All numeric
+// fields are sent as strings on the wire because FCM data payloads are
+// `Record<string, string>`-shaped — the per-order delta is computed
+// server-side (`executedOrders` / `remainingOrders` cursors). `reasonCode`
+// is set only on `status === 'failed'` and carries a known wire code (e.g.
+// `'2'` insufficient balance, `'3'` insufficient allowance); unknown codes
+// are tolerated (forwarded to analytics but not surfaced as a push).
+//
+// `numberOfOrders === '-1'` is the SDK's unlimited sentinel (matches
+// `RECURRING_UNLIMITED_ORDERS_SENTINEL`); the in-app row formats that as ∞.
+//
+// No `title` / `body` here — those live on the envelope (`notification`
+// field) so the backend can localize / version the copy without the
+// client schema needing to chase. The data block carries the machine-
+// readable progress fields the in-app notification list + deep-link
+// routing need.
+export const RecurringSwapDataSchema = object({
+  type: literal(NotificationTypes.RECURRING_SWAP),
+  orderId: string(),
+  owner: string().startsWith('0x'),
+  chainId: string(),
+  numberOfOrders: string(),
+  executedOrders: string(),
+  remainingOrders: string(),
+  tokenIn: string().startsWith('0x'),
+  tokenOut: string().startsWith('0x'),
+  amountIn: string(),
+  amountOut: string(),
+  status: string(),
+  reasonCode: string().optional()
+})
+
 // news notification covers the following:
 // 1/ automated price alerts (fixed list of tokens):
 //    uses urlV2 with internalId
@@ -52,7 +90,7 @@ export const NewsDataSchema = object({
 })
 
 export const NotificationPayloadSchema = object({
-  data: BalanceChangeDataSchema.or(NewsDataSchema),
+  data: BalanceChangeDataSchema.or(NewsDataSchema).or(RecurringSwapDataSchema),
   notification: object({
     title: string(),
     body: string(),
@@ -74,3 +112,5 @@ export type NotificationPayload = z.infer<typeof NotificationPayloadSchema>
 export type BalanceChangeData = z.infer<typeof BalanceChangeDataSchema>
 
 export type NewsData = z.infer<typeof NewsDataSchema>
+
+export type RecurringSwapData = z.infer<typeof RecurringSwapDataSchema>

--- a/packages/core-mobile/app/services/fcm/types.ts
+++ b/packages/core-mobile/app/services/fcm/types.ts
@@ -5,7 +5,7 @@ export enum NotificationTypes {
   BALANCE_CHANGES = 'BALANCE_CHANGES',
   NEWS = 'NEWS',
   // Recurring swap (DCA) per-order progress. Subscribed via
-  // `subscribeRecurringSwapNotifications`; payload shape comes from the
+  // `subscribeForRecurringSwap`; payload shape comes from the
   // notification-sender webhook fanout (Sarp's PR #172 / #174). Backend
   // gates these behind the device's balance-notification preference and
   // owns subscription teardown — no client-side unsubscribe path.

--- a/packages/core-mobile/app/services/notifications/recurringSwap/subscribeForRecurringSwap.ts
+++ b/packages/core-mobile/app/services/notifications/recurringSwap/subscribeForRecurringSwap.ts
@@ -1,4 +1,5 @@
 import Config from 'react-native-config'
+import Logger from 'utils/Logger'
 import { appCheckPostJson } from 'utils/api/common/appCheckFetch'
 
 // Backend (core-notification-sender): see Sarp's PR
@@ -32,7 +33,10 @@ export async function subscribeForRecurringSwap(
       deviceArn,
       orderId
     })
-  )
+  ).catch(error => {
+    Logger.error(`[subscribeForRecurringSwap.ts][subscribe]${error}`)
+    throw new Error(error)
+  })
 
   if (!response.ok) {
     throw new Error(`${response.status}:${response.statusText}`)

--- a/packages/core-mobile/app/services/notifications/recurringSwap/subscribeForRecurringSwap.ts
+++ b/packages/core-mobile/app/services/notifications/recurringSwap/subscribeForRecurringSwap.ts
@@ -34,8 +34,8 @@ export async function subscribeForRecurringSwap(
       orderId
     })
   ).catch(error => {
-    Logger.error(`[subscribeForRecurringSwap.ts][subscribe]${error}`)
-    throw new Error(error)
+    Logger.error('[subscribeForRecurringSwap.ts][subscribe]', error)
+    throw error instanceof Error ? error : new Error(String(error))
   })
 
   if (!response.ok) {

--- a/packages/core-mobile/app/services/notifications/recurringSwap/subscribeForRecurringSwap.ts
+++ b/packages/core-mobile/app/services/notifications/recurringSwap/subscribeForRecurringSwap.ts
@@ -22,7 +22,7 @@ type RecurringSwapNotificationSubscription = {
   deviceArn: string
 }
 
-export async function subscribeRecurringSwapNotifications(
+export async function subscribeForRecurringSwap(
   subscription: RecurringSwapNotificationSubscription
 ): Promise<void> {
   const { deviceArn, orderId } = subscription

--- a/packages/core-mobile/ios/Podfile.lock
+++ b/packages/core-mobile/ios/Podfile.lock
@@ -42,7 +42,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -79,7 +78,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -115,7 +113,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -146,7 +143,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -176,7 +172,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -202,7 +197,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -228,7 +222,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -299,7 +292,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -465,7 +457,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -496,7 +487,6 @@ PODS:
     - RCTTypeSafety
     - React-callinvoker
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -521,7 +511,6 @@ PODS:
     - RCTTypeSafety
     - React-callinvoker
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -544,7 +533,6 @@ PODS:
     - RCTTypeSafety
     - React-callinvoker
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -573,7 +561,6 @@ PODS:
     - RCTTypeSafety
     - React-callinvoker
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -616,7 +603,6 @@ PODS:
   - React-Core (0.85.3):
     - hermes-engine
     - RCTDeprecation
-    - React-Core-prebuilt
     - React-Core/Default (= 0.85.3)
     - React-cxxreact
     - React-featureflags
@@ -632,12 +618,9 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.85.3):
-    - ReactNativeDependencies
   - React-Core/CoreModulesHeaders (0.85.3):
     - hermes-engine
     - RCTDeprecation
-    - React-Core-prebuilt
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
@@ -656,7 +639,6 @@ PODS:
   - React-Core/Default (0.85.3):
     - hermes-engine
     - RCTDeprecation
-    - React-Core-prebuilt
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -674,7 +656,6 @@ PODS:
   - React-Core/DevSupport (0.85.3):
     - hermes-engine
     - RCTDeprecation
-    - React-Core-prebuilt
     - React-Core/Default (= 0.85.3)
     - React-Core/RCTWebSocket (= 0.85.3)
     - React-cxxreact
@@ -694,7 +675,6 @@ PODS:
   - React-Core/RCTActionSheetHeaders (0.85.3):
     - hermes-engine
     - RCTDeprecation
-    - React-Core-prebuilt
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
@@ -713,7 +693,6 @@ PODS:
   - React-Core/RCTAnimationHeaders (0.85.3):
     - hermes-engine
     - RCTDeprecation
-    - React-Core-prebuilt
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
@@ -732,7 +711,6 @@ PODS:
   - React-Core/RCTBlobHeaders (0.85.3):
     - hermes-engine
     - RCTDeprecation
-    - React-Core-prebuilt
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
@@ -751,7 +729,6 @@ PODS:
   - React-Core/RCTImageHeaders (0.85.3):
     - hermes-engine
     - RCTDeprecation
-    - React-Core-prebuilt
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
@@ -770,7 +747,6 @@ PODS:
   - React-Core/RCTLinkingHeaders (0.85.3):
     - hermes-engine
     - RCTDeprecation
-    - React-Core-prebuilt
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
@@ -789,7 +765,6 @@ PODS:
   - React-Core/RCTNetworkHeaders (0.85.3):
     - hermes-engine
     - RCTDeprecation
-    - React-Core-prebuilt
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
@@ -808,7 +783,6 @@ PODS:
   - React-Core/RCTSettingsHeaders (0.85.3):
     - hermes-engine
     - RCTDeprecation
-    - React-Core-prebuilt
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
@@ -827,7 +801,6 @@ PODS:
   - React-Core/RCTTextHeaders (0.85.3):
     - hermes-engine
     - RCTDeprecation
-    - React-Core-prebuilt
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
@@ -846,7 +819,6 @@ PODS:
   - React-Core/RCTVibrationHeaders (0.85.3):
     - hermes-engine
     - RCTDeprecation
-    - React-Core-prebuilt
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
@@ -865,7 +837,6 @@ PODS:
   - React-Core/RCTWebSocket (0.85.3):
     - hermes-engine
     - RCTDeprecation
-    - React-Core-prebuilt
     - React-Core/Default (= 0.85.3)
     - React-cxxreact
     - React-featureflags
@@ -883,7 +854,6 @@ PODS:
     - Yoga
   - React-CoreModules (0.85.3):
     - RCTTypeSafety (= 0.85.3)
-    - React-Core-prebuilt
     - React-Core/CoreModulesHeaders (= 0.85.3)
     - React-debug
     - React-featureflags
@@ -902,7 +872,6 @@ PODS:
   - React-cxxreact (0.85.3):
     - hermes-engine
     - React-callinvoker (= 0.85.3)
-    - React-Core-prebuilt
     - React-debug (= 0.85.3)
     - React-jsi (= 0.85.3)
     - React-jsinspector
@@ -919,7 +888,6 @@ PODS:
   - React-debug/redbox (0.85.3)
   - React-defaultsnativemodule (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-domnativemodule
     - React-Fabric/animated
     - React-featureflags
@@ -936,7 +904,6 @@ PODS:
     - Yoga
   - React-domnativemodule (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-Fabric
     - React-Fabric/bridging
     - React-FabricComponents
@@ -953,7 +920,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric/animated (= 0.85.3)
@@ -990,7 +956,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric/animationbackend
@@ -1010,7 +975,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1029,7 +993,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1048,7 +1011,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1067,7 +1029,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1086,7 +1047,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1105,7 +1065,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1124,7 +1083,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric/components/legacyviewmanagerinterop (= 0.85.3)
@@ -1147,7 +1105,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1166,7 +1123,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1185,7 +1141,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1204,7 +1159,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1225,7 +1179,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1244,7 +1197,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1263,7 +1215,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1282,7 +1233,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1301,7 +1251,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1320,7 +1269,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1339,7 +1287,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric/observers/events (= 0.85.3)
@@ -1361,7 +1308,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1380,7 +1326,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1399,7 +1344,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1418,7 +1362,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric/animationbackend
@@ -1441,7 +1384,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1460,7 +1402,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric/uimanager/consistency (= 0.85.3)
@@ -1481,7 +1422,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1501,7 +1441,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric
@@ -1524,7 +1463,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric
@@ -1556,7 +1494,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric
@@ -1577,7 +1514,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric
@@ -1598,7 +1534,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric
@@ -1619,7 +1554,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric
@@ -1640,7 +1574,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric
@@ -1661,7 +1594,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric
@@ -1682,7 +1614,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric
@@ -1703,7 +1634,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric
@@ -1724,7 +1654,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric
@@ -1745,7 +1674,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric
@@ -1766,7 +1694,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric
@@ -1787,7 +1714,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-Fabric
@@ -1807,7 +1733,6 @@ PODS:
     - hermes-engine
     - RCTRequired (= 0.85.3)
     - RCTTypeSafety (= 0.85.3)
-    - React-Core-prebuilt
     - React-Fabric
     - React-featureflags
     - React-graphics
@@ -1821,11 +1746,9 @@ PODS:
     - ReactNativeDependencies
     - Yoga
   - React-featureflags (0.85.3):
-    - React-Core-prebuilt
     - ReactNativeDependencies
   - React-featureflagsnativemodule (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-featureflags
     - React-jsi
     - React-jsiexecutor
@@ -1834,7 +1757,6 @@ PODS:
     - ReactNativeDependencies
   - React-graphics (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-featureflags
     - React-jsi
     - React-jsiexecutor
@@ -1842,7 +1764,6 @@ PODS:
     - ReactNativeDependencies
   - React-hermes (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-cxxreact (= 0.85.3)
     - React-jsi
     - React-jsiexecutor (= 0.85.3)
@@ -1856,7 +1777,6 @@ PODS:
     - ReactNativeDependencies
   - React-idlecallbacksnativemodule (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-jsi
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
@@ -1865,7 +1785,6 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
   - React-ImageManager (0.85.3):
-    - React-Core-prebuilt
     - React-Core/Default
     - React-debug
     - React-Fabric
@@ -1875,7 +1794,6 @@ PODS:
     - ReactNativeDependencies
   - React-intersectionobservernativemodule (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-cxxreact
     - React-Fabric
     - React-Fabric/bridging
@@ -1890,7 +1808,6 @@ PODS:
     - Yoga
   - React-jserrorhandler (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -1899,11 +1816,9 @@ PODS:
     - ReactNativeDependencies
   - React-jsi (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - ReactNativeDependencies
   - React-jsiexecutor (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-jserrorhandler
@@ -1918,7 +1833,6 @@ PODS:
     - ReactNativeDependencies
   - React-jsinspector (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-featureflags
     - React-jsi
     - React-jsinspectorcdp
@@ -1930,15 +1844,12 @@ PODS:
     - React-utils
     - ReactNativeDependencies
   - React-jsinspectorcdp (0.85.3):
-    - React-Core-prebuilt
     - ReactNativeDependencies
   - React-jsinspectornetwork (0.85.3):
-    - React-Core-prebuilt
     - React-jsinspectorcdp
     - ReactNativeDependencies
   - React-jsinspectortracing (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-jsi
     - React-jsinspectornetwork
     - React-oscompat
@@ -1947,7 +1858,6 @@ PODS:
     - ReactNativeDependencies
   - React-jsitooling (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-cxxreact (= 0.85.3)
     - React-debug
     - React-jsi (= 0.85.3)
@@ -1960,15 +1870,12 @@ PODS:
   - React-jsitracing (0.85.3):
     - React-jsi
   - React-logger (0.85.3):
-    - React-Core-prebuilt
     - ReactNativeDependencies
   - React-Mapbuffer (0.85.3):
-    - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
   - React-microtasksnativemodule (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-jsi
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
@@ -1976,7 +1883,6 @@ PODS:
     - ReactNativeDependencies
   - React-mutationobservernativemodule (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-cxxreact
     - React-Fabric
     - React-Fabric/bridging
@@ -1997,7 +1903,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2019,7 +1924,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2043,7 +1947,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2069,7 +1972,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2097,7 +1999,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2121,7 +2022,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2149,7 +2049,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2175,7 +2074,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2198,7 +2096,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2220,7 +2117,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2242,7 +2138,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2264,7 +2159,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2287,7 +2181,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2309,7 +2202,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2335,7 +2227,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2359,7 +2250,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2381,7 +2271,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2406,7 +2295,6 @@ PODS:
     - React
     - React-callinvoker
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2428,7 +2316,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2451,7 +2338,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2473,7 +2359,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2495,7 +2380,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2517,7 +2401,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2538,7 +2421,6 @@ PODS:
     - hermes-engine
     - React-callinvoker
     - React-Core
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -2550,7 +2432,6 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
   - React-networking (0.85.3):
-    - React-Core-prebuilt
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-performancetimeline
@@ -2558,18 +2439,15 @@ PODS:
     - ReactNativeDependencies
   - React-oscompat (0.85.3)
   - React-perflogger (0.85.3):
-    - React-Core-prebuilt
     - ReactNativeDependencies
   - React-performancecdpmetrics (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-jsi
     - React-performancetimeline
     - React-runtimeexecutor
     - React-timing
     - ReactNativeDependencies
   - React-performancetimeline (0.85.3):
-    - React-Core-prebuilt
     - React-featureflags
     - React-jsinspector
     - React-jsinspectortracing
@@ -2580,7 +2458,6 @@ PODS:
     - React-Core/RCTActionSheetHeaders (= 0.85.3)
   - React-RCTAnimation (0.85.3):
     - RCTTypeSafety
-    - React-Core-prebuilt
     - React-Core/RCTAnimationHeaders
     - React-debug
     - React-featureflags
@@ -2594,7 +2471,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-CoreModules
     - React-debug
     - React-defaultsnativemodule
@@ -2619,7 +2495,6 @@ PODS:
     - ReactNativeDependencies
   - React-RCTBlob (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-Core/RCTBlobHeaders
     - React-Core/RCTWebSocket
     - React-jsi
@@ -2634,7 +2509,6 @@ PODS:
     - hermes-engine
     - RCTSwiftUIWrapper
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-FabricComponents
@@ -2666,7 +2540,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec/components (= 0.85.3)
@@ -2677,7 +2550,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2691,7 +2563,6 @@ PODS:
     - Yoga
   - React-RCTImage (0.85.3):
     - RCTTypeSafety
-    - React-Core-prebuilt
     - React-Core/RCTImageHeaders
     - React-jsi
     - React-NativeModulesApple
@@ -2708,7 +2579,6 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.85.3)
   - React-RCTNetwork (0.85.3):
     - RCTTypeSafety
-    - React-Core-prebuilt
     - React-Core/RCTNetworkHeaders
     - React-debug
     - React-featureflags
@@ -2723,7 +2593,6 @@ PODS:
   - React-RCTRuntime (0.85.3):
     - hermes-engine
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-jsi
     - React-jsinspector
@@ -2738,7 +2607,6 @@ PODS:
     - ReactNativeDependencies
   - React-RCTSettings (0.85.3):
     - RCTTypeSafety
-    - React-Core-prebuilt
     - React-Core/RCTSettingsHeaders
     - React-jsi
     - React-NativeModulesApple
@@ -2749,7 +2617,6 @@ PODS:
     - React-Core/RCTTextHeaders (= 0.85.3)
     - Yoga
   - React-RCTVibration (0.85.3):
-    - React-Core-prebuilt
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
@@ -2761,13 +2628,11 @@ PODS:
     - React-debug
     - React-utils
   - React-rendererdebug (0.85.3):
-    - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
   - React-RuntimeApple (0.85.3):
     - hermes-engine
     - React-callinvoker
-    - React-Core-prebuilt
     - React-Core/Default
     - React-CoreModules
     - React-cxxreact
@@ -2789,7 +2654,6 @@ PODS:
     - ReactNativeDependencies
   - React-RuntimeCore (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-cxxreact
     - React-Fabric
     - React-featureflags
@@ -2804,7 +2668,6 @@ PODS:
     - React-utils
     - ReactNativeDependencies
   - React-runtimeexecutor (0.85.3):
-    - React-Core-prebuilt
     - React-debug
     - React-featureflags
     - React-jsi (= 0.85.3)
@@ -2812,7 +2675,6 @@ PODS:
     - ReactNativeDependencies
   - React-RuntimeHermes (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-featureflags
     - React-hermes
     - React-jsi
@@ -2828,7 +2690,6 @@ PODS:
   - React-runtimescheduler (0.85.3):
     - hermes-engine
     - React-callinvoker
-    - React-Core-prebuilt
     - React-cxxreact
     - React-debug
     - React-featureflags
@@ -2845,13 +2706,11 @@ PODS:
     - React-debug
   - React-utils (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-debug
     - React-jsi (= 0.85.3)
     - ReactNativeDependencies
   - React-webperformancenativemodule (0.85.3):
     - hermes-engine
-    - React-Core-prebuilt
     - React-cxxreact
     - React-jsi
     - React-jsiexecutor
@@ -2867,7 +2726,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-FabricImage
@@ -2883,13 +2741,11 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
   - ReactCommon (0.85.3):
-    - React-Core-prebuilt
     - ReactCommon/turbomodule (= 0.85.3)
     - ReactNativeDependencies
   - ReactCommon/turbomodule (0.85.3):
     - hermes-engine
     - React-callinvoker (= 0.85.3)
-    - React-Core-prebuilt
     - React-cxxreact (= 0.85.3)
     - React-jsi (= 0.85.3)
     - React-logger (= 0.85.3)
@@ -2900,7 +2756,6 @@ PODS:
   - ReactCommon/turbomodule/bridging (0.85.3):
     - hermes-engine
     - React-callinvoker (= 0.85.3)
-    - React-Core-prebuilt
     - React-cxxreact (= 0.85.3)
     - React-jsi (= 0.85.3)
     - React-logger (= 0.85.3)
@@ -2909,7 +2764,6 @@ PODS:
   - ReactCommon/turbomodule/core (0.85.3):
     - hermes-engine
     - React-callinvoker (= 0.85.3)
-    - React-Core-prebuilt
     - React-cxxreact (= 0.85.3)
     - React-debug (= 0.85.3)
     - React-featureflags (= 0.85.3)
@@ -2932,7 +2786,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2954,7 +2807,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2976,7 +2828,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -2998,7 +2849,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3020,7 +2870,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3060,7 +2909,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3083,7 +2931,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3107,7 +2954,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3129,7 +2975,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3158,7 +3003,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3180,7 +3024,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3206,7 +3049,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3230,7 +3072,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3254,7 +3095,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3278,7 +3118,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3303,7 +3142,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3327,7 +3165,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3349,7 +3186,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3371,7 +3207,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3394,7 +3229,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3416,7 +3250,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3441,7 +3274,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3464,7 +3296,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
     - React-debug
     - React-Fabric
     - React-featureflags
@@ -3563,7 +3394,6 @@ DEPENDENCIES:
   - React (from `../node_modules/react-native/`)
   - React-callinvoker (from `../node_modules/react-native/ReactCommon/callinvoker`)
   - React-Core (from `../node_modules/react-native/`)
-  - React-Core-prebuilt (from `../node_modules/react-native/React-Core-prebuilt.podspec`)
   - React-Core/RCTWebSocket (from `../node_modules/react-native/`)
   - React-CoreModules (from `../node_modules/react-native/React/CoreModules`)
   - React-cxxreact (from `../node_modules/react-native/ReactCommon/cxxreact`)
@@ -3851,8 +3681,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/callinvoker"
   React-Core:
     :path: "../node_modules/react-native/"
-  React-Core-prebuilt:
-    :podspec: "../node_modules/react-native/React-Core-prebuilt.podspec"
   React-CoreModules:
     :path: "../node_modules/react-native/React/CoreModules"
   React-cxxreact:
@@ -4101,7 +3929,7 @@ SPEC CHECKSUMS:
   DatadogInternal: bd8672d506a7e67936ed5f7ca612169e49029b44
   DatadogLogs: d683aa9e0c9339f5ae679ead70bbdbe41cdc32f6
   DatadogRUM: 8b794aa458e6323ea9b1cef3f820fd3d092cbe27
-  DatadogSDKReactNative: 53d710db046ab9ed8479b8bdd4b7c64a18060101
+  DatadogSDKReactNative: bfed3a327bd1da3bfda2e6a66cfaac36e6b207f8
   DatadogTrace: 3ba194791267efa09634234749111cac95abd3e5
   DatadogWebViewTracking: 8287d5ad06e992de5e46dd72a17e05c7513344be
   DGSwiftUtilities: 567f8d5ee618f0b7afb185b17aa45ff356315a0f
@@ -4109,10 +3937,10 @@ SPEC CHECKSUMS:
   EXConstants: e836b478e4f5c835f3c77921d8162e1918e2c06e
   EXJSONUtils: dba2755f4e24009eaf87a876b2d615ea06c16e42
   EXManifests: 7e19be8df665a338493060a419847dae76ffcd43
-  Expo: 885ec78d4827b0abf9b87c0a0308fbdf00ef8b8a
+  Expo: c93af8562ddd9468c668ad06ba698e83b1882b58
   expo-dev-client: 75bdde127a9032ac60c3e4ca6231b552073bdf0c
-  expo-dev-launcher: 7456ef9089162b6f0f98c4bd5a9990ccb91d156c
-  expo-dev-menu: 50612b5950e0086853dd030cbc9694c7c0dfd1d0
+  expo-dev-launcher: eed1e8487c087d4ac97610ba376267a3180581b1
+  expo-dev-menu: 59a4e0f0e52f674e199d29835c24ec5abccc5700
   expo-dev-menu-interface: 65402d4affb8b418aa6cec29b3abb0e313c8f443
   ExpoAdapterGoogleSignIn: 6393c1ad521f880f6e467bca40baf1e5dcaea4a3
   ExpoAlternateAppIcons: 8a7cb9b311700b92fb13652d1087beb2efdb9d84
@@ -4133,7 +3961,7 @@ SPEC CHECKSUMS:
   ExpoLocalAuthentication: 93f29833d2a8b957f996eddc05a632eb2bdeaa7d
   ExpoLocalization: cf50efc436b2ec313510131c1ee0e778366d64b0
   ExpoLogBox: 63977cf56b04547c713535d2d4e9bbf2f012e3c6
-  ExpoModulesCore: 317a6b4d491a6f6cc645aadce807fdb4259439cc
+  ExpoModulesCore: 8f247b586be27ee3445df7acb11dd1badcf7b89e
   ExpoModulesJSI: abc606cf32f6eeb4e2ad44ec3fc4b24143abd8f6
   ExpoModulesWorklets: 25d712f4e0a4eb37397d46c0ff5b450eca897fd1
   ExpoModulesWorkletsAdapter: c141a7854ac985cda989175ae6944c1bfe3ff91b
@@ -4145,7 +3973,7 @@ SPEC CHECKSUMS:
   ExpoUI: cb2928f5537135cff59e7b84b4adbeb72355f9fd
   ExpoVideo: 292b8c6be12bacf0b2e5a697276788280cdccdfb
   EXUpdatesInterface: 25408a97d682355eb9fb37e5aa6e22caece1881f
-  FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
+  FBLazyVector: 473b935415b82ae4f7f9aa9d5b3378491143ccbf
   Firebase: 7a56fe4f56b5ab81b86a6822f5b8f909ae6fc7e2
   FirebaseAppCheck: 1c4adb8028cc5ec6a8d3d10f18b60293cddc45a4
   FirebaseAppCheckInterop: 06fe5a3799278ae4667e6c432edd86b1030fa3df
@@ -4159,159 +3987,158 @@ SPEC CHECKSUMS:
   GoogleUtilities: 4f2618a4a1e762a1ee134a1e2323bba9843e06da
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  hermes-engine: 98dd077508f9ee776d0d4a44f6b32197518aa1c3
+  hermes-engine: e74751f2eb2e1b5df0c35f65e690435be647f2d7
   jail-monkey: 1846061ac12e861ac5a8ec7197b0daa775b83733
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: 8f959969761e9c45d70353667d00af0e5b9cadb3
-  lottie-react-native: ee142214581f3bb68fbda7efcf07b835a189eeda
+  lottie-react-native: 3234694e4dbd43853060e5eba15a35c323ed29ee
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
   MultiplatformBleAdapter: b1fddd0d499b96b607e00f0faa8e60648343dc1d
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  NitroFetch: f449a275cf739e5d8eb086ba49b05a111d5ef0ed
-  NitroMmkv: 4b4f95387a15161b346a6a93b9c7072c179e0e88
-  NitroModules: c41b7b778d6557f1e517a80ec681a670321fa001
+  NitroFetch: 3fb6cd75a82257b92fc5095123ddaf37428dfc6e
+  NitroMmkv: 4bafc4d924d1473b3c36d5fde8a5fc1966847c21
+  NitroModules: fc6c59f936853035f67ef4dc18a9559dfcb3717a
   OpenTelemetrySwiftApi: aaee576ed961e0c348af78df58b61300e95bd104
   PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
   PromisesObjC: 752c3227f599e3467650e47ea36f433eeb10c273
   PromisesSwift: 217dea0fd5d2ad65222a109c48698add13cc1c5b
-  QuickCrypto: 7a95e562662351d5db014253a5a19030b497e030
-  RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
-  RCTRequired: 9f3a7e5645d4bc3f551593de7550bb66ab6e42bc
-  RCTSwiftUI: 239ed2eb9e73de5a6f518810630f0c95e01c8702
-  RCTSwiftUIWrapper: 966ca7f5f22ac0b2b2255fb09cffc381f5440b03
-  RCTTypeSafety: 2a6403ba3492c04510e7c15bd635461646c43bb2
+  QuickCrypto: 12fbadf0bd716c10ea94fdc47caffb93b2c818cf
+  RCTDeprecation: 225e022b85a206cf0883a909c4a114159783363c
+  RCTRequired: 827a95c181af0886a11e21bc66c084088cf87839
+  RCTSwiftUI: 7babb07156ae0a8e5ea97f77e43959ddaca2c6f2
+  RCTSwiftUIWrapper: 30f2e591ca57d625a244acd866fa169fd4859273
+  RCTTypeSafety: 47f936a87875e1a08ccf1ffe34e8bf29f1d85567
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
-  React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
-  React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: 4a0b6b74f3211cb11eae89083c53debd080051f2
-  React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
-  React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
-  React-debug: 92944dc4d89f56d640e75498266cbde557a48189
-  React-defaultsnativemodule: cd64bc09d7ca24112bbaf1b91edbbcf3d81ea7dc
-  React-domnativemodule: dacf5bc055ae041039574f38b73a20b91e368774
-  React-Fabric: bb0baa33d91839631d315800eb23e9aaa4338a44
-  React-FabricComponents: c504d0b0e2f3054b2ba19af839f175cb361153c0
-  React-FabricImage: 91eaea1cc58d25ae2596a9277bcfe028f92374c3
-  React-featureflags: 5ac0455da0af12ca79b40402e2f42c5c7556b638
-  React-featureflagsnativemodule: df7da181b064f10f5959a7cd529b5aab3686ecb2
-  React-graphics: d25b1195baf24c7918543f4aff9be89cc080906f
-  React-hermes: 663286153a8ad6bf752b742654c766ff5e8991e7
-  React-idlecallbacksnativemodule: 0bd5392cb67f1ab25df736814b7c05213b1d3c68
-  React-ImageManager: a03eed3e3d4222130dc0ad503a1a5f3aa89de746
-  React-intersectionobservernativemodule: 5d0f1c3c7b30031b0f6f730ee52dd9d607e2c966
-  React-jserrorhandler: d5d6e7e20c5a2d6e8607e18d31d8712d7de676f6
-  React-jsi: eb7cc4cffcf24796cc302d5b2bca0e92544139a9
-  React-jsiexecutor: 65006f60e64c72c6b82f62ef6bd17c84846e73f8
-  React-jsinspector: 01e32e2247b2486117fbb143db7f7717ef462c6d
-  React-jsinspectorcdp: f1cbb34ca41d188ba22efd9b663cf258a911f6cd
-  React-jsinspectornetwork: f61acc94c881c41451f508abfe6efa748b956c21
-  React-jsinspectortracing: 9395894d9bd4d17931b9afcf230c0e7f4cb3d674
-  React-jsitooling: 03ead841daa12a93b18479f5e400ceab3732d36d
-  React-jsitracing: 4ae61c79e14360d1c6ab566031c62c490da78439
-  React-logger: bf149dea4343a9037b74bade36cced8b63f03f46
-  React-Mapbuffer: fec3e025f0ffba6b32cd2a1d7bbdee3e269aae90
-  React-microtasksnativemodule: ab33a818d339f5a1da308893c11b487be66121a8
-  React-mutationobservernativemodule: a42d1626651ccd7d0dc02a56e69d4ec77c248893
+  React-callinvoker: d3163d80425735b095cff517da3b8631691fd734
+  React-Core: efe6d8298e794a1f6ee1e018a0ee93789c152703
+  React-CoreModules: 1c097c5155f4345bccfb00a9a7309952b393f366
+  React-cxxreact: 1b54e6919cef2a406a79e5d350cd71bb83d6e49d
+  React-debug: df5c6b1f07e8f337207ac1dafa9664624ff8547c
+  React-defaultsnativemodule: a18213e5e0eb67f9977e5bf14c08b3cb924b538a
+  React-domnativemodule: cd09b7ff1905c56ec6126d494f7a31cb56e273e0
+  React-Fabric: cc0a73ebac59a2c609832f7e439cd06934348298
+  React-FabricComponents: 6c9b84936a267f9f061b5a1fb4f5cecbc1c72b3e
+  React-FabricImage: b79803dbf8b9d7d5d450b343c98201b904605f6f
+  React-featureflags: c8b471c808575ffae12e1b85cd9c035fc03b4b78
+  React-featureflagsnativemodule: 4c3238d4f9160a234f99bca64686ae0964f2f4f8
+  React-graphics: 256955d14073c7de133baa46b02f6b1982c8d9d7
+  React-hermes: 06b3d795c3ff087060a493520d74fa94d2c25879
+  React-idlecallbacksnativemodule: 9d3a584a5d150259c5f3f498a8977e732b92aa90
+  React-ImageManager: 8923c8e4b9ad903d2c49eb59f24003758ad925e1
+  React-intersectionobservernativemodule: 911acc232d87ef7aa438b1a9c0b7f21b32a09776
+  React-jserrorhandler: cbe62aa832f726a9cbf8d5757d13b7fd97b0dc18
+  React-jsi: 4ff0905b76d3b5d6bd7062821ff9fd7bf2371dc2
+  React-jsiexecutor: 8026d7cbef72b274838308759345d6208cd7be54
+  React-jsinspector: f6a0a239f658c13d52f9a8078436193c92e53d1e
+  React-jsinspectorcdp: a79e284e5e1dab6c550010cb4895a40e446f29da
+  React-jsinspectornetwork: c7b0324a69f3bc65d40b801a2db7f218fecd9143
+  React-jsinspectortracing: ce58479ac7ec6ab9b82b3c9b934de24eb50aae5a
+  React-jsitooling: e31a9eb9c45da6a62fe82a30d497837cb5ed6398
+  React-jsitracing: f3a5e8f02a50aa2b9b0e5c0d5a8b420c38b55832
+  React-logger: 611b08f6f0055e92c308679b4eb571e61004c8e0
+  React-Mapbuffer: b1d56d258c67c996f2ba88dd7bb8c1173b609fb1
+  React-microtasksnativemodule: d1ce88f0f9aca96283b04c02aa5111a679e71850
+  React-mutationobservernativemodule: 7104a51ed8954fccb09170fbc3d3e99559f8fce1
   react-native-aes: e2868d9f7203f573a2c1d797d95f4e88a54fa8cd
-  react-native-ble-plx: a36986e9db6cf306306484f7f49e2b232de7d017
-  react-native-bottom-tabs: 9bc516e03f7bc2b9116e24b6d4dbc828d60ed9af
+  react-native-ble-plx: 1c696efe881f1b519eab9efa2cd9308c007732c5
+  react-native-bottom-tabs: ec74c8b2896cea660984c2613a6cea2e09bd035d
   react-native-branch: 0229b46e762bc16ab5289e5eac167738b94c089b
-  react-native-compat: 9904bfee2e48796b2986ed4369679062a2a3b5a3
+  react-native-compat: 9843a22ea8f9fbcc3b87c2b7a052a03ffd1e3777
   react-native-config: ea75335a7cca1d3326de1da384227e580a7c082e
   react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
-  react-native-in-app-updates: ee037ee9e1c6651bb181869238d41d40f88a5baa
-  react-native-ios-context-menu: 39a8a99d5f62e675b159fa023ba76c3ccc12a362
-  react-native-ios-utilities: d1449ddce250f84a81a46db70439beed498f1e69
-  react-native-keyboard-controller: d020283065b2bdf25f5667937e5899f08df36ff9
-  react-native-menu: cef8fb263b5fbc4a748de65494fe768b7527c135
-  react-native-netinfo: 2f906d5d9a639090ed1c079135d6485a95f749f1
-  react-native-pager-view: d96d949dba87a182577231468bb88cdb0be5954c
-  react-native-passkey: 13c0e93e3d3077143f71bc4b61f6759c55e4be3b
-  react-native-performance: 5d997cbaec6fddc6da2724d1e056a9eed90dca23
+  react-native-in-app-updates: 2524a34f824eb5e7c0a0e2ff4c06177aa57941ad
+  react-native-ios-context-menu: 8221cb7a066bd51f742866fc1e5de83679ea1932
+  react-native-ios-utilities: 8abcfea9c8166398523c0249a70077cf20482c98
+  react-native-keyboard-controller: 410fc72668b0f5f3bae82d2815f9e6299d67503d
+  react-native-menu: b5652b6901671ec65c3cdcf1f3559d8caf6e0a47
+  react-native-netinfo: ac0848a4773ef5bd015399444409b5ea9ed75fa3
+  react-native-pager-view: 4434e33d808f274f00e040ab8b0560f48c33e18a
+  react-native-passkey: 4196749aca4d938ab5c1df42b5802c996a16fff8
+  react-native-performance: edf05020e74fcc84a9874ea37f964b6f02a2e1cb
   react-native-quick-base64: 6568199bb2ac8e72ecdfdc73a230fbc5c1d3aac4
   react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863
-  react-native-safe-area-context: 6b4966397ada0f7dd481e4486a2ef936834861a1
-  react-native-skia: b319389e81797af11985805fcfad0714b8670cab
-  react-native-slider: 08ecfc4e9cc16cc388a56dd9caeca51b55cd9bb7
-  react-native-theme-control: c5be440370069688dbba31af43775a62504d5092
-  react-native-view-shot: 5bf17256c542d46c02a6f2d2752fe88eb3a8d058
-  react-native-webview: 51acf11ff6710757bc99a7d31c94295c5b130062
-  React-NativeModulesApple: deba264b03bd79c6bd61014fa30e40321b5e443a
-  React-networking: 35e6070b084f435429f85c5db40b4d5b38652fe9
-  React-oscompat: 64a0c7ef5441855dc6e2a6afe8ba8f92aa05075e
-  React-perflogger: ca04287f205086a1edb5c95882be7b6068458889
-  React-performancecdpmetrics: cf1d0a3178ccd59353cedcacbda421f40100a889
-  React-performancetimeline: c9771212e7a43032d6f8d5edfb58280d46a7ce1f
-  React-RCTActionSheet: ab545c1e7b5f1ce4f8b40b6fa06afe2869095884
-  React-RCTAnimation: 343147a9cd68c93d0ca280799fedfc7102d76ce4
-  React-RCTAppDelegate: 5054754e92aaa9f8bfabe0f1022b84e46f3dcb57
-  React-RCTBlob: 8c7ae3422ca4e72bc64b7a0142fd730efc5d4dfb
-  React-RCTFabric: be458db054b206c4d8e4f20f666e75d5f2c2d420
-  React-RCTFBReactNativeSpec: 06db2e8d0f352d9fa23321aed1dd2cde25a3e83c
-  React-RCTImage: 481457bca63e039eb997f7d16c7560472f49657e
-  React-RCTLinking: 76cbb871240cec2dc5e7aa26c60f59e0ebbcf5a2
-  React-RCTNetwork: e23a778225b7672e38545d3c5c24e1f4aad6d15f
-  React-RCTRuntime: 93c830b3ab3f7b494bbe7ae7289784f8b07b3947
-  React-RCTSettings: 96196b535bef147381f96cc60ce9bda85d8be848
-  React-RCTText: 749ebbd1a999fd84d80f37002ea3bf597fcea6df
-  React-RCTVibration: 5b41a7f274757c2928845981d970916ef9e4ca14
-  React-rendererconsistency: 6708acd4bc39c1c5b00164370d0010d93b324c1f
-  React-renderercss: 80eb778756fed511d6128fc005188ac9008b0baf
-  React-rendererdebug: b46f338fb9d3f0bea6cf0621016c6c5a7a18e72e
-  React-RuntimeApple: c494b2089fad4a0c553cf63c2bb265f7eca2285d
-  React-RuntimeCore: b0bb151c3e2b26c6309d45d05c54aa65a6e0c094
-  React-runtimeexecutor: 00b18635b6216a1708f6eb35dbadfd993ec91c7b
-  React-RuntimeHermes: bb44c4c574ce1b9507cad2e6be015344d18b94a9
-  React-runtimescheduler: e1631e57209cb94b3efc29002b6a049cac3f6599
-  React-timing: 356b88317ca60d373b0d94b6e7a71b0a572899f5
-  React-utils: ccc01da318979af773259c4f6cdb1876f6f86f1a
-  React-webperformancenativemodule: f8b97c2cb6cfa94e92a503c09ad6d491c50a1390
+  react-native-safe-area-context: 866dbfc3292621c18abe9857bda29485bf20607a
+  react-native-skia: 65a19b18cfddadd1ba5f267216763a0b8467f2ec
+  react-native-slider: 8a70a9fbb0253489730cc274171dc78b44600b46
+  react-native-theme-control: 8b57c543cd3c752872ee56f1d41b04cae9500058
+  react-native-view-shot: e31564b1d0c57add676123f74ed1b6e7c7e22851
+  react-native-webview: efe2497dd5df985d9c4e847271b35005eced9028
+  React-NativeModulesApple: 8b90a93dd27efa8dfa63b1b73f9ae4abe76d7232
+  React-networking: 83e04a139514c3b37f749d4c42f8e4529fbea595
+  React-oscompat: 563c536fc2d9cece1f54442fa2a3d9f68a9621e3
+  React-perflogger: 2f9377d019d75920cb22572abcc53f770c56b276
+  React-performancecdpmetrics: 8984cb796dc1b0287c1cdacbb7b96dbedd10b1db
+  React-performancetimeline: f44750eb89f7da31b9635413547b7345089e0906
+  React-RCTActionSheet: ea8200cac284d410090bd780baf729903912e4e6
+  React-RCTAnimation: 1cd96318d09def3c9b4892a30bcbbf16b421b44b
+  React-RCTAppDelegate: 4e5703bda7aed317e93fc1388543bde281991f11
+  React-RCTBlob: 317a92a3f23cc82035cc381d95bea09425dca95f
+  React-RCTFabric: 62baea6be7128ceebdd1ae7fc9640c4ce932ab89
+  React-RCTFBReactNativeSpec: 53d2fb0393feb6e81327a6214399c88ba7950e0b
+  React-RCTImage: 30d09cd35be7d3876b7fda2cf7026a3edbd1c3ba
+  React-RCTLinking: c5dd340d5fee2fa01fee28750ae4211449fd3904
+  React-RCTNetwork: 86aac9640b06b1934b4bf943fa8c01f1f221bcd5
+  React-RCTRuntime: 65b9bff27f149bf20c3dd5554d80923c2679e2ce
+  React-RCTSettings: e1f2e8f15859662cbda170f0e9bc061e1e877f14
+  React-RCTText: 1d7a4f263266efbd5fa5335a107fbd00ff94ba9e
+  React-RCTVibration: f0b6e37ad82d6d3ef3f632619bd9d30a2f8bd850
+  React-rendererconsistency: b179eac76658beccd6a5c1d7c2a1d50502757bd4
+  React-renderercss: 02ff60e9dd36aff6c0c9366b3cb61bf9fb6120dd
+  React-rendererdebug: de05e161b9794436a26e97466261d0eee2ea5ac6
+  React-RuntimeApple: 5b36039ada1f67f7bf4b32eab62007eec36ff26d
+  React-RuntimeCore: a6e718962f5b89114d205a7c9ba79dd48d912b39
+  React-runtimeexecutor: 3c9efd8a0bce437cde84a8dcd1b3190aa27c73e2
+  React-RuntimeHermes: 13de1b869b1de89ecf806d4d713c0385de161812
+  React-runtimescheduler: 887d8d2eccc2c56cbe59e7ffab7393cf04829274
+  React-timing: 58952f6b837d79922e22d45d50847208c54e5888
+  React-utils: 6ff81064a3cf483a7416084f9118d3139950946a
+  React-webperformancenativemodule: a6171cb3e0ad0e52c251e0ae78cec80b9edb1ada
   ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
-  ReactCodegen: c8f81e6c6f762dcf442a6203a1fb58f7dafc8014
-  ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeDependencies: aaf829fb656ecb0bc87fcc5d14f121db8d44276e
+  ReactCodegen: 22f5ee7ee1e6410da1332d1ef8e9cf1cb4aa7b7d
+  ReactCommon: 14a0287b7145ef29530c15bcd7aca4154a3cb353
+  ReactNativeDependencies: 1338342f47b9f2dcbf29d76e09069f45578a0dd0
   ReactNativePerformance: fa4952a58739e1a1f6b90a4e9777657d463499a3
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   RNAppleAuthentication: 8d313d93fe2238d6b7ff0a39c67ebcf298d96653
   RNArgon2: 708e188b7a4d4ec8baf62463927c47abef453a94
-  RNBootSplash: 3b204c1a09c3b79efc4a6d87b1430fa28edd77fb
-  RNCAsyncStorage: 2ad919e88b8bc2cd80e8697ce66d04d006743283
-  RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
-  RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
-  RNDateTimePicker: 7b2738f1e595f83c14580a11c476872755c5befc
+  RNBootSplash: 661dc41c4b03d9a5921d9e6659e3194cad60c6b7
+  RNCAsyncStorage: 446abe7f5eb8df2f00063746a953524937033299
+  RNCClipboard: 67baa8005e30d7037e5704b90f1462f04775a6da
+  RNCMaskedView: a543b7a36c195a519d1bd7ef0291f1cbc6a84a0d
+  RNDateTimePicker: 52a5decb243f39119be9e0d62f137e9349f38bfb
   RNDeviceInfo: 36d7f232bfe7c9b5c494cb7793230424ed32c388
   RNDominantColor: 911de09d58e331bc8f84f22bf393e47d3cf8ca79
   RNFBApp: 33938c8ee95629bda8a14eda579e555a101212dd
   RNFBAppCheck: 9135ee6833548d2dbd2cbda7e15d0d61bcedbe3c
   RNFBMessaging: 1ea695eb9644bbb7aef5c459784f244af2b01cce
   RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
-  RNGestureHandler: 2ff61eac036eaf89f6818bf4ed9c39771a17d134
-  RNGoogleSignin: 9de45fdbecdddcf33d40f601b5d99d668b33401d
+  RNGestureHandler: e088832e6528268d5d5ba7e6dcbaecb11e9fd0ca
+  RNGoogleSignin: 9f2114f72b83bf0d44bd151d7b9262fe801c9567
   RNInAppBrowser: 6d3eb68d471b9834335c664704719b8be1bfdb20
-  RNKeychain: 6778b35b5bd067c322f8479526ac09b1d61f31d0
-  RNLocalize: e582274fa2dc3461a6c417c28b9bcfaf4cc83509
+  RNKeychain: 4530fe0da3b91041852ceeb935ceeffcce8b657a
+  RNLocalize: fe9785c233810caa53ad62a8557e7d4b7b4377de
   RNNotifee: 5e3b271e8ea7456a36eec994085543c9adca9168
   RNOS: d07e5090b5060c6f2b83116d740a32cfdb33afe3
-  RNPermissions: 7590795edd724ce66cb7f97e46a9efc46460dfb1
-  RNReanimated: 80a8d6e0854c9dddedc054efbce746294a8d3a3b
-  RNScreens: 991cc417cd396602a6cf59a42139e5a9d91462a9
+  RNPermissions: 239fd18384ca986d6684e0871bd39c49721530b3
+  RNReanimated: 5cbcdb713d6548c7ab0a769ad586a6b39fad73a9
+  RNScreens: 04eaa3cec7258c13d744af58aed4aec958a17eda
   RNSensors: 111159597ac51505df10413c61b28bcd28e88983
-  RNSentry: c2b739c5dbdd77f439fbd197d1d45724b22a0437
-  RNShare: 0ba5aef3eda20cbdaa31ac57ad5991aaa60b363b
-  RNSound: 679aee56bee0cc1d797fafd381497bc63c245d72
-  RNSVG: 0e52210d4d43165e7e2cf9c890a9848b27e513ac
-  RNWorklets: 2dd3ec21113976f9cf85f2864b9d9d27d9dedbaa
+  RNSentry: 3650d77f87428294f1558385190fdcf3f1227b0a
+  RNShare: f505641c60b67ad0e5214b025e6af0b4a5781c2e
+  RNSound: e52ec700bd9ce5d31d36b42808f24b94ffab1981
+  RNSVG: 4500e73768fce7ace39bdedb0b7b4c62751ae918
+  RNWorklets: 720601f970c2aa5d156cf4b6c7d6cdbcc5c0b28d
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   Sentry: d587a8fe91ca13503ecd69a1905f3e8a0fcf61be
   SwiftUIIntrospect: fee9aa07293ee280373a591e1824e8ddc869ba5d
-  Yoga: 77dfa8673de2874e1855002ae59c68b8be9b007b
+  Yoga: 2fe23f676416a73cb4be2c15929e352c9395b9cf
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: 2931ec2da3c5987843b9a9fdda7f04a6eae40bcd
+PODFILE CHECKSUM: ccd02ae33e9accb96822a9a46d84ee3a0354d37e
 
 COCOAPODS: 1.16.2

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -39,7 +39,7 @@
     "@avalabs/crypto-nitro": "0.3.2",
     "@avalabs/crypto-sdk": "1.0.2",
     "@avalabs/evm-module": "3.9.0",
-    "@avalabs/fusion-sdk": "0.24.0",
+    "@avalabs/fusion-sdk": "0.25.0",
     "@avalabs/glacier-sdk": "3.1.0-canary.672f5c3.0",
     "@avalabs/k2-alpine": "workspace:*",
     "@avalabs/perps-sdk": "0.0.0-feat-perps-sdk-20260521171718",

--- a/yarn.lock
+++ b/yarn.lock
@@ -478,7 +478,7 @@ __metadata:
     "@avalabs/crypto-nitro": 0.3.2
     "@avalabs/crypto-sdk": 1.0.2
     "@avalabs/evm-module": 3.9.0
-    "@avalabs/fusion-sdk": 0.24.0
+    "@avalabs/fusion-sdk": 0.25.0
     "@avalabs/glacier-sdk": 3.1.0-canary.672f5c3.0
     "@avalabs/k2-alpine": "workspace:*"
     "@avalabs/perps-sdk": 0.0.0-feat-perps-sdk-20260521171718
@@ -944,9 +944,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/fusion-sdk@npm:0.24.0":
-  version: 0.24.0
-  resolution: "@avalabs/fusion-sdk@npm:0.24.0"
+"@avalabs/fusion-sdk@npm:0.25.0":
+  version: 0.25.0
+  resolution: "@avalabs/fusion-sdk@npm:0.25.0"
   dependencies:
     "@bitcoinerlab/secp256k1": ^1.2.0
     "@layerzerolabs/lz-v2-utilities": ^3.0.17
@@ -962,7 +962,7 @@ __metadata:
     "@solana/kit": ^5.0.0 || ^6.0.0
     viem: ^2.38.0
     zod: ^4.1.0
-  checksum: 307a25cde65e3a7948fcefb042ccf30930b61d37423d10fc79b18a59f1e3624cf6e64b5cb3f6da8b53aca6f6bf6dbd597a2d62545584c5008a9fb34ff2c80b50
+  checksum: ada16f36c2d744167b96798ef1ad03fea94a427d55cd1472bba43d6f74615199ff8a302c3983002480f5d3b6cc99534da9476c36c5be4b5b06bdca3a3cdb361a
   languageName: node
   linkType: hard
 
@@ -36779,7 +36779,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: d6ceb75e1d0f5755370d6d91f67902bd2b8a23a3ca43cb853d2964b43798f30477e8ab0223ea8b620534fbdf5f56d39550f40d24bec2d2398c323ccfe8a5a556
+  checksum: e08d1254d04f3074970b63cdf0a363d6b189009270d457e868a26ef534addd69b320b85bef2a22e4eddb79006751bded431b56aaf2baf41976a6d0a5a2a2b91e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
iOS: 9057
Android: 9058

## Description

**Ticket: [CP-14581]** **Ticket: [CP-14582]** **Ticket: [CP-14584]**

Adds push notifications for recurring swap (DCA) schedule execution, re-introduces a Markr-specific per-order minimum, fixes a first-fill double-approval bug, adds a pre-submit balance guard for under-funded schedules, hardens the per-order-minimum submit gate against a loading-race, polishes the manage-screen loading state, and upgrades the fusion-sdk to its `0.25.0` release.

**Summary of changes**

- **Execution push notifications (core-notification-sender integration)**
  - `recurringSwapNotifications`: subscribes a device to per-order push via `/v1/push/recurring-swaps/subscribe` (AppCheck-authed). Re-subscribe is an idempotent reactivation, so retries are safe; teardown is webhook/event-driven server-side.
  - `subscribedOrders`: per-`(owner, chain)` MMKV set of already-subscribed order IDs so the `listOrders` watcher skips redundant subscribe calls (bounded to 2000 entries, evicted oldest-first).
  - `recurringSwap/store/listeners`: auto-subscribe watcher over `listOrders`.
  - Notifications feature: new `RecurringSwapItem` row + `NotificationIcon` / `NotificationsScreen` / `NotificationCenterService` / `schemas` / `types` / `utils` to parse and route the recurring-swap notification type (title/body formatted server-side; `data.status` drives the status badge).
  - FCM (`FCMService`, `types`): handle the recurring-swap remote-message type.

- **Notification row polish + subscribe efficiency**
  - `RecurringSwapItem` reads the structured `data` (status + order counts), not status alone: a mid-schedule fill renders a green **"Executed"** badge while the final leg renders **"Completed"**; failures render red **"Failed"**. Infinite/DCA schedules (`numberOfOrders === -1`) always read as a mid-schedule fill.
  - `isTerminalRecurringSwapNotification` + `hasActionableUrl`: terminal / last-leg recurring rows point at a schedule the manage screen no longer lists (Active / Paused only), so they're non-actionable (no chevron, press no-ops).
  - `RecurringSwapMetadataSchema.reasonCode` → `z.coerce.string()`: the FCM push stringifies every `data` value while the notification-center history API returns raw JSON. A failed notification always carries a `reasonCode`, so the non-coercing schema dropped the whole `data` block on the history path (breaking the failure badge + terminal detection).
  - `ensureOrderSubscriptions` resolves the device ARN (`/v1/push/register`) once per batch and memoizes it across batches (skipping register in the steady state); cache invalidated on subscribe failure, `onFcmTokenChange`, and `onLogOut`.

- **Per-order minimum + submit-gate race**
  - `useMinimumTransferAmount` gains an optional `serviceType` to pin a single service's floor instead of the blended "lowest across services" value.
  - `SwapScreen`: recurring validates the per-order amount against **Markr's** floor specifically (recurring is Markr-only) — blending in a lower non-Markr floor could let a sub-fillable per-order amount through.
  - **Race fix:** `computeValidationError` skips the below-minimum check while the minimum is unknown, and `isRecurringReady` only required a resolved recurring quote — so a quick tap in the window where the quote resolved but the Markr minimum query was still loading could submit a sub-minimum amount. Added `isRecurringMinimumReady` to the submit gate (`markrMinimumTransferAmount !== undefined`); Next stays disabled until the minimum query settles. No deadlock — if Fusion isn't ready the recurring quote can't resolve either, so `hasRecurringQuote` already gates Next.

- **Under-funded schedule guard (pre-submit balance validation)**
  - A native-source recurring swap surfaced a generic "Recurring swap failed — please try again" toast on submit. Root cause: the first fill pre-wraps the **entire** `totalAmountIn` (per-order × order count) to WAVAX in one tx (the schedule can't pull native per order), so when that total exceeds the native balance, `eth_estimateGas` reverts with `INSUFFICIENT_FUNDS` and the EVM module throws `rpcErrors.internal`. The app validated only the per-order amount against balance, never the total.
  - New tested `recurringBalanceGate` (`computeRecurringBalanceError`), wired into `computeValidationError` so it renders inline **and** disables Next via `isRecurringReady`:
    - **Native source:** require `nativeBalance ≥ totalAmountIn + additive native fees` (the SDK flags the one-time schedule fee with `fee.extra` as "balance-check separately") — one combined message quoting the full requirement.
    - **ERC-20 source:** principal checked against the token balance, the native schedule fee against the native balance — independent shortfalls surfaced together when both fall short ("needs X USDC and Y AVAX for the schedule fee").
    - Uses the authoritative `recurringQuote.totalAmountIn` + summed `extra` fees. Estimated **gas** is left to the SDK's own `estimateGas` (the quote reports it in gas units, not a reservable wei cost). Skipped for **Unlimited** (no finite total).
  - `fusionErrors`: new `recurringTotalExceedsBalance` / `recurringScheduleFeeExceedsNativeBalance` / `recurringInsufficientForTotalAndFee`.

- **Manage screen — loading state**
  - `RecurringSchedulesScreen`: while the first `listOrders` fetch is in flight, show only a centered spinner over the modal instead of flashing the large "0 recurring swaps scheduled" header + "Loading…" caption (the count is unknown until data resolves). Spinner color uses the `$textPrimary` theme token (light/dark aware) rather than a hardcoded hex.

- **First-fill double-approval fix**
  - `submitRecurringSwap`: pass `fallbackToDefaultOnBatchFailure: false`. Mobile's `signBatch` is non-atomic for recurring (it signs/broadcasts wrap → approve → swap sequentially), so the SDK's batch-failure fallback silently re-ran the whole sequence on any throw — producing a **second spend-limit approval** and a spurious **"User rejected the request."** from a superseded approval sheet. `false` surfaces a real failure once, with no double-execution. Ledger/WC peers are unaffected (recurring never issues a true atomic batch).

**Dependencies**

- Bumps `@avalabs/fusion-sdk` to `0.25.0` (recurring native-input release).

## Screenshots/Videos

https://github.com/user-attachments/assets/7dda133d-9c00-401e-9b46-f3573ed1b0b6

https://github.com/user-attachments/assets/d05942b8-b5a6-465c-914b-420c7a742241

## Testing

**Dev Testing**

Happy path
- Create a recurring swap (e.g. AVAX → USDC), set frequency + number of orders, tap Next and confirm.
- Confirm you are prompted for the spend-limit approval **exactly once** (then the swap approval), and the schedule is created — no duplicate spend-limit prompt.
- Confirm no "Recurring swap failed — please try again" toast appears on a successful schedule.
- When an order executes (or fails) on-chain, confirm a push notification arrives; tapping it opens the notification center showing the recurring-swap row with the correct status badge (Executed for a mid-schedule fill, Completed for the final leg, Failed for a failure). Confirm a terminal/last-leg row has no chevron and doesn't navigate.

Per-order minimum + gate race
- Enter a per-order amount below Markr's minimum for the pair → "Next" is disabled and the below-minimum error shows.
- Enter an amount at/above the minimum → "Next" enables.
- Immediately after configuring frequency + orders, confirm "Next" does not enable until pricing/the minimum has loaded — i.e. you can't tap through before the per-order floor is known.

Under-funded schedule (balance guard)
- Native source: with AVAX selected and a **total** (per-order × orders) greater than your AVAX balance, confirm "Next" is disabled and an inline "Insufficient balance — N orders require X AVAX" message shows — instead of a "Recurring swap failed" toast appearing only after you submit.
- Lower the order count or per-order amount so the total (plus the schedule fee) fits your balance → the message clears and "Next" enables.
- ERC-20 source where the token covers the principal but you lack the native gas-token for the schedule fee → confirm the "needs … for the schedule fee" message; if the token is also short, confirm the combined "needs X and Y for the schedule fee" message.
- "Unlimited" orders (where offered) → confirm the total-balance message does not appear (no finite total to check).

Manage screen
- Open the recurring-swap management modal while schedules are still loading → confirm only a centered spinner shows (no "0 recurring swaps scheduled" header flash, no "Loading…" text). Once loaded, the header + schedule cards (or the empty / error state) render normally.

**QA Testing**

- Verify the recurring swap schedule + first fill complete with a single spend-limit approval across software wallets (mnemonic, seedless).
- Verify execution/failure push notifications render correctly (Executed / Completed / Failed) and route into the notification center; terminal rows are non-actionable.
- Verify a recurring swap whose total exceeds balance is blocked at input time with a clear message (native and ERC-20 sources), and that a sufficiently-funded schedule proceeds normally.
- Verify the manage modal shows a centered spinner while loading and never flashes a "0 recurring swaps scheduled" header.
- Acceptance: scheduling a recurring swap never shows a duplicate spend-limit approval, never reports a rejection the user did not make, never fails on-chain for an under-funded total that could have been caught up front, and never lets a sub-minimum per-order amount through.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14581]: https://ava-labs.atlassian.net/browse/CP-14581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-14582]: https://ava-labs.atlassian.net/browse/CP-14582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-14584]: https://ava-labs.atlassian.net/browse/CP-14584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
