### PR TITLE
CP-14613: fix bottom-tab native crash when switching to a non-X/P account

### DIFF
--- a/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/_layout.tsx
@@ -98,17 +98,27 @@ export default function TabLayout(): JSX.Element {
           freezeOnBlur
         }}
       />
-      {hasXpAddresses && (
-        <BottomTabs.Screen
-          name="stake"
-          options={{
-            tabBarButtonTestID: 'stake_tab',
-            title: 'Stake',
-            tabBarIcon: () => stakeIcon,
-            freezeOnBlur
-          }}
-        />
-      )}
+      {/*
+       * Always register the stake screen; hide its button via tabBarItemHidden
+       * when the active account has no X/P addresses. Conditionally rendering
+       * (adding/removing) a native BottomTabs.Screen mutates the native tab
+       * controller's screen set at runtime, which crashes when hasXpAddresses
+       * flips on an account switch (e.g. primary Keystone account -> non-primary
+       * with empty X/P) and the user then opens the Browser tab. Mirror the
+       * earn/trade/activity tabs, which stay registered and use tabBarItemHidden
+       * (the custom TabBar below hides any tab whose tabBarItemHidden is set).
+       * (CP-14613)
+       */}
+      <BottomTabs.Screen
+        name="stake"
+        options={{
+          tabBarButtonTestID: 'stake_tab',
+          title: 'Stake',
+          tabBarIcon: () => stakeIcon,
+          freezeOnBlur,
+          tabBarItemHidden: !hasXpAddresses
+        }}
+      />
       <BottomTabs.Screen
         name="earn"
         options={{
@@ -161,7 +171,6 @@ const TabBar = ({
 }: BottomTabBarProps): JSX.Element => {
   const insets = useSafeAreaInsets()
   const { theme } = useTheme()
-  const hasXpAddresses = useHasXpAddresses()
   const backgroundColor = useMemo(() => {
     return theme.isDark
       ? isIOS
@@ -190,15 +199,11 @@ const TabBar = ({
       }}>
       {state.routes.map((route, index) => {
         const options = descriptors[route.key]?.options
-        // Check tabBarItemHidden option
+        // A tab opts out of the bar via its tabBarItemHidden option. Stake sets
+        // it when the account has no X/P addresses; earn/trade/activity set it
+        // from their feature flags. This single check is the only hide path, so
+        // there's no second source of truth to drift. (CP-14613)
         if (options?.tabBarItemHidden) {
-          return null
-        }
-        // Hide stake/earn tabs when user doesn't have XP addresses
-        if (
-          (route.name === 'stake' || route.name === 'earn') &&
-          !hasXpAddresses
-        ) {
           return null
         }
         const isActive = state.index === index

--- a/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/stake/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/stake/index.tsx
@@ -1,11 +1,28 @@
 import React from 'react'
+import { Redirect } from 'expo-router'
 import { StakeHomeScreen } from 'features/stake/screens/StakeHomeScreen'
 import { StakeHomeScreen as StakeHomeScreenV2 } from 'features/stake/v2/screens/StakeHomeScreen'
 import { useSelector } from 'react-redux'
 import { selectIsFastStakeBlocked } from 'store/posthog'
+import { useHasXpAddresses } from 'common/hooks/useHasXpAddresses'
 
 const HomeScreen = (): JSX.Element => {
   const isFastStakeBlocked = useSelector(selectIsFastStakeBlocked)
+  const hasXpAddresses = useHasXpAddresses()
+
+  // Staking is a P-Chain feature. The Stake tab is registered for every account
+  // so the native bottom-tab set stays stable across account switches (its
+  // button is hidden when there's no X/P — see (tabs)/_layout.tsx, CP-14613).
+  // Guard the screen itself so any other entry point into Stake for an account
+  // without X/P addresses — a core://stake deep link, programmatic navigation,
+  // navigation-state restore, or being left on the Stake tab after switching to
+  // a non-X/P account (e.g. a non-primary Keystone account) — redirects to
+  // Portfolio instead of mounting a stake flow that can't complete. Returning
+  // here before rendering the stake screens also avoids their child hooks (e.g.
+  // useStakes) firing X/P queries with empty addresses. (CP-14613)
+  if (!hasXpAddresses) {
+    return <Redirect href="/portfolio" />
+  }
 
   // fast_stake_enabled flag on: show the new streamlined stake home screen
   if (!isFastStakeBlocked) {


### PR DESCRIPTION
## What

Fixes [CP-14613](https://ava-labs.atlassian.net/browse/CP-14613): with a Keystone wallet, switching the active account to a non-primary account and then opening the Browser tab crashed the app instantly (release build, no JS stack trace).

## Root cause

CP-14606 made non-primary Keystone accounts exist with empty X/P addresses (`addressPVM`/`addressAVM` = `''`), so `useHasXpAddresses()` now flips between `true` (account 1) and `false` (account 2) on an account switch.

The `stake` tab was **conditionally rendered** as a child of the native `react-native-bottom-tabs` navigator (`{hasXpAddresses && <BottomTabs.Screen name="stake" />}`). Toggling that on an account switch changes the navigator's screen **count**, which tears down and re-initialises the native tab controller (on Android, `menu.clear()` fires only when the item count shrinks). Opening the Browser tab right after this trips a native crash. No JS error is produced, which is why it never showed up in Sentry.

## Fix

`app/new/routes/(signedIn)/(tabs)/_layout.tsx`
- Always register the `stake` screen; hide its button via `tabBarItemHidden: !hasXpAddresses` instead of adding/removing the screen. This keeps the native tab set's size constant across account switches (the same pattern `earn`/`trade`/`activity` already use). This is the crash fix.
- Stop hiding the **Earn** tab when there are no X/P addresses. Earn is C-chain DeFi (Aave deposit/borrow, `features/defiMarket`) and does not depend on X/P — it was swept into the X/P gate in CP-13202 when stake/earn were a single tab. Confirmed with JJ (author of CP-13202) in #core-mobile-dev that there's no reason to hide Earn for non-X/P accounts.

`app/new/routes/(signedIn)/(tabs)/stake/index.tsx`
- Redirect to Portfolio when the account has no X/P addresses. Because the stake screen is now always registered, this guards every other entry point (a `core://stake` deep link, programmatic navigation, navigation-state restore, or being left on the Stake tab after switching to a non-X/P account) so the user never lands on a stake flow that can't complete, and the stake screen's child hooks never fire X/P queries with empty addresses.

## Dev testing

Reviewer steps (Keystone wallet with a non-primary account, i.e. account 2):
1. On account 1: open the Browser tab (works); confirm the Stake tab is visible.
2. Switch the active account to account 2 -> the Stake tab disappears, no crash.
3. Open the Browser tab -> no crash (this was the repro).
4. Confirm the Earn tab stays visible on account 2 (with in-app DeFi enabled).
5. On account 1, open Stake, then switch to account 2 -> you are redirected to Portfolio (not left on a hidden/blank Stake tab).

Verified locally:
- Android (Pixel 8 Pro, internalDebug): reproduced the original crash on `main`, confirmed fixed on this branch. Stake hidden, Earn visible, Stake redirect works.
- iOS (iPhone 17 Pro Max simulator, iOS 26.2): app builds and runs; reviewers can verify the Keystone account-2 flow on the iOS Bitrise build below (the QA repro recording looked like iOS).
- `yarn lint`, `yarn tsc`: clean. Targeted jest (stake/earn/defiMarket/earn-hooks): 172 passed.

Bitrise builds (post-rebase, on the Expo 56 / RN 0.85 base):
- iOS: 9033
- Android: 9034

## Notes / follow-ups (out of scope)

- Pre-existing: `useStakes` uses `xpAddresses.every(...)`, which is vacuously true for an empty array, so it can fire a Glacier query with `addresses=''`. The redirect guard above prevents the stake screen from mounting for non-X/P accounts, so this is no longer reachable via the UI, but the guard in `useStakes` itself should be tightened separately (`xpAddresses.length > 0 && ...`).


[CP-14613]: https://ava-labs.atlassian.net/browse/CP-14613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ