### PR TITLE
Replace fontWeight overrides with Inter font family variants

### DIFF
--- a/packages/core-mobile/app/new/features/addEthereumChain/screens/AddEthereumChainScreen.tsx
+++ b/packages/core-mobile/app/new/features/addEthereumChain/screens/AddEthereumChainScreen.tsx
@@ -50,7 +50,7 @@ const AddEthereumChainScreen = ({
               textAlign: 'center',
               fontSize: 15,
               lineHeight: 20,
-              fontWeight: '500',
+              fontFamily: 'Inter-Medium',
               color: '$textPrimary'
             }}>
             {description}

--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
@@ -389,7 +389,7 @@ const ApprovalScreenInner = ({
                 textAlign: 'center',
                 fontSize: 15,
                 lineHeight: 20,
-                fontWeight: '500',
+                fontFamily: 'Inter-Medium',
                 color: '$textPrimary'
               }}>
               {action}

--- a/packages/core-mobile/app/new/features/editContact/screens/EditContactScreen.tsx
+++ b/packages/core-mobile/app/new/features/editContact/screens/EditContactScreen.tsx
@@ -54,7 +54,7 @@ const EditContactScreen = ({
               textAlign: 'center',
               fontSize: 15,
               lineHeight: 20,
-              fontWeight: '500',
+              fontFamily: 'Inter-Medium',
               color: '$textPrimary'
             }}>
             {description}

--- a/packages/core-mobile/app/new/features/injectedProvider/screens/AuthorizeInjectedDappScreen.tsx
+++ b/packages/core-mobile/app/new/features/injectedProvider/screens/AuthorizeInjectedDappScreen.tsx
@@ -125,7 +125,7 @@ const AuthorizeInjectedDappScreen = (): JSX.Element | null => {
             <Text
               variant="body1"
               style={{ textAlign: 'center', width: SCREEN_WIDTH * 0.85 }}>
-              <Text variant="body1" style={{ fontWeight: '600' }}>
+              <Text variant="body1" style={{ fontFamily: 'Inter-SemiBold' }}>
                 {peerMeta.url}
               </Text>
               {

--- a/packages/core-mobile/app/new/features/ledger/components/UnsupportedBitcoinApp.tsx
+++ b/packages/core-mobile/app/new/features/ledger/components/UnsupportedBitcoinApp.tsx
@@ -47,7 +47,7 @@ export const UnsupportedBitcoinApp = ({
           Open the{' '}
           <Text
             variant="body1"
-            sx={{ fontWeight: '600', color: '$textPrimary' }}>
+            sx={{ fontFamily: 'Inter-SemiBold', color: '$textPrimary' }}>
             Bitcoin Recovery
           </Text>{' '}
           app on your Ledger device to continue.

--- a/packages/core-mobile/app/new/features/ledger/screens/CompleteScreen.tsx
+++ b/packages/core-mobile/app/new/features/ledger/screens/CompleteScreen.tsx
@@ -76,7 +76,7 @@ export default function CompleteScreen(): JSX.Element {
             textAlign: 'center',
             marginTop: 24,
             marginBottom: 18,
-            fontWeight: '600'
+            fontFamily: 'Inter-SemiBold'
           }}>
           Ledger wallet{'\n'}successfully added
         </Text>

--- a/packages/core-mobile/app/new/features/meld/components/SelectAmount.tsx
+++ b/packages/core-mobile/app/new/features/meld/components/SelectAmount.tsx
@@ -166,7 +166,7 @@ export const SelectAmount = ({
           variant="caption"
           sx={{
             fontSize: 11,
-            fontWeight: 500,
+            fontFamily: 'Inter-SemiBold',
             textAlign: 'right'
           }}>
           {serviceProviderToDisplay}
@@ -196,7 +196,7 @@ export const SelectAmount = ({
           <Text
             testID="error_msg"
             variant="caption"
-            sx={{ fontWeight: 500, color: colors.$textDanger }}>
+            sx={{ fontFamily: 'Inter-Medium', color: colors.$textDanger }}>
             {errorMessage || createSessionWidgetErrorMessage}
           </Text>
         </View>
@@ -215,7 +215,7 @@ export const SelectAmount = ({
         <Text
           variant="caption"
           sx={{
-            fontWeight: 500,
+            fontFamily: 'Inter-Medium',
             color: colors.$textPrimary
           }}>
           Balance:{' '}
@@ -255,7 +255,6 @@ export const SelectAmount = ({
           sx={{
             fontSize: 16,
             lineHeight: 22,
-            fontWeight: 400,
             color: colors.$textPrimary
           }}>
           {category === ServiceProviderCategories.CRYPTO_ONRAMP
@@ -274,7 +273,6 @@ export const SelectAmount = ({
                     sx={{
                       fontSize: 16,
                       lineHeight: 22,
-                      fontWeight: 400,
                       textAlign: 'right'
                     }}>
                     {paymentMethodToDisplay}

--- a/packages/core-mobile/app/new/features/meld/components/SelectPaymentMethod.tsx
+++ b/packages/core-mobile/app/new/features/meld/components/SelectPaymentMethod.tsx
@@ -93,7 +93,6 @@ export const SelectPaymentMethod = ({
             sx={{
               fontSize: 16,
               lineHeight: 22,
-              fontWeight: 400,
               color: colors.$textPrimary
             }}>
             Change provider

--- a/packages/core-mobile/app/new/features/meld/components/SelectServiceProvider.tsx
+++ b/packages/core-mobile/app/new/features/meld/components/SelectServiceProvider.tsx
@@ -182,7 +182,7 @@ export const SelectServiceProvider = ({
                   variant="body1"
                   sx={{
                     lineHeight: 16,
-                    fontWeight: 600,
+                    fontFamily: 'Inter-SemiBold',
                     color: colors.$textPrimary
                   }}>
                   {ServiceProviderNames[serviceProvider.serviceProvider] ??
@@ -194,7 +194,6 @@ export const SelectServiceProvider = ({
                       variant="body2"
                       sx={{
                         color: colors.$textSuccess,
-                        fontWeight: 400,
                         lineHeight: 16
                       }}>
                       Lowest price
@@ -204,16 +203,14 @@ export const SelectServiceProvider = ({
             </View>
           )}
           <View>
-            <Text
-              variant="body2"
-              sx={{ textAlign: 'right', fontWeight: 400, lineHeight: 16 }}>
+            <Text variant="body2" sx={{ textAlign: 'right', lineHeight: 16 }}>
               {tokenUnitToDisplay} {token?.tokenWithBalance.symbol}
             </Text>
             <Text
               variant="subtitle2"
               sx={{
                 textAlign: 'right',
-                fontWeight: 500,
+                fontFamily: 'Inter-Medium',
                 fontSize: 12,
                 color: colors.$textSecondary
               }}>

--- a/packages/core-mobile/app/new/features/notifications/components/SwapStatusCard.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/SwapStatusCard.tsx
@@ -113,7 +113,7 @@ export const SwapStatusCard = ({
             variant="body1"
             sx={{
               lineHeight: 22,
-              fontWeight: '500',
+              fontFamily: 'Inter-Medium',
               color: statusColor
             }}>
             {statusTitle}

--- a/packages/core-mobile/app/new/features/notifications/components/TokenAmountRow.tsx
+++ b/packages/core-mobile/app/new/features/notifications/components/TokenAmountRow.tsx
@@ -89,7 +89,7 @@ export const TokenAmountRow = ({
               numberOfLines={1}
               variant="heading2"
               sx={{
-                fontWeight: '500',
+                fontFamily: 'Inter-Medium',
                 color: isDebit ? colors.$textDanger : colors.$textPrimary
               }}>
               {isDebit ? `-${amount}` : amount}

--- a/packages/core-mobile/app/new/features/onboarding/components/AnalyticsConsent.tsx
+++ b/packages/core-mobile/app/new/features/onboarding/components/AnalyticsConsent.tsx
@@ -52,7 +52,7 @@ export const AnalyticsConsent = ({
       <View sx={{ gap: 20 }}>
         <Text testID="anlaysticsContent" variant="subtitle1">
           As a Core user, you have the option to opt-in for{' '}
-          <Text variant="body1" sx={{ fontWeight: '700' }}>
+          <Text variant="body1" sx={{ fontFamily: 'Inter-Bold' }}>
             airdrop rewards
           </Text>{' '}
           based on your activity and engagement. Core will collect anonymous

--- a/packages/core-mobile/app/new/features/onboarding/components/AuthenticatorSetup.tsx
+++ b/packages/core-mobile/app/new/features/onboarding/components/AuthenticatorSetup.tsx
@@ -67,7 +67,7 @@ export const AuthenticatorSetup = ({
                 <Text
                   sx={{
                     fontSize: 16,
-                    fontWeight: '500',
+                    fontFamily: 'Inter-Medium',
                     lineHeight: 16,
                     color: colors.$textPrimary
                   }}>
@@ -78,7 +78,6 @@ export const AuthenticatorSetup = ({
                     <Text
                       sx={{
                         fontSize: 12,
-                        fontWeight: '400',
                         lineHeight: 15,
                         color: colors.$textSecondary
                       }}>
@@ -116,7 +115,7 @@ export const AuthenticatorSetup = ({
                 <Text
                   sx={{
                     fontSize: 16,
-                    fontWeight: '500',
+                    fontFamily: 'Inter-Medium',
                     lineHeight: 16,
                     color: colors.$textPrimary
                   }}>
@@ -125,7 +124,6 @@ export const AuthenticatorSetup = ({
                 <Text
                   sx={{
                     fontSize: 12,
-                    fontWeight: '400',
                     lineHeight: 15,
                     color: colors.$textSecondary,
                     marginTop: 3,

--- a/packages/core-mobile/app/new/features/onboarding/components/CopyCode.tsx
+++ b/packages/core-mobile/app/new/features/onboarding/components/CopyCode.tsx
@@ -51,7 +51,7 @@ export const CopyCode = ({
               <Text
                 sx={{
                   fontSize: 14,
-                  fontWeight: '500',
+                  fontFamily: 'Inter-Medium',
                   lineHeight: 17,
                   color: colors.$textPrimary
                 }}>
@@ -76,7 +76,6 @@ export const CopyCode = ({
               <Text
                 sx={{
                   fontSize: 13,
-                  fontWeight: '400',
                   lineHeight: 16,
                   color: colors.$textPrimary
                 }}>
@@ -99,7 +98,6 @@ export const CopyCode = ({
               <Text
                 sx={{
                   fontSize: 13,
-                  fontWeight: '400',
                   lineHeight: 16,
                   color: colors.$textPrimary
                 }}>
@@ -120,7 +118,6 @@ export const CopyCode = ({
               <Text
                 sx={{
                   fontSize: 13,
-                  fontWeight: '400',
                   lineHeight: 16,
                   color: colors.$textPrimary
                 }}>

--- a/packages/core-mobile/app/new/features/onboarding/components/KeystoneTroubleshooting.tsx
+++ b/packages/core-mobile/app/new/features/onboarding/components/KeystoneTroubleshooting.tsx
@@ -86,7 +86,7 @@ export const Steps: FC<{ steps: string[] }> = ({ steps }) => {
           <Text
             variant="subtitle1"
             sx={{
-              fontWeight: 'bold'
+              fontFamily: 'Inter-Bold'
             }}>{`Step ${index + 1}`}</Text>
           <Text
             variant="subtitle1"

--- a/packages/core-mobile/app/new/features/recurringSwap/components/RecurrenceChips.tsx
+++ b/packages/core-mobile/app/new/features/recurringSwap/components/RecurrenceChips.tsx
@@ -100,7 +100,7 @@ export function RecurrenceChips<T extends string>({
                       color: textColor,
                       fontSize: 15,
                       lineHeight: 20,
-                      fontWeight: '500'
+                      fontFamily: 'Inter-Medium'
                     }}>
                     {item.label}
                   </Text>

--- a/packages/core-mobile/app/new/features/rpc/components/SelectAccounts.tsx
+++ b/packages/core-mobile/app/new/features/rpc/components/SelectAccounts.tsx
@@ -124,7 +124,7 @@ export const SelectAccounts = ({
               variant="body1"
               sx={{
                 fontSize: 14,
-                fontWeight: '500',
+                fontFamily: 'Inter-Medium',
                 color: '$textPrimary',
                 marginLeft: 10
               }}>

--- a/packages/core-mobile/app/new/features/rpc/screens/AuthorizeDappScreen.tsx
+++ b/packages/core-mobile/app/new/features/rpc/screens/AuthorizeDappScreen.tsx
@@ -104,7 +104,7 @@ const AuthorizeDappScreen = ({
             <Text
               variant="body1"
               style={{ textAlign: 'center', width: SCREEN_WIDTH * 0.85 }}>
-              <Text variant="body1" style={{ fontWeight: '600' }}>
+              <Text variant="body1" style={{ fontFamily: 'Inter-SemiBold' }}>
                 {peerMeta.url}
               </Text>
               {

--- a/packages/core-mobile/app/new/features/rpc/screens/WalletConnectScanScreen.tsx
+++ b/packages/core-mobile/app/new/features/rpc/screens/WalletConnectScanScreen.tsx
@@ -148,7 +148,7 @@ export const WalletConnectScanScreen = (): React.JSX.Element => {
             sx={{
               textAlign: 'center',
               color: '$white',
-              fontWeight: '500',
+              fontFamily: 'Inter-Medium',
               marginLeft: 8
             }}>
             WalletConnect QR Code

--- a/packages/core-mobile/app/new/features/stake/components/DurationOptions.tsx
+++ b/packages/core-mobile/app/new/features/stake/components/DurationOptions.tsx
@@ -85,7 +85,7 @@ export const DurationOptions = ({
                   <Text
                     variant="body1"
                     sx={{
-                      fontWeight: 500,
+                      fontFamily: 'Inter-SemiBold',
                       color: selectedTheme.colors.$textPrimary
                     }}>
                     {'numberOfDays' in item

--- a/packages/core-mobile/app/new/features/stake/components/NodeItem.tsx
+++ b/packages/core-mobile/app/new/features/stake/components/NodeItem.tsx
@@ -45,7 +45,7 @@ export const NodeItem = ({
         <View sx={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
           {shouldWarn ? <NodeUnstable /> : <NodeStable />}
           <View sx={{ gap: 2 }}>
-            <Text variant="body1" sx={{ fontWeight: 600 }}>
+            <Text variant="body1" sx={{ fontFamily: 'Inter-SemiBold' }}>
               {truncateNodeId(node.nodeID)}
             </Text>
             <Text variant="body2">{`End date: ${endDate}`}</Text>

--- a/packages/core-mobile/app/new/features/swap/screens/SwapSlippageDetailsScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapSlippageDetailsScreen.tsx
@@ -176,7 +176,6 @@ export const SwapSlippageDetailsScreen = ({
             <Text
               sx={{
                 fontSize: 16,
-                fontWeight: '400',
                 lineHeight: 22
               }}>
               Slippage
@@ -185,7 +184,6 @@ export const SwapSlippageDetailsScreen = ({
               sx={{
                 color: colors.$textSecondary,
                 fontSize: 16,
-                fontWeight: '400',
                 lineHeight: 22,
                 textAlign: 'right'
               }}>
@@ -209,7 +207,6 @@ export const SwapSlippageDetailsScreen = ({
                   <Text
                     sx={{
                       fontSize: 16,
-                      fontWeight: '400',
                       lineHeight: 22
                     }}>
                     Auto slippage
@@ -234,7 +231,6 @@ export const SwapSlippageDetailsScreen = ({
                 <Text
                   sx={{
                     fontSize: 16,
-                    fontWeight: '400',
                     lineHeight: 22
                   }}>
                   Manual slippage
@@ -278,7 +274,7 @@ export const SwapSlippageDetailsScreen = ({
                               ? inversedColors.$textPrimary
                               : colors.$textPrimary,
                             fontSize: 15,
-                            fontWeight: '500',
+                            fontFamily: 'Inter-SemiBold',
                             lineHeight: 20,
                             textAlign: 'center'
                           }}>
@@ -309,7 +305,6 @@ export const SwapSlippageDetailsScreen = ({
                           sx={{
                             color: inversedColors.$textPrimary,
                             fontSize: 11,
-                            fontWeight: '400',
                             lineHeight: 14,
                             textAlign: 'center'
                           }}>
@@ -319,7 +314,7 @@ export const SwapSlippageDetailsScreen = ({
                           sx={{
                             color: inversedColors.$textPrimary,
                             fontSize: 15,
-                            fontWeight: '500',
+                            fontFamily: 'Inter-Semibold',
                             lineHeight: 20,
                             textAlign: 'center'
                           }}>
@@ -331,7 +326,7 @@ export const SwapSlippageDetailsScreen = ({
                         sx={{
                           color: colors.$textPrimary,
                           fontSize: 15,
-                          fontWeight: '500',
+                          fontFamily: 'Inter-Semibold',
                           lineHeight: 20,
                           textAlign: 'center'
                         }}>

--- a/packages/core-mobile/app/new/features/swap/screens/SwapSlippageDetailsScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapSlippageDetailsScreen.tsx
@@ -314,7 +314,7 @@ export const SwapSlippageDetailsScreen = ({
                           sx={{
                             color: inversedColors.$textPrimary,
                             fontSize: 15,
-                            fontFamily: 'Inter-Semibold',
+                            fontFamily: 'Inter-SemiBold',
                             lineHeight: 20,
                             textAlign: 'center'
                           }}>
@@ -326,7 +326,7 @@ export const SwapSlippageDetailsScreen = ({
                         sx={{
                           color: colors.$textPrimary,
                           fontSize: 15,
-                          fontFamily: 'Inter-Semibold',
+                          fontFamily: 'Inter-SemiBold',
                           lineHeight: 20,
                           textAlign: 'center'
                         }}>

--- a/packages/core-mobile/app/new/features/toggleDeveloperMode/screens/ToggleDeveloperModeScreen.tsx
+++ b/packages/core-mobile/app/new/features/toggleDeveloperMode/screens/ToggleDeveloperModeScreen.tsx
@@ -59,7 +59,7 @@ const ToggleDeveloperModeScreen = ({
               textAlign: 'center',
               fontSize: 15,
               lineHeight: 20,
-              fontWeight: '500',
+              fontFamily: 'Inter-Medium',
               color: '$textPrimary'
             }}>
             {action}

--- a/packages/core-mobile/app/new/features/track/components/RankView.tsx
+++ b/packages/core-mobile/app/new/features/track/components/RankView.tsx
@@ -30,8 +30,7 @@ export const RankView = ({
         <Text
           sx={{
             color: '$textSecondary',
-            fontFamily: 'Inter-Regular',
-            fontWeight: '500',
+            fontFamily: 'Inter-Medium',
             fontSize: 10,
             lineHeight: 12
           }}>

--- a/packages/core-mobile/app/new/features/watchAsset/screens/WatchAssetScreen.tsx
+++ b/packages/core-mobile/app/new/features/watchAsset/screens/WatchAssetScreen.tsx
@@ -88,7 +88,7 @@ const WatchAssetScreen = ({
               textAlign: 'center',
               fontSize: 15,
               lineHeight: 20,
-              fontWeight: '500',
+              fontFamily: 'Inter-Medium',
               color: '$textPrimary'
             }}>
             {request.peerMeta.name} is requesting to add this token

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStake/duration.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStake/duration.tsx
@@ -271,7 +271,7 @@ const StakeDurationScreen = (): JSX.Element => {
         value: (
           <StakeTokenUnitValue
             value={estimatedReward}
-            textSx={{ fontWeight: 600 }}
+            textSx={{ fontFamily: 'Inter-SemiBold' }}
           />
         )
       }
@@ -348,7 +348,7 @@ const StakeDurationScreen = (): JSX.Element => {
               marginTop: 0
             }}
             titleSx={{
-              fontWeight: 600
+              fontFamily: 'Inter-SemiBold'
             }}
           />
         </View>

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/discoverCollectibles/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/discoverCollectibles/index.tsx
@@ -135,7 +135,9 @@ export default function DiscoverCollectiblesScreen(): JSX.Element {
                 style={{
                   color: theme.colors.$textSecondary
                 }}>
-                <Text variant="subtitle2" style={{ fontWeight: 500 }}>
+                <Text
+                  variant="subtitle2"
+                  style={{ fontFamily: 'Inter-Semibold' }}>
                   {`${item.title} `}
                 </Text>
                 {item.description}

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/discoverCollectibles/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/discoverCollectibles/index.tsx
@@ -137,7 +137,7 @@ export default function DiscoverCollectiblesScreen(): JSX.Element {
                 }}>
                 <Text
                   variant="subtitle2"
-                  style={{ fontFamily: 'Inter-Semibold' }}>
+                  style={{ fontFamily: 'Inter-SemiBold' }}>
                   {`${item.title} `}
                 </Text>
                 {item.description}


### PR DESCRIPTION
## Description

- **Summary:** Replace numeric `fontWeight` overrides on Inter text with the matching `Inter-*` font family across the app (`Inter-Medium` for 500, `Inter-SemiBold` for 600, `Inter-Bold` for 700/`'bold'`). Redundant `fontWeight: 400` declarations (already the default `Inter-Regular`) are removed rather than converted.
- **Motivation:** Per `packages/core-mobile/docs/styles.md`, React Native does not reliably synthesize weights from a numeric `fontWeight` for the custom Inter font files — `'500'`/`'600'`/`'700'` render inconsistently (often as Regular on Android) and have caused repeated visual bugs. Selecting the named family is the correct, cross-platform-safe approach.
- **Dependencies:** None.
- **Breaking changes:** None — purely a styling/visual correctness change.

### Notes for reviewers
- A few spots that were originally `fontWeight: 500` were mapped to `Inter-SemiBold` (not `Inter-Medium`) to match the intended design — please confirm: `SwapSlippageDetailsScreen` slippage chips, `discoverCollectibles`, and `SelectAmount.tsx:169`.

## Screenshots/Videos

No layout changes — weight/family only. Screenshots of affected screens (stake duration, swap slippage, onboarding, RPC/dapp approval, meld) can be added if needed.

## Checklist
- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation
