### PR TITLE
CP-14615: build injected provider shim once per tab to fix swap spinner after network switch

### DIFF
--- a/packages/core-mobile/app/hooks/browser/evmProviderShim.test.ts
+++ b/packages/core-mobile/app/hooks/browser/evmProviderShim.test.ts
@@ -93,6 +93,36 @@ describe('buildEvmProviderShim', () => {
     })
   })
 
+  describe('__coreProviderReassertChain (CP-14615)', () => {
+    it('defines an idempotent chain re-assert helper', () => {
+      const shim = buildEvmProviderShim(defaultParams)
+      expect(shim).toContain(
+        'window.__coreProviderReassertChain = function(data)'
+      )
+    })
+
+    it('dedupes numerically so a non-canonical hex (0x01 / 0xA86A) is not re-emitted', () => {
+      // Native always sends canonical '0x'+n.toString(16); a dApp-supplied chain
+      // (wallet_addEthereumChain) may be zero-padded/uppercase. A string compare
+      // would miss those; the numeric compare is the correct dedupe.
+      const shim = buildEvmProviderShim(defaultParams)
+      expect(shim).toContain('parseInt(data, 16) === parseInt(_chainId, 16)')
+    })
+
+    it('emits chainChanged via __coreProviderEmit when the chain actually changed', () => {
+      const shim = buildEvmProviderShim(defaultParams)
+      expect(shim).toContain("window.__coreProviderEmit('chainChanged', data)")
+    })
+
+    it('normalizes the optimistic wallet_switchEthereumChain chainId to canonical hex', () => {
+      // A dApp may send a non-canonical chainId ('1' / '0x01' / '0xA86A'); the shim
+      // must store canonical '0x'+n.toString(16) so eth_chainId is well-formed and
+      // the numeric re-assert dedupe stays consistent. CP-14615.
+      const shim = buildEvmProviderShim(defaultParams)
+      expect(shim).toContain("swTargetChainId = '0x' + swParsed.toString(16)")
+    })
+  })
+
   describe('EIP-1193 provider object', () => {
     let shim: string
 

--- a/packages/core-mobile/app/hooks/browser/evmProviderShim.ts
+++ b/packages/core-mobile/app/hooks/browser/evmProviderShim.ts
@@ -161,6 +161,25 @@ export function buildEvmProviderShim({
     emit(eventName, data);
   };
 
+  // Idempotent chain re-assertion used by the native per-commit hook to correct a
+  // fresh document whose baked chainId is stale (full reload / cross-origin nav /
+  // pull-to-refresh). Deduped against the live _chainId: a same-origin SPA
+  // navigation that did NOT change chains — or a re-assert that races a still
+  // pending wallet_switchEthereumChain — is a no-op, so listeners never churn and
+  // we never fight the optimistic emit (React #185). Kept distinct from
+  // __coreProviderEmit so the CP-13671 disconnect->same-chain recovery path, which
+  // legitimately re-emits the current chainId to flip _connected back on, is
+  // unaffected by this dedupe.
+  window.__coreProviderReassertChain = function(data) {
+    // Compare numerically, not by string: _chainId may hold a non-canonical hex
+    // a dApp supplied via wallet_addEthereumChain (leading zeros / uppercase, e.g.
+    // '0x0539', '0xA86A'), while the native re-assert always sends canonical
+    // '0x'+n.toString(16). A string compare would miss those and emit a spurious
+    // same-chain chainChanged; parseInt makes the dedupe format/case-insensitive.
+    if (parseInt(data, 16) === parseInt(_chainId, 16)) return;
+    window.__coreProviderEmit('chainChanged', data);
+  };
+
   function emit(eventName, data) {
     var fns = _listeners[eventName];
     if (!fns) return;
@@ -213,6 +232,16 @@ export function buildEvmProviderShim({
           return Promise.reject({ code: ${JSON_RPC_RESOURCE_UNAVAILABLE_CODE}, message: 'wallet_switchEthereumChain already pending' });
         }
         var swTargetChainId = (params[0] && params[0].chainId) || null;
+        // Normalize to canonical lowercase hex ('0x'+n.toString(16)) so eth_chainId
+        // and chainChanged never expose a dApp-supplied non-canonical form ('1',
+        // '0x01', '0xA86A'). This also keeps the per-commit __coreProviderReassertChain
+        // dedupe (numeric) consistent: without it a malformed _chainId could never
+        // be corrected to canonical, and an uppercase target would spuriously
+        // re-emit chainChanged for the same chain. CP-14615.
+        if (swTargetChainId) {
+          var swParsed = parseInt(swTargetChainId, 16);
+          if (!isNaN(swParsed)) { swTargetChainId = '0x' + swParsed.toString(16); }
+        }
         if (swTargetChainId && swTargetChainId !== _chainId) {
           _chainId = swTargetChainId;
           provider.chainId = swTargetChainId;

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.test.ts
@@ -225,6 +225,60 @@ describe('useEvmInjectedProvider', () => {
       const { result } = renderProvider()
       expect(result.current.providerShimJs).toBe('SHIM(0xa86a)')
     })
+
+    it('is built once per tab — a wallet_switchEthereumChain (tabChainId change) does NOT rebuild it (CP-14615)', () => {
+      // Rebuilding providerShimJs changes the WebView's
+      // injectedJavaScriptBeforeContentLoaded prop, which makes react-native-webview
+      // call resetupScripts and silently drop the switch's own response injection —
+      // the dApp's switchChain promise then hangs forever (endless spinner).
+      setupMocks({ tabChainId: undefined })
+      const { result, rerender } = renderHook(() =>
+        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+      )
+      expect(result.current.providerShimJs).toBe('SHIM(0xa86a)')
+
+      // The tab gets pinned to Ethereum by a switch; the shim must stay identical.
+      setupMocks({ tabChainId: 1 })
+      rerender()
+      expect(result.current.providerShimJs).toBe('SHIM(0xa86a)')
+    })
+  })
+
+  describe('chain re-assert on committed URL (CP-14615 Part B)', () => {
+    it('re-asserts the live EVM chain via __coreProviderReassertChain on a commit', () => {
+      const { result } = renderHook(() =>
+        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+      )
+      mockInjectJavaScript.mockClear()
+      act(() => {
+        result.current.handleCommittedUrl('https://example.com')
+      })
+      expect(mockInjectJavaScript).toHaveBeenCalledWith(
+        expect.stringContaining("__coreProviderReassertChain('0xa86a')")
+      )
+    })
+
+    it('does NOT re-assert when the resolved live chain is non-EVM', () => {
+      const btc = {
+        vmName: NetworkVMType.BITCOIN,
+        chainId: 99999,
+        rpcUrl: 'https://btc.example'
+      }
+      setupMocks({
+        network: btc,
+        allNetworks: { ...mockAllNetworks, 99999: btc }
+      })
+      const { result } = renderHook(() =>
+        useEvmInjectedProvider(mockWebViewRef, 'test-tab-id')
+      )
+      mockInjectJavaScript.mockClear()
+      act(() => {
+        result.current.handleCommittedUrl('https://example.com')
+      })
+      expect(mockInjectJavaScript).not.toHaveBeenCalledWith(
+        expect.stringContaining('__coreProviderReassertChain')
+      )
+    })
   })
 
   describe('sendResponse', () => {

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -223,7 +223,13 @@ export function useEvmInjectedProvider(
       // tab that retains a live EVM chain after the wallet moved to a non-EVM
       // network (CP-13672) is still re-asserted.
       const liveChainId = browserNetworkRef.current.chainId
-      const liveNetwork = allNetworksRef.current[liveChainId]
+      // Fall back to the store like requestReadOnly does: allNetworksRef syncs via
+      // a useEffect, so a chain just added through wallet_addEthereumChain can be
+      // in Redux but not yet in the ref. Without the fallback a reload in that
+      // window would skip the re-assert for that fresh EVM chain.
+      const liveNetwork =
+        allNetworksRef.current[liveChainId] ??
+        selectAllNetworks(store.getState())[liveChainId]
       if (liveNetwork?.vmName === NetworkVMType.EVM) {
         webViewRef.current?.injectJavaScript(
           `window.__coreProviderReassertChain && window.__coreProviderReassertChain('0x${liveChainId.toString(
@@ -241,9 +247,13 @@ export function useEvmInjectedProvider(
       // prime point that re-establishes connected state. CP-13772.
       primeAccountsRef.current?.()
     },
-    [tabId, webViewRef]
+    [tabId, webViewRef, store]
   )
 
+  // Only consumed by initialChainIdHexRef below (read once at mount). Kept as a
+  // useMemo rather than inlined into the hook body so this branch stays in a
+  // nested function — inlining it tips useEvmInjectedProvider over the
+  // sonarjs/cognitive-complexity limit.
   const chainIdHex = useMemo(() => {
     if (activeNetwork.vmName !== NetworkVMType.EVM) return '0x1'
     return '0x' + initialChainId.toString(16)

--- a/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
+++ b/packages/core-mobile/app/hooks/browser/useEvmInjectedProvider.ts
@@ -203,6 +203,35 @@ export function useEvmInjectedProvider(
         }
       }
 
+      // Re-assert the live chain on every committed URL, alongside the account
+      // re-prime below. The shim is built exactly once per tab (see
+      // providerShimJs), so its baked chainId is only the value seen at the FIRST
+      // document load; any later fresh document — cross-origin nav, or a
+      // same-origin full reload / pull-to-refresh — re-runs that stale baked
+      // chain and would otherwise report the wrong chainId until something else
+      // emitted chainChanged. We re-assert `browserNetworkRef` (the chain Core
+      // actually routes this tab's RPC/signing to), so a fresh document is
+      // corrected to the live chain. The re-assert is idempotent:
+      // __coreProviderReassertChain drops a value equal to the shim's live
+      // _chainId, so a same-origin SPA pushState (no chain change) does not churn
+      // listeners or fight a still-pending switch (React #185).
+      //
+      // Guard on the *resolved chain's* own vmName — NOT tabChainId/activeNetwork
+      // — so a non-EVM chainId is never emitted to the EVM provider: a tab pinned
+      // to a non-EVM chain (wallet_switchEthereumChain validates only membership
+      // in the cross-VM network map, not EVM-ness) is skipped, while an unpinned
+      // tab that retains a live EVM chain after the wallet moved to a non-EVM
+      // network (CP-13672) is still re-asserted.
+      const liveChainId = browserNetworkRef.current.chainId
+      const liveNetwork = allNetworksRef.current[liveChainId]
+      if (liveNetwork?.vmName === NetworkVMType.EVM) {
+        webViewRef.current?.injectJavaScript(
+          `window.__coreProviderReassertChain && window.__coreProviderReassertChain('0x${liveChainId.toString(
+            16
+          )}'); true;`
+        )
+      }
+
       // Prime the shim's _accounts cache on every committed URL: the initial
       // page load, cross-origin navigation, and same-origin SPA navigation
       // (pushState/replaceState). domain_metadata no longer primes (it arrives
@@ -212,7 +241,7 @@ export function useEvmInjectedProvider(
       // prime point that re-establishes connected state. CP-13772.
       primeAccountsRef.current?.()
     },
-    [tabId]
+    [tabId, webViewRef]
   )
 
   const chainIdHex = useMemo(() => {
@@ -220,12 +249,28 @@ export function useEvmInjectedProvider(
     return '0x' + initialChainId.toString(16)
   }, [activeNetwork.vmName, initialChainId])
 
-  const providerShimJs = useMemo(() => {
-    return buildEvmProviderShim({
-      chainId: chainIdHex,
-      uuid: getInjectedProviderUuid()
-    })
-  }, [chainIdHex])
+  // Build the injected shim EXACTLY ONCE per tab. `providerShimJs` is consumed
+  // as the WebView's `injectedJavaScriptBeforeContentLoaded`; changing that prop
+  // makes react-native-webview call `resetupScripts` (removeAllUserScripts +
+  // re-add) on the live WKWebView, and any `injectJavaScript` issued in that same
+  // tick is silently dropped. Previously this memo depended on `chainIdHex`, so a
+  // `wallet_switchEthereumChain` (which dispatches `setTabChainId` -> new
+  // chainIdHex) rebuilt the shim and dropped the switch's OWN response injection,
+  // leaving the dApp's switchChain promise — and the swap awaiting it — hung
+  // forever (CP-14615). The baked chainId only seeds the first document load; the
+  // live chain is kept current at runtime via the shim's optimistic `_chainId`
+  // update on switch, the unpinned sync effect's chainChanged emit, and the
+  // per-document-load re-assert in handleCommittedUrl. So bake the initial value
+  // once and never change the prop.
+  const initialChainIdHexRef = useRef(chainIdHex)
+  const providerShimJs = useMemo(
+    () =>
+      buildEvmProviderShim({
+        chainId: initialChainIdHexRef.current,
+        uuid: getInjectedProviderUuid()
+      }),
+    []
+  )
 
   const sendResponse = useCallback(
     (id: number, error: unknown, result: unknown) => {


### PR DESCRIPTION
## Summary

The in-app browser's injected EVM provider froze with an endless spinner when a dApp (e.g. Uniswap) switched networks and then tried to swap. Seedless + Ethereum worked and the first tx worked; the freeze surfaced after switching networks — matching QA's "first tx works, switching confuses eth/avax". This is **not** a signer/MFA/C-Chain-specific bug.

### Root cause
`providerShimJs` was memoized on `chainIdHex`. A `wallet_switchEthereumChain` dispatches `setTabChainId`, which changes `chainIdHex` → rebuilds `providerShimJs` → changes the WebView's `injectedJavaScriptBeforeContentLoaded` prop. react-native-webview responds by calling `resetupScripts` (removeAllUserScripts + re-add) on the live WKWebView, and the `injectJavaScript` issued in that same tick — the switch's own `__coreProviderRespond` — is silently dropped. The dApp's `switchChain` promise never resolves, so wagmi / the swap saga hangs forever. (Confirmed on device: the switch's `sendResponse` ran natively but its injected JS never executed.)

### Fix
- **Build `providerShimJs` exactly once per tab** (`useRef(chainIdHex)` + `useMemo(..., [])`). A chain switch no longer changes the WebView prop, so `resetupScripts` no longer drops the switch response. The shim keeps its live chain current via the optimistic emit + the re-assert below, so the baked initial chain only matters on first load. Does not touch the optimistic-emit path → no React #185 regression.
- **Re-assert the live chain on every committed URL** so a fresh document (full reload / cross-origin nav / pull-to-refresh) isn't stuck on the stale baked chainId. Guarded on the resolved chain's own `vmName` (EVM only), via the new `__coreProviderReassertChain`.
- **`__coreProviderReassertChain`** dedupes numerically against the shim's live `_chainId` (no churn on same-origin SPA navigation; handles non-canonical hex), kept separate from `__coreProviderEmit` so the disconnect→same-chain recovery path is unaffected.
- **Normalize the optimistic `wallet_switchEthereumChain` chainId** to canonical lowercase hex so `eth_chainId` is always well-formed.

Unit tests added for each part.

## Dev testing

Device-validated on a physical iOS build (seedless wallet):
1. In-app browser → Uniswap → connect the seedless account.
2. Switch the tab between Ethereum and Avalanche repeatedly.
3. Swap on Ethereum, then swap AVAX → USDC on Avalanche C-Chain.

Expected: every switch resolves and both swaps complete — **no endless spinner**. Confirmed: both swaps landed (FCM "received USDC on Avalanche (C-Chain)"), and the wallet held the correct chain across a pull-to-refresh.

Bitrise builds: iOS #9045, Android #9046.
