### PR TITLE
Fix fading-header setOptions churn causing JS-thread CPU spike

### DIFF
--- a/packages/core-mobile/app/new/common/components/ListScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ListScreen.tsx
@@ -149,9 +149,17 @@ export const ListScreen = <T,>({
     [scrollViewRef]
   )
 
+  // Stable header element — recreated only when the title text changes, so
+  // `useFadingHeaderNavigation`'s header-title sync effect doesn't re-run (and
+  // re-`setOptions`) on every render. See ScrollScreen for the same fix.
+  const navigationHeader = useMemo(
+    () => <NavigationTitleHeader title={navigationTitle ?? title ?? ''} />,
+    [navigationTitle, title]
+  )
+
   const { onScroll, scrollY, targetHiddenProgress } = useFadingHeaderNavigation(
     {
-      header: <NavigationTitleHeader title={navigationTitle ?? title ?? ''} />,
+      header: navigationHeader,
       targetLayout,
       hideHeaderBackground: shouldShowStickyHeader,
       hasSeparator: shouldShowStickyHeader

--- a/packages/core-mobile/app/new/common/components/ListScreenV2.tsx
+++ b/packages/core-mobile/app/new/common/components/ListScreenV2.tsx
@@ -180,9 +180,17 @@ export const ListScreenV2 = <T,>({
     [scrollViewRef]
   )
 
+  // Stable header element — recreated only when the title text changes, so
+  // `useFadingHeaderNavigation`'s header-title sync effect doesn't re-run (and
+  // re-`setOptions`) on every render. See ScrollScreen for the same fix.
+  const navigationHeader = useMemo(
+    () => <NavigationTitleHeader title={navigationTitle ?? title ?? ''} />,
+    [navigationTitle, title]
+  )
+
   const { onScroll, scrollY, targetHiddenProgress } = useFadingHeaderNavigation(
     {
-      header: <NavigationTitleHeader title={navigationTitle ?? title ?? ''} />,
+      header: navigationHeader,
       targetLayout,
       hideHeaderBackground: shouldShowStickyHeader,
       hasSeparator: shouldShowStickyHeader

--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -6,7 +6,13 @@ import {
 } from '@avalabs/k2-alpine'
 import { useEffectiveHeaderHeight } from 'common/hooks/useEffectiveHeaderHeight'
 import { useFadingHeaderNavigation } from 'common/hooks/useFadingHeaderNavigation'
-import React, { forwardRef, useCallback, useRef, useState } from 'react'
+import React, {
+  forwardRef,
+  useCallback,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import {
   LayoutChangeEvent,
   LayoutRectangle,
@@ -199,12 +205,22 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
 
     const headerRef = useRef<View>(null)
 
+    // Stable header element — recreated only when the title text changes. Passing
+    // a fresh JSX element every render made `useFadingHeaderNavigation`'s
+    // header-title sync effect re-run each render → repeated `navigation
+    // .setOptions`, which (stacked across nested modal screens) churned the
+    // native header and pegged the JS thread.
+    const navigationHeader = useMemo(
+      () => <NavigationTitleHeader title={navigationTitle ?? title ?? ''} />,
+      [navigationTitle, title]
+    )
+
     const {
       onScroll: onFadingScroll,
       scrollY,
       targetHiddenProgress
     } = useFadingHeaderNavigation({
-      header: <NavigationTitleHeader title={navigationTitle ?? title ?? ''} />,
+      header: navigationHeader,
       targetLayout: headerLayout,
       hasParent,
       hideHeaderBackground: hideHeaderBackground || isModal,
@@ -249,14 +265,37 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
       }
     })
 
+    // Commit a new layout object only when the measured rect actually changed.
+    // `onLayout` can fire repeatedly with identical values (notably when a
+    // screen is re-measured every frame while backgrounded behind another in a
+    // native-stack — e.g. the delegate node screens behind the amount step).
+    // Setting a fresh object each time would re-render → re-lay out → fire
+    // `onLayout` again, spinning a layout↔setState loop that pegs the JS thread
+    // (visible as a flood of `UIManagerBinding::get` in a CPU profile).
     const handleHeaderLayout = useCallback((event: LayoutChangeEvent) => {
       const { x, y, width, height } = event.nativeEvent.layout
-      setHeaderLayout({ x, y, width, height })
+      setHeaderLayout(prev =>
+        prev &&
+        prev.x === x &&
+        prev.y === y &&
+        prev.width === width &&
+        prev.height === height
+          ? prev
+          : { x, y, width, height }
+      )
     }, [])
 
     const handleFooterLayout = useCallback((event: LayoutChangeEvent) => {
       const { x, y, width, height } = event.nativeEvent.layout
-      setFooterLayout({ x, y, width, height })
+      setFooterLayout(prev =>
+        prev &&
+        prev.x === x &&
+        prev.y === y &&
+        prev.width === width &&
+        prev.height === height
+          ? prev
+          : { x, y, width, height }
+      )
     }, [])
 
     const animatedBorderStyle = useAnimatedStyle(() => {

--- a/packages/core-mobile/app/new/common/hooks/useFadingHeaderNavigation.tsx
+++ b/packages/core-mobile/app/new/common/hooks/useFadingHeaderNavigation.tsx
@@ -69,7 +69,20 @@ export const useFadingHeaderNavigation = ({
   }, [targetLayout])
 
   const handleLayout = useCallback((event: LayoutChangeEvent): void => {
-    setNavigationHeaderLayout(event.nativeEvent.layout)
+    const { x, y, width, height } = event.nativeEvent.layout
+    // Only commit a new object when the rect actually changed. `onLayout` can
+    // fire repeatedly with identical values while the native header re-renders
+    // (e.g. after `setOptions`); committing a fresh object each time would
+    // re-render → re-set header options → re-layout, a churn loop.
+    setNavigationHeaderLayout(prev =>
+      prev &&
+      prev.x === x &&
+      prev.y === y &&
+      prev.width === width &&
+      prev.height === height
+        ? prev
+        : { x, y, width, height }
+    )
   }, [])
 
   const handleScroll = (

--- a/packages/core-mobile/app/new/features/activity/screens/ActivityHomeScreen.tsx
+++ b/packages/core-mobile/app/new/features/activity/screens/ActivityHomeScreen.tsx
@@ -54,8 +54,15 @@ const ActivityHomeScreen = (): JSX.Element => {
 
   const selectedSegmentIndex = useSharedValue(0)
 
+  // Stable header element so `useFadingHeaderNavigation`'s header-title sync
+  // effect doesn't re-run (and re-`setOptions`) on every render.
+  const navigationHeader = useMemo(
+    () => <NavigationTitleHeader title={'Activity'} />,
+    []
+  )
+
   const { onScroll, targetHiddenProgress } = useFadingHeaderNavigation({
-    header: <NavigationTitleHeader title={'Activity'} />,
+    header: navigationHeader,
     targetLayout: balanceHeaderLayout,
     hasSeparator: false
   })


### PR DESCRIPTION
## Description

### Summary

Fixes a JS-thread CPU spike / UI freeze that occurred on stacked native-stack modal screens (most visibly the delegate staking flow: *Choose a way to start staking → Find node → Node details → How much would you like to stake?*). The freeze was triggered by background data updates (e.g. balance polling), pegged the JS thread, and was only cleared by a UI touch / keyboard focus change.

Two root causes, both in the shared fading-header machinery:

1. **`setOptions` churn.** Every screen using `useFadingHeaderNavigation` passed a freshly-created `<NavigationTitleHeader />` JSX element as the `header` prop on every render. The hook's header-title sync effect depends on `header`, so it re-ran each render and called `navigation.setOptions({ headerTitle })` every time. Stacked across several nested modal screens, this churned the native header continuously and blocked the JS thread.
   - Fix: memoize the header element so it is only recreated when the title text changes. Applied to `ScrollScreen`, `ListScreenV2`, `ListScreen` (v1), and `ActivityHomeScreen` — bringing them in line with the screens that already memoized (`StakeHomeScreen`, `track`, `EarnHomeScreen`, `XpTokenDetailScreen`, `DepositDetailScreen`).

2. **`onLayout` ↔ `setState` loop.** The layout handlers committed a brand-new layout object on every `onLayout` event, even when the measured rect was identical. `onLayout` can fire repeatedly with unchanged values (notably while a screen is re-measured behind another in a native-stack), so each event re-rendered → re-laid out → fired `onLayout` again.
   - Fix: only commit a new layout object when the rect actually changed (functional updater returns the previous reference otherwise, so React bails the re-render). Applied to `useFadingHeaderNavigation.handleLayout` (benefits every consumer) and to `ScrollScreen`'s header/footer layout handlers.

### Motivation and context

The freeze predates the Expo 56 / RN 0.85 upgrade. Diagnosis (breadcrumb logging that survives the freeze + CPU profiling) pointed to a `UIManagerBinding` / native-header churn loop rather than any single screen's logic. Because the fix lives entirely in shared components/hooks, it also reduces per-render header `setOptions` traffic app-wide, not just in the staking flow.

### Dependencies introduced

None.

## Screenshots/Videos

N/A — behavior fix (no visual change). CPU/JS-thread stops spiking on the delegate amount screen; header behavior is unchanged.

## Testing
iOS: 9046
Android: 9047

**Dev Testing**
This is a pure performance/behavior fix — **there should be no functional or visual change** to any screen. The goal of testing is to confirm existing behavior is fully preserved while the CPU/JS-thread spike is gone.

- **No regression in header behavior:** The fading navigation-title header must look and behave exactly as before — same fade in/out on scroll, same title text, same background/separator — on `ScrollScreen`, `ListScreen`, `ListScreenV2`, and the Activity tab. Nothing should look different.
- **Title still updates while focused:** Existing behavior where the header title reflects the current context must be unchanged (e.g. switching account on Portfolio still updates the nav header title).

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation
