### PR TITLE
CP-14633: fix clipped token detail balance on iOS

### DIFF
--- a/packages/core-mobile/app/new/common/components/TokenHeader.tsx
+++ b/packages/core-mobile/app/new/common/components/TokenHeader.tsx
@@ -50,33 +50,36 @@ export const TokenHeader = ({
           }}>
           {isPrivacyModeEnabled ? (
             <HiddenBalanceText isCurrency={false} sx={{ lineHeight: 38 }} />
+          ) : token?.balanceDisplayValue ? (
+            <View
+              sx={{
+                flexDirection: 'row',
+                alignItems: 'flex-end',
+                flexShrink: 1
+              }}>
+              <SubTextNumber
+                number={token.balanceDisplayValue}
+                textColor={colors.$textPrimary}
+                textVariant="heading2"
+              />
+              <Text
+                variant="heading2"
+                sx={{
+                  fontFamily: 'Aeonik-Medium',
+                  color: colors.$textPrimary,
+                  fontSize: 18,
+                  lineHeight: 18,
+                  marginBottom: 4
+                }}>
+                {token.symbol}
+              </Text>
+            </View>
           ) : (
             <Text
               variant="heading2"
               sx={{ lineHeight: 38, flexShrink: 1 }}
               numberOfLines={1}>
-              {token?.balanceDisplayValue ? (
-                <View sx={{ flexDirection: 'row', alignItems: 'flex-end' }}>
-                  <SubTextNumber
-                    number={token.balanceDisplayValue}
-                    textColor={colors.$textPrimary}
-                    textVariant="heading2"
-                  />
-                  <Text
-                    variant="heading2"
-                    sx={{
-                      fontFamily: 'Aeonik-Medium',
-                      color: colors.$textPrimary,
-                      fontSize: 18,
-                      lineHeight: 18,
-                      marginBottom: 4
-                    }}>
-                    {token.symbol}
-                  </Text>
-                </View>
-              ) : (
-                UNKNOWN_AMOUNT
-              )}
+              {UNKNOWN_AMOUNT}
             </Text>
           )}
         </View>

--- a/packages/core-mobile/app/new/common/components/TokenHeader.tsx
+++ b/packages/core-mobile/app/new/common/components/TokenHeader.tsx
@@ -55,7 +55,8 @@ export const TokenHeader = ({
               sx={{
                 flexDirection: 'row',
                 alignItems: 'flex-end',
-                flexShrink: 1
+                flexShrink: 1,
+                minHeight: 38
               }}>
               <SubTextNumber
                 number={token.balanceDisplayValue}
@@ -64,6 +65,7 @@ export const TokenHeader = ({
               />
               <Text
                 variant="heading2"
+                numberOfLines={1}
                 sx={{
                   fontFamily: 'Aeonik-Medium',
                   color: colors.$textPrimary,


### PR DESCRIPTION
## Description

**Ticket: [CP-14633](https://ava-labs.atlassian.net/browse/CP-14633)**

The top of the balance text (e.g. `0.60007 AVAX`) was cut off on the owned token detail screen on iOS.

**Root cause:** In `TokenHeader`, the balance value was rendered by nesting a `<View>` (`SubTextNumber` + symbol) *inside* a `<Text>` as an inline attachment. This View-in-Text pattern was tolerated before, but the RN 0.85 / Expo 56 (New Architecture / Fabric) upgrade changed iOS inline line-box handling so the glyph tops got clipped.

**Fix:** Render the balance value in a plain `<View>` (proper `View → Text` hierarchy) instead of nesting it in a `<Text>`. The `<Text>` parent is only kept for the `UNKNOWN_AMOUNT` string branch. No `lineHeight` changes were needed — `lineHeight` stays at the original values. This also removes a redundant wrapper layer and moves `flexShrink: 1` onto the value `View`.

- Dependencies introduced: none
- Breaking changes: none

## Screenshots/Videos
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-07-01 at 00 40 31" src="https://github.com/user-attachments/assets/b272089e-13dc-47eb-8d72-5f90bfc3ea98" />


## Testing
iOS: 9049
Android: 9050

**Dev Testing**

- Open the owned token detail screen for a token (both C-Chain and X/P-Chain AVAX go through `TokenHeader`) and confirm the balance text is no longer clipped at the top on iOS.
- Edge cases:
  - Privacy mode on: `HiddenBalanceText` renders and aligns correctly.
  - Token with no balance value: `UNKNOWN_AMOUNT` renders and aligns correctly.
- Verify Android is unaffected.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14633]: https://ava-labs.atlassian.net/browse/CP-14633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ