### PR TITLE
CP-14363: stuck-funds banner + CCT recovery

### DIFF
--- a/packages/core-mobile/app/consts/reactQueryKeys.ts
+++ b/packages/core-mobile/app/consts/reactQueryKeys.ts
@@ -52,6 +52,7 @@ export enum ReactQueryKeys {
   FUSION_TOKENS = 'fusionTokens',
   FUSION_MINIMUM_TRANSFER_AMOUNT = 'fusionMinimumTransferAmount',
   FUSION_SWAP_FEE_ESTIMATE = 'fusionSwapFeeEstimate',
+  FUSION_STUCK_ATOMIC_FUNDS = 'fusionStuckAtomicFunds',
 
   // recurring swaps (DCA). `RECURRING_ALLOWANCE` was dropped — the SDK
   // reads on-chain allowance internally inside `executeFirstFill` so mobile

--- a/packages/core-mobile/app/new/common/components/TokenInputWidget.tsx
+++ b/packages/core-mobile/app/new/common/components/TokenInputWidget.tsx
@@ -44,7 +44,12 @@ type TokenInputWidgetProps = {
   balance?: bigint
   shouldShowBalance?: boolean
   network?: Network
-  onAmountChange: (amount: bigint) => void
+  /**
+   * `valueString` is the raw entered text: `''` when the field is empty/cleared,
+   * `'0'` for an explicit typed 0 (both carry `amount` 0n). Callers that need to
+   * tell empty apart from a typed 0 use it; others can ignore the second arg.
+   */
+  onAmountChange: (amount: bigint, valueString: string) => void
   /**
    * Fires when the Max percentage button is pressed (100% of balance).
    * Distinct from `onAmountChange` so callers can flag analytics events
@@ -121,7 +126,9 @@ export const TokenInputWidget = forwardRef<
       value = BigInt(Math.floor(Number(balance ?? 0n) * button.percent))
     }
 
-    onAmountChange?.(value)
+    // A percentage/Max button always sets a concrete amount, never "empty",
+    // so pass a non-empty valueString.
+    onAmountChange?.(value, value.toString())
     if (button.percent === 1) {
       onPressMax?.()
     }
@@ -144,7 +151,7 @@ export const TokenInputWidget = forwardRef<
         }))
       )
 
-      onAmountChange?.(value.value)
+      onAmountChange?.(value.value, value.valueString)
     },
     [onAmountChange, balance]
   )

--- a/packages/core-mobile/app/new/features/notifications/screens/NotificationsScreen.tsx
+++ b/packages/core-mobile/app/new/features/notifications/screens/NotificationsScreen.tsx
@@ -17,6 +17,7 @@ import {
 import { selectAccounts, selectActiveAccount } from 'store/account'
 import { selectWallets } from 'store/wallet/slice'
 import { ScrollScreen } from 'common/components/ScrollScreen'
+import { StuckFundsBanner } from 'features/swap/components/StuckFundsBanner'
 import { LoadingState } from 'common/components/LoadingState'
 import { useFusionTransfers } from 'features/swap/hooks/useZustandStore'
 import { FusionTransfer } from 'features/swap/types'
@@ -446,6 +447,11 @@ export const NotificationsScreen = (): JSX.Element => {
       navigationTitle={TITLE}
       renderFooter={renderFooter}
       renderHeader={renderHeader}>
+      {/* Stuck-funds banner — stranded cross-chain AVAX. Self-hides (and
+          reserves no space) when none. */}
+      <StuckFundsBanner
+        sx={{ marginHorizontal: 16, marginTop: 15, marginBottom: 10 }}
+      />
       {renderContent()}
     </ScrollScreen>
   )

--- a/packages/core-mobile/app/new/features/portfolio/screens/PortfolioScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/screens/PortfolioScreen.tsx
@@ -31,6 +31,7 @@ import { ActionButtonTitle } from 'features/portfolio/assets/consts'
 import { CollectibleFilterAndSortInitialState } from 'features/portfolio/collectibles/hooks/useCollectiblesFilterAndSort'
 import { CollectiblesScreen } from 'features/portfolio/collectibles/screens/CollectiblesScreen'
 import { BalanceHeaderSection } from 'features/portfolio/components/BalanceHeaderSection'
+import { StuckFundsBanner } from 'features/swap/components/StuckFundsBanner'
 import { DeFiScreen } from 'features/portfolio/defi/components/DeFiScreen'
 import { ActivityScreen } from 'features/activity/screens/ActivityScreen'
 import { useAccountBalanceSummary } from 'features/portfolio/hooks/useAccountBalanceSummary'
@@ -350,11 +351,16 @@ const PortfolioHomeScreen = (): JSX.Element => {
           backgroundColor={theme.colors.$surfacePrimary}
         />
 
+        {/* Stuck-funds banner — stranded cross-chain AVAX. Self-hides (and
+            reserves no space) when none. */}
+        <StuckFundsBanner sx={{ marginHorizontal: 16, marginTop: 21 }} />
+
         {filteredTokenList.length > 0 && (
           <ActionButtons
             buttons={actionButtons}
             contentContainerStyle={{
               padding: 16,
+              paddingTop: 20,
               paddingBottom: 20
             }}
           />

--- a/packages/core-mobile/app/new/features/recurringSwap/components/RecurringSchedulesBanner.tsx
+++ b/packages/core-mobile/app/new/features/recurringSwap/components/RecurringSchedulesBanner.tsx
@@ -24,7 +24,14 @@ import { RecurringOrderStatus } from '../types'
 // renderHeader returns a fresh JSX instance, which without `memo` mounts
 // a new RecurringSchedulesBanner subtree and re-runs `useRecurringSchedules`
 // on every parent render.
-function RecurringSchedulesBannerImpl(): JSX.Element | null {
+function RecurringSchedulesBannerImpl({
+  sx
+}: {
+  // Applied to the banner root; only takes effect when the banner renders, so
+  // callers pass spacing (e.g. marginBottom) here rather than wrapping in a
+  // container that would reserve space while the banner is self-hidden.
+  sx?: React.ComponentProps<typeof View>['sx']
+} = {}): JSX.Element | null {
   const router = useRouter()
   const {
     theme: { colors }
@@ -62,7 +69,8 @@ function RecurringSchedulesBannerImpl(): JSX.Element | null {
           backgroundColor: '$surfaceSecondary',
           borderRadius: 18,
           paddingVertical: 16,
-          paddingHorizontal: 12
+          paddingHorizontal: 12,
+          ...sx
         }}>
         <Icons.Notification.RotateRight
           width={24}

--- a/packages/core-mobile/app/new/features/stake/screens/StakeHomeScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/screens/StakeHomeScreen.tsx
@@ -8,6 +8,7 @@ import { LayoutChangeEvent, LayoutRectangle } from 'react-native'
 import Animated, { useAnimatedStyle } from 'react-native-reanimated'
 import { useSafeAreaFrame } from 'react-native-safe-area-context'
 import { useBottomTabBarHeight } from 'common/hooks/useBottomTabBarHeight'
+import { StuckFundsBanner } from 'features/swap/components/StuckFundsBanner'
 import {
   StakeCardList,
   StakeCardListHeaderProps
@@ -80,6 +81,9 @@ export const StakeHomeScreen = (): JSX.Element => {
               </Text>
             )}
           </Animated.View>
+          {/* Stuck-funds banner — stranded cross-chain AVAX. Self-hides (and
+              reserves no space) when none. */}
+          <StuckFundsBanner sx={{ marginHorizontal: 16, marginBottom: 16 }} />
           {isEmpty === false && <Banner />}
           <DropdownSelections
             filter={filter}

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeHomeScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeHomeScreen.tsx
@@ -19,6 +19,7 @@ import { LayoutChangeEvent, LayoutRectangle } from 'react-native'
 import Animated, { useAnimatedStyle } from 'react-native-reanimated'
 import { useSafeAreaFrame } from 'react-native-safe-area-context'
 import { useBottomTabBarHeight } from 'common/hooks/useBottomTabBarHeight'
+import { StuckFundsBanner } from 'features/swap/components/StuckFundsBanner'
 import {
   StakeCardList,
   StakeCardListHeaderProps
@@ -99,6 +100,9 @@ export const StakeHomeScreen = (): JSX.Element => {
               Network
             </Text>
           </Animated.View>
+          {/* Stuck-funds banner — stranded cross-chain AVAX. Self-hides (and
+              reserves no space) when none. */}
+          <StuckFundsBanner sx={{ marginHorizontal: 16, marginBottom: 16 }} />
           <Banner />
           {!isEmpty && (
             <View

--- a/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.test.tsx
+++ b/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react'
+import renderer, { act } from 'react-test-renderer'
+import type { StuckRoute } from '../utils/stuckFundsRoutes'
+import { StuckFundsBanner } from './StuckFundsBanner'
+
+const mockRecover = jest.fn()
+
+// Mock @avalabs/k2-alpine so we don't need a dripsy theme provider.
+jest.mock('@avalabs/k2-alpine', () => {
+  const rn = require('react-native') as typeof import('react-native')
+  const r = require('react') as typeof import('react')
+  const passthrough =
+    (Component: React.ComponentType<unknown>) =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ({ children, sx: _sx, variant: _v, ...rest }: any) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      r.createElement(Component as any, rest as any, children)
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Text: passthrough(rn.Text as any),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    View: passthrough(rn.View as any),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Button: passthrough(rn.TouchableOpacity as any),
+    Separator: () => null,
+    Icons: { Navigation: { ExpandMore: () => null } },
+    useTheme: () => ({ theme: { colors: { $textSecondary: '#888' } } })
+  }
+})
+
+jest.mock('@avalabs/core-utils-sdk', () => ({
+  TokenUnit: class {
+    value: number
+    constructor(amount: bigint, decimals: number) {
+      this.value = Number(amount) / 10 ** decimals
+    }
+    toDisplay(): string {
+      return String(this.value)
+    }
+  }
+}))
+
+const mockUseStuckAtomicFunds = jest.fn()
+jest.mock('../hooks/useStuckAtomicFunds', () => ({
+  useStuckAtomicFunds: () => mockUseStuckAtomicFunds()
+}))
+
+jest.mock('../hooks/useStuckFundsRecovery', () => ({
+  stuckRouteKey: (route: StuckRoute) => `${route.source}-${route.dest}`,
+  useStuckFundsRecovery: () => ({ recover: mockRecover, recoveringKey: null })
+}))
+
+const setRoutes = (routes: StuckRoute[]): void => {
+  mockUseStuckAtomicFunds.mockReturnValue({
+    routes,
+    totalNAvax: routes.reduce((acc, r) => acc + r.amountNAvax, 0n),
+    hasAnyAtomics: routes.length > 0,
+    invalidate: jest.fn()
+  })
+}
+
+const flatten = (node: renderer.ReactTestRendererJSON | null): string => {
+  if (!node) return ''
+  return (node.children ?? [])
+    .map(c => (typeof c === 'string' ? c : flatten(c)))
+    .join('')
+}
+
+describe('StuckFundsBanner', () => {
+  beforeEach(() => {
+    mockRecover.mockReset()
+  })
+
+  it('renders nothing when there are no stranded funds', () => {
+    setRoutes([])
+    let tree!: renderer.ReactTestRenderer
+    act(() => {
+      tree = renderer.create(<StuckFundsBanner />)
+    })
+    expect(tree.toJSON()).toBeNull()
+  })
+
+  it('shows the detected-funds title with the total amount', () => {
+    setRoutes([{ source: 'C', dest: 'P', amountNAvax: 100_000_000n }])
+    let tree!: renderer.ReactTestRenderer
+    act(() => {
+      tree = renderer.create(<StuckFundsBanner />)
+    })
+    const text = flatten(tree.toJSON() as renderer.ReactTestRendererJSON)
+    expect(text).toContain('Core has detected stuck funds')
+    expect(text).toContain('0.1 AVAX')
+  })
+
+  it('expands to show route rows and Recover triggers recovery for that route', () => {
+    const route: StuckRoute = {
+      source: 'C',
+      dest: 'P',
+      amountNAvax: 100_000_000n
+    }
+    setRoutes([route])
+    let tree!: renderer.ReactTestRenderer
+    act(() => {
+      tree = renderer.create(<StuckFundsBanner />)
+    })
+
+    // expand
+    const toggle = tree.root.findByProps({ testID: 'stuckFundsBanner_toggle' })
+    act(() => {
+      toggle.props.onPress()
+    })
+
+    const text = flatten(tree.toJSON() as renderer.ReactTestRendererJSON)
+    expect(text).toContain('C-Chain to P-Chain')
+
+    // tap Recover
+    const recover = tree.root.findByProps({
+      testID: 'stuckFundsBanner_recover_C_P'
+    })
+    act(() => {
+      recover.props.onPress()
+    })
+
+    expect(mockRecover).toHaveBeenCalledWith(route)
+  })
+})

--- a/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.test.tsx
+++ b/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.test.tsx
@@ -50,6 +50,10 @@ jest.mock('../hooks/useStuckFundsRecovery', () => ({
   useStuckFundsRecovery: () => ({ recover: mockRecover, recoveringKey: null })
 }))
 
+jest.mock('../hooks/useZustandStore', () => ({
+  useIsFusionServiceReady: () => [true]
+}))
+
 const setRoutes = (routes: StuckRoute[]): void => {
   mockUseStuckAtomicFunds.mockReturnValue({
     routes,

--- a/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.test.tsx
+++ b/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.test.tsx
@@ -40,6 +40,14 @@ jest.mock('@avalabs/core-utils-sdk', () => ({
   }
 }))
 
+jest.mock('react-redux', () => ({
+  useSelector: (fn: () => unknown) => fn()
+}))
+
+jest.mock('store/posthog', () => ({
+  selectIsFusionAvalancheCctEnabled: () => true
+}))
+
 const mockUseStuckAtomicFunds = jest.fn()
 jest.mock('../hooks/useStuckAtomicFunds', () => ({
   useStuckAtomicFunds: () => mockUseStuckAtomicFunds()

--- a/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.tsx
+++ b/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.tsx
@@ -1,5 +1,11 @@
-import React, { useEffect, useState } from 'react'
-import { TouchableOpacity } from 'react-native'
+import React, { useCallback, useEffect, useState } from 'react'
+import { LayoutChangeEvent, TouchableOpacity } from 'react-native'
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming
+} from 'react-native-reanimated'
 import {
   Button,
   Icons,
@@ -21,6 +27,13 @@ import { routeLabel } from '../utils/stuckFundsRoutes'
 
 // Atomic AVAX amounts are denominated in nAVAX (9 decimals).
 const NAVAX_DECIMALS = 9
+
+// Expand/collapse timing, matched to the wallets screen's WalletCard so the
+// motion feels consistent across the app.
+const EXPAND_TIMING = {
+  duration: 300,
+  easing: Easing.bezier(0.25, 1, 0.5, 1)
+}
 
 // Title / amount rows: Inter Regular 16 / 22 per Figma. No k2-alpine variant
 // encodes 16/22 exactly, so we anchor on `body1` (Inter Regular, primary color)
@@ -52,6 +65,35 @@ export const StuckFundsBanner = ({
   const { recover, recoveringKey } = useStuckFundsRecovery()
   const [isFusionServiceReady] = useIsFusionServiceReady()
   const [expanded, setExpanded] = useState(false)
+
+  // Natural height of the rows, measured off an absolutely-positioned layer so
+  // it's the intrinsic content height regardless of the animated wrapper's
+  // clipped height. Kept in a shared value so it drives the animation on the UI
+  // thread. Measured up front (rows always rendered) so the first open animates.
+  const contentHeight = useSharedValue(0)
+  // 0 = collapsed, 1 = expanded — the only time-animated value.
+  const expandProgress = useSharedValue(0)
+
+  const onContentLayout = useCallback(
+    (event: LayoutChangeEvent): void => {
+      contentHeight.value = event.nativeEvent.layout.height
+    },
+    [contentHeight]
+  )
+
+  useEffect(() => {
+    expandProgress.value = withTiming(expanded ? 1 : 0, EXPAND_TIMING)
+  }, [expanded, expandProgress])
+
+  // Wrapper height animates between 0 and the measured content height; overflow
+  // is clipped so the rows are revealed/hidden as it grows/shrinks.
+  const animatedContentStyle = useAnimatedStyle(() => ({
+    height: expandProgress.value * contentHeight.value
+  }))
+
+  const animatedChevronStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${expandProgress.value * 180}deg` }]
+  }))
 
   // Gate on the CCT flag (recovery relies on CCT deps that aren't wired when the
   // flag is off) and hide until Fusion is ready, so Recover is never shown in an
@@ -105,15 +147,20 @@ export const StuckFundsBanner = ({
               )} stuck in atomic memory from incomplete cross-chain transfer${plural}`}
             </Text>
           </View>
-          <Icons.Navigation.ExpandMore
-            color={theme.colors.$textSecondary}
-            style={{ transform: [{ rotate: expanded ? '180deg' : '0deg' }] }}
-          />
+          <Animated.View style={animatedChevronStyle}>
+            <Icons.Navigation.ExpandMore color={theme.colors.$textSecondary} />
+          </Animated.View>
         </View>
       </TouchableOpacity>
 
-      {expanded && (
-        <View>
+      <Animated.View
+        pointerEvents={expanded ? 'auto' : 'none'}
+        style={[animatedContentStyle, { overflow: 'hidden' }]}>
+        {/* Absolutely positioned so onLayout reports the intrinsic row height,
+            independent of the wrapper's animated (clipped) height. */}
+        <View
+          onLayout={onContentLayout}
+          style={{ position: 'absolute', left: 0, right: 0, top: 0 }}>
           {routes.map(route => {
             const key = stuckRouteKey(route)
             const isRecovering = recoveringKey === key
@@ -151,7 +198,7 @@ export const StuckFundsBanner = ({
             )
           })}
         </View>
-      )}
+      </Animated.View>
     </View>
   )
 }

--- a/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.tsx
+++ b/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.tsx
@@ -14,6 +14,7 @@ import {
   stuckRouteKey,
   useStuckFundsRecovery
 } from '../hooks/useStuckFundsRecovery'
+import { useIsFusionServiceReady } from '../hooks/useZustandStore'
 import { routeLabel } from '../utils/stuckFundsRoutes'
 
 // Atomic AVAX amounts are denominated in nAVAX (9 decimals).
@@ -46,9 +47,12 @@ export const StuckFundsBanner = ({
   const { theme } = useTheme()
   const { routes, totalNAvax, hasAnyAtomics } = useStuckAtomicFunds()
   const { recover, recoveringKey } = useStuckFundsRecovery()
+  const [isFusionServiceReady] = useIsFusionServiceReady()
   const [expanded, setExpanded] = useState(false)
 
-  if (!hasAnyAtomics) {
+  // Hide until Fusion is ready so Recover is never shown in an unusable state
+  // (recovery builds a Fusion quote + transfer).
+  if (!hasAnyAtomics || !isFusionServiceReady) {
     return null
   }
 

--- a/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.tsx
+++ b/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react'
+import { TouchableOpacity } from 'react-native'
+import {
+  Button,
+  Icons,
+  Separator,
+  Text,
+  View,
+  useTheme
+} from '@avalabs/k2-alpine'
+import { TokenUnit } from '@avalabs/core-utils-sdk'
+import { useStuckAtomicFunds } from '../hooks/useStuckAtomicFunds'
+import {
+  stuckRouteKey,
+  useStuckFundsRecovery
+} from '../hooks/useStuckFundsRecovery'
+import { routeLabel } from '../utils/stuckFundsRoutes'
+
+// Atomic AVAX amounts are denominated in nAVAX (9 decimals).
+const NAVAX_DECIMALS = 9
+
+// Title / amount rows: Inter Regular 16 / 22 per Figma. No k2-alpine variant
+// encodes 16/22 exactly, so we anchor on `body1` (Inter Regular, primary color)
+// for the font family/weight and override only the two differing dimensions.
+const TITLE_TEXT_SX = { fontSize: 16, lineHeight: 22 } as const
+
+const formatAvax = (amountNAvax: bigint): string =>
+  `${new TokenUnit(amountNAvax, NAVAX_DECIMALS, 'AVAX').toDisplay()} AVAX`
+
+/**
+ * Shared banner surfacing AVAX stranded in atomic memory after an incomplete
+ * cross-chain transfer. Collapsed by default; expands to one row per stranded
+ * route, each with a Recover action that builds an import-only recovery quote
+ * and broadcasts it directly (via useStuckFundsRecovery), surfacing the standard
+ * CCT approval — no swap-screen detour, matching core-web's Recover UX.
+ *
+ * Renders nothing (and reserves no space) when there are no stranded funds, so
+ * callers should NOT wrap it in a spacing container — pass margins via `sx`
+ * instead, which apply only when the banner actually renders.
+ */
+export const StuckFundsBanner = ({
+  sx
+}: {
+  sx?: React.ComponentProps<typeof View>['sx']
+} = {}): JSX.Element | null => {
+  const { theme } = useTheme()
+  const { routes, totalNAvax, hasAnyAtomics } = useStuckAtomicFunds()
+  const { recover, recoveringKey } = useStuckFundsRecovery()
+  const [expanded, setExpanded] = useState(false)
+
+  if (!hasAnyAtomics) {
+    return null
+  }
+
+  const plural = routes.length > 1 ? 's' : ''
+
+  return (
+    <View
+      testID="stuckFundsBanner"
+      sx={{
+        backgroundColor: '$surfaceSecondary',
+        borderRadius: 12,
+        paddingHorizontal: 16,
+        ...sx
+      }}>
+      <TouchableOpacity
+        testID="stuckFundsBanner_toggle"
+        accessibilityRole="button"
+        onPress={() => setExpanded(prev => !prev)}>
+        <View
+          sx={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 8,
+            paddingVertical: 14
+          }}>
+          <View sx={{ flex: 1 }}>
+            <Text variant="body1" sx={TITLE_TEXT_SX}>
+              Core has detected stuck funds
+            </Text>
+            <Text variant="subtitle2" sx={{ color: '$textSecondary' }}>
+              {`You have ${formatAvax(
+                totalNAvax
+              )} stuck in atomic memory from incomplete cross-chain transfer${plural}`}
+            </Text>
+          </View>
+          <Icons.Navigation.ExpandMore
+            color={theme.colors.$textSecondary}
+            style={{ transform: [{ rotate: expanded ? '180deg' : '0deg' }] }}
+          />
+        </View>
+      </TouchableOpacity>
+
+      {expanded && (
+        <View>
+          {routes.map(route => {
+            const key = stuckRouteKey(route)
+            const isRecovering = recoveringKey === key
+            return (
+              <View key={key}>
+                {/* Flush divider above every row, including the first (separates
+                    it from the header), per Figma's menu-row borders. */}
+                <Separator />
+                <View
+                  sx={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    paddingVertical: 14,
+                    gap: 8
+                  }}>
+                  <View sx={{ flex: 1 }}>
+                    <Text variant="body1" sx={TITLE_TEXT_SX}>
+                      {formatAvax(route.amountNAvax)}
+                    </Text>
+                    <Text variant="subtitle2" sx={{ color: '$textSecondary' }}>
+                      {routeLabel(route.source, route.dest)}
+                    </Text>
+                  </View>
+                  <Button
+                    testID={`stuckFundsBanner_recover_${route.source}_${route.dest}`}
+                    type="secondary"
+                    size="small"
+                    disabled={recoveringKey !== null}
+                    onPress={() => recover(route)}>
+                    {isRecovering ? 'Recovering' : 'Recover'}
+                  </Button>
+                </View>
+              </View>
+            )
+          })}
+        </View>
+      )}
+    </View>
+  )
+}

--- a/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.tsx
+++ b/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { TouchableOpacity } from 'react-native'
 import {
   Button,
@@ -56,7 +56,18 @@ export const StuckFundsBanner = ({
   // Gate on the CCT flag (recovery relies on CCT deps that aren't wired when the
   // flag is off) and hide until Fusion is ready, so Recover is never shown in an
   // unusable state. Detection is already flag-gated, so this is defense-in-depth.
-  if (!isAvalancheCctEnabled || !hasAnyAtomics || !isFusionServiceReady) {
+  const isHidden =
+    !isAvalancheCctEnabled || !hasAnyAtomics || !isFusionServiceReady
+
+  // Collapse when hidden so the banner re-shows collapsed (e.g. after a recovery
+  // clears the routes) — React keeps the component mounted when it returns null.
+  useEffect(() => {
+    if (isHidden && expanded) {
+      setExpanded(false)
+    }
+  }, [isHidden, expanded])
+
+  if (isHidden) {
     return null
   }
 
@@ -74,6 +85,7 @@ export const StuckFundsBanner = ({
       <TouchableOpacity
         testID="stuckFundsBanner_toggle"
         accessibilityRole="button"
+        accessibilityState={{ expanded }}
         onPress={() => setExpanded(prev => !prev)}>
         <View
           sx={{

--- a/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.tsx
+++ b/packages/core-mobile/app/new/features/swap/components/StuckFundsBanner.tsx
@@ -9,6 +9,8 @@ import {
   useTheme
 } from '@avalabs/k2-alpine'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
+import { useSelector } from 'react-redux'
+import { selectIsFusionAvalancheCctEnabled } from 'store/posthog'
 import { useStuckAtomicFunds } from '../hooks/useStuckAtomicFunds'
 import {
   stuckRouteKey,
@@ -45,14 +47,16 @@ export const StuckFundsBanner = ({
   sx?: React.ComponentProps<typeof View>['sx']
 } = {}): JSX.Element | null => {
   const { theme } = useTheme()
+  const isAvalancheCctEnabled = useSelector(selectIsFusionAvalancheCctEnabled)
   const { routes, totalNAvax, hasAnyAtomics } = useStuckAtomicFunds()
   const { recover, recoveringKey } = useStuckFundsRecovery()
   const [isFusionServiceReady] = useIsFusionServiceReady()
   const [expanded, setExpanded] = useState(false)
 
-  // Hide until Fusion is ready so Recover is never shown in an unusable state
-  // (recovery builds a Fusion quote + transfer).
-  if (!hasAnyAtomics || !isFusionServiceReady) {
+  // Gate on the CCT flag (recovery relies on CCT deps that aren't wired when the
+  // flag is off) and hide until Fusion is ready, so Recover is never shown in an
+  // unusable state. Detection is already flag-gated, so this is defense-in-depth.
+  if (!isAvalancheCctEnabled || !hasAnyAtomics || !isFusionServiceReady) {
     return null
   }
 

--- a/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
+++ b/packages/core-mobile/app/new/features/swap/contexts/SwapContext.tsx
@@ -22,7 +22,8 @@ import { showSnackbar, transactionSnackbar } from 'common/utils/toast'
 import Logger from 'utils/Logger'
 import {
   selectMarkrSwapMaxRetries,
-  selectFusionTransferGasMarginBps
+  selectFusionTransferGasMarginBps,
+  selectIsFusionAvalancheCctEnabled
 } from 'store/posthog'
 import { audioFeedback, Audios } from 'utils/AudioFeedback'
 // Nest Egg disabled (CP-14058) — see swapCompleted dispatch below
@@ -53,6 +54,7 @@ import {
 } from '../utils/fusionErrors'
 import { trackFusionTransfer } from '../store/actions'
 import { findNextQuote } from '../utils/findNextQuote'
+import { isAvalancheCctZeroAmountRoute } from '../utils/isAvalancheCctRoute'
 import { logSdkError } from '../utils/fusionLogger'
 import { matchQuoteByIdentifiers } from '../utils/matchQuoteByIdentifiers'
 
@@ -174,6 +176,7 @@ export const SwapContextProvider = ({
   const activeAccount = useSelector(selectActiveAccount)
   const maxRetries = useSelector(selectMarkrSwapMaxRetries)
   const transferGasMarginBps = useSelector(selectFusionTransferGasMarginBps)
+  const isAvalancheCctEnabled = useSelector(selectIsFusionAvalancheCctEnabled)
   const { getNetwork } = useNetworks()
   const fromNetwork = useMemo(
     () => (fromToken ? getNetwork(fromToken.networkChainId) : undefined),
@@ -207,6 +210,14 @@ export const SwapContextProvider = ({
     })
   }, [])
 
+  // AVALANCHE_CCT routes accept amountIn=0 so the SDK can emit an import-only
+  // recovery quote (recover stranded funds straight from the swap screen).
+  const allowZeroAmount = isAvalancheCctZeroAmountRoute({
+    isAvalancheCctEnabled,
+    fromToken,
+    toToken
+  })
+
   // Subscribe to quote stream
   const { isLoading: isQuoteLoading, error: quoteError } = useQuoteStreaming({
     fromToken,
@@ -219,7 +230,8 @@ export const SwapContextProvider = ({
     // When auto slippage is enabled, pass undefined to let SDK determine optimal slippage
     // When manual, use the user's specified slippage value
     slippageBps: autoSlippage ? undefined : slippage * 100,
-    onNoQuotesError
+    onNoQuotesError,
+    allowZeroAmount
   })
 
   // Method to select a specific quote or auto mode. Also clears any

--- a/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/usePreQuote.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/usePreQuote.ts
@@ -1,49 +1,10 @@
 import { useState, useEffect } from 'react'
 import type { LocalTokenWithBalance } from 'store/balance'
 import { NetworkWithCaip2ChainId } from 'store/network'
-import FusionService from '../../services/FusionService'
-import { logSdkError } from '../../utils/fusionLogger'
 import { toSwappableAsset, toChain } from '../../utils/fusionTypeConverters'
+import { subscribeToFirstQuote } from '../../utils/subscribeToFirstQuote'
 import type { Quote } from '../../types'
-import type { QuoterParams } from '../../services/types'
 import { getTokenKey } from '../../utils/tokenKey'
-
-/**
- * Subscribes to the first quote emitted by a Quoter for the given params,
- * calls onQuote with it, then unsubscribes. Returns a cleanup function or
- * undefined if the quoter could not be created.
- */
-const subscribeToFirstQuote = (
-  params: QuoterParams,
-  onQuote: (quote: Quote) => void,
-  onFailed: () => void
-): (() => void) | undefined => {
-  try {
-    const quoter = FusionService.getQuoter(params)
-    if (!quoter) return undefined
-
-    let settled = false
-    const unsubscribe = quoter.subscribe((event, data) => {
-      if (settled) return
-      if (event === 'quote') {
-        settled = true
-        onQuote(data.bestQuote)
-        unsubscribe()
-      } else if (event === 'done' || event === 'error') {
-        settled = true
-        onFailed()
-        unsubscribe()
-      }
-    })
-    return () => {
-      settled = true
-      unsubscribe()
-    }
-  } catch (error) {
-    logSdkError('[subscribeToFirstQuote] error', error)
-    return undefined
-  }
-}
 
 type PreQuoteEntry = {
   quote: Quote

--- a/packages/core-mobile/app/new/features/swap/hooks/useQuoteStreaming.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useQuoteStreaming.ts
@@ -76,6 +76,7 @@ export function useQuoteStreaming(
 
     // Empty input never quotes. A CCT route additionally allows an explicit 0
     // (import-only recovery quote); every other route needs a positive amount.
+    // Negatives are always rejected, even when allowZeroAmount is set.
     if (
       !fromToken ||
       !fromNetwork ||
@@ -84,7 +85,8 @@ export function useQuoteStreaming(
       !fromAddress ||
       !toAddress ||
       fromAmount === undefined ||
-      (fromAmount <= 0n && !allowZeroAmount)
+      fromAmount < 0n ||
+      (fromAmount === 0n && !allowZeroAmount)
     ) {
       return { quoter: null, error: null }
     }

--- a/packages/core-mobile/app/new/features/swap/hooks/useQuoteStreaming.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useQuoteStreaming.ts
@@ -25,6 +25,9 @@ interface UseQuoteStreamingParams {
   toAddress: string | undefined
   slippageBps: number | undefined
   onNoQuotesError?: (retry: () => void) => void
+  // When true, a 0 amount is a valid request: an AVALANCHE_CCT route where the
+  // SDK emits an import-only recovery quote for amountIn=0.
+  allowZeroAmount?: boolean
 }
 
 interface UseQuoteStreamingResult {
@@ -48,7 +51,8 @@ export function useQuoteStreaming(
     fromAddress,
     toAddress,
     slippageBps,
-    onNoQuotesError
+    onNoQuotesError,
+    allowZeroAmount = false
   } = params
 
   // Subscribe to FusionService ready state
@@ -70,16 +74,17 @@ export function useQuoteStreaming(
       return { quoter: null, error: null }
     }
 
-    // Validate all required parameters
+    // Empty input never quotes. A CCT route additionally allows an explicit 0
+    // (import-only recovery quote); every other route needs a positive amount.
     if (
       !fromToken ||
       !fromNetwork ||
       !toToken ||
       !toNetwork ||
-      !fromAmount ||
-      fromAmount <= 0n ||
       !fromAddress ||
-      !toAddress
+      !toAddress ||
+      fromAmount === undefined ||
+      (fromAmount <= 0n && !allowZeroAmount)
     ) {
       return { quoter: null, error: null }
     }
@@ -128,6 +133,7 @@ export function useQuoteStreaming(
     fromAddress,
     toAddress,
     slippageBps,
+    allowZeroAmount,
     retryCount
   ])
 

--- a/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.test.ts
@@ -5,8 +5,13 @@ import { useStuckAtomicFunds } from './useStuckAtomicFunds'
 const mockInvalidateQueries = jest.fn()
 
 jest.mock('@tanstack/react-query', () => ({
-  useQuery: jest.fn(),
-  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries })
+  useQuery: jest.fn()
+}))
+
+jest.mock('contexts/ReactQueryProvider', () => ({
+  queryClient: {
+    invalidateQueries: (...args: unknown[]) => mockInvalidateQueries(...args)
+  }
 }))
 
 jest.mock('react-redux', () => ({
@@ -15,6 +20,9 @@ jest.mock('react-redux', () => ({
 
 jest.mock('store/account', () => ({
   selectActiveAccount: () => ({ id: 'acc-1' })
+}))
+jest.mock('store/posthog', () => ({
+  selectIsFusionAvalancheCctEnabled: () => true
 }))
 jest.mock('store/settings/advanced', () => ({
   selectIsDeveloperMode: () => false

--- a/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.test.ts
@@ -67,7 +67,7 @@ describe('useStuckAtomicFunds', () => {
     result.current.invalidate()
 
     expect(mockInvalidateQueries).toHaveBeenCalledWith({
-      queryKey: ['stuckAtomicFunds']
+      queryKey: ['fusionStuckAtomicFunds']
     })
   })
 })

--- a/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.test.ts
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react-hooks'
+import type { StuckRoute } from '../utils/stuckFundsRoutes'
+import { useStuckAtomicFunds } from './useStuckAtomicFunds'
+
+const mockInvalidateQueries = jest.fn()
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: jest.fn(),
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries })
+}))
+
+jest.mock('react-redux', () => ({
+  useSelector: (fn: () => unknown) => fn()
+}))
+
+jest.mock('store/account', () => ({
+  selectActiveAccount: () => ({ id: 'acc-1' })
+}))
+jest.mock('store/settings/advanced', () => ({
+  selectIsDeveloperMode: () => false
+}))
+jest.mock('hooks/useXPAddresses/useXPAddresses', () => ({
+  useXPAddresses: () => ({ xpAddresses: ['P-fuji1abc'] })
+}))
+jest.mock('services/wallet/AvalancheWalletService', () => ({
+  __esModule: true,
+  default: { getAllAtomicUTXOs: jest.fn() }
+}))
+jest.mock('services/wallet/utils', () => ({
+  getAvaxAssetId: () => 'avax-asset-id'
+}))
+
+const { useQuery } = jest.requireMock('@tanstack/react-query')
+
+describe('useStuckAtomicFunds', () => {
+  beforeEach(() => {
+    mockInvalidateQueries.mockReset()
+  })
+
+  it('aggregates total and hasAnyAtomics from the query data', () => {
+    const routes: StuckRoute[] = [
+      { source: 'C', dest: 'P', amountNAvax: 100_000_000n },
+      { source: 'X', dest: 'C', amountNAvax: 50_000_000n }
+    ]
+    useQuery.mockReturnValue({ data: routes })
+
+    const { result } = renderHook(() => useStuckAtomicFunds())
+
+    expect(result.current.routes).toBe(routes)
+    expect(result.current.totalNAvax).toBe(150_000_000n)
+    expect(result.current.hasAnyAtomics).toBe(true)
+  })
+
+  it('reports no atomics when query data is empty', () => {
+    useQuery.mockReturnValue({ data: [] })
+
+    const { result } = renderHook(() => useStuckAtomicFunds())
+
+    expect(result.current.totalNAvax).toBe(0n)
+    expect(result.current.hasAnyAtomics).toBe(false)
+  })
+
+  it('invalidate clears the stuck-atomic-funds query', () => {
+    useQuery.mockReturnValue({ data: [] })
+
+    const { result } = renderHook(() => useStuckAtomicFunds())
+    result.current.invalidate()
+
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['stuckAtomicFunds']
+    })
+  })
+})

--- a/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.test.ts
@@ -37,6 +37,9 @@ jest.mock('services/wallet/AvalancheWalletService', () => ({
 jest.mock('services/wallet/utils', () => ({
   getAvaxAssetId: () => 'avax-asset-id'
 }))
+jest.mock('./useZustandStore', () => ({
+  useIsFusionServiceReady: () => [true]
+}))
 
 const { useQuery } = jest.requireMock('@tanstack/react-query')
 

--- a/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.ts
@@ -6,18 +6,23 @@ import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { useXPAddresses } from 'hooks/useXPAddresses/useXPAddresses'
 import AvalancheWalletService from 'services/wallet/AvalancheWalletService'
 import { getAvaxAssetId } from 'services/wallet/utils'
+import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import {
   mapAtomicUtxosToRoutes,
   type StuckRoute
 } from '../utils/stuckFundsRoutes'
 
-export const STUCK_ATOMIC_FUNDS_KEY = 'stuckAtomicFunds'
+// Poll while the banner is on-screen so a route stranded during the session
+// surfaces without the user backgrounding/navigating. Safe to poll because
+// detection is read-only (never prompts the device); paused in the background.
+const STUCK_ATOMIC_FUNDS_REFETCH_INTERVAL = 60_000
 
 /**
  * Detects AVAX stranded in atomic memory after an incomplete cross-chain
  * transfer, across all six CCT routes. Read-only (never prompts the device),
- * so it refreshes on the app's normal foreground cadence rather than polling.
- * Call `invalidate` after a recovery completes to clear a recovered route.
+ * so it polls on a 60s interval (foreground only) plus the app's normal
+ * mount/foreground refresh. Call `invalidate` after a recovery completes to
+ * clear a recovered route.
  */
 export const useStuckAtomicFunds = (): {
   routes: StuckRoute[]
@@ -31,8 +36,15 @@ export const useStuckAtomicFunds = (): {
   const queryClient = useQueryClient()
 
   const { data: routes = [] } = useQuery({
-    queryKey: [STUCK_ATOMIC_FUNDS_KEY, account, isDeveloperMode, xpAddresses],
+    queryKey: [
+      ReactQueryKeys.FUSION_STUCK_ATOMIC_FUNDS,
+      account,
+      isDeveloperMode,
+      xpAddresses
+    ],
     enabled: !!account && xpAddresses.length > 0,
+    refetchInterval: STUCK_ATOMIC_FUNDS_REFETCH_INTERVAL,
+    refetchIntervalInBackground: false,
     queryFn: async () => {
       if (!account) return []
       return AvalancheWalletService.getAllAtomicUTXOs({
@@ -45,7 +57,9 @@ export const useStuckAtomicFunds = (): {
   })
 
   const invalidate = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: [STUCK_ATOMIC_FUNDS_KEY] })
+    queryClient.invalidateQueries({
+      queryKey: [ReactQueryKeys.FUSION_STUCK_ATOMIC_FUNDS]
+    })
   }, [queryClient])
 
   return {

--- a/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.ts
@@ -1,0 +1,57 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useCallback } from 'react'
+import { useSelector } from 'react-redux'
+import { selectActiveAccount } from 'store/account'
+import { selectIsDeveloperMode } from 'store/settings/advanced'
+import { useXPAddresses } from 'hooks/useXPAddresses/useXPAddresses'
+import AvalancheWalletService from 'services/wallet/AvalancheWalletService'
+import { getAvaxAssetId } from 'services/wallet/utils'
+import {
+  mapAtomicUtxosToRoutes,
+  type StuckRoute
+} from '../utils/stuckFundsRoutes'
+
+export const STUCK_ATOMIC_FUNDS_KEY = 'stuckAtomicFunds'
+
+/**
+ * Detects AVAX stranded in atomic memory after an incomplete cross-chain
+ * transfer, across all six CCT routes. Read-only (never prompts the device),
+ * so it refreshes on the app's normal foreground cadence rather than polling.
+ * Call `invalidate` after a recovery completes to clear a recovered route.
+ */
+export const useStuckAtomicFunds = (): {
+  routes: StuckRoute[]
+  totalNAvax: bigint
+  hasAnyAtomics: boolean
+  invalidate: () => void
+} => {
+  const account = useSelector(selectActiveAccount)
+  const isDeveloperMode = useSelector(selectIsDeveloperMode)
+  const { xpAddresses } = useXPAddresses(account)
+  const queryClient = useQueryClient()
+
+  const { data: routes = [] } = useQuery({
+    queryKey: [STUCK_ATOMIC_FUNDS_KEY, account, isDeveloperMode, xpAddresses],
+    enabled: !!account && xpAddresses.length > 0,
+    queryFn: async () => {
+      if (!account) return []
+      return AvalancheWalletService.getAllAtomicUTXOs({
+        account,
+        isTestnet: isDeveloperMode,
+        xpAddresses
+      })
+    },
+    select: raw => mapAtomicUtxosToRoutes(raw, getAvaxAssetId(isDeveloperMode))
+  })
+
+  const invalidate = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: [STUCK_ATOMIC_FUNDS_KEY] })
+  }, [queryClient])
+
+  return {
+    routes,
+    totalNAvax: routes.reduce((acc, r) => acc + r.amountNAvax, 0n),
+    hasAnyAtomics: routes.length > 0,
+    invalidate
+  }
+}

--- a/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.ts
@@ -1,16 +1,29 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useCallback } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { useSelector } from 'react-redux'
 import { selectActiveAccount } from 'store/account'
+import { selectIsFusionAvalancheCctEnabled } from 'store/posthog'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { useXPAddresses } from 'hooks/useXPAddresses/useXPAddresses'
 import AvalancheWalletService from 'services/wallet/AvalancheWalletService'
 import { getAvaxAssetId } from 'services/wallet/utils'
+import { queryClient } from 'contexts/ReactQueryProvider'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import {
   mapAtomicUtxosToRoutes,
   type StuckRoute
 } from '../utils/stuckFundsRoutes'
+
+/**
+ * Invalidates the stuck-atomic-funds query. A plain function (uses the app's
+ * singleton queryClient) so callers that only need to refresh detection — e.g.
+ * after a recovery completes — don't have to subscribe to the polling query
+ * (which would register a second useQuery consumer / refetch-interval).
+ */
+export const invalidateStuckAtomicFunds = (): void => {
+  queryClient.invalidateQueries({
+    queryKey: [ReactQueryKeys.FUSION_STUCK_ATOMIC_FUNDS]
+  })
+}
 
 // Poll while the banner is on-screen so a route stranded during the session
 // surfaces without the user backgrounding/navigating. Safe to poll because
@@ -32,17 +45,22 @@ export const useStuckAtomicFunds = (): {
 } => {
   const account = useSelector(selectActiveAccount)
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
+  const isAvalancheCctEnabled = useSelector(selectIsFusionAvalancheCctEnabled)
   const { xpAddresses } = useXPAddresses(account)
-  const queryClient = useQueryClient()
 
   const { data: routes = [] } = useQuery({
+    // account.id is the stable identity for the key; the queryFn reads the whole
+    // account object, but its atomic-UTXO inputs are the id + xpAddresses (both keyed).
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: [
       ReactQueryKeys.FUSION_STUCK_ATOMIC_FUNDS,
-      account,
+      account?.id,
       isDeveloperMode,
       xpAddresses
     ],
-    enabled: !!account && xpAddresses.length > 0,
+    // Gate detection on the CCT flag: it's the feature's kill switch and stops
+    // the 6-RPC/60s poll for every XP user when CCT recovery isn't enabled.
+    enabled: isAvalancheCctEnabled && !!account && xpAddresses.length > 0,
     refetchInterval: STUCK_ATOMIC_FUNDS_REFETCH_INTERVAL,
     refetchIntervalInBackground: false,
     queryFn: async () => {
@@ -56,16 +74,10 @@ export const useStuckAtomicFunds = (): {
     select: raw => mapAtomicUtxosToRoutes(raw, getAvaxAssetId(isDeveloperMode))
   })
 
-  const invalidate = useCallback(() => {
-    queryClient.invalidateQueries({
-      queryKey: [ReactQueryKeys.FUSION_STUCK_ATOMIC_FUNDS]
-    })
-  }, [queryClient])
-
   return {
     routes,
     totalNAvax: routes.reduce((acc, r) => acc + r.amountNAvax, 0n),
     hasAnyAtomics: routes.length > 0,
-    invalidate
+    invalidate: invalidateStuckAtomicFunds
   }
 }

--- a/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useStuckAtomicFunds.ts
@@ -12,6 +12,7 @@ import {
   mapAtomicUtxosToRoutes,
   type StuckRoute
 } from '../utils/stuckFundsRoutes'
+import { useIsFusionServiceReady } from './useZustandStore'
 
 /**
  * Invalidates the stuck-atomic-funds query. A plain function (uses the app's
@@ -46,6 +47,7 @@ export const useStuckAtomicFunds = (): {
   const account = useSelector(selectActiveAccount)
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const isAvalancheCctEnabled = useSelector(selectIsFusionAvalancheCctEnabled)
+  const [isFusionServiceReady] = useIsFusionServiceReady()
   const { xpAddresses } = useXPAddresses(account)
 
   const { data: routes = [] } = useQuery({
@@ -58,9 +60,15 @@ export const useStuckAtomicFunds = (): {
       isDeveloperMode,
       xpAddresses
     ],
-    // Gate detection on the CCT flag: it's the feature's kill switch and stops
-    // the 6-RPC/60s poll for every XP user when CCT recovery isn't enabled.
-    enabled: isAvalancheCctEnabled && !!account && xpAddresses.length > 0,
+    // Gate detection on the CCT flag (the feature's kill switch, stops the
+    // 6-RPC/60s poll for every XP user when CCT recovery isn't enabled) and on
+    // Fusion readiness, since the banner is hidden until Fusion is ready anyway
+    // — no point polling during the post-unlock init window.
+    enabled:
+      isAvalancheCctEnabled &&
+      isFusionServiceReady &&
+      !!account &&
+      xpAddresses.length > 0,
     refetchInterval: STUCK_ATOMIC_FUNDS_REFETCH_INTERVAL,
     refetchIntervalInBackground: false,
     queryFn: async () => {

--- a/packages/core-mobile/app/new/features/swap/hooks/useStuckFundsRecovery.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useStuckFundsRecovery.ts
@@ -55,18 +55,21 @@ const awaitTransferConclusion = (
   transfer: Transfer
 ): Promise<ConcludedTransfer> =>
   new Promise((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error('Recovery tracking timed out')),
-      RECOVERY_TRACK_TIMEOUT_MS
-    )
-    FusionService.trackTransfer(
+    const timer: { id?: ReturnType<typeof setTimeout> } = {}
+    const cancelTracking = FusionService.trackTransfer(
       transfer,
       () => undefined,
       concluded => {
-        clearTimeout(timer)
+        if (timer.id) clearTimeout(timer.id)
         resolve(concluded)
       }
     )
+    // On timeout, stop the SDK-side tracking too (not just this promise) so it
+    // doesn't keep polling in the background past the UI's patience.
+    timer.id = setTimeout(() => {
+      cancelTracking()
+      reject(new Error('Recovery tracking timed out'))
+    }, RECOVERY_TRACK_TIMEOUT_MS)
   })
 
 /**

--- a/packages/core-mobile/app/new/features/swap/hooks/useStuckFundsRecovery.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useStuckFundsRecovery.ts
@@ -18,7 +18,6 @@ import { subscribeToFirstQuote } from '../utils/subscribeToFirstQuote'
 import type { Quote } from '../types'
 import type { QuoterParams } from '../services/types'
 import { useStuckAtomicFunds } from './useStuckAtomicFunds'
-import { useIsFusionServiceReady } from './useZustandStore'
 
 type GetNetwork = (chainId: number) => NetworkWithCaip2ChainId | undefined
 
@@ -95,26 +94,24 @@ export const useStuckFundsRecovery = (): {
   const transferGasMarginBps = useSelector(selectFusionTransferGasMarginBps)
   const { getNetwork } = useNetworks()
   const { invalidate } = useStuckAtomicFunds()
-  const [isFusionServiceReady] = useIsFusionServiceReady()
   const [recoveringKey, setRecoveringKey] = useState<string | null>(null)
 
   const recover = useCallback(
     async (route: StuckRoute): Promise<void> => {
       if (recoveringKey) return
 
-      const params = resolveRecoveryQuoterParams({
-        route,
-        account,
-        isDeveloperMode,
-        getNetwork
-      })
-      if (!isFusionServiceReady || !params) {
-        showSnackbar('Recovery is unavailable right now')
-        return
-      }
-
+      // The banner only renders once Fusion is ready, so recovery is reachable
+      // only in a usable state; any resolution failure surfaces via the catch.
       setRecoveringKey(stuckRouteKey(route))
       try {
+        const params = resolveRecoveryQuoterParams({
+          route,
+          account,
+          isDeveloperMode,
+          getNetwork
+        })
+        if (!params) throw new Error('Could not resolve recovery route')
+
         // amountIn=0 yields an import-only recovery quote; take the first one.
         const quote = await new Promise<Quote>((resolve, reject) => {
           const cleanup = subscribeToFirstQuote(params, resolve, () =>
@@ -149,7 +146,6 @@ export const useStuckFundsRecovery = (): {
       transferGasMarginBps,
       getNetwork,
       invalidate,
-      isFusionServiceReady,
       recoveringKey
     ]
   )

--- a/packages/core-mobile/app/new/features/swap/hooks/useStuckFundsRecovery.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useStuckFundsRecovery.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { selectActiveAccount } from 'store/account'
 import type { Account } from 'store/account'
@@ -17,9 +17,13 @@ import { aliasToCaip2, type StuckRoute } from '../utils/stuckFundsRoutes'
 import { subscribeToFirstQuote } from '../utils/subscribeToFirstQuote'
 import type { Quote } from '../types'
 import type { QuoterParams } from '../services/types'
-import { useStuckAtomicFunds } from './useStuckAtomicFunds'
+import { invalidateStuckAtomicFunds } from './useStuckAtomicFunds'
 
 type GetNetwork = (chainId: number) => NetworkWithCaip2ChainId | undefined
+
+// Backstop for a quote stream that never emits a terminal event: without it a
+// stalled stream would leave every Recover button disabled until remount.
+const RECOVERY_QUOTE_TIMEOUT_MS = 30_000
 
 export const stuckRouteKey = (route: StuckRoute): string =>
   `${route.source}-${route.dest}`
@@ -93,16 +97,34 @@ export const useStuckFundsRecovery = (): {
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const transferGasMarginBps = useSelector(selectFusionTransferGasMarginBps)
   const { getNetwork } = useNetworks()
-  const { invalidate } = useStuckAtomicFunds()
   const [recoveringKey, setRecoveringKey] = useState<string | null>(null)
+
+  // Synchronous mutex: `recoveringKey` is captured per-render, so a rapid
+  // double-tap could start a second recovery before the state update disables
+  // the button. The ref guards that gap.
+  const isRecoveringRef = useRef(false)
+  // Cleanup for the in-flight quote subscription, torn down on unmount so the
+  // quoter doesn't keep running (and settling against a dead hook) off-screen.
+  const activeCleanupRef = useRef<(() => void) | null>(null)
+  const isMountedRef = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false
+      activeCleanupRef.current?.()
+      activeCleanupRef.current = null
+    }
+  }, [])
 
   const recover = useCallback(
     async (route: StuckRoute): Promise<void> => {
-      if (recoveringKey) return
+      if (isRecoveringRef.current) return
+      isRecoveringRef.current = true
 
       // The banner only renders once Fusion is ready, so recovery is reachable
       // only in a usable state; any resolution failure surfaces via the catch.
       setRecoveringKey(stuckRouteKey(route))
+      let timeoutId: ReturnType<typeof setTimeout> | undefined
       try {
         const params = resolveRecoveryQuoterParams({
           route,
@@ -117,8 +139,19 @@ export const useStuckFundsRecovery = (): {
           const cleanup = subscribeToFirstQuote(params, resolve, () =>
             reject(new Error('No recovery quote available'))
           )
-          if (!cleanup) reject(new Error('Could not create recovery quote'))
+          if (!cleanup) {
+            reject(new Error('Could not create recovery quote'))
+            return
+          }
+          activeCleanupRef.current = cleanup
+          timeoutId = setTimeout(
+            () => reject(new Error('Recovery quote timed out')),
+            RECOVERY_QUOTE_TIMEOUT_MS
+          )
         })
+        // The first quote settled the subscription itself; stand the guards
+        // down so the finally doesn't double-unsubscribe.
+        activeCleanupRef.current = null
 
         const transfer = await FusionService.transferAsset(quote, {
           estimateGasMarginBps: transferGasMarginBps
@@ -130,24 +163,24 @@ export const useStuckFundsRecovery = (): {
           throw new Error(`Recovery transfer failed: ${reason}`)
         }
 
-        invalidate()
+        invalidateStuckAtomicFunds()
       } catch (error) {
         if (!isUserRejectionError(error)) {
           Logger.error('[useStuckFundsRecovery] recovery failed', error)
-          showSnackbar('Recovery failed. Please try again.')
+          if (isMountedRef.current) {
+            showSnackbar('Recovery failed. Please try again.')
+          }
         }
       } finally {
-        setRecoveringKey(null)
+        if (timeoutId) clearTimeout(timeoutId)
+        // Tear down a still-live subscription (timeout / early throw path).
+        activeCleanupRef.current?.()
+        activeCleanupRef.current = null
+        isRecoveringRef.current = false
+        if (isMountedRef.current) setRecoveringKey(null)
       }
     },
-    [
-      account,
-      isDeveloperMode,
-      transferGasMarginBps,
-      getNetwork,
-      invalidate,
-      recoveringKey
-    ]
+    [account, isDeveloperMode, transferGasMarginBps, getNetwork]
   )
 
   return { recover, recoveringKey }

--- a/packages/core-mobile/app/new/features/swap/hooks/useStuckFundsRecovery.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useStuckFundsRecovery.ts
@@ -1,4 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import type {
+  CompletedTransfer,
+  FailedTransfer,
+  RefundedTransfer,
+  Transfer
+} from '@avalabs/fusion-sdk'
 import { useSelector } from 'react-redux'
 import { selectActiveAccount } from 'store/account'
 import type { Account } from 'store/account'
@@ -24,6 +30,66 @@ type GetNetwork = (chainId: number) => NetworkWithCaip2ChainId | undefined
 // Backstop for a quote stream that never emits a terminal event: without it a
 // stalled stream would leave every Recover button disabled until remount.
 const RECOVERY_QUOTE_TIMEOUT_MS = 30_000
+
+// Stop tracking a submitted transfer after this long so the Recover button
+// can't stay disabled forever if the SDK never reports a terminal status; the
+// 60s detection poll reconciles the row either way.
+const RECOVERY_TRACK_TIMEOUT_MS = 90_000
+
+// After the import confirms, give the atomic-UTXO indexer a beat to reflect it
+// before refetching detection, mirroring web's post-confirmation delay.
+const RECOVERY_INDEXER_BUFFER_MS = 1500
+
+type ConcludedTransfer = CompletedTransfer | FailedTransfer | RefundedTransfer
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms))
+
+/**
+ * Resolves once the submitted transfer reaches a terminal status (completed /
+ * failed / refunded), or rejects after RECOVERY_TRACK_TIMEOUT_MS. This is the
+ * mobile counterpart to web's poll-until-confirmed: `transferAsset` only submits
+ * the import, so detection must not be refreshed until the tx actually lands.
+ */
+const awaitTransferConclusion = (
+  transfer: Transfer
+): Promise<ConcludedTransfer> =>
+  new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('Recovery tracking timed out')),
+      RECOVERY_TRACK_TIMEOUT_MS
+    )
+    FusionService.trackTransfer(
+      transfer,
+      () => undefined,
+      concluded => {
+        clearTimeout(timer)
+        resolve(concluded)
+      }
+    )
+  })
+
+/**
+ * Waits for a submitted recovery transfer to conclude on-chain, then refreshes
+ * detection so the row clears the moment the import actually lands (not at
+ * submission). Adds a short post-confirmation buffer like web, surfaces a
+ * failure toast on failed/refunded, and always re-checks detection at the end
+ * (a timed-out tracking may still confirm; the refetch reconciles).
+ */
+const settleRecoveryTransfer = async (transfer: Transfer): Promise<void> => {
+  try {
+    const concluded = await awaitTransferConclusion(transfer)
+    if (concluded.status === 'completed') {
+      await sleep(RECOVERY_INDEXER_BUFFER_MS)
+    } else {
+      showSnackbar('Recovery failed. Please try again.')
+    }
+  } catch (error) {
+    Logger.error('[useStuckFundsRecovery] transfer tracking failed', error)
+  } finally {
+    invalidateStuckAtomicFunds()
+  }
+}
 
 export const stuckRouteKey = (route: StuckRoute): string =>
   `${route.source}-${route.dest}`
@@ -121,11 +187,13 @@ const awaitFirstRecoveryQuote = (
  * Recovers a stranded CCT route directly from the banner (no swap screen).
  * Mirrors web's Recover UX: builds an import-only recovery quote via the Fusion
  * SDK (`amountIn=0`, the flow the SDK author prescribed) and calls
- * `transferAsset`, which surfaces the standard CCT approval and broadcasts the
- * import. Detection is invalidated on success so the row clears.
+ * `transferAsset`, which surfaces the standard CCT approval and submits the
+ * import. It then tracks the transfer to on-chain conclusion (web polls the tx)
+ * before refreshing detection, so the row clears when the funds actually move.
  *
- * `recoveringKey` is the key (`source-dest`) of the route currently recovering,
- * or null — callers use it to show per-row progress and disable re-entry.
+ * `recoveringKey` is the key (`source-dest`) of the route currently recovering
+ * — held until the transfer concludes — or null; callers use it to show per-row
+ * progress and disable re-entry.
  */
 export const useStuckFundsRecovery = (): {
   recover: (route: StuckRoute) => Promise<void>
@@ -179,17 +247,15 @@ export const useStuckFundsRecovery = (): {
         // so the finally doesn't double-unsubscribe.
         activeCleanupRef.current = null
 
+        // transferAsset only *submits* the import (surfacing the CCT approval);
+        // it resolves before the tx confirms. Keep the row in its "Recovering"
+        // state and wait for the transfer to conclude on-chain before refreshing
+        // detection, so the row clears when the funds actually move — not at
+        // submission (which was too early to ever see the cleared state).
         const transfer = await FusionService.transferAsset(quote, {
           estimateGasMarginBps: transferGasMarginBps
         })
-
-        if (transfer.status === 'failed') {
-          const reason =
-            transfer.errorReason ?? transfer.errorCode ?? 'Unknown reason'
-          throw new Error(`Recovery transfer failed: ${reason}`)
-        }
-
-        invalidateStuckAtomicFunds()
+        await settleRecoveryTransfer(transfer)
       } catch (error) {
         if (!isUserRejectionError(error)) {
           Logger.error('[useStuckFundsRecovery] recovery failed', error)

--- a/packages/core-mobile/app/new/features/swap/hooks/useStuckFundsRecovery.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useStuckFundsRecovery.ts
@@ -1,0 +1,158 @@
+import { useCallback, useState } from 'react'
+import { useSelector } from 'react-redux'
+import { selectActiveAccount } from 'store/account'
+import type { Account } from 'store/account'
+import { getAddressByNetwork } from 'store/account/utils'
+import { selectIsDeveloperMode } from 'store/settings/advanced'
+import { selectFusionTransferGasMarginBps } from 'store/posthog'
+import { useNetworks } from 'hooks/networks/useNetworks'
+import type { NetworkWithCaip2ChainId } from 'store/network'
+import { getAvalancheChainId } from 'utils/caip2ChainIds'
+import Logger from 'utils/Logger'
+import { showSnackbar } from 'common/utils/toast'
+import FusionService from '../services/FusionService'
+import { toChain } from '../utils/fusionTypeConverters'
+import { isUserRejectionError } from '../utils/fusionErrors'
+import { aliasToCaip2, type StuckRoute } from '../utils/stuckFundsRoutes'
+import { subscribeToFirstQuote } from '../utils/subscribeToFirstQuote'
+import type { Quote } from '../types'
+import type { QuoterParams } from '../services/types'
+import { useStuckAtomicFunds } from './useStuckAtomicFunds'
+import { useIsFusionServiceReady } from './useZustandStore'
+
+type GetNetwork = (chainId: number) => NetworkWithCaip2ChainId | undefined
+
+export const stuckRouteKey = (route: StuckRoute): string =>
+  `${route.source}-${route.dest}`
+
+const networkForAlias = (
+  alias: StuckRoute['source'],
+  isDeveloperMode: boolean,
+  getNetwork: GetNetwork
+): NetworkWithCaip2ChainId | undefined => {
+  const chainId = getAvalancheChainId(aliasToCaip2(alias, isDeveloperMode))
+  return chainId ? getNetwork(chainId) : undefined
+}
+
+/**
+ * Resolves the Fusion quoter params for a recovery of `route`, or null if the
+ * account/networks/addresses can't be resolved. AVAX is native, so both the
+ * asset and chain come from the network's native token.
+ */
+const resolveRecoveryQuoterParams = ({
+  route,
+  account,
+  isDeveloperMode,
+  getNetwork
+}: {
+  route: StuckRoute
+  account: Account | undefined
+  isDeveloperMode: boolean
+  getNetwork: GetNetwork
+}): QuoterParams | null => {
+  const sourceNetwork = networkForAlias(
+    route.source,
+    isDeveloperMode,
+    getNetwork
+  )
+  const targetNetwork = networkForAlias(route.dest, isDeveloperMode, getNetwork)
+  if (!account || !sourceNetwork || !targetNetwork) return null
+
+  const fromAddress = getAddressByNetwork(account, sourceNetwork)
+  const toAddress = getAddressByNetwork(account, targetNetwork)
+  if (!fromAddress || !toAddress) return null
+
+  const sourceChain = toChain(sourceNetwork)
+  const targetChain = toChain(targetNetwork)
+  return {
+    fromAddress,
+    toAddress,
+    sourceAsset: sourceChain.networkToken,
+    sourceChain,
+    targetAsset: targetChain.networkToken,
+    targetChain,
+    amount: 0n,
+    slippageBps: undefined
+  }
+}
+
+/**
+ * Recovers a stranded CCT route directly from the banner (no swap screen).
+ * Mirrors web's Recover UX: builds an import-only recovery quote via the Fusion
+ * SDK (`amountIn=0`, the flow the SDK author prescribed) and calls
+ * `transferAsset`, which surfaces the standard CCT approval and broadcasts the
+ * import. Detection is invalidated on success so the row clears.
+ *
+ * `recoveringKey` is the key (`source-dest`) of the route currently recovering,
+ * or null — callers use it to show per-row progress and disable re-entry.
+ */
+export const useStuckFundsRecovery = (): {
+  recover: (route: StuckRoute) => Promise<void>
+  recoveringKey: string | null
+} => {
+  const account = useSelector(selectActiveAccount)
+  const isDeveloperMode = useSelector(selectIsDeveloperMode)
+  const transferGasMarginBps = useSelector(selectFusionTransferGasMarginBps)
+  const { getNetwork } = useNetworks()
+  const { invalidate } = useStuckAtomicFunds()
+  const [isFusionServiceReady] = useIsFusionServiceReady()
+  const [recoveringKey, setRecoveringKey] = useState<string | null>(null)
+
+  const recover = useCallback(
+    async (route: StuckRoute): Promise<void> => {
+      if (recoveringKey) return
+
+      const params = resolveRecoveryQuoterParams({
+        route,
+        account,
+        isDeveloperMode,
+        getNetwork
+      })
+      if (!isFusionServiceReady || !params) {
+        showSnackbar('Recovery is unavailable right now')
+        return
+      }
+
+      setRecoveringKey(stuckRouteKey(route))
+      try {
+        // amountIn=0 yields an import-only recovery quote; take the first one.
+        const quote = await new Promise<Quote>((resolve, reject) => {
+          const cleanup = subscribeToFirstQuote(params, resolve, () =>
+            reject(new Error('No recovery quote available'))
+          )
+          if (!cleanup) reject(new Error('Could not create recovery quote'))
+        })
+
+        const transfer = await FusionService.transferAsset(quote, {
+          estimateGasMarginBps: transferGasMarginBps
+        })
+
+        if (transfer.status === 'failed') {
+          const reason =
+            transfer.errorReason ?? transfer.errorCode ?? 'Unknown reason'
+          throw new Error(`Recovery transfer failed: ${reason}`)
+        }
+
+        invalidate()
+      } catch (error) {
+        if (!isUserRejectionError(error)) {
+          Logger.error('[useStuckFundsRecovery] recovery failed', error)
+          showSnackbar('Recovery failed. Please try again.')
+        }
+      } finally {
+        setRecoveringKey(null)
+      }
+    },
+    [
+      account,
+      isDeveloperMode,
+      transferGasMarginBps,
+      getNetwork,
+      invalidate,
+      isFusionServiceReady,
+      recoveringKey
+    ]
+  )
+
+  return { recover, recoveringKey }
+}

--- a/packages/core-mobile/app/new/features/swap/hooks/useStuckFundsRecovery.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useStuckFundsRecovery.ts
@@ -80,6 +80,44 @@ const resolveRecoveryQuoterParams = ({
 }
 
 /**
+ * Resolves the first import-only recovery quote for `params`, rejecting on
+ * stream failure or after RECOVERY_QUOTE_TIMEOUT_MS. Passes the subscription's
+ * cleanup to `registerCleanup` so the caller can tear it down on unmount. The
+ * timeout is cleared the moment the quote settles, so a slow approval doesn't
+ * leave the timer armed to fire needlessly.
+ */
+const awaitFirstRecoveryQuote = (
+  params: QuoterParams,
+  registerCleanup: (cleanup: () => void) => void
+): Promise<Quote> =>
+  new Promise<Quote>((resolve, reject) => {
+    const timer: { id?: ReturnType<typeof setTimeout> } = {}
+    const clearTimer = (): void => {
+      if (timer.id) clearTimeout(timer.id)
+    }
+    const cleanup = subscribeToFirstQuote(
+      params,
+      quote => {
+        clearTimer()
+        resolve(quote)
+      },
+      () => {
+        clearTimer()
+        reject(new Error('No recovery quote available'))
+      }
+    )
+    if (!cleanup) {
+      reject(new Error('Could not create recovery quote'))
+      return
+    }
+    registerCleanup(cleanup)
+    timer.id = setTimeout(
+      () => reject(new Error('Recovery quote timed out')),
+      RECOVERY_QUOTE_TIMEOUT_MS
+    )
+  })
+
+/**
  * Recovers a stranded CCT route directly from the banner (no swap screen).
  * Mirrors web's Recover UX: builds an import-only recovery quote via the Fusion
  * SDK (`amountIn=0`, the flow the SDK author prescribed) and calls
@@ -124,7 +162,6 @@ export const useStuckFundsRecovery = (): {
       // The banner only renders once Fusion is ready, so recovery is reachable
       // only in a usable state; any resolution failure surfaces via the catch.
       setRecoveringKey(stuckRouteKey(route))
-      let timeoutId: ReturnType<typeof setTimeout> | undefined
       try {
         const params = resolveRecoveryQuoterParams({
           route,
@@ -135,22 +172,11 @@ export const useStuckFundsRecovery = (): {
         if (!params) throw new Error('Could not resolve recovery route')
 
         // amountIn=0 yields an import-only recovery quote; take the first one.
-        const quote = await new Promise<Quote>((resolve, reject) => {
-          const cleanup = subscribeToFirstQuote(params, resolve, () =>
-            reject(new Error('No recovery quote available'))
-          )
-          if (!cleanup) {
-            reject(new Error('Could not create recovery quote'))
-            return
-          }
+        const quote = await awaitFirstRecoveryQuote(params, cleanup => {
           activeCleanupRef.current = cleanup
-          timeoutId = setTimeout(
-            () => reject(new Error('Recovery quote timed out')),
-            RECOVERY_QUOTE_TIMEOUT_MS
-          )
         })
-        // The first quote settled the subscription itself; stand the guards
-        // down so the finally doesn't double-unsubscribe.
+        // The first quote settled the subscription itself; stand the guard down
+        // so the finally doesn't double-unsubscribe.
         activeCleanupRef.current = null
 
         const transfer = await FusionService.transferAsset(quote, {
@@ -172,7 +198,6 @@ export const useStuckFundsRecovery = (): {
           }
         }
       } finally {
-        if (timeoutId) clearTimeout(timeoutId)
         // Tear down a still-live subscription (timeout / early throw path).
         activeCleanupRef.current?.()
         activeCleanupRef.current = null

--- a/packages/core-mobile/app/new/features/swap/hooks/useSupportedChains.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useSupportedChains.ts
@@ -2,11 +2,11 @@ import { useQuery } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import type { Network } from '@avalabs/core-chains-sdk'
+import { compareDestinationChains } from '@avalabs/fusion-sdk'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import { useNetworks } from 'hooks/networks/useNetworks'
 import Logger from 'utils/Logger'
 import { getCaip2ChainId } from 'utils/caip2ChainIds'
-import { isAvalancheChainId } from 'services/network/utils/isAvalancheNetwork'
 import { isSolanaNetwork } from 'utils/network/isSolanaNetwork'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { selectActiveAccountHasSolanaAddress } from 'store/account'
@@ -23,7 +23,9 @@ const STALE_TIME = 2 * 60 * 1000 // 2 minutes
 /**
  * Helper function to filter and sort networks
  * - Filters out Solana networks if blocked or not derived
- * - Sorts with Avalanche C-Chain first
+ * - Sorts using the shared Fusion SDK destination-chain ordering so mobile,
+ *   web, and extension present chains in the same deterministic order
+ *   (C-Chain, P-Chain, X-Chain, Ethereum, Bitcoin, Solana, then the rest)
  */
 function filterAndSortNetworks(
   networks: Network[],
@@ -34,15 +36,14 @@ function filterAndSortNetworks(
       // Filter out Solana networks if blocked or account has no Solana address
       return !(hideSolana && isSolanaNetwork(network))
     })
-    .sort((a, b) => {
-      // Avalanche C-Chain always first
-      const aIsAvalanche = isAvalancheChainId(a.chainId)
-      const bIsAvalanche = isAvalancheChainId(b.chainId)
-
-      if (aIsAvalanche && !bIsAvalanche) return -1
-      if (!aIsAvalanche && bIsAvalanche) return 1
-      return 0
-    })
+    .sort((a, b) =>
+      // The SDK normalizes numeric ids as EIP-155, so pass the CAIP-2 id via
+      // universalChainId to keep non-EVM chains (BTC, Solana, X/P) in the right bucket
+      compareDestinationChains(
+        { universalChainId: getCaip2ChainId(a.chainId), name: a.chainName },
+        { universalChainId: getCaip2ChainId(b.chainId), name: b.chainName }
+      )
+    )
 }
 
 /**

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -744,7 +744,17 @@ export const SwapScreen = (): JSX.Element => {
   }, [swap, activeQuote, slippage])
 
   const handleFromAmountChange = useCallback(
-    (amount: bigint): void => {
+    (amount: bigint, valueString: string): void => {
+      // An empty/cleared field emits valueString '' (a typed 0 emits '0'); both
+      // carry amount 0n. Map empty to undefined so the rest of the screen can
+      // tell them apart: undefined = no amount (never a recovery, no quote),
+      // 0n = an explicit typed 0 (the CCT recovery input).
+      if (valueString === '') {
+        setFromTokenValue(undefined)
+        setDestination(SwapSide.SELL)
+        setUserClickedMax(false)
+        return
+      }
       // CCT atomic txs operate in nAVAX (1e9). For 18-decimal C-Chain AVAX,
       // floor the trailing wei so what the user sees is what gets sent.
       // Mirrors the staking flow's `toFixed(9)` clamp.
@@ -1211,10 +1221,13 @@ export const SwapScreen = (): JSX.Element => {
   }, [fromToken, toToken, isValidDestination, setToToken])
 
   useEffect(() => {
-    if (!debouncedFromTokenValue) {
+    // `!debouncedFromTokenValue` is also true for 0n, but a CCT recovery (an
+    // explicit 0) has a real amountOut to show, so don't clear it here — let
+    // applyQuote govern the To for that case (matches applyQuote's own guard).
+    if (!debouncedFromTokenValue && !isCctRecovery) {
       setToTokenValue(undefined)
     }
-  }, [debouncedFromTokenValue])
+  }, [debouncedFromTokenValue, isCctRecovery])
 
   usePreventScreenRemoval(isSwapping)
 

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -669,8 +669,10 @@ export const SwapScreen = (): JSX.Element => {
     toToken
   })
 
-  // Recovery flow = a CCT route with 0 explicitly entered (empty input is not
-  // treated as recovery, so the button stays "Next" until the user types 0).
+  // Recovery flow = an enabled CCT route with a 0 amount. Note the amount input
+  // emits 0n for a cleared/empty field as well, so clearing the amount also
+  // enters recovery (button reads "Recover"). Distinguishing an empty field from
+  // an explicit typed 0 is tracked as a follow-up.
   const isCctRecovery = allowZeroAmount && debouncedFromTokenValue === 0n
 
   const validateInputs = useCallback(() => {

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -62,7 +62,8 @@ import { selectActiveAccountHasSolanaAddress } from 'store/account'
 import {
   selectIsRecurringSwapsBlocked,
   selectIsSolanaSwapBlocked,
-  selectMarkrSwapMaxRetries
+  selectMarkrSwapMaxRetries,
+  selectIsFusionAvalancheCctEnabled
 } from 'store/posthog'
 import { useRecurringSwapContext } from 'features/recurringSwap/contexts/RecurringSwapContext'
 import { useRecurringEligibility } from 'features/recurringSwap/hooks/useRecurringEligibility'
@@ -88,6 +89,7 @@ import { clampToNAvax } from '../utils/clampToNAvax'
 import { StuckFundsBanner } from '../components/StuckFundsBanner'
 import {
   isAvalancheCctRoute,
+  isAvalancheCctZeroAmountRoute,
   isCctOnlySource
 } from '../utils/isAvalancheCctRoute'
 import { shouldShowAvalancheCctTwoTxNotice } from '../utils/shouldShowAvalancheCctTwoTxNotice'
@@ -448,6 +450,7 @@ export const SwapScreen = (): JSX.Element => {
   const showSolanaSwap = hasSolanaAddress && !isSolanaSwapBlocked
 
   const isRecurringBlocked = useSelector(selectIsRecurringSwapsBlocked)
+  const isAvalancheCctEnabled = useSelector(selectIsFusionAvalancheCctEnabled)
   const recurring = useRecurringSwapContext()
 
   // Recurring is Markr-only, so its per-order floor is Markr's minimum
@@ -658,6 +661,18 @@ export const SwapScreen = (): JSX.Element => {
     [recurringQuote.data?.fees]
   )
 
+  // CCT routes accept 0 (the SDK emits an import-only recovery quote), so the
+  // "enter an amount" gate is relaxed and the submit button reads "Recover".
+  const allowZeroAmount = isAvalancheCctZeroAmountRoute({
+    isAvalancheCctEnabled,
+    fromToken,
+    toToken
+  })
+
+  // Recovery flow = a CCT route with 0 explicitly entered (empty input is not
+  // treated as recovery, so the button stays "Next" until the user types 0).
+  const isCctRecovery = allowZeroAmount && debouncedFromTokenValue === 0n
+
   const validateInputs = useCallback(() => {
     // fromTokenValue drives the reset — if it's undefined (token just changed),
     // clear any error immediately without waiting for the debounce to settle.
@@ -672,7 +687,8 @@ export const SwapScreen = (): JSX.Element => {
         numberOfOrders: recurring.numberOfOrders,
         recurringTotalAmountIn: recurringQuote.data?.totalAmountIn,
         recurringAdditiveNativeFee,
-        nativeFromToken
+        nativeFromToken,
+        allowZeroAmount
       })
     )
   }, [
@@ -685,11 +701,15 @@ export const SwapScreen = (): JSX.Element => {
     recurring.numberOfOrders,
     recurringQuote.data?.totalAmountIn,
     recurringAdditiveNativeFee,
-    nativeFromToken
+    nativeFromToken,
+    allowZeroAmount
   ])
 
   const applyQuote = useCallback(() => {
-    if (!debouncedFromTokenValue || !activeQuote) {
+    // Show the received amount whenever a quote is in hand. A CCT recovery
+    // (0 entered) has amountIn=0, so keep the amount visible; an empty or
+    // no-quote input clears it.
+    if (!activeQuote || (!debouncedFromTokenValue && !isCctRecovery)) {
       setToTokenValue(undefined)
       return
     }
@@ -701,7 +721,7 @@ export const SwapScreen = (): JSX.Element => {
     if (amountOut) {
       setToTokenValue(amountOut)
     }
-  }, [activeQuote, debouncedFromTokenValue])
+  }, [activeQuote, debouncedFromTokenValue, isCctRecovery])
 
   const isMarkrRoute = activeQuote?.serviceType === ServiceType.MARKR
 
@@ -1423,7 +1443,13 @@ export const SwapScreen = (): JSX.Element => {
           size="large"
           onPress={handleNext}
           disabled={!canSubmit || isBusy}>
-          {isBusy ? <ActivityIndicator size="small" /> : 'Next'}
+          {isBusy ? (
+            <ActivityIndicator size="small" />
+          ) : isCctRecovery ? (
+            'Recover'
+          ) : (
+            'Next'
+          )}
         </Button>
       </>
     )
@@ -1433,7 +1459,8 @@ export const SwapScreen = (): JSX.Element => {
     isSwapping,
     recurringSubmitting,
     isLombard,
-    renderLombardLogo
+    renderLombardLogo,
+    isCctRecovery
   ])
 
   const renderCctTwoTxNotice = useCallback(() => {

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -1,6 +1,5 @@
 import LombardWordmarkDark from 'assets/icons/lombard-wordmark-dark.svg'
 import LombardWordmarkLight from 'assets/icons/lombard-wordmark-light.svg'
-import { formatTokenAmount } from 'utils/Utils'
 import { bigintToBig, TokenUnit } from '@avalabs/core-utils-sdk'
 import {
   ActivityIndicator,
@@ -51,6 +50,7 @@ import { useSelector } from 'react-redux'
 import AnalyticsService from 'services/analytics/AnalyticsService'
 import { LocalTokenWithBalance } from 'store/balance'
 import { basisPointsToPercentage } from 'utils/basisPointsToPercentage'
+import { formatTokenAmount } from 'utils/Utils'
 import { useTokensWithZeroBalanceByNetworksForAccount } from 'features/portfolio/hooks/useTokensWithZeroBalanceByNetworksForAccount'
 import { selectActiveAccount } from 'store/account'
 import Logger from 'utils/Logger'
@@ -85,6 +85,7 @@ import {
   isUserRejectionError
 } from '../utils/fusionErrors'
 import { clampToNAvax } from '../utils/clampToNAvax'
+import { StuckFundsBanner } from '../components/StuckFundsBanner'
 import {
   isAvalancheCctRoute,
   isCctOnlySource
@@ -187,6 +188,9 @@ function buildSwapDetailItems({
 /**
  * Computes the current swap validation error (or null if inputs are valid).
  * Extracted from SwapScreen to keep the component's cognitive complexity within limit.
+ *
+ * `allowZeroAmount` relaxes the "enter an amount" gate for AVALANCHE_CCT routes,
+ * where 0 is a valid input that triggers the SDK's import-only recovery quote.
  */
 function computeValidationError({
   fromTokenValue,
@@ -198,7 +202,8 @@ function computeValidationError({
   numberOfOrders,
   recurringTotalAmountIn,
   recurringAdditiveNativeFee,
-  nativeFromToken
+  nativeFromToken,
+  allowZeroAmount = false
 }: {
   fromTokenValue: bigint | undefined
   debouncedFromTokenValue: bigint | undefined
@@ -210,9 +215,11 @@ function computeValidationError({
   recurringTotalAmountIn: bigint | undefined
   recurringAdditiveNativeFee: bigint
   nativeFromToken: LocalTokenWithBalance | undefined
+  allowZeroAmount?: boolean
 }): FusionQuoteError | null {
   if (fromTokenValue === undefined) return null
   if (debouncedFromTokenValue !== undefined && debouncedFromTokenValue === 0n) {
+    if (allowZeroAmount) return null
     return fusionErrors.enterAmount()
   }
   // Recurring: validate the full schedule commitment (principal + additive
@@ -1520,13 +1527,15 @@ export const SwapScreen = (): JSX.Element => {
       isModal
       shouldAvoidKeyboard
       contentContainerStyle={{ flexGrow: 1, padding: 16 }}>
+      {/* Stuck-funds banner — surfaces AVAX stranded in atomic memory from an
+          incomplete cross-chain transfer. Self-hides (and reserves no space)
+          when there are none, so the margins live on the banner itself. */}
+      <StuckFundsBanner sx={{ marginTop: 10, marginBottom: 20 }} />
       {/* Schedule-management entry point: surfaces above the new-swap flow so
           users with existing schedules see + manage them before entering a
           new pair. Self-hides via `count === 0` when there are none. */}
       {!isRecurringBlocked && (
-        <View sx={{ marginBottom: 20 }}>
-          <RecurringSchedulesBanner />
-        </View>
+        <RecurringSchedulesBanner sx={{ marginBottom: 20 }} />
       )}
       {renderFromAndToSections()}
       {renderAdditiveFeesNotice()}

--- a/packages/core-mobile/app/new/features/swap/services/FusionService.ts
+++ b/packages/core-mobile/app/new/features/swap/services/FusionService.ts
@@ -374,6 +374,7 @@ class FusionService implements IFusionService {
    * @param transfer The transfer to track
    * @param updateListener Callback invoked on every status change
    * @param onCompleted Optional callback invoked once when tracking concludes
+   * @returns a canceller that stops tracking this transfer immediately
    */
   trackTransfer(
     transfer: Transfer,
@@ -381,7 +382,7 @@ class FusionService implements IFusionService {
     onCompleted?: (
       concluded: CompletedTransfer | FailedTransfer | RefundedTransfer
     ) => void
-  ): void {
+  ): () => void {
     const wrappedListener = (updated: Transfer): void => {
       Logger.info('[FusionService] new transfer status', {
         transferId: updated.id,
@@ -408,6 +409,14 @@ class FusionService implements IFusionService {
         Logger.error('[FusionService] trackTransfer error', err)
         this.#trackingCancels.delete(transfer.id)
       })
+
+    // Return a per-transfer canceller so callers that give up early (e.g. a UI
+    // timeout) can stop the SDK-side tracking instead of leaving it running
+    // until the next full `cleanup()`.
+    return () => {
+      cancel()
+      this.#trackingCancels.delete(transfer.id)
+    }
   }
 
   /**

--- a/packages/core-mobile/app/new/features/swap/services/types.ts
+++ b/packages/core-mobile/app/new/features/swap/services/types.ts
@@ -3,14 +3,17 @@ import type { FeatureFlags } from 'services/posthog/types'
 import type {
   BitcoinFunctions,
   BtcSigner,
+  CompletedTransfer,
   Environment,
   EstimateNativeFeeOptions,
   EvmSignerWithMessage,
+  FailedTransfer,
   GasSettings,
   GetMinimumTransferAmountProps,
   NativeFeeEstimate,
   Quote,
   QuoterInterface,
+  RefundedTransfer,
   ServiceType,
   Transfer,
   TransferManager,
@@ -108,11 +111,16 @@ export interface IFusionService {
    * Track a transfer's status changes via the SDK
    * @param transfer The transfer to track
    * @param updateListener Callback invoked on every status change
+   * @param onCompleted Optional callback invoked once when tracking concludes
+   * @returns a canceller that stops tracking this transfer immediately
    */
   trackTransfer(
     transfer: Transfer,
-    updateListener: (updated: Transfer) => void
-  ): void
+    updateListener: (updated: Transfer) => void,
+    onCompleted?: (
+      concluded: CompletedTransfer | FailedTransfer | RefundedTransfer
+    ) => void
+  ): () => void
 
   /**
    * Estimate the native fee required to execute the provided quote.

--- a/packages/core-mobile/app/new/features/swap/utils/isAvalancheCctRoute.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/isAvalancheCctRoute.ts
@@ -68,3 +68,21 @@ export const isAvalancheCctRoute = ({
   }
   return fromToken.networkChainId !== toToken.networkChainId
 }
+
+/**
+ * True when a 0 input amount is valid for the selected pair: an enabled
+ * AVALANCHE_CCT route. In that state the SDK emits an import-only recovery
+ * quote for `amountIn=0`, letting a user recover stranded funds straight from
+ * the swap screen (and the submit button reads "Recover"). Mirrors core-web's
+ * `isAvalancheCctZeroAmountQuoteRoute`.
+ */
+export const isAvalancheCctZeroAmountRoute = ({
+  isAvalancheCctEnabled,
+  fromToken,
+  toToken
+}: {
+  isAvalancheCctEnabled: boolean
+  fromToken: LocalTokenWithBalance | undefined
+  toToken: LocalTokenWithBalance | undefined
+}): boolean =>
+  isAvalancheCctEnabled && isAvalancheCctRoute({ fromToken, toToken })

--- a/packages/core-mobile/app/new/features/swap/utils/stuckFundsRoutes.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/stuckFundsRoutes.test.ts
@@ -1,0 +1,89 @@
+import { AvalancheCaip2ChainId } from '@avalabs/core-chains-sdk'
+import type { utils } from '@avalabs/avalanchejs'
+import type { Avalanche } from '@avalabs/core-wallets-sdk'
+import {
+  aliasToCaip2,
+  mapAtomicUtxosToRoutes,
+  routeLabel,
+  type AtomicUtxosByRoute
+} from './stuckFundsRoutes'
+
+const AVAX = 'avax-asset-id'
+
+// Minimal UtxoSet stub: one entry per (assetId, amount) pair.
+const utxoSet = (
+  entries: { assetId: string; amount: bigint }[]
+): utils.UtxoSet =>
+  ({
+    getUTXOs: () =>
+      entries.map(e => ({
+        getAssetId: () => e.assetId,
+        output: { amount: () => e.amount }
+      }))
+  } as unknown as utils.UtxoSet)
+
+const route = (
+  source: Avalanche.ChainIDAlias,
+  dest: Avalanche.ChainIDAlias,
+  entries: { assetId: string; amount: bigint }[]
+): AtomicUtxosByRoute => ({ source, dest, utxos: utxoSet(entries) })
+
+describe('stuckFundsRoutes', () => {
+  describe('routeLabel', () => {
+    it('formats a route as "<source>-Chain to <dest>-Chain"', () => {
+      expect(routeLabel('C', 'P')).toBe('C-Chain to P-Chain')
+      expect(routeLabel('X', 'C')).toBe('X-Chain to C-Chain')
+      expect(routeLabel('P', 'X')).toBe('P-Chain to X-Chain')
+    })
+  })
+
+  describe('aliasToCaip2', () => {
+    it('maps aliases to mainnet CAIP-2 ids', () => {
+      expect(aliasToCaip2('P', false)).toBe(AvalancheCaip2ChainId.P)
+      expect(aliasToCaip2('X', false)).toBe(AvalancheCaip2ChainId.X)
+      expect(aliasToCaip2('C', false)).toBe(AvalancheCaip2ChainId.C)
+    })
+
+    it('maps aliases to testnet CAIP-2 ids', () => {
+      expect(aliasToCaip2('P', true)).toBe(AvalancheCaip2ChainId.P_TESTNET)
+      expect(aliasToCaip2('X', true)).toBe(AvalancheCaip2ChainId.X_TESTNET)
+      expect(aliasToCaip2('C', true)).toBe(AvalancheCaip2ChainId.C_TESTNET)
+    })
+  })
+
+  describe('mapAtomicUtxosToRoutes', () => {
+    it('sums AVAX per route and drops empty routes', () => {
+      const raw: AtomicUtxosByRoute[] = [
+        route('C', 'P', [
+          { assetId: AVAX, amount: 60_000_000n },
+          { assetId: AVAX, amount: 40_000_000n }
+        ]),
+        route('X', 'P', []),
+        route('P', 'C', [{ assetId: AVAX, amount: 100_000_000n }]),
+        route('X', 'C', []),
+        route('P', 'X', []),
+        route('C', 'X', [])
+      ]
+
+      const result = mapAtomicUtxosToRoutes(raw, AVAX)
+
+      expect(result).toStrictEqual([
+        { source: 'C', dest: 'P', amountNAvax: 100_000_000n },
+        { source: 'P', dest: 'C', amountNAvax: 100_000_000n }
+      ])
+    })
+
+    it('ignores non-AVAX assets', () => {
+      const raw: AtomicUtxosByRoute[] = [
+        route('C', 'P', [
+          { assetId: 'some-erc20', amount: 999n },
+          { assetId: AVAX, amount: 5n }
+        ])
+      ]
+
+      expect(mapAtomicUtxosToRoutes(raw, AVAX)).toStrictEqual([
+        { source: 'C', dest: 'P', amountNAvax: 5n }
+      ])
+    })
+  })
+})

--- a/packages/core-mobile/app/new/features/swap/utils/stuckFundsRoutes.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/stuckFundsRoutes.ts
@@ -1,0 +1,62 @@
+import type { utils } from '@avalabs/avalanchejs'
+import type { Avalanche } from '@avalabs/core-wallets-sdk'
+import { getAvalancheChainAliasCaip2 } from 'utils/caip2ChainIds'
+
+/**
+ * A single stranded cross-chain transfer route: AVAX exported from `source`
+ * sitting in `dest`'s atomic memory, waiting to be imported.
+ */
+export type StuckRoute = {
+  source: Avalanche.ChainIDAlias
+  dest: Avalanche.ChainIDAlias
+  amountNAvax: bigint
+}
+
+/** Raw per-route atomic UTXO set, as returned by `getAllAtomicUTXOs`. */
+export type AtomicUtxosByRoute = {
+  dest: Avalanche.ChainIDAlias
+  source: Avalanche.ChainIDAlias
+  utxos: utils.UtxoSet
+}
+
+/** Sum the AVAX (nAVAX) held by a UTXO set, ignoring non-AVAX assets. */
+const sumAvaxNAvax = (utxos: utils.UtxoSet, avaxAssetId: string): bigint =>
+  utxos.getUTXOs().reduce((acc, utxo) => {
+    if (utxo.getAssetId() !== avaxAssetId) return acc
+    const output = utxo.output as unknown as { amount?: () => bigint }
+    return typeof output.amount === 'function' ? acc + output.amount() : acc
+  }, 0n)
+
+/**
+ * Map raw per-route atomic UTXO sets to stranded routes, dropping any route
+ * with no importable AVAX.
+ */
+export const mapAtomicUtxosToRoutes = (
+  raw: AtomicUtxosByRoute[],
+  avaxAssetId: string
+): StuckRoute[] =>
+  raw
+    .map(r => ({
+      source: r.source,
+      dest: r.dest,
+      amountNAvax: sumAvaxNAvax(r.utxos, avaxAssetId)
+    }))
+    .filter(r => r.amountNAvax > 0n)
+
+const CHAIN_NAME: Record<Avalanche.ChainIDAlias, string> = {
+  C: 'C-Chain',
+  P: 'P-Chain',
+  X: 'X-Chain'
+}
+
+/** Human label for a route, e.g. `C-Chain to P-Chain`. */
+export const routeLabel = (
+  source: Avalanche.ChainIDAlias,
+  dest: Avalanche.ChainIDAlias
+): string => `${CHAIN_NAME[source]} to ${CHAIN_NAME[dest]}`
+
+/** CAIP-2 id for an Avalanche chain alias, network-aware. */
+export const aliasToCaip2 = (
+  alias: Avalanche.ChainIDAlias,
+  isTestnet: boolean
+): string => getAvalancheChainAliasCaip2(alias, isTestnet)

--- a/packages/core-mobile/app/new/features/swap/utils/subscribeToFirstQuote.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/subscribeToFirstQuote.test.ts
@@ -1,0 +1,114 @@
+import type { QuoterEventHandler, QuoterInterface } from '@avalabs/fusion-sdk'
+import FusionService from '../services/FusionService'
+import type { Quote } from '../types'
+import type { QuoterParams } from '../services/types'
+import { subscribeToFirstQuote } from './subscribeToFirstQuote'
+
+jest.mock('../services/FusionService', () => ({
+  __esModule: true,
+  default: {
+    getQuoter: jest.fn()
+  }
+}))
+
+jest.mock('./fusionLogger', () => ({
+  logSdkError: jest.fn()
+}))
+
+const mockGetQuoter = jest.mocked(FusionService.getQuoter)
+
+const params = {} as QuoterParams
+const bestQuote = { amountOut: 42n } as unknown as Quote
+
+// Builds a fake quoter that captures the subscribed handler so tests can drive
+// events, and exposes the unsubscribe spy the util is expected to call.
+const makeQuoter = (): {
+  quoter: QuoterInterface
+  unsubscribe: jest.Mock
+  emit: (event: string, payload: unknown) => void
+} => {
+  const unsubscribe = jest.fn()
+  let handler: QuoterEventHandler | undefined
+  const quoter = {
+    subscribe: (h: QuoterEventHandler) => {
+      handler = h
+      return unsubscribe
+    }
+  } as unknown as QuoterInterface
+  return {
+    quoter,
+    unsubscribe,
+    // Cast through never so a single helper can drive the discriminated
+    // (event, payload) tuple union without per-event overloads.
+    emit: (event, payload) => handler?.(event as never, payload as never)
+  }
+}
+
+describe('subscribeToFirstQuote', () => {
+  beforeEach(() => {
+    mockGetQuoter.mockReset()
+  })
+
+  it('resolves on the first quote and unsubscribes', () => {
+    const { quoter, unsubscribe, emit } = makeQuoter()
+    mockGetQuoter.mockReturnValue(quoter)
+    const onQuote = jest.fn()
+    const onFailed = jest.fn()
+
+    subscribeToFirstQuote(params, onQuote, onFailed)
+    emit('quote', { bestQuote, quote: bestQuote, quotes: [bestQuote] })
+
+    expect(onQuote).toHaveBeenCalledWith(bestQuote)
+    expect(onFailed).not.toHaveBeenCalled()
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['done', 'error'] as const)(
+    'calls onFailed on %s before any quote and unsubscribes',
+    event => {
+      const { quoter, unsubscribe, emit } = makeQuoter()
+      mockGetQuoter.mockReturnValue(quoter)
+      const onQuote = jest.fn()
+      const onFailed = jest.fn()
+
+      subscribeToFirstQuote(params, onQuote, onFailed)
+      // payload shape differs per event; the util ignores it here
+      emit(
+        event,
+        event === 'error' ? new Error('boom') : { reason: 'no-quotes' }
+      )
+
+      expect(onFailed).toHaveBeenCalledTimes(1)
+      expect(onQuote).not.toHaveBeenCalled()
+      expect(unsubscribe).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('ignores events after the returned cleanup runs, without calling callbacks', () => {
+    const { quoter, unsubscribe, emit } = makeQuoter()
+    mockGetQuoter.mockReturnValue(quoter)
+    const onQuote = jest.fn()
+    const onFailed = jest.fn()
+
+    const cleanup = subscribeToFirstQuote(params, onQuote, onFailed)
+    cleanup?.()
+    // A late event after teardown must not fire either callback.
+    emit('quote', { bestQuote, quote: bestQuote, quotes: [bestQuote] })
+
+    expect(unsubscribe).toHaveBeenCalled()
+    expect(onQuote).not.toHaveBeenCalled()
+    expect(onFailed).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined when the quoter cannot be created', () => {
+    mockGetQuoter.mockReturnValue(null)
+    expect(subscribeToFirstQuote(params, jest.fn(), jest.fn())).toBeUndefined()
+  })
+
+  it('returns undefined when getQuoter throws', () => {
+    mockGetQuoter.mockImplementation(() => {
+      throw new Error('boom')
+    })
+    expect(subscribeToFirstQuote(params, jest.fn(), jest.fn())).toBeUndefined()
+  })
+})

--- a/packages/core-mobile/app/new/features/swap/utils/subscribeToFirstQuote.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/subscribeToFirstQuote.ts
@@ -1,0 +1,46 @@
+import FusionService from '../services/FusionService'
+import type { Quote } from '../types'
+import type { QuoterParams } from '../services/types'
+import { logSdkError } from './fusionLogger'
+
+/**
+ * Subscribes to the first quote emitted by a Quoter for the given params, calls
+ * `onQuote` with it, then unsubscribes. Calls `onFailed` if the stream ends
+ * (`done`) or errors before a quote arrives. Returns a cleanup function, or
+ * undefined if the quoter could not be created.
+ *
+ * Settles exactly once: `unsubscribe()` synchronously fires a `done`
+ * (`unsubscribed`) event, which the `settled` guard ignores so a resolved quote
+ * isn't clobbered.
+ */
+export const subscribeToFirstQuote = (
+  params: QuoterParams,
+  onQuote: (quote: Quote) => void,
+  onFailed: () => void
+): (() => void) | undefined => {
+  try {
+    const quoter = FusionService.getQuoter(params)
+    if (!quoter) return undefined
+
+    let settled = false
+    const unsubscribe = quoter.subscribe((event, data) => {
+      if (settled) return
+      if (event === 'quote') {
+        settled = true
+        onQuote(data.bestQuote)
+        unsubscribe()
+      } else if (event === 'done' || event === 'error') {
+        settled = true
+        onFailed()
+        unsubscribe()
+      }
+    })
+    return () => {
+      settled = true
+      unsubscribe()
+    }
+  } catch (error) {
+    logSdkError('[subscribeToFirstQuote] error', error)
+    return undefined
+  }
+}

--- a/packages/core-mobile/app/services/wallet/AvalancheWalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/AvalancheWalletService.test.ts
@@ -222,11 +222,17 @@ describe('WalletService', () => {
       getAtomicUTXOs: getAtomicUTXOsMock
     })
 
+    let readOnlySignerSpy: jest.SpyInstance
+
     beforeAll(() => {
-      jest // @ts-ignore
+      readOnlySignerSpy = jest // @ts-ignore
         .spyOn(AvalancheWalletService, 'getReadOnlySigner')
         // @ts-ignore
         .mockImplementation(() => atomicMockWallet())
+    })
+
+    afterAll(() => {
+      readOnlySignerSpy.mockRestore()
     })
 
     it('returns all six CCT routes, one signer call per (dest, source) pair', async () => {

--- a/packages/core-mobile/app/services/wallet/AvalancheWalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/AvalancheWalletService.test.ts
@@ -211,4 +211,40 @@ describe('WalletService', () => {
       expect(unsignedTx).toStrictEqual(mockUnsignedTx)
     })
   })
+
+  describe('getAllAtomicUTXOs', () => {
+    // Returns a sentinel UtxoSet tagged with the (dest, source) it was called
+    // with, so we can assert each route maps to the right signer call.
+    const getAtomicUTXOsMock = jest
+      .fn()
+      .mockImplementation((dest: string, source: string) => ({ dest, source }))
+    const atomicMockWallet = jest.fn().mockReturnValue({
+      getAtomicUTXOs: getAtomicUTXOsMock
+    })
+
+    beforeAll(() => {
+      jest // @ts-ignore
+        .spyOn(AvalancheWalletService, 'getReadOnlySigner')
+        // @ts-ignore
+        .mockImplementation(() => atomicMockWallet())
+    })
+
+    it('returns all six CCT routes, one signer call per (dest, source) pair', async () => {
+      const result = await AvalancheWalletService.getAllAtomicUTXOs({
+        account: { index: 0 } as Account,
+        isTestnet: true,
+        xpAddresses: ['P-fuji1abc']
+      })
+
+      const pairs = result.map(r => `${r.source}->${r.dest}`).sort()
+      expect(pairs).toStrictEqual(
+        ['C->P', 'X->P', 'P->C', 'X->C', 'P->X', 'C->X'].sort()
+      )
+      // each entry's utxos came from getAtomicUTXOs(dest, source)
+      result.forEach(r => {
+        expect(r.utxos).toStrictEqual({ dest: r.dest, source: r.source })
+      })
+      expect(getAtomicUTXOsMock).toHaveBeenCalledTimes(6)
+    })
+  })
 })

--- a/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
+++ b/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
@@ -86,13 +86,28 @@ class AvalancheWalletService {
       ['X', 'P']
     ]
 
-    return Promise.all(
+    // allSettled (not all): a single flaky route must not reject the whole
+    // detection query, or one bad chain would hide genuinely stuck funds that
+    // loaded fine on the other routes. Drop only the routes that failed.
+    const settled = await Promise.allSettled(
       routes.map(async ([dest, source]) => ({
         dest,
         source,
         utxos: await readOnlySigner.getAtomicUTXOs(dest, source)
       }))
     )
+
+    return settled
+      .filter(
+        (
+          result
+        ): result is PromiseFulfilledResult<{
+          dest: Avalanche.ChainIDAlias
+          source: Avalanche.ChainIDAlias
+          utxos: utils.UtxoSet
+        }> => result.status === 'fulfilled'
+      )
+      .map(result => result.value)
   }
 
   /**

--- a/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
+++ b/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
@@ -51,6 +51,51 @@ class AvalancheWalletService {
   }
 
   /**
+   * Get importable atomic UTXOs for every CCT route across the primary network
+   * (C/P/X), one read-only signer call per (destination, source) pair. Used by
+   * the stuck-funds banner to detect AVAX stranded in atomic memory after an
+   * incomplete cross-chain transfer. Read-only: never prompts the device.
+   */
+  public async getAllAtomicUTXOs({
+    account,
+    isTestnet,
+    xpAddresses
+  }: {
+    account: Account
+    isTestnet: boolean
+    xpAddresses: string[]
+  }): Promise<
+    {
+      dest: Avalanche.ChainIDAlias
+      source: Avalanche.ChainIDAlias
+      utxos: utils.UtxoSet
+    }[]
+  > {
+    const readOnlySigner = await this.getReadOnlySigner({
+      account,
+      isTestnet,
+      xpAddresses
+    })
+
+    const routes: [Avalanche.ChainIDAlias, Avalanche.ChainIDAlias][] = [
+      ['P', 'C'],
+      ['P', 'X'],
+      ['C', 'P'],
+      ['C', 'X'],
+      ['X', 'C'],
+      ['X', 'P']
+    ]
+
+    return Promise.all(
+      routes.map(async ([dest, source]) => ({
+        dest,
+        source,
+        utxos: await readOnlySigner.getAtomicUTXOs(dest, source)
+      }))
+    )
+  }
+
+  /**
    * Get atomic UTXOs for P-Chain.
    */
   public async getPChainAtomicUTXOs({

--- a/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
+++ b/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
@@ -97,6 +97,21 @@ class AvalancheWalletService {
       }))
     )
 
+    // Log dropped routes so intermittent RPC/chain failures are observable on
+    // the 60s poll without breaking detection for the routes that succeeded.
+    settled.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        const [dest, source] = routes[index] as [
+          Avalanche.ChainIDAlias,
+          Avalanche.ChainIDAlias
+        ]
+        Logger.warn(
+          `[getAllAtomicUTXOs] atomic UTXO fetch failed for ${source}->${dest}`,
+          result.reason
+        )
+      }
+    })
+
     return settled
       .filter(
         (

--- a/packages/k2-alpine/src/components/TokenAmountInput/TokenAmountInput.tsx
+++ b/packages/k2-alpine/src/components/TokenAmountInput/TokenAmountInput.tsx
@@ -31,7 +31,7 @@ export interface TokenAmountInputRef {
 
 /**
  * TokenAmountInput takes user's input via InputText component and calls "onChange" callback with { value: bigint; valueString: string } object.
- * If there's no input, callback value is set to { value: new BigInt(0), valueString: '0' }.
+ * If the field is empty, callback value is set to { value: 0n, valueString: '' } — an empty `valueString` lets callers tell a cleared/empty field apart from an explicit typed "0" (which emits valueString: '0'), since both carry value 0n.
  * Because of that, if "value" passed to TokenAmountInput is zero it is sanitized to "undefined" so that user can delete all zeroes from input.
  */
 export const TokenAmountInput = forwardRef<
@@ -88,7 +88,9 @@ export const TokenAmountInput = forwardRef<
     const handleChangeText = (rawValue: string): void => {
       const valueText = normalizeNumericTextInput(rawValue)
       if (!valueText) {
-        onChange?.({ value: 0n, valueString: '0' })
+        // Empty field: emit an empty valueString so callers can distinguish a
+        // cleared/empty field from an explicit typed "0" (both carry value 0n).
+        onChange?.({ value: 0n, valueString: '' })
         setValueAsString('')
         return
       }


### PR DESCRIPTION
## Description

**Ticket: [CP-14363](https://ava-labs.atlassian.net/browse/CP-14363)**

A cross-chain transfer is a two-step export + import. If the import never broadcasts (app closed mid-flow, network blip), AVAX ends up stranded in atomic memory and mobile had no way to surface or recover it. This adds a shared "stuck funds" banner across portfolio, stake, swap, and notification center that detects stranded funds and lets the user recover them, mirroring core-web's pattern. Recovery runs the Fusion `amountIn=0` import-only quote and broadcasts directly from the banner (no swap detour); the swap screen also accepts a 0 amount for the same recovery. Detection is read-only, so it never prompts hardware wallets.

## Screenshots/Videos
https://github.com/user-attachments/assets/27b28551-9486-41fb-9bc6-8c6c1b3eef75

## Testing
**iOS: 0.0.0.9070
Android: 0.0.0.9071**

- Strand funds first: start a CCT transfer (e.g. C-Chain to P-Chain) and reject the second approval (the import), so AVAX sits stranded in atomic memory.
- Portfolio: open the Portfolio tab and confirm the "Core has detected stuck funds" banner appears below the balance, above the action buttons. Expand it and confirm one row per stranded route (e.g. `0.1 AVAX / C-Chain to P-Chain`) with a Recover button.
- Tap Recover and confirm the import approval opens, approve it, and confirm the import broadcasts and the row clears once it confirms on-chain.
- Confirm the same banner renders on Stake home, the Swap screen (below the title), and the Notifications screen (header).
- Multi-route: strand two routes (e.g. C to P and C to X) and confirm two separate rows.
- Swap screen recovery: on a CCT route (AVAX on C-Chain to AVAX on P-Chain) enter 0; confirm the receive field shows the recovered amount and the submit button reads "Recover", then approve to complete the import.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14363]: https://ava-labs.atlassian.net/browse/CP-14363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ