### PR TITLE
CP-14672: fix Android Send amount input not accepting input

### DIFF
--- a/packages/core-mobile/app/new/features/send/components/SendToken.tsx
+++ b/packages/core-mobile/app/new/features/send/components/SendToken.tsx
@@ -360,7 +360,11 @@ export const SendToken = ({
           onChange={setAmount}
           validateAmount={validateSendAmount}
           disabled={isSending || selectedToken === undefined}
-          autoFocus
+          // iOS auto-focuses immediately on mount. Android focuses later, once
+          // the form-sheet transition and keyboard layout have settled (see the
+          // useAfterScreenEnterTransition call above); focusing on mount there
+          // leaves a broken InputConnection ~1 in 5 times. See CP-14672.
+          autoFocus={Platform.OS === 'ios'}
           maxAmount={maxAmount}
         />
       )}

--- a/packages/core-mobile/app/new/features/send/components/SendToken.tsx
+++ b/packages/core-mobile/app/new/features/send/components/SendToken.tsx
@@ -20,6 +20,8 @@ import {
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import { TRUNCATE_ADDRESS_LENGTH } from 'common/consts/text'
 import { usePrevious } from 'common/hooks/usePrevious'
+import { useAfterScreenEnterTransition } from 'common/hooks/useAfterScreenEnterTransition'
+import { Platform } from 'react-native'
 import { dismissKeyboardIfNeeded } from 'common/utils/dismissKeyboardIfNeeded'
 import { loadAvatar } from 'common/utils/loadAvatar'
 import { stripAddressPrefix } from 'common/utils/stripAddressPrefix'
@@ -31,6 +33,10 @@ import { useSelector } from 'react-redux'
 import { selectSelectedCurrency } from 'store/settings/currency'
 import { useSendContext } from '../context/sendContext'
 import { useSendSelectedToken } from '../store'
+
+// Delay (after the form-sheet transition ends) before auto-focusing the amount
+// input on Android, so the sheet/keyboard layout settles first. See CP-14672.
+const ANDROID_AMOUNT_FOCUS_BUFFER_MS = 500
 
 export const SendToken = ({
   onSend,
@@ -72,6 +78,18 @@ export const SendToken = ({
       tokenUnitInputWidgetRef.current?.setValue('')
     }
   }, [prevSelectedToken, selectedToken, resetAmount])
+
+  // Android: focus the amount input only after the form-sheet enter transition
+  // has ended AND a short layout/keyboard settle buffer. Focusing during the
+  // still-settling window leaves a broken InputConnection (cursor shows but
+  // keystrokes never reach JS). iOS keeps the input's own autoFocus. See CP-14672.
+  useAfterScreenEnterTransition(
+    () => tokenUnitInputWidgetRef.current?.focus(),
+    {
+      enabled: Platform.OS === 'android',
+      layoutBufferMs: ANDROID_AMOUNT_FOCUS_BUFFER_MS
+    }
+  )
 
   useEffect(() => {
     if (!isTokenTouched && selectedToken) {

--- a/packages/core-mobile/app/new/features/send/components/SendToken.tsx
+++ b/packages/core-mobile/app/new/features/send/components/SendToken.tsx
@@ -79,18 +79,6 @@ export const SendToken = ({
     }
   }, [prevSelectedToken, selectedToken, resetAmount])
 
-  // Android: focus the amount input only after the form-sheet enter transition
-  // has ended AND a short layout/keyboard settle buffer. Focusing during the
-  // still-settling window leaves a broken InputConnection (cursor shows but
-  // keystrokes never reach JS). iOS keeps the input's own autoFocus. See CP-14672.
-  useAfterScreenEnterTransition(
-    () => tokenUnitInputWidgetRef.current?.focus(),
-    {
-      enabled: Platform.OS === 'android',
-      layoutBufferMs: ANDROID_AMOUNT_FOCUS_BUFFER_MS
-    }
-  )
-
   useEffect(() => {
     if (!isTokenTouched && selectedToken) {
       setIsTokenTouched(true)
@@ -137,6 +125,23 @@ export const SendToken = ({
       selectedToken?.symbol ?? ''
     )
   }, [network.networkToken.decimals, selectedToken])
+
+  // Android: focus the amount input only after the form-sheet enter transition
+  // has ended AND a short layout/keyboard settle buffer. Focusing during the
+  // still-settling window leaves a broken InputConnection (cursor shows but
+  // keystrokes never reach JS). iOS keeps the input's own autoFocus. See CP-14672.
+  //
+  // Gating `enabled` on `tokenBalance` also handles a late-mounting widget: the
+  // input only renders once `tokenBalance` is truthy, so if it isn't ready when
+  // the transition ends, `enabled` flips to true when it becomes available and
+  // the helper re-arms (enabled is one of its effect deps) and focuses then.
+  useAfterScreenEnterTransition(
+    () => tokenUnitInputWidgetRef.current?.focus(),
+    {
+      enabled: Platform.OS === 'android' && !!tokenBalance,
+      layoutBufferMs: ANDROID_AMOUNT_FOCUS_BUFFER_MS
+    }
+  )
 
   const addressToSendWithoutPrefix = useMemo(() => {
     if (selectedToken === undefined && toAddress?.recipientType !== 'address') {

--- a/packages/k2-alpine/src/components/TokenUnitInput/SendTokenUnitInputWidget.tsx
+++ b/packages/k2-alpine/src/components/TokenUnitInput/SendTokenUnitInputWidget.tsx
@@ -24,6 +24,7 @@ type PresetDefinition = {
 
 export type SendTokenUnitInputWidgetHandle = {
   setValue: (value: string) => void
+  focus: () => void
 }
 
 type SendTokenUnitInputWidgetProps = {
@@ -81,7 +82,8 @@ export const SendTokenUnitInputWidget = forwardRef<
     const textInputRef = useRef<TokenUnitInputHandle>(null)
 
     useImperativeHandle(ref, () => ({
-      setValue: (newValue: string) => textInputRef.current?.setValue(newValue)
+      setValue: (newValue: string) => textInputRef.current?.setValue(newValue),
+      focus: () => textInputRef.current?.focus()
     }))
 
     // Preset targets depend only on balance/max/token — not on `amount`, so typing

--- a/packages/k2-alpine/src/components/TokenUnitInput/TokenUnitInput.tsx
+++ b/packages/k2-alpine/src/components/TokenUnitInput/TokenUnitInput.tsx
@@ -144,17 +144,11 @@ export const TokenUnitInput = forwardRef<
     }))
 
     useEffect(() => {
-      // Android intentionally does not auto-focus this amount input. On the New
-      // Architecture (Fabric), inside a react-native-screens form-sheet,
-      // programmatically focusing the field while the screen/keyboard is still
-      // settling leaves a broken InputConnection ~1 in 5 times: the cursor shows
-      // but keystrokes never reach JS, so the amount can't be entered (CP-14672).
-      // A user tap always establishes a healthy connection, so on Android we let
-      // the user tap to focus. iOS is unaffected and keeps auto-focus.
-      if (!autoFocus || Platform.OS !== 'ios') return
-      requestAnimationFrame(() => {
-        textInputRef.current?.focus()
-      })
+      if (autoFocus) {
+        requestAnimationFrame(() => {
+          textInputRef.current?.focus()
+        })
+      }
     }, [autoFocus])
 
     return (

--- a/packages/k2-alpine/src/components/TokenUnitInput/TokenUnitInput.tsx
+++ b/packages/k2-alpine/src/components/TokenUnitInput/TokenUnitInput.tsx
@@ -144,11 +144,17 @@ export const TokenUnitInput = forwardRef<
     }))
 
     useEffect(() => {
-      if (autoFocus) {
-        requestAnimationFrame(() => {
-          textInputRef.current?.focus()
-        })
-      }
+      // Android intentionally does not auto-focus this amount input. On the New
+      // Architecture (Fabric), inside a react-native-screens form-sheet,
+      // programmatically focusing the field while the screen/keyboard is still
+      // settling leaves a broken InputConnection ~1 in 5 times: the cursor shows
+      // but keystrokes never reach JS, so the amount can't be entered (CP-14672).
+      // A user tap always establishes a healthy connection, so on Android we let
+      // the user tap to focus. iOS is unaffected and keeps auto-focus.
+      if (!autoFocus || Platform.OS !== 'ios') return
+      requestAnimationFrame(() => {
+        textInputRef.current?.focus()
+      })
     }, [autoFocus])
 
     return (


### PR DESCRIPTION
## Description

**Ticket: [CP-14672](https://ava-labs.atlassian.net/browse/CP-14672)**

On Android, the Send amount field was auto-focusing the moment the screen mounted, while the form-sheet and keyboard were still animating in. About 1 in 5 times that left the native input with a broken connection: the cursor blinked but keystrokes never registered, so you couldn't enter an amount until you killed and reopened the app. The fix waits for the sheet's enter transition to finish plus a short settle buffer before focusing on Android, so the input is ready when it receives focus. iOS is unchanged (still auto-focuses on mount).

The platform/timing decision lives in the Send screen; the shared `TokenUnitInput` stays generic and only exposes a `focus()` handle.

## Testing
**iOS: 0.0.0.9107
Android: 0.0.0.9108**

- On an **Android** device, fresh install. From Portfolio tap **Send**, enter a recipient (e.g. Account 2), tap **AVAX** on the token screen, and land on the "How much would you like to send?" screen. The keyboard should come up on its own after a brief moment, and typing `0.01` should register every digit.
- Repeat the flow **8–10 times** (the bug reproduced ~1 in 5). The amount field should accept input every time — no more "cursor shows but nothing types" state.
- Back out and re-enter the amount screen a few times; confirm it still auto-focuses and accepts input on each visit.
- On **iOS**, confirm the amount field still auto-focuses immediately as before (no behavior change).

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14672]: https://ava-labs.atlassian.net/browse/CP-14672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ