### PR TITLE
CP-14702: treat Android Apple sign-in bridge cancellations as USER_CANCELED (stop false SeedlessLoginFailed events)

### DIFF
--- a/packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.android.test.ts
+++ b/packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.android.test.ts
@@ -8,7 +8,8 @@ jest.mock('@invertase/react-native-apple-authentication', () => ({
     signIn: jest.fn(),
     Scope: { EMAIL: 'EMAIL' },
     ResponseType: { ALL: 'ALL' },
-    Error: { SIGNIN_CANCELLED: 'SIGNIN_CANCELLED' }
+    // Real runtime value from the native module's getConstants()
+    Error: { SIGNIN_CANCELLED: 'E_SIGNIN_CANCELLED_ERROR' }
   }
 }))
 
@@ -72,7 +73,19 @@ describe('AppleSignInService.android', () => {
   describe('preserved behavior', () => {
     it('still throws USER_CANCELED when the user cancels', async () => {
       const cancelled = Object.assign(new Error('cancelled'), {
-        code: 'SIGNIN_CANCELLED'
+        code: 'E_SIGNIN_CANCELLED_ERROR'
+      })
+      signInMock.mockRejectedValueOnce(cancelled)
+
+      await expect(AppleSignInService.signIn()).rejects.toThrow('USER_CANCELED')
+    })
+
+    it('treats bridge rejections carrying E_SIGNIN_CANCELLED_ERROR in the message as USER_CANCELED', async () => {
+      // The library's native module cancels via promise.reject(String), which
+      // the RN bridge surfaces as code EUNSPECIFIED with the constant as the
+      // message — so the code-based check above never sees these.
+      const cancelled = Object.assign(new Error('E_SIGNIN_CANCELLED_ERROR'), {
+        code: 'EUNSPECIFIED'
       })
       signInMock.mockRejectedValueOnce(cancelled)
 

--- a/packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.android.test.ts
+++ b/packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.android.test.ts
@@ -73,7 +73,7 @@ describe('AppleSignInService.android', () => {
   describe('preserved behavior', () => {
     it('still throws USER_CANCELED when the user cancels', async () => {
       const cancelled = Object.assign(new Error('cancelled'), {
-        code: 'E_SIGNIN_CANCELLED_ERROR'
+        code: appleAuthAndroid.Error.SIGNIN_CANCELLED
       })
       signInMock.mockRejectedValueOnce(cancelled)
 

--- a/packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.android.ts
+++ b/packages/core-mobile/app/services/socialSignIn/apple/AppleSignInService.android.ts
@@ -45,11 +45,15 @@ class AppleSigninService implements AppleSigninServiceInterface {
 
       return { oidcToken: response.id_token }
     } catch (error) {
+      // The native module cancels via promise.reject(String), which the RN
+      // bridge surfaces with code EUNSPECIFIED and the constant as the
+      // message — so match the message as well as the code.
       if (
         error instanceof Error &&
-        'code' in error &&
-        (error as Error & { code: string }).code ===
-          appleAuthAndroid.Error.SIGNIN_CANCELLED
+        (('code' in error &&
+          (error as Error & { code: string }).code ===
+            appleAuthAndroid.Error.SIGNIN_CANCELLED) ||
+          error.message.includes('E_SIGNIN_CANCELLED_ERROR'))
       ) {
         throw new Error('USER_CANCELED')
       }


### PR DESCRIPTION
## Description

**Ticket: [CP-14702](https://ava-labs.atlassian.net/browse/CP-14702)**

**Summary:** Android Apple sign-in cancellations are being recorded as `SeedlessLoginFailed` analytics events. This PR makes the cancellation filter match the error shape the RN bridge actually produces, so user cancellations are classified as `USER_CANCELED` (already excluded from analytics) instead of failures.

**Motivation / context:** The June 2026 re-read of the [failure investigation](https://app.notion.com/p/Core-Mobile-Android-Failures-Root-Cause-Investigation-3590e2bd5180811bbfc2e5042fb9258c) shows 178 events / 106 devices in one month with reason `Android Apple sign in error: EUNSPECIFIED: E_SIGNIN_CANCELLED_ERROR` — **~29% of all Android `SeedlessLoginFailed` events are users tapping cancel on the Apple sign-in sheet.**

Root cause: `@invertase/react-native-apple-authentication`'s Android module cancels via the single-argument `promise.reject(E_SIGNIN_CANCELLED_ERROR)`. RN's bridge (`PromiseImpl`) surfaces single-arg rejections with `code = EUNSPECIFIED` and the constant as the **message**. Our existing filter compares `error.code === appleAuthAndroid.Error.SIGNIN_CANCELLED`, which therefore never matches — that branch is effectively dead in production. The fix adds a message-based match (`E_SIGNIN_CANCELLED_ERROR`) alongside the code check.

Verified against library + RN source that no other reject path in the native module can contain this string, so genuine failures cannot be misclassified. Behavior now matches iOS Apple and Google cancels (no analytics event; generic error snackbar still shows).

**Dependencies:** none. **Breaking:** no.

## Screenshots/Videos

N/A — analytics classification change only; no UI change.

## Testing

**Dev Testing (if applicable)**

iOS: 9311
Android: 9312

- Happy path: on an Android device, start Apple sign-in from onboarding, complete sign-in → succeeds as before.
- Cancellation: start Apple sign-in, dismiss/cancel the Apple web sheet → generic "unable to sign up" snackbar still appears, but **no** `SeedlessLoginFailed` event is captured (verify via PostHog live events or debug logs) and no Sentry `useSeedlessRegister error` is logged.
- Genuine failure (edge case): covered by unit tests — non-cancel errors still throw `Android Apple sign in error: <detail>` and capture analytics with full detail.
- Bitrise build: will reference the PR-triggered build here once it completes.

**QA Testing (if applicable)**

- Android only. Regression-check Apple sign-in end to end (new signup + existing login). Cancelling the Apple sheet should return the user to the sign-in screen with the existing error toast; completing it should sign in normally.
- Expected: no change in user-facing behavior other than analytics no longer counting cancellations as login failures.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CP-14702]: https://ava-labs.atlassian.net/browse/CP-14702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ