### PR TITLE
CP-14704: fix Big serialization crash by not capturing list data in worklets

### DIFF
--- a/packages/core-mobile/app/new/common/components/ListScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ListScreen.tsx
@@ -252,6 +252,11 @@ export const ListScreen = <T,>({
     }
   })
 
+  // Capture only the emptiness flag — referencing `data` inside the worklet
+  // would serialize the whole array to the UI thread, which throws on
+  // non-plain values (e.g. Big instances) since react-native-worklets 0.10.
+  const isListEmpty = data.length === 0
+
   const animatedTitleStyle = useAnimatedStyle(() => {
     const scale = interpolate(
       scrollY.value,
@@ -264,7 +269,7 @@ export const ListScreen = <T,>({
     )
     return {
       opacity: 1 - targetHiddenProgress.value,
-      transform: [{ scale: data.length === 0 ? 1 : scale }],
+      transform: [{ scale: isListEmpty ? 1 : scale }],
       transformOrigin: 'bottom left'
     }
   })

--- a/packages/core-mobile/app/new/common/components/ListScreenV2.tsx
+++ b/packages/core-mobile/app/new/common/components/ListScreenV2.tsx
@@ -288,6 +288,11 @@ export const ListScreenV2 = <T,>({
     }
   })
 
+  // Capture only the emptiness flag — referencing `data` inside the worklet
+  // would serialize the whole array to the UI thread, which throws on
+  // non-plain values (e.g. Big instances) since react-native-worklets 0.10.
+  const isListEmpty = data.length === 0
+
   const animatedTitleStyle = useAnimatedStyle(() => {
     const scale = interpolate(
       scrollY.value,
@@ -300,7 +305,7 @@ export const ListScreenV2 = <T,>({
     )
     return {
       opacity: 1 - targetHiddenProgress.value,
-      transform: [{ scale: data.length === 0 ? 1 : scale }],
+      transform: [{ scale: isListEmpty ? 1 : scale }],
       transformOrigin: 'bottom left'
     }
   })


### PR DESCRIPTION
## Description

**Ticket: [CP-14704]**

Fixes a render crash `[Worklets] Cannot copy value of type \`Big\`.` (seen on the Aave select-collateral screen, reproducible on any screen feeding `ListScreen` data that contains `Big`/`TokenUnit` instances).

- `ListScreen` / `ListScreenV2` referenced `data.length` inside the `animatedTitleStyle` `useAnimatedStyle` worklet, so the worklet closure captured the entire `data` array and react-native-worklets serialized it to the UI thread on every render.
- Since the reanimated 4.5.1 upgrade (react-native-worklets 0.9.2 → 0.10.1, #3944), serialization of non-plain class instances throws eagerly instead of silently substituting an inaccessible proxy, so any list whose items contain `Big` values (e.g. `asset.mintTokenBalance.balanceValue.value`) crashed at render.
- Fix: compute `const isListEmpty = data.length === 0` outside the worklet and capture only that boolean. No behavior change; also avoids copying the whole list to the UI thread on every data update.

No new dependencies, not breaking.

## Screenshots/Videos

N/A — crash fix; the affected screens render identically.

## Testing
iOS: 9124
Android: 9125

**Dev Testing (if applicable)**

- Open Borrow → select collateral (Aave) with at least one deposit: previously threw the render error, now renders.
- Scroll a `ListScreen`-based screen and verify the title scale/fade animation still works, including the empty-list state (no scale animation when empty).

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CP-14704]: https://ava-labs.atlassian.net/browse/CP-14704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ