### PR TITLE
fix: load in-app browser first search/URL on Android

### DIFF
--- a/packages/core-mobile/app/new/features/browser/BrowserContext.test.tsx
+++ b/packages/core-mobile/app/new/features/browser/BrowserContext.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { renderHook, act } from '@testing-library/react-hooks'
+import { useSelector, useDispatch } from 'react-redux'
+import { addHistoryForActiveTab } from 'store/browser'
+import { BrowserProvider, useBrowserContext } from './BrowserContext'
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+  useDispatch: jest.fn()
+}))
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>
+const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>
+
+const activeTab = {
+  id: 'tab-1',
+  historyIds: [],
+  activeHistoryIndex: -1,
+  activeHistory: undefined,
+  lastVisited: 0
+}
+
+describe('BrowserContext handleUrlSubmit', () => {
+  const mockDispatch = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseDispatch.mockReturnValue(mockDispatch)
+    mockUseSelector.mockReturnValue(activeTab)
+  })
+
+  const renderBrowserContext = (): ReturnType<typeof useBrowserContext> => {
+    const wrapper = ({
+      children
+    }: {
+      children: React.ReactNode
+    }): React.JSX.Element => <BrowserProvider>{children}</BrowserProvider>
+    const { result } = renderHook(() => useBrowserContext(), { wrapper })
+    return result.current
+  }
+
+  // Reproduces the "first search does nothing, works on retry" bug: on the very
+  // first submit the per-tab WebView ref (browserRefs.current[tab.id].current)
+  // has not attached yet. Navigation must still be dispatched to Redux, because
+  // the WebView is driven off the history entry — not the imperative ref.
+  it('dispatches navigation on first submit even when the tab ref is not attached yet', () => {
+    const ctx = renderBrowserContext()
+
+    act(() => {
+      ctx.handleUrlSubmit('hello world')
+    })
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      addHistoryForActiveTab({
+        title: 'https://www.google.com/search?q=hello%20world',
+        url: 'https://www.google.com/search?q=hello%20world'
+      })
+    )
+  })
+
+  it('dispatches navigation on first submit for a direct URL when the tab ref is not attached yet', () => {
+    const ctx = renderBrowserContext()
+
+    act(() => {
+      ctx.handleUrlSubmit('example.com')
+    })
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      addHistoryForActiveTab({
+        title: 'https://example.com',
+        url: 'https://example.com'
+      })
+    )
+  })
+})

--- a/packages/core-mobile/app/new/features/browser/BrowserContext.tsx
+++ b/packages/core-mobile/app/new/features/browser/BrowserContext.tsx
@@ -83,16 +83,23 @@ function useBrowserContextValue(): BrowserContextType {
 
   const openUrl = (url: string): void => {
     setUrlEntry(url)
-    if (activeTab?.id && browserRefs.current[activeTab.id]?.current) {
-      dispatch(
-        addHistoryForActiveTab({
-          title: url,
-          url: url
-        })
-      )
+    if (!activeTab?.id) return
 
-      browserRefs.current[activeTab.id]?.current?.loadUrl(url)
-    }
+    // Drive navigation through Redux history: BrowserTab renders its WebView off
+    // the active history entry, so this alone loads the page. This must NOT be
+    // gated on the imperative tab ref — on the first submit (notably Android)
+    // the per-tab ref hasn't attached yet, and gating here dropped the whole
+    // navigation, so nothing happened until a second submit.
+    dispatch(
+      addHistoryForActiveTab({
+        title: url,
+        url: url
+      })
+    )
+
+    // Best-effort imperative load for the already-mounted WebView. Redundant
+    // with the history-driven path above, so it's fine when the ref is absent.
+    browserRefs.current[activeTab.id]?.current?.loadUrl(url)
   }
 
   const handleClearAndFocus = (): void => {


### PR DESCRIPTION
iOS: 9128
Android: 9129

Navigation from the address bar was gated behind the per-tab WebView ref (browserRefs.current[tab.id].current) in openUrl. That ref is attached in an effect after a re-render, so on the first submit of a session on Android it isn't ready yet, and the guard skipped BOTH the Redux history dispatch and the imperative loadUrl. Nothing loaded until a second submit.

The WebView renders off the active history entry, so the dispatch is what actually drives navigation and must not depend on the imperative ref. Dispatch addHistoryForActiveTab whenever there's an active tab and keep loadUrl as a best-effort optimization for the mounted WebView.

## Description

**Ticket: [CP-]**

Please provide:

- A summary of the changes
- Motivation and context for this change
- Any dependencies introduced
- (If breaking) migration steps and instructions

## Screenshots/Videos

Include relevant screenshots or screen recordings of iOS and Android.

## Testing

**Dev Testing (if applicable)**

- Provide steps to test the happy path of your feature
- Provide steps to test edge cases and error states
- Trigger a build on bitrise and reference it here
- Move the ticket into the "Testing" column on Jira

**QA Testing (if applicable)**

- Provide instructions for QA to test this feature thoroughly
- State expected behavior / acceptance criteria

## Checklist

Please check all that apply (if applicable)

- [ ] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [ ] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation
