### PR TITLE
CP-14187: Restake

### DIFF
--- a/packages/core-mobile/app/contexts/DelegationContext.tsx
+++ b/packages/core-mobile/app/contexts/DelegationContext.tsx
@@ -49,6 +49,13 @@ interface DelegationContextState {
   steps: Step[]
   computeSteps: ComputeSteps
   delegate: Delegate
+  /**
+   * Whether `computeSteps` has all of its async inputs (fee state, C-Chain
+   * base fee, providers, account addresses). While false, `computeSteps`
+   * resolves to an empty step list without computing anything — callers that
+   * need a real funding answer must wait for this to become true.
+   */
+  isComputeReady: boolean
 }
 
 export const DelegationContext = createContext<DelegationContextState>(
@@ -60,15 +67,16 @@ export const DelegationContextProvider = ({
 }: {
   children: ReactNode
 }): JSX.Element => {
-  const { steps, computeSteps, delegate } = useDelegation()
+  const { steps, computeSteps, delegate, isComputeReady } = useDelegation()
 
   const state: DelegationContextState = useMemo(
     () => ({
       steps,
       computeSteps,
-      delegate
+      delegate,
+      isComputeReady
     }),
-    [computeSteps, delegate, steps]
+    [computeSteps, delegate, steps, isComputeReady]
   )
 
   return (

--- a/packages/core-mobile/app/hooks/earn/useDelegation.ts
+++ b/packages/core-mobile/app/hooks/earn/useDelegation.ts
@@ -67,6 +67,7 @@ export const useDelegation = (): {
   computeSteps: ComputeSteps
   delegate: Delegate
   steps: Step[]
+  isComputeReady: boolean
 } => {
   const [steps, setSteps] = useState<Step[]>(EMPTY_STEPS)
   const cChainBalance = useCChainBalance()
@@ -83,6 +84,20 @@ export const useDelegation = (): {
   const avalancheEvmProvider = useAvalancheEvmProvider(isDeveloperMode)
   const cChainBaseFee = useCChainBaseFee()
   const pChainBalance = usePChainBalance()
+
+  // Mirrors the guard at the top of `computeSteps`: while any of these inputs
+  // is still loading, `computeSteps` resolves to EMPTY_STEPS without actually
+  // computing (or validating) anything. Callers that need a real answer — the
+  // confirm screen's funding pre-flight — must wait for this to be true,
+  // otherwise an "empty success" is indistinguishable from a funded stake.
+  const isComputeReady = Boolean(
+    activeAccount?.addressPVM &&
+      activeAccount.addressC &&
+      defaultFeeState &&
+      cChainBaseFee.data &&
+      avaxProvider &&
+      avalancheEvmProvider
+  )
 
   const computeSteps: ComputeSteps = useCallback(
     async (stakeAmount: bigint, additionalOutputAmount = 0n) => {
@@ -284,5 +299,5 @@ export const useDelegation = (): {
     ]
   )
 
-  return { computeSteps, delegate, steps }
+  return { computeSteps, delegate, steps, isComputeReady }
 }

--- a/packages/core-mobile/app/new/features/stake/hooks/useStakeFilterAndSort.ts
+++ b/packages/core-mobile/app/new/features/stake/hooks/useStakeFilterAndSort.ts
@@ -2,12 +2,26 @@ import { useCallback, useMemo, useState } from 'react'
 import { DropdownSelection } from 'common/types'
 import { DropdownGroup } from 'common/components/DropdownMenu'
 import { PChainTransaction, SortOrder } from '@avalabs/glacier-sdk'
+import { isDelegationTx } from 'features/stake/v2/utils/isDelegationTx'
+import { isFastStakeTx } from 'features/stake/v2/utils/isFastStakeTx'
+import { useSelector } from 'react-redux'
+import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { isCompleted, isOnGoing } from 'utils/earn/status'
 
 export const useStakeFilterAndSort = ({
-  stakes
+  stakes,
+  includeTypeFilters = false
 }: {
   stakes: PChainTransaction[]
+  /**
+   * Adds the stake-type filters (Fast stakes / Delegation) after the status
+   * ones, mirroring core-web's stake-table filter set. Opt-in so the legacy
+   * (V1) stake list keeps its original All/Active/Completed choices; the V2
+   * home screen turns it on. The web-parity semantics intentionally overlap:
+   * Delegation matches on txType (which includes fast stakes), while Fast
+   * stakes matches on the convenience-fee escrow output (`isFastStakeTx`).
+   */
+  includeTypeFilters?: boolean
 }): {
   data: PChainTransaction[]
   filter: DropdownSelection
@@ -18,6 +32,7 @@ export const useStakeFilterAndSort = ({
     StakeFilter.All
   )
   const [selectedSort, setSelectedSort] = useState<SortOrder>(SortOrder.DESC)
+  const isDeveloperMode = useSelector(selectIsDeveloperMode)
 
   const resetFilter = useCallback(() => {
     setSelectedFilter(StakeFilter.All)
@@ -36,18 +51,23 @@ export const useStakeFilterAndSort = ({
             return isOnGoing(tx, now)
           case StakeFilter.Completed:
             return isCompleted(tx, now)
+          case StakeFilter.FastStakes:
+            return isFastStakeTx(tx, isDeveloperMode)
+          case StakeFilter.Delegation:
+            return isDelegationTx(tx)
           default:
             return true
         }
       })
     },
-    [selectedFilter]
+    [selectedFilter, isDeveloperMode]
   )
 
   const filtered = useMemo(() => getFiltered(stakes), [getFiltered, stakes])
 
   const filterData = useMemo(() => {
-    return STAKE_FILTERS.map(s => {
+    const groups = includeTypeFilters ? STAKE_FILTERS_WITH_TYPES : STAKE_FILTERS
+    return groups.map(s => {
       return {
         key: s.key,
         items: s.items.map(i => ({
@@ -57,7 +77,7 @@ export const useStakeFilterAndSort = ({
         }))
       }
     })
-  }, [selectedFilter])
+  }, [selectedFilter, includeTypeFilters])
 
   const sortData = useMemo(() => {
     return STAKE_SORTS.map(s => {
@@ -107,7 +127,11 @@ export const useStakeFilterAndSort = ({
 export enum StakeFilter {
   All = 'All',
   Active = 'Active',
-  Completed = 'Completed'
+  Completed = 'Completed',
+  // Stake-type filters (V2 home screen only — see `includeTypeFilters`).
+  // Labels match core-web's stake-table filter set.
+  FastStakes = 'Fast stakes',
+  Delegation = 'Delegation'
 }
 
 export enum StakeSort {
@@ -130,6 +154,26 @@ export const STAKE_FILTERS: DropdownGroup[] = [
       {
         id: StakeFilter.Completed,
         title: StakeFilter.Completed
+      }
+    ]
+  }
+]
+
+// Status filters plus the stake-type ones, in core-web's order (All, Active,
+// Completed, Fast stakes, Delegation — Validation is follow-up work alongside
+// the card badge). Used when `includeTypeFilters` is on.
+export const STAKE_FILTERS_WITH_TYPES: DropdownGroup[] = [
+  {
+    key: 'stake-filters',
+    items: [
+      ...(STAKE_FILTERS[0]?.items ?? []),
+      {
+        id: StakeFilter.FastStakes,
+        title: StakeFilter.FastStakes
+      },
+      {
+        id: StakeFilter.Delegation,
+        title: StakeFilter.Delegation
       }
     ]
   }

--- a/packages/core-mobile/app/new/features/stake/v2/components/StakeCard.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/components/StakeCard.tsx
@@ -1,4 +1,11 @@
-import { BaseCard, Motion, Separator, Text, View } from '@avalabs/k2-alpine'
+import {
+  BaseCard,
+  Button,
+  Motion,
+  Separator,
+  Text,
+  View
+} from '@avalabs/k2-alpine'
 import React, { useState } from 'react'
 import { LayoutChangeEvent, Platform, StyleSheet } from 'react-native'
 import { ProgressWave } from './ProgressWave'
@@ -30,6 +37,12 @@ export interface StakeCardProps {
   badge?: StakeBadgeType
   width?: number
   onPress?: () => void
+  /**
+   * Restake handler — when provided (completed stakes whose tx can seed a
+   * restake, see `useRestake`), a Restake button renders at the bottom of
+   * the card, mirroring web's stake-table Restake action.
+   */
+  onRestake?: () => void
 }
 
 const DEFAULT_WIDTH = 200
@@ -52,7 +65,8 @@ export const StakeCard = ({
   motion,
   badge,
   width = DEFAULT_WIDTH,
-  onPress
+  onPress,
+  onRestake
 }: StakeCardProps): JSX.Element => {
   const isCompleted = variant === 'completed'
   const showWave = !isCompleted && progress !== undefined
@@ -140,6 +154,25 @@ export const StakeCard = ({
         label="Status"
         value={<StakeStatusValue isActive={!isCompleted} size="small" />}
       />
+      {onRestake && (
+        // BaseCard fires its onPress from raw touch-event bubbling (see k2's
+        // `usePressableGesture`), so the nested Button does NOT swallow the
+        // touch — without stopping propagation here, tapping Restake would
+        // also trigger the card's onPress and stack the stake details screen
+        // on top of the review flow.
+        <View
+          onTouchStart={e => e.stopPropagation()}
+          onTouchEnd={e => e.stopPropagation()}>
+          <Button
+            type="secondary"
+            size="small"
+            style={{ marginTop: 12 }}
+            onPress={onRestake}
+            testID="stake_card_restake_btn">
+            Restake
+          </Button>
+        </View>
+      )}
     </BaseCard>
   )
 }

--- a/packages/core-mobile/app/new/features/stake/v2/components/StakeCardList.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/components/StakeCardList.tsx
@@ -72,7 +72,10 @@ export const StakeCardList = ({
     filter,
     sort
   } = useStakeFilterAndSort({
-    stakes
+    stakes,
+    // Web parity: the V2 home screen's chip row includes the stake-type
+    // filters (Fast stakes / Delegation) after the status ones.
+    includeTypeFilters: true
   })
 
   const data: StakeCardType[] = useMemo(

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useAdvancedReviewSource.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useAdvancedReviewSource.ts
@@ -100,13 +100,18 @@ export const useAdvancedReviewSource = (): StakeReviewSource => {
 
   // Restake only: the node's remaining delegation capacity must still cover
   // the original amount (the seeded shared amount). The normal flow enforces
-  // this on the amount screen, which restake skips.
+  // this on the amount screen, which restake skips. Suppressed while the
+  // validators query is (re)fetching: a warm cache serves the node instantly,
+  // and evaluating against that stale snapshot could fire the confirm route's
+  // irreversible redirect-to-picker alert for a node fresh data would pass —
+  // same settle-first treatment the not-found case gets below (the CTA is
+  // already held during the fetch via `isFetching`).
   const [stakeAmount] = useStakeAmount()
   const isRestakeNodeFull = useMemo(() => {
-    if (!isRestake || !node) return false
+    if (!isRestake || !node || isFetchingValidators) return false
     const { maxAmount } = getDelegateNodeLimits(node, isDeveloperMode)
     return stakeAmount.gt(maxAmount)
-  }, [isRestake, node, isDeveloperMode, stakeAmount])
+  }, [isRestake, node, isFetchingValidators, isDeveloperMode, stakeAmount])
 
   // Restake only: the node's own validation period must have room for at
   // least a minimum-duration stake (anchored at now + the same 1-minute
@@ -116,15 +121,16 @@ export const useAdvancedReviewSource = (): StakeReviewSource => {
   // original duration, the stake proceeds with the end time clamped to the
   // validator's — shown on the review — mirroring web's `DelegationForm`,
   // which clamps its prefilled duration to the node's remaining days.
+  // Suppressed while fetching for the same reason as the capacity gate.
   const now = useNow()
   const isRestakeNodeEnding = useMemo(() => {
-    if (!isRestake || !node) return false
+    if (!isRestake || !node || isFetchingValidators) return false
     const { maxEndDate } = getDelegateNodeLimits(node, isDeveloperMode)
     return (
       maxEndDate.getTime() - now <
       MIN_START_TIME_BUFFER_MS + getMinimumStakeDurationMs(isDeveloperMode)
     )
-  }, [isRestake, node, isDeveloperMode, now])
+  }, [isRestake, node, isFetchingValidators, isDeveloperMode, now])
 
   return useMemo<StakeReviewSource>(() => {
     const isRestakeNodeUnusable = isRestakeNodeFull || isRestakeNodeEnding

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useAdvancedReviewSource.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useAdvancedReviewSource.ts
@@ -1,3 +1,5 @@
+import { useLocalSearchParams } from 'expo-router'
+import { useNodes } from 'hooks/earn/useNodes'
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { selectIsDelegationFeeBlocked } from 'store/posthog'
@@ -12,6 +14,15 @@ import { useDelegateNodeSelection } from '../store'
 // Hoisted so the memo doesn't allocate a fresh Error on every recompute when no
 // node is selected.
 const NO_NODE_SELECTED_ERROR = new Error('No node selected')
+/**
+ * Sentinel for "the restake target validator has left the active set".
+ * Exported so the delegate confirm route can identity-match it and redirect
+ * to the node picker (web parity) instead of letting the confirm screen
+ * surface its generic no-match alert.
+ */
+export const RESTAKE_NODE_UNAVAILABLE_ERROR = new Error(
+  'The original node is no longer available for delegation'
+)
 
 /**
  * Advanced delegate data source for `StakeConfirmScreen`.
@@ -19,6 +30,13 @@ const NO_NODE_SELECTED_ERROR = new Error('No node selected')
  * Unlike Fast Stake (which resolves a validator server-side), the advanced
  * flow uses the node the user picked on the Node details screen — held in the
  * delegate node-selection store.
+ *
+ * Restake is the exception: `useRestake` navigates straight to the delegate
+ * confirm with a `restakeNodeId` param (the original stake's node), and this
+ * hook resolves it against the current validator set — `isFetching` drives
+ * the confirm screen's loading state, and a node that has left the active set
+ * surfaces as an error (the screen's no-match alert), since restaking reuses
+ * the original node verbatim rather than auto-selecting a substitute.
  *
  * The service fee mirrors Fast Stake's convenience fee, but is gated behind
  * its own `delegation-fee-enabled` flag and paid to a delegate-specific escrow
@@ -28,14 +46,38 @@ const NO_NODE_SELECTED_ERROR = new Error('No node selected')
 export const useAdvancedReviewSource = (): StakeReviewSource => {
   const nodes = useDelegateNodeSelection(state => state.nodes)
   const index = useDelegateNodeSelection(state => state.index)
-  const node = nodes[index]
+  const selectedNode = nodes[index]
+
+  // Only present on the restake path — the normal delegate flow never sets it.
+  const { restakeNodeId } = useLocalSearchParams<{ restakeNodeId?: string }>()
+  const isRestake = restakeNodeId !== undefined && restakeNodeId !== ''
+  const {
+    data: validatorsData,
+    isFetching: isFetchingValidators,
+    error: validatorsError
+  } = useNodes(isRestake)
+
+  const node = useMemo(() => {
+    if (!isRestake) return selectedNode
+    return validatorsData?.validators.find(v => v.nodeID === restakeNodeId)
+  }, [isRestake, selectedNode, validatorsData, restakeNodeId])
 
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const isDelegationFeeBlocked = useSelector(selectIsDelegationFeeBlocked)
   const isDelegationFeeEnabled = !isDelegationFeeBlocked
 
-  return useMemo<StakeReviewSource>(
-    () => ({
+  return useMemo<StakeReviewSource>(() => {
+    let error: Error | null = null
+    if (!node) {
+      if (isRestake) {
+        error = isFetchingValidators
+          ? null
+          : validatorsError ?? RESTAKE_NODE_UNAVAILABLE_ERROR
+      } else {
+        error = NO_NODE_SELECTED_ERROR
+      }
+    }
+    return {
       validator: node
         ? {
             nodeID: node.nodeID,
@@ -43,15 +85,21 @@ export const useAdvancedReviewSource = (): StakeReviewSource => {
             delegationFee: node.delegationFee
           }
         : undefined,
-      isFetching: false,
-      error: node ? null : NO_NODE_SELECTED_ERROR,
+      isFetching: isRestake ? isFetchingValidators : false,
+      error,
       feePolicy: isDelegationFeeEnabled
         ? {
             rate: DELEGATION_FEE_RATE,
             recipientAddresses: [getDelegationFeeEscrowAddress(isDeveloperMode)]
           }
         : null
-    }),
-    [node, isDelegationFeeEnabled, isDeveloperMode]
-  )
+    }
+  }, [
+    node,
+    isRestake,
+    isFetchingValidators,
+    validatorsError,
+    isDelegationFeeEnabled,
+    isDeveloperMode
+  ])
 }

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useAdvancedReviewSource.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useAdvancedReviewSource.ts
@@ -1,8 +1,10 @@
 import { useLocalSearchParams } from 'expo-router'
 import { useNodes } from 'hooks/earn/useNodes'
 import { useStakeAmount } from 'hooks/earn/useStakeAmount'
+import { useNow } from 'hooks/time/useNow'
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
+import { getMinimumStakeDurationMs } from 'services/earn/utils'
 import { selectIsDelegationFeeBlocked } from 'store/posthog'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import {
@@ -12,6 +14,10 @@ import {
 import { StakeReviewSource } from '../types'
 import { useDelegateNodeSelection } from '../store'
 import { getDelegateNodeLimits } from './useSelectedDelegateNodeLimits'
+
+// Matches `useValidateStakingEndTime`'s min-start-time buffer (submission is
+// anchored at now + 1 minute).
+const MIN_START_TIME_BUFFER_MS = 60 * 1000
 
 // Hoisted so the memo doesn't allocate a fresh Error on every recompute when no
 // node is selected.
@@ -35,6 +41,19 @@ export const RESTAKE_NODE_UNAVAILABLE_ERROR = new Error(
  */
 export const RESTAKE_NODE_FULL_ERROR = new Error(
   'The original node no longer has enough delegation capacity'
+)
+/**
+ * Sentinel for "the restake target validator is still active but its own
+ * validation period ends too soon to host even a minimum-duration stake".
+ * The normal flow catches this on the duration screen (`exceedsNodeEndTime`);
+ * restake skips that screen, and `useValidateStakingEndTime` clamps the end
+ * time to the validator's *after* its min-duration adjustment — so without
+ * this gate a sub-minimum stake could reach the chain (which rejects it after
+ * the cross-chain import has already run). Surfaced to the confirm route the
+ * same way as the other restake sentinels.
+ */
+export const RESTAKE_NODE_ENDING_ERROR = new Error(
+  "The original node's remaining validation period is too short"
 )
 
 /**
@@ -89,7 +108,26 @@ export const useAdvancedReviewSource = (): StakeReviewSource => {
     return stakeAmount.gt(maxAmount)
   }, [isRestake, node, isDeveloperMode, stakeAmount])
 
+  // Restake only: the node's own validation period must have room for at
+  // least a minimum-duration stake (anchored at now + the same 1-minute
+  // buffer `useValidateStakingEndTime` uses for the start time). The normal
+  // flow enforces this on the duration screen (`exceedsNodeEndTime`), which
+  // restake skips. When the remaining time covers the minimum but not the
+  // original duration, the stake proceeds with the end time clamped to the
+  // validator's — shown on the review — mirroring web's `DelegationForm`,
+  // which clamps its prefilled duration to the node's remaining days.
+  const now = useNow()
+  const isRestakeNodeEnding = useMemo(() => {
+    if (!isRestake || !node) return false
+    const { maxEndDate } = getDelegateNodeLimits(node, isDeveloperMode)
+    return (
+      maxEndDate.getTime() - now <
+      MIN_START_TIME_BUFFER_MS + getMinimumStakeDurationMs(isDeveloperMode)
+    )
+  }, [isRestake, node, isDeveloperMode, now])
+
   return useMemo<StakeReviewSource>(() => {
+    const isRestakeNodeUnusable = isRestakeNodeFull || isRestakeNodeEnding
     let error: Error | null = null
     if (!node) {
       if (isRestake) {
@@ -99,14 +137,17 @@ export const useAdvancedReviewSource = (): StakeReviewSource => {
       } else {
         error = NO_NODE_SELECTED_ERROR
       }
+    } else if (isRestakeNodeEnding) {
+      error = RESTAKE_NODE_ENDING_ERROR
     } else if (isRestakeNodeFull) {
       error = RESTAKE_NODE_FULL_ERROR
     }
     return {
-      // A capacity-exhausted restake node reads as "no validator" so the
-      // confirm screen can't proceed with it even if the redirect is slow.
+      // A capacity-exhausted / soon-ending restake node reads as "no
+      // validator" so the confirm screen can't proceed with it even if the
+      // redirect is slow.
       validator:
-        node && !isRestakeNodeFull
+        node && !isRestakeNodeUnusable
           ? {
               nodeID: node.nodeID,
               endTime: node.endTime,
@@ -126,6 +167,7 @@ export const useAdvancedReviewSource = (): StakeReviewSource => {
     node,
     isRestake,
     isRestakeNodeFull,
+    isRestakeNodeEnding,
     isFetchingValidators,
     validatorsError,
     isDelegationFeeEnabled,

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useAdvancedReviewSource.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useAdvancedReviewSource.ts
@@ -1,8 +1,9 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { useLocalSearchParams } from 'expo-router'
 import { useNodes } from 'hooks/earn/useNodes'
 import { useStakeAmount } from 'hooks/earn/useStakeAmount'
 import { useNow } from 'hooks/time/useNow'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { getMinimumStakeDurationMs } from 'services/earn/utils'
 import { selectIsDelegationFeeBlocked } from 'store/posthog'
@@ -18,6 +19,16 @@ import { getDelegateNodeLimits } from './useSelectedDelegateNodeLimits'
 // Matches `useValidateStakingEndTime`'s min-start-time buffer (submission is
 // anchored at now + 1 minute).
 const MIN_START_TIME_BUFFER_MS = 60 * 1000
+
+// Covers the wall-clock drift between this render-time check and the actual
+// submission: `computeDelegateDates` re-anchors the start at submit time
+// (+1 min) and, for minimum-duration stakes, extends the end date by the
+// elapsed time — so a node that clears the gate by only a few seconds can
+// still produce a delegation the chain rejects (past the validator's end, or
+// under the minimum duration from the fresh start) after the C→P import has
+// already run. Five minutes comfortably exceeds any realistic review dwell
+// time; a validator that close to its end is a bad restake target anyway.
+const SUBMIT_DRIFT_MARGIN_MS = 5 * 60 * 1000
 
 // Hoisted so the memo doesn't allocate a fresh Error on every recompute when no
 // node is selected.
@@ -55,6 +66,49 @@ export const RESTAKE_NODE_FULL_ERROR = new Error(
 export const RESTAKE_NODE_ENDING_ERROR = new Error(
   "The original node's remaining validation period is too short"
 )
+/**
+ * Sentinel for "the validators query itself failed" (network / RPC), so the
+ * confirm route can surface a connection-appropriate message instead of the
+ * confirm screen's generic "no node matches your requirements" alert — which
+ * describes a filtering miss, not a dropped connection.
+ */
+export const RESTAKE_NODES_FETCH_FAILED_ERROR = new Error(
+  'Unable to load the validator list for restake'
+)
+
+/**
+ * Maps the source's resolution state to the error surfaced to the confirm
+ * screen / route. Module-level so the branch chain stays out of the hook's
+ * cognitive-complexity budget. A failed fetch means we couldn't even check
+ * the node, so it gets its own sentinel (connection-appropriate copy)
+ * instead of "node unavailable" (which implies we checked).
+ */
+const pickSourceError = ({
+  hasNode,
+  isRestake,
+  isFetchingValidators,
+  validatorsError,
+  isRestakeNodeEnding,
+  isRestakeNodeFull
+}: {
+  hasNode: boolean
+  isRestake: boolean
+  isFetchingValidators: boolean
+  validatorsError: Error | null
+  isRestakeNodeEnding: boolean
+  isRestakeNodeFull: boolean
+}): Error | null => {
+  if (!hasNode) {
+    if (!isRestake) return NO_NODE_SELECTED_ERROR
+    if (isFetchingValidators) return null
+    return validatorsError
+      ? RESTAKE_NODES_FETCH_FAILED_ERROR
+      : RESTAKE_NODE_UNAVAILABLE_ERROR
+  }
+  if (isRestakeNodeEnding) return RESTAKE_NODE_ENDING_ERROR
+  if (isRestakeNodeFull) return RESTAKE_NODE_FULL_ERROR
+  return null
+}
 
 /**
  * Advanced delegate data source for `StakeConfirmScreen`.
@@ -88,6 +142,20 @@ export const useAdvancedReviewSource = (): StakeReviewSource => {
     isFetching: isFetchingValidators,
     error: validatorsError
   } = useNodes(isRestake)
+
+  // Restake entry always re-fetches the validator set: `useNodes` has a
+  // 5-minute staleTime, so a warm cache (e.g. the user was just in the node
+  // picker) would otherwise serve the eligibility gates a stale snapshot with
+  // no refetch at all. Invalidating on entry keeps the gates — and the
+  // confirm CTA hold on `isFetching` — anchored to current data.
+  const queryClient = useQueryClient()
+  useEffect(() => {
+    if (!isRestake) return
+    queryClient.invalidateQueries({ queryKey: ['nodes'] })
+    // Entry-time effect by design: `isRestake` is fixed for the life of the
+    // route (it comes from the navigation params).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const node = useMemo(() => {
     if (!isRestake) return selectedNode
@@ -128,26 +196,22 @@ export const useAdvancedReviewSource = (): StakeReviewSource => {
     const { maxEndDate } = getDelegateNodeLimits(node, isDeveloperMode)
     return (
       maxEndDate.getTime() - now <
-      MIN_START_TIME_BUFFER_MS + getMinimumStakeDurationMs(isDeveloperMode)
+      MIN_START_TIME_BUFFER_MS +
+        getMinimumStakeDurationMs(isDeveloperMode) +
+        SUBMIT_DRIFT_MARGIN_MS
     )
   }, [isRestake, node, isFetchingValidators, isDeveloperMode, now])
 
   return useMemo<StakeReviewSource>(() => {
     const isRestakeNodeUnusable = isRestakeNodeFull || isRestakeNodeEnding
-    let error: Error | null = null
-    if (!node) {
-      if (isRestake) {
-        error = isFetchingValidators
-          ? null
-          : validatorsError ?? RESTAKE_NODE_UNAVAILABLE_ERROR
-      } else {
-        error = NO_NODE_SELECTED_ERROR
-      }
-    } else if (isRestakeNodeEnding) {
-      error = RESTAKE_NODE_ENDING_ERROR
-    } else if (isRestakeNodeFull) {
-      error = RESTAKE_NODE_FULL_ERROR
-    }
+    const error = pickSourceError({
+      hasNode: node !== undefined,
+      isRestake,
+      isFetchingValidators,
+      validatorsError,
+      isRestakeNodeEnding,
+      isRestakeNodeFull
+    })
     return {
       // A capacity-exhausted / soon-ending restake node reads as "no
       // validator" so the confirm screen can't proceed with it even if the

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useAdvancedReviewSource.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useAdvancedReviewSource.ts
@@ -1,5 +1,6 @@
 import { useLocalSearchParams } from 'expo-router'
 import { useNodes } from 'hooks/earn/useNodes'
+import { useStakeAmount } from 'hooks/earn/useStakeAmount'
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { selectIsDelegationFeeBlocked } from 'store/posthog'
@@ -10,6 +11,7 @@ import {
 } from '../constants'
 import { StakeReviewSource } from '../types'
 import { useDelegateNodeSelection } from '../store'
+import { getDelegateNodeLimits } from './useSelectedDelegateNodeLimits'
 
 // Hoisted so the memo doesn't allocate a fresh Error on every recompute when no
 // node is selected.
@@ -22,6 +24,17 @@ const NO_NODE_SELECTED_ERROR = new Error('No node selected')
  */
 export const RESTAKE_NODE_UNAVAILABLE_ERROR = new Error(
   'The original node is no longer available for delegation'
+)
+/**
+ * Sentinel for "the restake target validator is still active but no longer
+ * has enough delegation capacity for the original amount". The normal flow
+ * catches this on the amount screen (`exceedsNodeCapacity`); restake skips
+ * that screen, so the check happens here at node-resolution time instead —
+ * without it, the user could slide-to-stake something the chain will reject.
+ * Surfaced to the confirm route the same way as the unavailable sentinel.
+ */
+export const RESTAKE_NODE_FULL_ERROR = new Error(
+  'The original node no longer has enough delegation capacity'
 )
 
 /**
@@ -66,6 +79,16 @@ export const useAdvancedReviewSource = (): StakeReviewSource => {
   const isDelegationFeeBlocked = useSelector(selectIsDelegationFeeBlocked)
   const isDelegationFeeEnabled = !isDelegationFeeBlocked
 
+  // Restake only: the node's remaining delegation capacity must still cover
+  // the original amount (the seeded shared amount). The normal flow enforces
+  // this on the amount screen, which restake skips.
+  const [stakeAmount] = useStakeAmount()
+  const isRestakeNodeFull = useMemo(() => {
+    if (!isRestake || !node) return false
+    const { maxAmount } = getDelegateNodeLimits(node, isDeveloperMode)
+    return stakeAmount.gt(maxAmount)
+  }, [isRestake, node, isDeveloperMode, stakeAmount])
+
   return useMemo<StakeReviewSource>(() => {
     let error: Error | null = null
     if (!node) {
@@ -76,15 +99,20 @@ export const useAdvancedReviewSource = (): StakeReviewSource => {
       } else {
         error = NO_NODE_SELECTED_ERROR
       }
+    } else if (isRestakeNodeFull) {
+      error = RESTAKE_NODE_FULL_ERROR
     }
     return {
-      validator: node
-        ? {
-            nodeID: node.nodeID,
-            endTime: node.endTime,
-            delegationFee: node.delegationFee
-          }
-        : undefined,
+      // A capacity-exhausted restake node reads as "no validator" so the
+      // confirm screen can't proceed with it even if the redirect is slow.
+      validator:
+        node && !isRestakeNodeFull
+          ? {
+              nodeID: node.nodeID,
+              endTime: node.endTime,
+              delegationFee: node.delegationFee
+            }
+          : undefined,
       isFetching: isRestake ? isFetchingValidators : false,
       error,
       feePolicy: isDelegationFeeEnabled
@@ -97,6 +125,7 @@ export const useAdvancedReviewSource = (): StakeReviewSource => {
   }, [
     node,
     isRestake,
+    isRestakeNodeFull,
     isFetchingValidators,
     validatorsError,
     isDelegationFeeEnabled,

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useFastStakeReviewSource.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useFastStakeReviewSource.ts
@@ -28,9 +28,14 @@ import { useFastStakeNode } from './useFastStakeNode'
  */
 export const useFastStakeReviewSource = (): StakeReviewSource => {
   const [stakingAmount] = useStakeAmount()
-  // Optional in the type because the param can be missing at runtime (deep
+  // Optional in the type because the params can be missing at runtime (deep
   // links / state restoration); the defensive parse below depends on that.
-  const { stakeEndTime } = useLocalSearchParams<{ stakeEndTime?: string }>()
+  // `preferredNodeId` only arrives on the restake path — the original
+  // stake's node gets first refusal before auto-selection kicks in.
+  const { stakeEndTime, preferredNodeId } = useLocalSearchParams<{
+    stakeEndTime?: string
+    preferredNodeId?: string
+  }>()
   // Defensive parse — missing / non-finite / non-positive params yield
   // `undefined` and surface as a source error below, instead of cascading a
   // NaN into the Glacier query (which would then produce a confusing
@@ -49,7 +54,8 @@ export const useFastStakeReviewSource = (): StakeReviewSource => {
   // round-trip with a bogus stake duration.
   const { data, isFetching, error } = useFastStakeNode({
     stakingAmount,
-    stakingEndTime
+    stakingEndTime,
+    preferredNodeId
   })
 
   return useMemo<StakeReviewSource>(() => {

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.test.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.test.ts
@@ -1,0 +1,174 @@
+import { PChainTransaction } from '@avalabs/glacier-sdk'
+import { renderHook } from '@testing-library/react-hooks'
+import { addDays, addHours, getUnixTime } from 'date-fns'
+import { useStakeAmount } from 'hooks/earn/useStakeAmount'
+import {
+  clearRestakePrefill,
+  createDefaultDelegateFilters,
+  getRestakePrefill,
+  setDelegateNodeSelection,
+  takeRestakeEntry,
+  useDelegateFilters,
+  useDelegateNodeSelection
+} from '../store'
+import { useRestake } from './useRestake'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockNavigate = jest.fn()
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ navigate: mockNavigate })
+}))
+
+// The hook only reads `selectIsDeveloperMode`; return the flag directly.
+let mockIsDeveloperMode = false
+jest.mock('react-redux', () => ({
+  useSelector: () => mockIsDeveloperMode
+}))
+jest.mock('store/settings/advanced', () => ({
+  selectIsDeveloperMode: jest.fn()
+}))
+
+// Branch classification is covered by the utils' own tests — mock them here
+// so each navigation branch can be exercised deterministically.
+const mockIsFastStakeTx = jest.fn()
+jest.mock('../utils/isFastStakeTx', () => ({
+  isFastStakeTx: (...args: unknown[]) => mockIsFastStakeTx(...args)
+}))
+const mockIsDelegationTx = jest.fn()
+jest.mock('../utils/isDelegationTx', () => ({
+  isDelegationTx: (...args: unknown[]) => mockIsDelegationTx(...args)
+}))
+
+// `useStakeAmount` transitively imports the MMKV-backed zustand storage;
+// stub the barrel so the test never touches native storage.
+jest.mock('utils/mmkv', () => ({
+  zustandPersistStorage: {}
+}))
+
+// The real module drags in EarnService → WalletService → ModuleManager (native
+// deps); the hook only reads two static staking-config fields. Mainnet values.
+jest.mock('services/earn/utils', () => ({
+  getStakingConfig: () => ({
+    MinDelegationFee: 20000n, // permillion → 2%
+    MinStakeDuration: 14 * 24 * 60 * 60 // seconds → 14 days
+  })
+}))
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const DAY_SECONDS = 24 * 60 * 60
+const FIXED_NOW = new Date('2026-01-15T00:00:00Z')
+
+const makeTx = (
+  overrides: Partial<PChainTransaction> = {}
+): PChainTransaction =>
+  ({
+    nodeId: 'NodeID-A',
+    startTimestamp: 1_000_000,
+    endTimestamp: 1_000_000 + 14 * DAY_SECONDS,
+    amountStaked: [{ amount: '25000000000' }],
+    txHash: '0xabc',
+    ...overrides
+  } as unknown as PChainTransaction)
+
+// Web-parity end time: now + whole-day duration + 1h slack (see useRestake).
+const expectedStakeEndTime = getUnixTime(addHours(addDays(FIXED_NOW, 14), 1))
+
+const getOnRestake = (): ReturnType<typeof useRestake>['getOnRestake'] =>
+  renderHook(() => useRestake()).result.current.getOnRestake
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useRestake', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(FIXED_NOW)
+    mockNavigate.mockReset()
+    mockIsFastStakeTx.mockReset().mockReturnValue(false)
+    mockIsDelegationTx.mockReset().mockReturnValue(false)
+    mockIsDeveloperMode = false
+    // Reset the shared stores the handler seeds.
+    useStakeAmount.setState(prev => prev.sub(prev)) // zero, keeps unit shape
+    clearRestakePrefill()
+    takeRestakeEntry() // drain the one-shot flag
+    setDelegateNodeSelection([], 0)
+    useDelegateFilters.getState().reset()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('returns undefined for stakes that are not completed', () => {
+    mockIsFastStakeTx.mockReturnValue(true)
+    expect(getOnRestake()(makeTx(), false)).toBeUndefined()
+  })
+
+  it('returns undefined when the tx cannot seed restake params', () => {
+    mockIsFastStakeTx.mockReturnValue(true)
+    expect(getOnRestake()(makeTx({ nodeId: undefined }), true)).toBeUndefined()
+  })
+
+  it('returns undefined when the tx is neither fast stake nor delegation', () => {
+    expect(getOnRestake()(makeTx(), true)).toBeUndefined()
+  })
+
+  it('fast stake: seeds amount/prefill/entry flag and navigates to the fast confirm', () => {
+    mockIsFastStakeTx.mockReturnValue(true)
+
+    const handler = getOnRestake()(makeTx(), true)
+    expect(handler).toBeDefined()
+    handler?.()
+
+    // Original amount seeded into the shared store (25 AVAX in nAVAX).
+    expect(useStakeAmount.getState().toSubUnit()).toBe(25_000_000_000n)
+    // Restake prefill + one-shot layout flag are pending.
+    expect(getRestakePrefill()).toEqual({ durationDays: 14 })
+    expect(takeRestakeEntry()).toBe(true)
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/addStakeV2/fastStake/confirm?stakeEndTime=${expectedStakeEndTime}&preferredNodeId=NodeID-A`
+    )
+  })
+
+  it('delegation: seeds stores, resets the node selection and navigates to the delegate confirm', () => {
+    mockIsDelegationTx.mockReturnValue(true)
+    // Simulate a stale selection from a previous delegate flow.
+    setDelegateNodeSelection([{ nodeID: 'NodeID-STALE' }] as never[], 0)
+
+    const handler = getOnRestake()(makeTx(), true)
+    expect(handler).toBeDefined()
+    handler?.()
+
+    expect(useStakeAmount.getState().toSubUnit()).toBe(25_000_000_000n)
+    expect(getRestakePrefill()).toEqual({ durationDays: 14 })
+    expect(takeRestakeEntry()).toBe(true)
+    // Stale node selection cleared so the confirm can't read it.
+    expect(useDelegateNodeSelection.getState().nodes).toHaveLength(0)
+
+    // Web-parity default filters seeded from the (mocked) staking config:
+    // fee ≤ 2%, remaining time ≥ 14 days.
+    expect(useDelegateFilters.getState().filters).toEqual(
+      createDefaultDelegateFilters({ minFeePercent: 2, minStakeDays: 14 })
+    )
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/addStakeV2/delegate/confirm?stakeEndTime=${expectedStakeEndTime}&restakeNodeId=NodeID-A`
+    )
+  })
+
+  it('sums multiple staked assets into the seeded amount', () => {
+    mockIsFastStakeTx.mockReturnValue(true)
+    const handler = getOnRestake()(
+      makeTx({
+        amountStaked: [
+          { amount: '25000000000' },
+          { amount: '5000000000' }
+        ] as PChainTransaction['amountStaked']
+      }),
+      true
+    )
+    handler?.()
+    expect(useStakeAmount.getState().toSubUnit()).toBe(30_000_000_000n)
+  })
+})

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.ts
@@ -1,6 +1,6 @@
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { PChainTransaction } from '@avalabs/glacier-sdk'
-import { addDays, getUnixTime } from 'date-fns'
+import { addDays, addHours, getUnixTime } from 'date-fns'
 import { Href, useRouter } from 'expo-router'
 import { useStakeAmount } from 'hooks/earn/useStakeAmount'
 import { useCallback } from 'react'
@@ -79,10 +79,13 @@ export const useRestake = (): {
         // clears it and re-seeds the amount so nothing leaks (overwritten by
         // the next restake, cleared by the layout on a normal modal entry).
         setRestakePrefill({ durationDays: params.durationDays })
-        // Same end-time derivation web uses: now + the original stake's
-        // whole-day duration.
+        // Same end-time derivation web uses (`FastStakeReview` /
+        // `DelegationForm`): now + the original stake's whole-day duration,
+        // plus 1h of slack — calendar-day math shifts by ±1h across DST
+        // transitions, and the slack keeps a spring-forward from landing the
+        // duration below the original (and below the network minimum).
         const stakeEndTime = getUnixTime(
-          addDays(new Date(), params.durationDays)
+          addHours(addDays(new Date(), params.durationDays), 1)
         )
 
         if (isFastStake) {

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.ts
@@ -1,0 +1,118 @@
+import { TokenUnit } from '@avalabs/core-utils-sdk'
+import { PChainTransaction } from '@avalabs/glacier-sdk'
+import { addDays, getUnixTime } from 'date-fns'
+import { Href, useRouter } from 'expo-router'
+import { useStakeAmount } from 'hooks/earn/useStakeAmount'
+import { useCallback } from 'react'
+import { useSelector } from 'react-redux'
+import { getStakingConfig } from 'services/earn/utils'
+import { selectIsDeveloperMode } from 'store/settings/advanced'
+import {
+  applyDefaultDelegateFilters,
+  beginRestakeEntry,
+  clearRestakePrefill,
+  setDelegateNodeSelection,
+  setRestakePrefill
+} from '../store'
+import { getRestakeParams } from '../utils/getRestakeParams'
+import { isDelegationTx } from '../utils/isDelegationTx'
+import { isFastStakeTx } from '../utils/isFastStakeTx'
+
+// `MinDelegationFee` is in the [0, 1_000_000] permillion range; divide to %.
+const PERMILLION_PER_PERCENT = 10000
+const SECONDS_PER_DAY = 24 * 60 * 60
+
+/**
+ * Builds the Restake handler for a COMPLETED stake, or `undefined` when the
+ * tx can't seed one. Mirrors core-web's `getOnRestake`
+ * (`StakingNewTable.tsx`): only completed stakes restake (an active stake's
+ * funds are still locked), and the original stake's amount, node and
+ * duration are reused as-is — the user lands straight on the confirm screen
+ * with no amount/duration steps in between. The flow branches on how the
+ * stake was created:
+ *
+ * - Fast Stake tx → the Fast Stake confirm, which requalifies the original
+ *   node (`preferredNodeId`) and falls back to auto-selection.
+ * - Delegation tx → the delegate confirm, which resolves the exact original
+ *   node (`restakeNodeId`, see `useAdvancedReviewSource`). When that node
+ *   has left the active set, the confirm route redirects to the node picker
+ *   with a notice, and the amount/duration steps open prefilled with the
+ *   original stake's values (web parity — see `setRestakePrefill`).
+ *
+ * Both confirm screens re-run the delegation-steps computation themselves
+ * (`useStakeFundingPreflight`), so skipping the amount screen's
+ * `computeSteps` call is safe.
+ *
+ * The shared amount is seeded here, *before* navigating: `useStakeAmount` is
+ * a global store, and the add-stake layout's own min-amount seeding effect
+ * would otherwise overwrite the restake amount (parent effects run after
+ * child effects on mount) — `beginRestakeEntry` tells the layout to skip
+ * that seed for this one entry.
+ */
+export const useRestake = (): {
+  getOnRestake: (
+    stake: PChainTransaction,
+    isCompleted: boolean
+  ) => (() => void) | undefined
+} => {
+  const { navigate } = useRouter()
+  const isDeveloperMode = useSelector(selectIsDeveloperMode)
+
+  const getOnRestake = useCallback(
+    (
+      stake: PChainTransaction,
+      isCompleted: boolean
+    ): (() => void) | undefined => {
+      if (!isCompleted) return undefined
+
+      const params = getRestakeParams(stake)
+      if (!params) return undefined
+
+      const isFastStake = isFastStakeTx(stake, isDeveloperMode)
+      if (!isFastStake && !isDelegationTx(stake)) return undefined
+
+      return () => {
+        beginRestakeEntry()
+        clearRestakePrefill()
+        useStakeAmount.setState(new TokenUnit(params.amountNAvax, 9, 'AVAX'))
+        // Same end-time derivation web uses: now + the original stake's
+        // whole-day duration.
+        const stakeEndTime = getUnixTime(
+          addDays(new Date(), params.durationDays)
+        )
+
+        if (isFastStake) {
+          navigate(
+            `/addStakeV2/fastStake/confirm?stakeEndTime=${stakeEndTime}&preferredNodeId=${params.nodeId}` as Href
+          )
+          return
+        }
+
+        // If the original node has left the active set, the confirm route
+        // drops the user into the node picker (web parity) — seed the same
+        // defaults a fresh delegate flow applies so the picker behaves
+        // normally, and stash the original duration so the amount/duration
+        // steps open prefilled with the original stake's values.
+        const config = getStakingConfig(isDeveloperMode)
+        applyDefaultDelegateFilters({
+          minFeePercent:
+            Number(config.MinDelegationFee) / PERMILLION_PER_PERCENT,
+          minStakeDays: Math.floor(
+            Number(config.MinStakeDuration) / SECONDS_PER_DAY
+          )
+        })
+        setRestakePrefill({ durationDays: params.durationDays })
+        // Clear any node left over from a previous delegate flow so the
+        // confirm can't fall back to a stale selection while the restake
+        // node resolves.
+        setDelegateNodeSelection([], 0)
+        navigate(
+          `/addStakeV2/delegate/confirm?stakeEndTime=${stakeEndTime}&restakeNodeId=${params.nodeId}` as Href
+        )
+      }
+    },
+    [navigate, isDeveloperMode]
+  )
+
+  return { getOnRestake }
+}

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.ts
@@ -10,7 +10,6 @@ import { selectIsDeveloperMode } from 'store/settings/advanced'
 import {
   applyDefaultDelegateFilters,
   beginRestakeEntry,
-  clearRestakePrefill,
   setDelegateNodeSelection,
   setRestakePrefill
 } from '../store'
@@ -73,8 +72,13 @@ export const useRestake = (): {
 
       return () => {
         beginRestakeEntry()
-        clearRestakePrefill()
         useStakeAmount.setState(new TokenUnit(params.amountNAvax, 9, 'AVAX'))
+        // Set for BOTH branches: the delegate node-gone fallback consumes it
+        // as the amount/duration prefill, and `useStartStaking` treats its
+        // presence as "restake leftovers pending" — a chooser-initiated flow
+        // clears it and re-seeds the amount so nothing leaks (overwritten by
+        // the next restake, cleared by the layout on a normal modal entry).
+        setRestakePrefill({ durationDays: params.durationDays })
         // Same end-time derivation web uses: now + the original stake's
         // whole-day duration.
         const stakeEndTime = getUnixTime(
@@ -88,11 +92,11 @@ export const useRestake = (): {
           return
         }
 
-        // If the original node has left the active set, the confirm route
-        // drops the user into the node picker (web parity) — seed the same
-        // defaults a fresh delegate flow applies so the picker behaves
-        // normally, and stash the original duration so the amount/duration
-        // steps open prefilled with the original stake's values.
+        // If the original node has left the active set (or lost capacity),
+        // the confirm route drops the user into the node picker (web parity)
+        // — seed the same defaults a fresh delegate flow applies so the
+        // picker behaves normally, while the prefill above keeps the
+        // amount/duration steps opening with the original stake's values.
         const config = getStakingConfig(isDeveloperMode)
         applyDefaultDelegateFilters({
           minFeePercent:
@@ -101,7 +105,6 @@ export const useRestake = (): {
             Number(config.MinStakeDuration) / SECONDS_PER_DAY
           )
         })
-        setRestakePrefill({ durationDays: params.durationDays })
         // Clear any node left over from a previous delegate flow so the
         // confirm can't fall back to a stale selection while the restake
         // node resolves.

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useSelectedDelegateNodeLimits.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useSelectedDelegateNodeLimits.ts
@@ -4,18 +4,50 @@ import { useSelector } from 'react-redux'
 import { getAvailableDelegationWeight } from 'services/earn/utils'
 import NetworkService from 'services/network/NetworkService'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
+import { NodeValidator } from 'types/earn'
 import { useDelegateNodeSelection } from '../store'
 
 /**
- * Limits the amount + duration steps must honour for the node the user picked
- * in the advanced delegate flow (mirrors core-web, which caps the stake amount
- * by the validator's delegation capacity and the end date by its end time):
+ * Computes the limits a delegation to `node` must honour (mirrors core-web,
+ * which caps the stake amount by the validator's delegation capacity and the
+ * end date by its end time):
  *
  * - `maxAmount`: how much can still be delegated to the node.
  * - `maxEndDate`: the validator's end time — the stake can't outlast it.
  *
- * Returns empty values when no node is selected (e.g. Fast Stake, which passes
- * neither limit).
+ * Pure so both the selection-store hook below and the restake path (which
+ * resolves its node from a fresh validators fetch instead of the store) can
+ * share the math.
+ */
+export const getDelegateNodeLimits = (
+  node: NodeValidator,
+  isDeveloperMode: boolean
+): { maxAmount: TokenUnit; maxEndDate: Date } => {
+  const { networkToken } = NetworkService.getAvalancheNetworkP(isDeveloperMode)
+  const validatorWeight = new TokenUnit(
+    node.weight ?? 0,
+    networkToken.decimals,
+    networkToken.symbol
+  )
+  const delegatorWeight = new TokenUnit(
+    node.delegatorWeight ?? 0,
+    networkToken.decimals,
+    networkToken.symbol
+  )
+  return {
+    maxAmount: getAvailableDelegationWeight({
+      isDeveloperMode,
+      validatorWeight,
+      delegatorWeight
+    }),
+    maxEndDate: new Date(Number(node.endTime) * 1000)
+  }
+}
+
+/**
+ * `getDelegateNodeLimits` for the node the user picked in the advanced
+ * delegate flow (held in the node-selection store). Returns empty values when
+ * no node is selected (e.g. Fast Stake, which passes neither limit).
  */
 export const useSelectedDelegateNodeLimits = (): {
   maxAmount?: TokenUnit
@@ -25,27 +57,9 @@ export const useSelectedDelegateNodeLimits = (): {
   const index = useDelegateNodeSelection(state => state.index)
   const node = nodes[index]
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
-  const { networkToken } = NetworkService.getAvalancheNetworkP(isDeveloperMode)
 
   return useMemo(() => {
     if (!node) return {}
-    const validatorWeight = new TokenUnit(
-      node.weight ?? 0,
-      networkToken.decimals,
-      networkToken.symbol
-    )
-    const delegatorWeight = new TokenUnit(
-      node.delegatorWeight ?? 0,
-      networkToken.decimals,
-      networkToken.symbol
-    )
-    return {
-      maxAmount: getAvailableDelegationWeight({
-        isDeveloperMode,
-        validatorWeight,
-        delegatorWeight
-      }),
-      maxEndDate: new Date(Number(node.endTime) * 1000)
-    }
-  }, [node, networkToken, isDeveloperMode])
+    return getDelegateNodeLimits(node, isDeveloperMode)
+  }, [node, isDeveloperMode])
 }

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useStakeCardRenderer.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useStakeCardRenderer.tsx
@@ -16,6 +16,7 @@ import { isDelegationTx } from '../utils/isDelegationTx'
 import { isFastStakeTx } from '../utils/isFastStakeTx'
 import { ensureCurrencySuffix, formatEndDate } from '../utils/cardFormat'
 import { getStakeTitle } from '../utils'
+import { useRestake } from './useRestake'
 
 export interface UseStakeCardRendererArgs {
   /** Time snapshot used for status detection and progress calculation. */
@@ -56,6 +57,7 @@ export const useStakeCardRenderer = ({
   const avaxPrice = useAvaxPrice()
   const { formatTokenInCurrency } = useFormatCurrency()
   const selectedCurrency = useSelector(selectSelectedCurrency)
+  const { getOnRestake } = useRestake()
 
   return useCallback(
     (stake: PChainTransaction): JSX.Element | null => {
@@ -112,6 +114,10 @@ export const useStakeCardRenderer = ({
           }
           width={width}
           onPress={() => onPressStake(stake.txHash)}
+          // Undefined for active stakes and for txs that can't seed a
+          // restake, hiding the card's Restake button (web parity: only
+          // completed stakes offer Restake).
+          onRestake={getOnRestake(stake, stakeIsCompleted)}
         />
       )
     },
@@ -124,7 +130,8 @@ export const useStakeCardRenderer = ({
       selectedCurrency,
       motion,
       width,
-      onPressStake
+      onPressStake,
+      getOnRestake
     ]
   )
 }

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useStakeFundingPreflight.test.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useStakeFundingPreflight.test.ts
@@ -1,0 +1,140 @@
+import { act, renderHook } from '@testing-library/react-hooks'
+import { Operation, Step } from 'services/earn/computeDelegationSteps/types'
+import { useStakeFundingPreflight } from './useStakeFundingPreflight'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockComputeSteps = jest.fn()
+let mockIsComputeReady = true
+jest.mock('contexts/DelegationContext', () => ({
+  useDelegationContext: () => ({
+    computeSteps: mockComputeSteps,
+    isComputeReady: mockIsComputeReady
+  })
+}))
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const DELEGATE_STEPS: Step[] = [
+  { operation: Operation.DELEGATE, amount: 1_000_000_000n, fee: 1n }
+]
+
+const INSUFFICIENT_ERROR = new Error(
+  'Insufficient balance for the stake amount and fees.\nKindly adjust the amount accordingly.'
+)
+
+const defaultProps = {
+  enabled: true,
+  stakeAmountNanoAvax: 1_000_000_000n,
+  additionalOutputs: undefined
+}
+
+const renderPreflight = (props: Partial<typeof defaultProps> = {}) =>
+  renderHook((p: typeof defaultProps) => useStakeFundingPreflight(p), {
+    initialProps: { ...defaultProps, ...props }
+  })
+
+// Flush the pending computeSteps promise scheduled by the effect.
+const flush = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+describe('useStakeFundingPreflight', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsComputeReady = true
+    mockComputeSteps.mockResolvedValue(DELEGATE_STEPS)
+  })
+
+  it('reports a passed check when computeSteps resolves with steps', async () => {
+    const { result } = renderPreflight()
+    await flush()
+
+    expect(mockComputeSteps).toHaveBeenCalledWith(1_000_000_000n, 0n)
+    expect(result.current).toEqual({
+      isCheckingFunding: false,
+      hasInsufficientFunds: false
+    })
+  })
+
+  it('flags insufficient funds when computeSteps rejects with an underfunded error', async () => {
+    mockComputeSteps.mockRejectedValue(INSUFFICIENT_ERROR)
+
+    const { result } = renderPreflight()
+    await flush()
+
+    expect(result.current).toEqual({
+      isCheckingFunding: false,
+      hasInsufficientFunds: true
+    })
+  })
+
+  it('ignores transient (non-funding) errors so the submit path can handle them', async () => {
+    mockComputeSteps.mockRejectedValue(new Error('network request failed'))
+
+    const { result } = renderPreflight()
+    await flush()
+
+    expect(result.current).toEqual({
+      isCheckingFunding: false,
+      hasInsufficientFunds: false
+    })
+  })
+
+  it('does not run and reports idle while disabled', async () => {
+    const { result } = renderPreflight({ enabled: false })
+    await flush()
+
+    expect(mockComputeSteps).not.toHaveBeenCalled()
+    expect(result.current.isCheckingFunding).toBe(false)
+  })
+
+  describe('when computeSteps inputs are still loading (restake race)', () => {
+    it('holds the CTA as checking instead of passing the check', async () => {
+      mockIsComputeReady = false
+
+      const { result } = renderPreflight()
+      await flush()
+
+      // The regression this guards: before the fee-state / base-fee queries
+      // resolve, computeSteps would return [] without validating anything —
+      // reporting "not checking, funded" here enabled slide-to-confirm on an
+      // unaffordable restake.
+      expect(mockComputeSteps).not.toHaveBeenCalled()
+      expect(result.current.isCheckingFunding).toBe(true)
+    })
+
+    it('runs the real check once the inputs become ready', async () => {
+      mockIsComputeReady = false
+      mockComputeSteps.mockRejectedValue(INSUFFICIENT_ERROR)
+
+      const { result, rerender } = renderPreflight()
+      await flush()
+      expect(result.current.isCheckingFunding).toBe(true)
+
+      mockIsComputeReady = true
+      rerender(defaultProps)
+      await flush()
+
+      expect(mockComputeSteps).toHaveBeenCalledTimes(1)
+      expect(result.current).toEqual({
+        isCheckingFunding: false,
+        hasInsufficientFunds: true
+      })
+    })
+
+    it('keeps holding the CTA when computeSteps bails with no steps', async () => {
+      // Inputs vanished between the readiness check and the call (e.g. account
+      // switch): computeSteps resolves [] without validating anything.
+      mockComputeSteps.mockResolvedValue([])
+
+      const { result } = renderPreflight()
+      await flush()
+
+      expect(result.current.isCheckingFunding).toBe(true)
+      expect(result.current.hasInsufficientFunds).toBe(false)
+    })
+  })
+})

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useStakeFundingPreflight.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useStakeFundingPreflight.ts
@@ -15,6 +15,16 @@ import { isInsufficientFundsError } from '../utils/isInsufficientFundsError'
  * Only underfunded results are surfaced as `hasInsufficientFunds`; transient
  * errors (network, etc.) are ignored here so they don't strand the user — the
  * normal submit + error-alert path handles those.
+ *
+ * The check counts as complete only once `computeSteps` had all of its async
+ * inputs (`isComputeReady`) and returned actual steps. Before that,
+ * `computeSteps` resolves to an empty list without validating anything, which
+ * must NOT enable the CTA: a restake lands directly on the confirm screen
+ * with a cached validator, so the pre-flight can fire before the fee-state /
+ * base-fee queries resolve — treating that empty result as "funded" let an
+ * unaffordable stake through with no inline error (it then failed after the
+ * slide). While the inputs are still loading we report `isCheckingFunding`
+ * and re-run the real check when `isComputeReady` flips true.
  */
 export const useStakeFundingPreflight = ({
   enabled,
@@ -27,7 +37,7 @@ export const useStakeFundingPreflight = ({
   /** Convenience-fee escrow output(s); undefined when no fee applies. */
   additionalOutputs: readonly AdditionalDelegatorOutput[] | undefined
 }): { isCheckingFunding: boolean; hasInsufficientFunds: boolean } => {
-  const { computeSteps } = useDelegationContext()
+  const { computeSteps, isComputeReady } = useDelegationContext()
   const [fundingError, setFundingError] = useState<Error | null>(null)
   const [isCheckingFunding, setIsCheckingFunding] = useState(false)
 
@@ -59,23 +69,38 @@ export const useStakeFundingPreflight = ({
       setIsCheckingFunding(false)
       return
     }
+    if (!isComputeReady) {
+      // `computeSteps` would resolve to an empty list without validating
+      // anything. Hold the CTA as "checking" until the inputs are ready; the
+      // dep below re-runs the real check the moment they are.
+      setIsCheckingFunding(true)
+      return
+    }
     let cancelled = false
     setIsCheckingFunding(true)
     computeStepsRef
       .current(stakeAmountNanoAvax, additionalOutputAmount)
-      .then(() => {
-        if (!cancelled) setFundingError(null)
+      .then(steps => {
+        if (cancelled) return
+        if (steps.length === 0) {
+          // An input vanished between the readiness check and the call (e.g.
+          // account switch mid-flight) — nothing was validated, so don't mark
+          // the check as passed. `isComputeReady` flips false for the same
+          // reason and re-arms this effect, keeping the CTA held meanwhile.
+          return
+        }
+        setFundingError(null)
+        setIsCheckingFunding(false)
       })
       .catch((e: unknown) => {
-        if (!cancelled) setFundingError(e as Error)
-      })
-      .finally(() => {
-        if (!cancelled) setIsCheckingFunding(false)
+        if (cancelled) return
+        setFundingError(e as Error)
+        setIsCheckingFunding(false)
       })
     return () => {
       cancelled = true
     }
-  }, [enabled, stakeAmountNanoAvax, additionalOutputAmount])
+  }, [enabled, isComputeReady, stakeAmountNanoAvax, additionalOutputAmount])
 
   return {
     isCheckingFunding,

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useStartStaking.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useStartStaking.ts
@@ -2,8 +2,12 @@ import { useRouter } from 'expo-router'
 import { useStakeBalanceGuard } from 'features/stake/hooks/useStakeBalanceGuard'
 import {
   applyDefaultDelegateFilters,
+  clearRestakePrefill,
+  getRestakePrefill,
   setDelegateNodeSelection
 } from 'features/stake/v2/store'
+import { useStakeAmount } from 'hooks/earn/useStakeAmount'
+import useStakingParams from 'hooks/earn/useStakingParams'
 import { useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { getStakingConfig } from 'services/earn/utils'
@@ -33,8 +37,24 @@ export const useStartStaking = (): {
 } => {
   const { navigate } = useRouter()
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
+  const [, setStakeAmount] = useStakeAmount()
+  const { minStakeAmount } = useStakingParams()
   const { hasEnoughAvax, canAddStake, showNotEnoughAvaxAlert } =
     useStakeBalanceGuard()
+
+  // Defensive cleanup at sub-flow entry: a restake entry seeds the shared
+  // amount (and the restake prefill) before navigating, and the layout's
+  // entry-time cleanup intentionally skips restake entries. Should the
+  // chooser ever become reachable within a restake-opened modal (router
+  // behavior change, new back affordance, deep link), starting a flow from
+  // it would otherwise inherit the old stake's amount/duration. Presence of
+  // the prefill is the "restake leftovers pending" marker — drop it and
+  // re-seed the amount like a normal entry.
+  const clearRestakeLeftovers = useCallback(() => {
+    if (getRestakePrefill() === null) return
+    clearRestakePrefill()
+    setStakeAmount(minStakeAmount)
+  }, [setStakeAmount, minStakeAmount])
 
   const startFastStake = useCallback(() => {
     // Balance still loading — ignore the press. The chooser also gates
@@ -43,17 +63,25 @@ export const useStartStaking = (): {
     if (!canAddStake) return
 
     if (hasEnoughAvax) {
+      clearRestakeLeftovers()
       navigate({ pathname: '/addStakeV2/fastStake/amount' })
     } else {
       showNotEnoughAvaxAlert('fast stake')
     }
-  }, [navigate, canAddStake, hasEnoughAvax, showNotEnoughAvaxAlert])
+  }, [
+    navigate,
+    canAddStake,
+    hasEnoughAvax,
+    showNotEnoughAvaxAlert,
+    clearRestakeLeftovers
+  ])
 
   const startDelegate = useCallback(() => {
     // Balance still loading — ignore the press (mirrors `startFastStake`).
     if (!canAddStake) return
 
     if (hasEnoughAvax) {
+      clearRestakeLeftovers()
       // Seed the same default filters core-web applies on entry (uptime ≥ 75%,
       // fee ≤ network min, remaining time ≥ min stake duration) so the node
       // list opens pre-filtered to the same nodes — and so a previous session's
@@ -79,7 +107,8 @@ export const useStartStaking = (): {
     canAddStake,
     hasEnoughAvax,
     showNotEnoughAvaxAlert,
-    isDeveloperMode
+    isDeveloperMode,
+    clearRestakeLeftovers
   ])
 
   return { hasEnoughAvax, canAddStake, startFastStake, startDelegate }

--- a/packages/core-mobile/app/new/features/stake/v2/screens/DelegateAmountScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/DelegateAmountScreen.tsx
@@ -23,6 +23,7 @@ import AnalyticsService from 'services/analytics/AnalyticsService'
 import { xpChainToken } from 'utils/units/knownTokens'
 import { zeroAvaxPChain } from 'utils/units/zeroValues'
 import { useSelectedDelegateNodeLimits } from '../hooks/useSelectedDelegateNodeLimits'
+import { getRestakePrefill } from '../store'
 
 // Reserve headroom for network fees (mirrors V1): the "Max" button stakes
 // 99.99% of the balance so the remainder covers fees.
@@ -47,6 +48,18 @@ const DelegateAmountScreen = (): JSX.Element => {
   const [error, setError] = useState<Error | null>(null)
   const { computeSteps } = useDelegationContext()
   const [stakeAmount, setStakeAmount] = useStakeAmount()
+  // Delegate-restake fallback path (original validator gone → node picker →
+  // here): the restake prefill is active and the shared amount still holds
+  // the original stake's amount — keep it and show it in the keypad instead
+  // of starting from zero (web parity: `DelegationForm`'s `initialAmount`
+  // applies whichever node ends up selected). Captured once at mount;
+  // `TokenUnitInputWidget`'s `amount` prop only seeds the input's initial
+  // text, so a stable value keeps later keypad edits from fighting it.
+  const [initialAmount] = useState<TokenUnit | undefined>(() =>
+    getRestakePrefill() !== null && !stakeAmount.isZero()
+      ? stakeAmount
+      : undefined
+  )
   const { minStakeAmount } = useStakingParams()
   const { maxAmount } = useSelectedDelegateNodeLimits()
   const cChainBalance = useCChainBalance()
@@ -76,9 +89,12 @@ const DelegateAmountScreen = (): JSX.Element => {
   // Fast Stake's dial starts at a valid value. This screen's keypad, however,
   // starts empty (0), so reset the amount to zero on mount — otherwise the
   // unseen seeded value would leave `Next` enabled before the user types.
+  // The restake prefill is the exception: its amount IS shown in the keypad
+  // (via `initialAmount`), so it stays.
   useEffect(() => {
+    if (initialAmount !== undefined) return
     setStakeAmount(zeroAvaxPChain())
-  }, [setStakeAmount])
+  }, [setStakeAmount, initialAmount])
 
   const handleAmountChange = useCallback(
     (amount: TokenUnit) => {
@@ -187,6 +203,7 @@ const DelegateAmountScreen = (): JSX.Element => {
       shouldAvoidKeyboard
       contentContainerStyle={{ padding: 16 }}>
       <TokenUnitInputWidget
+        amount={initialAmount}
         disabled={isComputing}
         balance={cumulativeBalance}
         token={xpChainToken}

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeConfirmScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeConfirmScreen.tsx
@@ -852,12 +852,14 @@ const StakeConfirmScreen = ({
         isSubmitting={isIssueDelegationPending}
         isSubmitDisabled={
           !validator ||
-          // Also hold the CTA during a background validator refetch — the
-          // source can serve a cached validator immediately (`useNodes` has a
-          // 5-min staleTime), and the eligibility gates (restake capacity /
-          // remaining time, fast-stake requalification) only re-run once
-          // fresh data lands. Without this, a stale-cache restake could be
-          // submitted inside that window.
+          // Also hold the CTA while a validator (re)fetch is in flight — the
+          // source can serve a cached validator immediately, and the
+          // eligibility gates (restake capacity / remaining time, fast-stake
+          // requalification) only re-run once fresh data lands. Restake
+          // entries invalidate the nodes cache on mount (see
+          // `useAdvancedReviewSource`), so for them a fetch is always in
+          // flight here and this hold covers it; outside a fetch this is NOT
+          // a staleness guarantee — the chain remains the final backstop.
           isFetchingValidator ||
           !isFeeContextReady ||
           isIssueDelegationPending ||

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeConfirmScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeConfirmScreen.tsx
@@ -852,6 +852,13 @@ const StakeConfirmScreen = ({
         isSubmitting={isIssueDelegationPending}
         isSubmitDisabled={
           !validator ||
+          // Also hold the CTA during a background validator refetch — the
+          // source can serve a cached validator immediately (`useNodes` has a
+          // 5-min staleTime), and the eligibility gates (restake capacity /
+          // remaining time, fast-stake requalification) only re-run once
+          // fresh data lands. Without this, a stale-cache restake could be
+          // submitted inside that window.
+          isFetchingValidator ||
           !isFeeContextReady ||
           isIssueDelegationPending ||
           isCheckingFunding ||
@@ -876,6 +883,7 @@ const StakeConfirmScreen = ({
     retryRewardEstimate,
     isIssueDelegationPending,
     validator,
+    isFetchingValidator,
     isFeeContextReady,
     isCheckingFunding,
     isWaitingForFeeReward,

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeDetailScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeDetailScreen.tsx
@@ -32,10 +32,11 @@ import AnalyticsService from 'services/analytics/AnalyticsService'
 import NetworkService from 'services/network/NetworkService'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { selectStakeAnnualPercentageYieldBPS } from 'store/posthog'
-import { isOnGoing } from 'utils/earn/status'
+import { isCompleted, isOnGoing } from 'utils/earn/status'
 import { getExplorerAddressByNetwork } from 'utils/getExplorerAddressByNetwork'
 import { truncateNodeId } from 'utils/Utils'
 import { StakeStatusValue } from '../components/StakeStatusValue'
+import { useRestake } from '../hooks/useRestake'
 import { isDelegationTx } from '../utils/isDelegationTx'
 import { isFastStakeTx } from '../utils/isFastStakeTx'
 
@@ -63,6 +64,16 @@ export const StakeDetailScreen = (): React.JSX.Element => {
     if (!stake) return false
     return isOnGoing(stake, now)
   }, [stake, now])
+
+  // Restake CTA — completed stakes only (web parity), and only when the tx
+  // carries enough data to seed a restake (see `useRestake`). Note completed
+  // is checked explicitly rather than as `!isActive`, so pending stakes don't
+  // offer it either.
+  const { getOnRestake } = useRestake()
+  const onRestake = useMemo(
+    () => (stake ? getOnRestake(stake, isCompleted(stake, now)) : undefined),
+    [stake, getOnRestake, now]
+  )
 
   const progressPercent = useMemo(() => {
     if (!stake) return 0
@@ -291,6 +302,20 @@ export const StakeDetailScreen = (): React.JSX.Element => {
     <ScrollScreen
       title="Stake details"
       navigationTitle="Stake details"
+      renderFooter={
+        onRestake
+          ? () => (
+              <Button
+                testID="stake_detail_restake_btn"
+                accessible={true}
+                type="primary"
+                size="large"
+                onPress={onRestake}>
+                Restake
+              </Button>
+            )
+          : undefined
+      }
       contentContainerStyle={{ padding: 16 }}>
       <View sx={{ marginTop: 8, gap: 10 }}>
         {identitySection.length > 0 && (

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
@@ -11,6 +11,8 @@ import { UTCDate } from '@date-fns/utc'
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import {
+  addDays,
+  addHours,
   differenceInDays,
   format,
   getUnixTime,
@@ -65,7 +67,8 @@ const DELEGATION_FEE_FOR_ESTIMATION = 2
 const StakeDurationScreen = ({
   nextRoute,
   maxEndDate,
-  delegationFeePercent
+  delegationFeePercent,
+  initialDurationDays
 }: {
   /** Pathname pushed onto the router when the user presses `Next`. */
   nextRoute: string
@@ -82,6 +85,14 @@ const StakeDurationScreen = ({
    * it (node unknown at this step) and falls back to the 2% cap.
    */
   delegationFeePercent?: number
+  /**
+   * Restake prefill: the original stake's duration in whole days. When it
+   * matches a preset, that preset starts selected; otherwise the screen opens
+   * on a custom end date of now + N days (+1h of slack so the duration can't
+   * round below the original — mirrors core-web's `DelegationForm`
+   * `initialDurationMs`). The user can still change it freely.
+   */
+  initialDurationDays?: number
 }): JSX.Element => {
   const { navigate } = useRouter()
 
@@ -106,13 +117,32 @@ const StakeDurationScreen = ({
     () => getCustomDurationIndex(isDeveloperMode),
     [isDeveloperMode]
   )
+  // Restake prefill (all captured once, at mount): when the original stake's
+  // duration matches a preset we start on that preset; otherwise we start on
+  // a custom end date. `undefined` initial chart index = the custom state
+  // (same convention `handleSelectDuration` uses when the user picks Custom).
+  const [initialPresetIndex] = useState<number | undefined>(() => {
+    if (initialDurationDays === undefined) return undefined
+    const index = durationsWithDays.findIndex(
+      duration => duration.numberOfDays === initialDurationDays
+    )
+    return index >= 0 ? index : undefined
+  })
+  const [initialCustomEndDate] = useState<UTCDate | undefined>(() =>
+    initialDurationDays !== undefined && initialPresetIndex === undefined
+      ? new UTCDate(addHours(addDays(now, initialDurationDays), 1).getTime())
+      : undefined
+  )
+  const initialChartIndex = initialCustomEndDate
+    ? undefined
+    : initialPresetIndex ?? defaultDurationIndex
   const animatedChartIndex = useSharedValue<number | undefined>(
-    defaultDurationIndex
+    initialChartIndex
   )
   // Mirror the shared value to a state variable so that React re-renders when it changes.
   const [selectedChartIndex, setSelectedChartIndex] = useState<
     number | undefined
-  >(defaultDurationIndex)
+  >(initialChartIndex)
   useAnimatedReaction(
     () => animatedChartIndex.value,
     (current, previous) => {
@@ -130,8 +160,10 @@ const StakeDurationScreen = ({
     300
   )
   const [stakeEndTime, setStakeEndTime] = useState<UnixTime>(() => {
+    if (initialCustomEndDate) return getUnixTime(initialCustomEndDate)
     const defaultDelegationTime =
-      durationsWithDays[defaultDurationIndex] ?? THREE_MONTHS
+      durationsWithDays[initialChartIndex ?? defaultDurationIndex] ??
+      THREE_MONTHS
     return getStakeEndDate({
       startDateUnix: millisecondsToSeconds(now),
       stakeDurationFormat: defaultDelegationTime.stakeDurationFormat,
@@ -139,7 +171,9 @@ const StakeDurationScreen = ({
       isDeveloperMode: isDeveloperMode
     })
   })
-  const [customEndDate, setCustomEndDate] = useState<UTCDate>()
+  const [customEndDate, setCustomEndDate] = useState<UTCDate | undefined>(
+    initialCustomEndDate
+  )
   const [isCustomEndDatePickerVisible, setIsCustomEndDatePickerVisible] =
     useState(false)
 
@@ -373,7 +407,7 @@ const StakeDurationScreen = ({
         <View sx={{ gap: 12, marginTop: 16 }}>
           <StakeRewardChart
             ref={rewardChartRef}
-            initialIndex={defaultDurationIndex}
+            initialIndex={initialChartIndex}
             style={{
               height: 270
             }}

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeHomeScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeHomeScreen.tsx
@@ -14,8 +14,14 @@ import BlurredBarsContentLayout from 'common/components/BlurredBarsContentLayout
 import { useFadingHeaderNavigation } from 'common/hooks/useFadingHeaderNavigation'
 import { LinearGradient } from 'expo-linear-gradient'
 import { useRouter } from 'expo-router'
-import React, { useCallback, useMemo, useState } from 'react'
-import { LayoutChangeEvent, LayoutRectangle } from 'react-native'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
+import {
+  LayoutChangeEvent,
+  LayoutRectangle,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  ScrollView as RNScrollView
+} from 'react-native'
 import Animated, { useAnimatedStyle } from 'react-native-reanimated'
 import { useSafeAreaFrame } from 'react-native-safe-area-context'
 import { useBottomTabBarHeight } from 'common/hooks/useBottomTabBarHeight'
@@ -75,6 +81,28 @@ export const StakeHomeScreen = (): JSX.Element => {
     navigate({ pathname: '/stakeSearch' })
   }, [navigate])
 
+  // Selecting a chip changes the list's filter, and `StakeCardList` keys its
+  // FlashList by the active selection (a Fabric masonry workaround), so the
+  // whole header — this chip ScrollView included — remounts and would snap
+  // back to x=0. Track the offset across remounts and restore it once the
+  // fresh ScrollView has measured its content.
+  const chipScrollRef = useRef<RNScrollView>(null)
+  const chipScrollOffsetX = useRef(0)
+  const handleChipScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      chipScrollOffsetX.current = event.nativeEvent.contentOffset.x
+    },
+    []
+  )
+  const restoreChipScroll = useCallback(() => {
+    if (chipScrollOffsetX.current > 0) {
+      chipScrollRef.current?.scrollTo({
+        x: chipScrollOffsetX.current,
+        animated: false
+      })
+    }
+  }, [])
+
   const renderHeader = useCallback(
     ({ isEmpty, filter }: StakeCardListHeaderProps): JSX.Element => {
       return (
@@ -117,8 +145,12 @@ export const StakeHomeScreen = (): JSX.Element => {
                 }}>
                 <View sx={{ flex: 1, overflow: 'hidden' }}>
                   <ScrollView
+                    ref={chipScrollRef}
                     horizontal
                     showsHorizontalScrollIndicator={false}
+                    onScroll={handleChipScroll}
+                    scrollEventThrottle={16}
+                    onContentSizeChange={restoreChipScroll}
                     contentContainerStyle={{
                       flexDirection: 'row',
                       gap: 8,
@@ -195,7 +227,9 @@ export const StakeHomeScreen = (): JSX.Element => {
       theme.colors.$textSecondary,
       handleHeaderLayout,
       animatedHeaderStyle,
-      handleSearchPress
+      handleSearchPress,
+      handleChipScroll,
+      restoreChipScroll
     ]
   )
 

--- a/packages/core-mobile/app/new/features/stake/v2/store.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/store.ts
@@ -211,7 +211,7 @@ export const setRestakePrefill = (prefill: { durationDays: number }): void => {
   restakePrefill = prefill
 }
 
-/** Peeks the active restake prefill (null outside a delegate restake). */
+/** Peeks the active restake prefill (null when no restake entry is pending). */
 export const getRestakePrefill = (): { durationDays: number } | null =>
   restakePrefill
 

--- a/packages/core-mobile/app/new/features/stake/v2/store.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/store.ts
@@ -167,3 +167,51 @@ export const setDelegateNodeSelection = (
   nodes: NodeValidator[],
   index: number
 ): void => useDelegateNodeSelection.getState().setSelection(nodes, index)
+
+/**
+ * One-shot "entering via restake" flag. `useRestake` seeds the shared stake
+ * amount with the original stake's amount *before* navigating, but the
+ * add-stake layout re-seeds that store with the minimum stakable amount in a
+ * mount effect — and parent effects run after child effects, so the layout
+ * would clobber the restake amount. Setting this flag ahead of navigation
+ * lets the layout skip that one seed. A module-level slot rather than a
+ * zustand store: nothing re-renders on it and it must not outlive a single
+ * modal entry.
+ */
+let pendingRestakeEntry = false
+
+export const beginRestakeEntry = (): void => {
+  pendingRestakeEntry = true
+}
+
+/** Returns whether a restake entry is pending and clears it (one-shot). */
+export const takeRestakeEntry = (): boolean => {
+  const pending = pendingRestakeEntry
+  pendingRestakeEntry = false
+  return pending
+}
+
+/**
+ * Delegate-restake prefill, mirroring web's `restake` location state on the
+ * delegate page: when the original validator has left the active set and the
+ * user is dropped into the node picker, the amount and duration steps still
+ * open prefilled with the original stake's values (web's `DelegationForm`
+ * keeps `initialAmount` / `initialDurationMs` regardless of which node ends
+ * up selected). Unlike the entry flag above this persists for the whole
+ * modal session — re-visiting a step re-applies the prefill, like web's
+ * page-level state — and is cleared on the next non-restake flow entry (see
+ * the add-stake layout) or overwritten by the next restake.
+ */
+let restakePrefill: { durationDays: number } | null = null
+
+export const setRestakePrefill = (prefill: { durationDays: number }): void => {
+  restakePrefill = prefill
+}
+
+/** Peeks the active restake prefill (null outside a delegate restake). */
+export const getRestakePrefill = (): { durationDays: number } | null =>
+  restakePrefill
+
+export const clearRestakePrefill = (): void => {
+  restakePrefill = null
+}

--- a/packages/core-mobile/app/new/features/stake/v2/store.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/store.ts
@@ -192,15 +192,18 @@ export const takeRestakeEntry = (): boolean => {
 }
 
 /**
- * Delegate-restake prefill, mirroring web's `restake` location state on the
- * delegate page: when the original validator has left the active set and the
- * user is dropped into the node picker, the amount and duration steps still
- * open prefilled with the original stake's values (web's `DelegationForm`
- * keeps `initialAmount` / `initialDurationMs` regardless of which node ends
- * up selected). Unlike the entry flag above this persists for the whole
- * modal session — re-visiting a step re-applies the prefill, like web's
- * page-level state — and is cleared on the next non-restake flow entry (see
- * the add-stake layout) or overwritten by the next restake.
+ * Restake prefill, mirroring web's `restake` location state on the delegate
+ * page: when the original validator has left the active set and the user is
+ * dropped into the node picker, the amount and duration steps still open
+ * prefilled with the original stake's values (web's `DelegationForm` keeps
+ * `initialAmount` / `initialDurationMs` regardless of which node ends up
+ * selected). Set on EVERY restake entry (fast stake included) so its
+ * presence doubles as the "restake leftovers pending" marker that
+ * `useStartStaking` checks before a chooser-initiated flow. Unlike the entry
+ * flag above this persists for the whole modal session — re-visiting a step
+ * re-applies the prefill, like web's page-level state — and is cleared on
+ * the next non-restake modal entry (see the add-stake layout), a
+ * chooser-initiated flow start, or the next restake (overwrite).
  */
 let restakePrefill: { durationDays: number } | null = null
 

--- a/packages/core-mobile/app/new/features/stake/v2/utils/getRestakeParams.test.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/utils/getRestakeParams.test.ts
@@ -1,0 +1,48 @@
+import { PChainTransaction } from '@avalabs/glacier-sdk'
+import { getRestakeParams } from './getRestakeParams'
+
+const DAY = 24 * 60 * 60
+
+const makeTx = (overrides: Partial<PChainTransaction>): PChainTransaction =>
+  ({
+    nodeId: 'NodeID-A',
+    startTimestamp: 1_000_000,
+    endTimestamp: 1_000_000 + 14 * DAY,
+    amountStaked: [{ amount: '25000000000' }],
+    ...overrides
+  } as unknown as PChainTransaction)
+
+describe('getRestakeParams', () => {
+  it('derives node, summed amount and whole-day duration', () => {
+    const tx = makeTx({
+      amountStaked: [
+        { amount: '25000000000' },
+        { amount: '5000000000' }
+      ] as PChainTransaction['amountStaked']
+    })
+    expect(getRestakeParams(tx)).toEqual({
+      nodeId: 'NodeID-A',
+      amountNAvax: 30000000000n,
+      durationDays: 14
+    })
+  })
+
+  it('rounds the duration to whole days', () => {
+    const tx = makeTx({
+      endTimestamp: 1_000_000 + 14 * DAY + 13 * 60 * 60 // +13h → rounds up
+    })
+    expect(getRestakeParams(tx)?.durationDays).toBe(15)
+  })
+
+  it.each([
+    ['missing nodeId', { nodeId: undefined }],
+    ['missing startTimestamp', { startTimestamp: undefined }],
+    ['missing endTimestamp', { endTimestamp: undefined }],
+    ['zero-day duration', { endTimestamp: 1_000_000 + 60 }],
+    ['no staked amount', { amountStaked: [] }]
+  ] as const)('returns undefined for %s', (_label, override) => {
+    expect(
+      getRestakeParams(makeTx(override as Partial<PChainTransaction>))
+    ).toBeUndefined()
+  })
+})

--- a/packages/core-mobile/app/new/features/stake/v2/utils/getRestakeParams.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/utils/getRestakeParams.ts
@@ -1,0 +1,40 @@
+import { PChainTransaction } from '@avalabs/glacier-sdk'
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000
+
+export interface RestakeParams {
+  nodeId: string
+  /** Total staked amount in nAVAX (sum of all staked assets, like web). */
+  amountNAvax: bigint
+  /** Original stake duration, rounded to whole days (mirrors web). */
+  durationDays: number
+}
+
+/**
+ * Derives the parameters a restake re-uses from the original stake tx —
+ * the node, the staked amount, and the original duration. Mirrors core-web's
+ * `getOnRestake` (`StakingNewTable.tsx`): bail when the tx is missing a
+ * node or timestamps, sum every staked asset, and round the duration to
+ * whole days. Returns `undefined` when the tx can't seed a restake.
+ */
+export const getRestakeParams = (
+  tx: PChainTransaction
+): RestakeParams | undefined => {
+  const { nodeId, startTimestamp, endTimestamp } = tx
+  if (!nodeId || startTimestamp === undefined || endTimestamp === undefined) {
+    return undefined
+  }
+
+  const durationDays = Math.round(
+    ((endTimestamp - startTimestamp) * 1000) / MILLISECONDS_PER_DAY
+  )
+  if (durationDays <= 0) return undefined
+
+  const amountNAvax = (tx.amountStaked ?? []).reduce(
+    (sum, asset) => sum + BigInt(asset.amount),
+    0n
+  )
+  if (amountNAvax <= 0n) return undefined
+
+  return { nodeId, amountNAvax, durationDays }
+}

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/_layout.tsx
@@ -5,6 +5,7 @@ import {
   useModalScreensOptions
 } from 'common/consts/screenOptions'
 import { DelegationContextProvider } from 'contexts/DelegationContext'
+import { clearRestakePrefill, takeRestakeEntry } from 'features/stake/v2/store'
 import { useStakeAmount } from 'hooks/earn/useStakeAmount'
 import useStakingParams from 'hooks/earn/useStakingParams'
 import React, { useEffect, useRef } from 'react'
@@ -32,8 +33,18 @@ export default function StakeLayoutV2(): JSX.Element {
   // Captured via ref so a dev-mode toggle mid-flow (which changes
   // `minStakeAmount`) doesn't stomp on the user's typed value — only
   // the value at modal entry seeds the input.
+  //
+  // Restake entries skip the seed entirely: `useRestake` pre-seeds the
+  // original stake's amount before navigating, and this effect runs
+  // *after* any child screen's (parent effects fire last on mount), so
+  // it would otherwise overwrite the restake amount with the minimum.
   const initialAmountRef = useRef(minStakeAmount)
   useEffect(() => {
+    if (takeRestakeEntry()) return
+    // Non-restake entry: drop any prefill left behind by a restake that was
+    // abandoned mid-flow, so a fresh Fast Stake / Delegate session doesn't
+    // inherit the old stake's amount or duration.
+    clearRestakePrefill()
     setStakeAmount(initialAmountRef.current)
   }, [setStakeAmount])
 

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/delegate/confirm.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/delegate/confirm.tsx
@@ -2,6 +2,7 @@ import { showAlert } from '@avalabs/k2-alpine'
 import { LoadingState } from 'common/components/LoadingState'
 import { Href, useLocalSearchParams, useRouter } from 'expo-router'
 import {
+  RESTAKE_NODE_ENDING_ERROR,
   RESTAKE_NODE_FULL_ERROR,
   RESTAKE_NODE_UNAVAILABLE_ERROR,
   useAdvancedReviewSource
@@ -17,10 +18,11 @@ import { truncateNodeId } from 'utils/Utils'
  * `delegation-fee-enabled` flag is on (see `useAdvancedReviewSource`).
  *
  * Restake lands here directly with a `restakeNodeId` param. When that
- * validator has left the active set — or is still active but no longer has
- * enough delegation capacity for the original amount — this wrapper redirects
- * to the node picker with a notice instead of rendering the confirm (which
- * would fire its generic no-match alert) — web parity with
+ * validator has left the active set — or is still active but can't host the
+ * stake anymore (delegation capacity below the original amount, or its own
+ * validation period ending before a minimum-duration stake could) — this
+ * wrapper redirects to the node picker with a notice instead of rendering the
+ * confirm (which would fire its generic no-match alert) — web parity with
  * `StakingDelegatePage`'s validator-not-found search fallback. The restake
  * prefill (amount/duration) stays active, so the picker flow reopens with the
  * original stake's values.
@@ -30,18 +32,24 @@ export default function DelegateConfirmRoute(): JSX.Element {
   const { replace } = useRouter()
   const { restakeNodeId } = useLocalSearchParams<{ restakeNodeId?: string }>()
   const isRestakeNodeFull = source.error === RESTAKE_NODE_FULL_ERROR
+  const isRestakeNodeEnding = source.error === RESTAKE_NODE_ENDING_ERROR
   const isRestakeNodeUnusable =
-    source.error === RESTAKE_NODE_UNAVAILABLE_ERROR || isRestakeNodeFull
+    source.error === RESTAKE_NODE_UNAVAILABLE_ERROR ||
+    isRestakeNodeFull ||
+    isRestakeNodeEnding
 
   useEffect(() => {
     if (!isRestakeNodeUnusable) return
     const nodeId = truncateNodeId(restakeNodeId ?? '')
+    // Capacity copy mirrors core-web's `ReviewDelegationTx` toast.
+    const description = isRestakeNodeFull
+      ? `Validator ${nodeId} is no longer eligible for staking. The capacity has been reached. Please select a different one.`
+      : isRestakeNodeEnding
+      ? `Validator ${nodeId} does not have enough time remaining in its validation period for a new stake. Please select a different one.`
+      : `Validator ${nodeId} is no longer available for delegation. Please select a different one.`
     showAlert({
       title: 'Node unavailable',
-      // Capacity copy mirrors core-web's `ReviewDelegationTx` toast.
-      description: isRestakeNodeFull
-        ? `Validator ${nodeId} is no longer eligible for staking. The capacity has been reached. Please select a different one.`
-        : `Validator ${nodeId} is no longer available for delegation. Please select a different one.`,
+      description,
       buttons: [
         {
           text: 'OK',
@@ -49,7 +57,13 @@ export default function DelegateConfirmRoute(): JSX.Element {
         }
       ]
     })
-  }, [isRestakeNodeUnusable, isRestakeNodeFull, restakeNodeId, replace])
+  }, [
+    isRestakeNodeUnusable,
+    isRestakeNodeFull,
+    isRestakeNodeEnding,
+    restakeNodeId,
+    replace
+  ])
 
   // Keep showing a spinner behind the alert (and while the redirect
   // settles) — rendering the confirm screen here would fire its generic

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/delegate/confirm.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/delegate/confirm.tsx
@@ -5,10 +5,11 @@ import {
   RESTAKE_NODE_ENDING_ERROR,
   RESTAKE_NODE_FULL_ERROR,
   RESTAKE_NODE_UNAVAILABLE_ERROR,
+  RESTAKE_NODES_FETCH_FAILED_ERROR,
   useAdvancedReviewSource
 } from 'features/stake/v2/hooks/useAdvancedReviewSource'
 import StakeConfirmScreen from 'features/stake/v2/screens/StakeConfirmScreen'
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { truncateNodeId } from 'utils/Utils'
 
 /**
@@ -25,7 +26,9 @@ import { truncateNodeId } from 'utils/Utils'
  * confirm (which would fire its generic no-match alert) — web parity with
  * `StakingDelegatePage`'s validator-not-found search fallback. The restake
  * prefill (amount/duration) stays active, so the picker flow reopens with the
- * original stake's values.
+ * original stake's values. A failed validators fetch takes the same redirect
+ * with connection-appropriate copy — the picker has its own error + retry
+ * surface for a still-failing query.
  */
 export default function DelegateConfirmRoute(): JSX.Element {
   const source = useAdvancedReviewSource()
@@ -33,22 +36,33 @@ export default function DelegateConfirmRoute(): JSX.Element {
   const { restakeNodeId } = useLocalSearchParams<{ restakeNodeId?: string }>()
   const isRestakeNodeFull = source.error === RESTAKE_NODE_FULL_ERROR
   const isRestakeNodeEnding = source.error === RESTAKE_NODE_ENDING_ERROR
+  const isRestakeFetchFailed = source.error === RESTAKE_NODES_FETCH_FAILED_ERROR
   const isRestakeNodeUnusable =
     source.error === RESTAKE_NODE_UNAVAILABLE_ERROR ||
     isRestakeNodeFull ||
-    isRestakeNodeEnding
+    isRestakeNodeEnding ||
+    isRestakeFetchFailed
 
+  // One-shot: a background refetch can flip the classification (e.g. FULL ↔
+  // ENDING) while the alert is already up, and without the latch the effect
+  // would stack a second alert on top of the first.
+  const hasShownAlertRef = useRef(false)
   useEffect(() => {
-    if (!isRestakeNodeUnusable) return
+    if (!isRestakeNodeUnusable || hasShownAlertRef.current) return
+    hasShownAlertRef.current = true
     const nodeId = truncateNodeId(restakeNodeId ?? '')
     // Capacity copy mirrors core-web's `ReviewDelegationTx` toast.
-    const description = isRestakeNodeFull
+    const description = isRestakeFetchFailed
+      ? `We couldn't load the validator list. Please check your connection and try again.`
+      : isRestakeNodeFull
       ? `Validator ${nodeId} is no longer eligible for staking. The capacity has been reached. Please select a different one.`
       : isRestakeNodeEnding
       ? `Validator ${nodeId} does not have enough time remaining in its validation period for a new stake. Please select a different one.`
       : `Validator ${nodeId} is no longer available for delegation. Please select a different one.`
     showAlert({
-      title: 'Node unavailable',
+      title: isRestakeFetchFailed
+        ? 'Unable to load validators'
+        : 'Node unavailable',
       description,
       buttons: [
         {
@@ -61,6 +75,7 @@ export default function DelegateConfirmRoute(): JSX.Element {
     isRestakeNodeUnusable,
     isRestakeNodeFull,
     isRestakeNodeEnding,
+    isRestakeFetchFailed,
     restakeNodeId,
     replace
   ])

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/delegate/confirm.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/delegate/confirm.tsx
@@ -1,5 +1,5 @@
+import { showAlert } from '@avalabs/k2-alpine'
 import { LoadingState } from 'common/components/LoadingState'
-import { showSnackbar } from 'common/utils/toast'
 import { Href, useLocalSearchParams, useRouter } from 'expo-router'
 import {
   RESTAKE_NODE_UNAVAILABLE_ERROR,
@@ -31,16 +31,23 @@ export default function DelegateConfirmRoute(): JSX.Element {
 
   useEffect(() => {
     if (!isRestakeNodeUnavailable) return
-    showSnackbar(
-      `Validator ${truncateNodeId(
+    showAlert({
+      title: 'Node unavailable',
+      description: `Validator ${truncateNodeId(
         restakeNodeId ?? ''
-      )} is no longer available for delegation. Please select a different one.`
-    )
-    replace('/addStakeV2/delegate/selectNode' as Href)
+      )} is no longer available for delegation. Please select a different one.`,
+      buttons: [
+        {
+          text: 'OK',
+          onPress: () => replace('/addStakeV2/delegate/selectNode' as Href)
+        }
+      ]
+    })
   }, [isRestakeNodeUnavailable, restakeNodeId, replace])
 
-  // Keep showing a spinner while the redirect settles — rendering the
-  // confirm screen here would flash its no-match alert first.
+  // Keep showing a spinner behind the alert (and while the redirect
+  // settles) — rendering the confirm screen here would fire its generic
+  // no-match alert on top.
   if (isRestakeNodeUnavailable) {
     return <LoadingState sx={{ flex: 1 }} />
   }

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/delegate/confirm.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/delegate/confirm.tsx
@@ -1,14 +1,49 @@
-import React from 'react'
+import { LoadingState } from 'common/components/LoadingState'
+import { showSnackbar } from 'common/utils/toast'
+import { Href, useLocalSearchParams, useRouter } from 'expo-router'
+import {
+  RESTAKE_NODE_UNAVAILABLE_ERROR,
+  useAdvancedReviewSource
+} from 'features/stake/v2/hooks/useAdvancedReviewSource'
 import StakeConfirmScreen from 'features/stake/v2/screens/StakeConfirmScreen'
-import { useAdvancedReviewSource } from 'features/stake/v2/hooks/useAdvancedReviewSource'
+import React, { useEffect } from 'react'
+import { truncateNodeId } from 'utils/Utils'
 
 /**
  * Advanced delegate confirm route. Feeds the user-selected validator (via
  * `useAdvancedReviewSource`) into the shared `StakeConfirmScreen` with
  * `isAdvanced` for analytics. A service fee applies when the
  * `delegation-fee-enabled` flag is on (see `useAdvancedReviewSource`).
+ *
+ * Restake lands here directly with a `restakeNodeId` param. When that
+ * validator has left the active set, this wrapper redirects to the node
+ * picker with a notice instead of rendering the confirm (which would fire
+ * its generic no-match alert) — web parity with `StakingDelegatePage`'s
+ * validator-not-found search fallback. The restake prefill (amount/duration)
+ * stays active, so the picker flow reopens with the original stake's values.
  */
 export default function DelegateConfirmRoute(): JSX.Element {
   const source = useAdvancedReviewSource()
+  const { replace } = useRouter()
+  const { restakeNodeId } = useLocalSearchParams<{ restakeNodeId?: string }>()
+  const isRestakeNodeUnavailable =
+    source.error === RESTAKE_NODE_UNAVAILABLE_ERROR
+
+  useEffect(() => {
+    if (!isRestakeNodeUnavailable) return
+    showSnackbar(
+      `Validator ${truncateNodeId(
+        restakeNodeId ?? ''
+      )} is no longer available for delegation. Please select a different one.`
+    )
+    replace('/addStakeV2/delegate/selectNode' as Href)
+  }, [isRestakeNodeUnavailable, restakeNodeId, replace])
+
+  // Keep showing a spinner while the redirect settles — rendering the
+  // confirm screen here would flash its no-match alert first.
+  if (isRestakeNodeUnavailable) {
+    return <LoadingState sx={{ flex: 1 }} />
+  }
+
   return <StakeConfirmScreen source={source} isAdvanced={true} />
 }

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/delegate/confirm.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/delegate/confirm.tsx
@@ -2,6 +2,7 @@ import { showAlert } from '@avalabs/k2-alpine'
 import { LoadingState } from 'common/components/LoadingState'
 import { Href, useLocalSearchParams, useRouter } from 'expo-router'
 import {
+  RESTAKE_NODE_FULL_ERROR,
   RESTAKE_NODE_UNAVAILABLE_ERROR,
   useAdvancedReviewSource
 } from 'features/stake/v2/hooks/useAdvancedReviewSource'
@@ -16,26 +17,31 @@ import { truncateNodeId } from 'utils/Utils'
  * `delegation-fee-enabled` flag is on (see `useAdvancedReviewSource`).
  *
  * Restake lands here directly with a `restakeNodeId` param. When that
- * validator has left the active set, this wrapper redirects to the node
- * picker with a notice instead of rendering the confirm (which would fire
- * its generic no-match alert) — web parity with `StakingDelegatePage`'s
- * validator-not-found search fallback. The restake prefill (amount/duration)
- * stays active, so the picker flow reopens with the original stake's values.
+ * validator has left the active set — or is still active but no longer has
+ * enough delegation capacity for the original amount — this wrapper redirects
+ * to the node picker with a notice instead of rendering the confirm (which
+ * would fire its generic no-match alert) — web parity with
+ * `StakingDelegatePage`'s validator-not-found search fallback. The restake
+ * prefill (amount/duration) stays active, so the picker flow reopens with the
+ * original stake's values.
  */
 export default function DelegateConfirmRoute(): JSX.Element {
   const source = useAdvancedReviewSource()
   const { replace } = useRouter()
   const { restakeNodeId } = useLocalSearchParams<{ restakeNodeId?: string }>()
-  const isRestakeNodeUnavailable =
-    source.error === RESTAKE_NODE_UNAVAILABLE_ERROR
+  const isRestakeNodeFull = source.error === RESTAKE_NODE_FULL_ERROR
+  const isRestakeNodeUnusable =
+    source.error === RESTAKE_NODE_UNAVAILABLE_ERROR || isRestakeNodeFull
 
   useEffect(() => {
-    if (!isRestakeNodeUnavailable) return
+    if (!isRestakeNodeUnusable) return
+    const nodeId = truncateNodeId(restakeNodeId ?? '')
     showAlert({
       title: 'Node unavailable',
-      description: `Validator ${truncateNodeId(
-        restakeNodeId ?? ''
-      )} is no longer available for delegation. Please select a different one.`,
+      // Capacity copy mirrors core-web's `ReviewDelegationTx` toast.
+      description: isRestakeNodeFull
+        ? `Validator ${nodeId} is no longer eligible for staking. The capacity has been reached. Please select a different one.`
+        : `Validator ${nodeId} is no longer available for delegation. Please select a different one.`,
       buttons: [
         {
           text: 'OK',
@@ -43,12 +49,12 @@ export default function DelegateConfirmRoute(): JSX.Element {
         }
       ]
     })
-  }, [isRestakeNodeUnavailable, restakeNodeId, replace])
+  }, [isRestakeNodeUnusable, isRestakeNodeFull, restakeNodeId, replace])
 
   // Keep showing a spinner behind the alert (and while the redirect
   // settles) — rendering the confirm screen here would fire its generic
   // no-match alert on top.
-  if (isRestakeNodeUnavailable) {
+  if (isRestakeNodeUnusable) {
     return <LoadingState sx={{ flex: 1 }} />
   }
 

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/delegate/duration.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/delegate/duration.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
 import StakeDurationScreen from 'features/stake/v2/screens/StakeDurationScreen'
 import { useSelectedDelegateNodeLimits } from 'features/stake/v2/hooks/useSelectedDelegateNodeLimits'
-import { useDelegateNodeSelection } from 'features/stake/v2/store'
+import {
+  getRestakePrefill,
+  useDelegateNodeSelection
+} from 'features/stake/v2/store'
 
 /**
  * Advanced delegate "How long do you want to stake?" route. Same shared
@@ -9,6 +12,11 @@ import { useDelegateNodeSelection } from 'features/stake/v2/store'
  * capping the custom end date at the selected node's end time, and baking
  * the node's actual delegation fee into the reward chart so the estimates
  * match the confirm screen's quote.
+ *
+ * On the delegate-restake fallback path (original validator gone → node
+ * picker → amount → here), the restake prefill supplies the original
+ * stake's duration so the screen opens pre-selected on it (web parity:
+ * `DelegationForm`'s `initialDurationMs`).
  */
 export default function DelegateDurationRoute(): JSX.Element {
   const { maxEndDate } = useSelectedDelegateNodeLimits()
@@ -18,6 +26,7 @@ export default function DelegateDurationRoute(): JSX.Element {
       nextRoute="/addStakeV2/delegate/confirm"
       maxEndDate={maxEndDate}
       delegationFeePercent={node ? Number(node.delegationFee) : undefined}
+      initialDurationDays={getRestakePrefill()?.durationDays}
     />
   )
 }

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/delegate/selectNode.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/delegate/selectNode.tsx
@@ -1,11 +1,35 @@
-import React from 'react'
+import { Stack } from 'common/components/Stack'
+import { useNavigation } from 'expo-router'
 import SelectNodeScreen from 'features/stake/v2/screens/SelectNodeScreen'
+import React, { useState } from 'react'
 
 /**
  * Delegate flow entry: the validator picker pushed when the user chooses
  * "Delegate" from the staking chooser. Node selection comes first in the
  * delegate flow, followed by amount, duration, and confirmation.
+ *
+ * The stack-level header options render a back button unconditionally, but
+ * this screen can also land as the modal stack's only route (the restake
+ * fallback `replace`s to here when the original node can't be reused) —
+ * where the button wouldn't pop anything: `router.back()` falls through to
+ * dismissing the whole modal. So the back button is hidden whenever there is
+ * no previous screen in this stack (the sheet gesture still dismisses).
+ * Captured once at mount: this screen's position in the stack can't change,
+ * and a live subscription would flash the button while screens pushed on top
+ * animate away.
  */
 export default function DelegateSelectNodeRoute(): JSX.Element {
-  return <SelectNodeScreen />
+  const navigation = useNavigation()
+  const [hasPreviousScreen] = useState(() => navigation.getState()?.index !== 0)
+
+  return (
+    <>
+      {!hasPreviousScreen && (
+        <Stack.Screen
+          options={{ headerLeft: () => null, headerBackVisible: false }}
+        />
+      )}
+      <SelectNodeScreen />
+    </>
+  )
 }


### PR DESCRIPTION
## Description

**Ticket: [CP-14187]**

Adds **Restake** to the V2 staking flow, plus stake-type filter chips on the Stake home screen. Mirrors core-web's restake behavior (`getOnRestake` in `StakingNewTable`): only **completed** stakes can be restaked, and the original stake's **node, amount, and duration are reused as-is** — the user lands directly on the review screen with no amount/duration steps in between.

### Entry points (completed stakes only)

- **Restake button** at the bottom of a completed stake card
- **Restake CTA** at the bottom of the Stake details screen

### Flow branches (web parity)

- **Fast Stake tx** → straight to the Fast Stake confirm. The original node gets first refusal: it's re-validated against the Fast Stake criteria (active, uptime ≥ 98%, fee ≤ 2%, capacity, time remaining) via `preferredNodeId`, and auto-selection kicks in only if it no longer qualifies.
- **Delegation tx** → straight to the delegate confirm, which resolves the exact original node (`restakeNodeId`). If the validator has left the active set, an alert is shown and the user is dropped into the node picker — with the original **amount and duration prefilled** through the rest of the flow (mirrors web's `DelegationForm` `initialAmount`/`initialDurationMs` + validator-not-found search fallback).

### Also included

- **Stake-type filter chips** on the Stake home screen: `Fast stakes` and `Delegation` after All/Active/Completed (web's filter set; semantics match web — Delegation is txType-based and includes fast stakes, Fast stakes is escrow-output-based). V1 list is untouched (opt-in flag).
- **Fix**: selecting a chip no longer resets the chip row's horizontal scroll (the FlashList remount workaround was remounting the header; the scroll offset is now preserved and restored).
- **Fix**: tapping Restake on a card no longer also triggers the card's own press (raw touch-event bubbling in `BaseCard` — propagation is stopped at the button wrapper).

### Implementation notes for reviewers

- The add-stake layout seeds the shared stake amount with the minimum on entry; parent effects run **after** child effects on mount, so it would clobber the restake amount. A one-shot `beginRestakeEntry` flag makes the layout skip that seed for restake entries.
- Skipping the amount screen is safe: both confirm screens re-run the delegation-steps computation themselves via `useStakeFundingPreflight`.
- The delegate restake prefill lives in a module-level slot that persists for the modal session (like web's page-level state) and is cleared on the next non-restake flow entry.

No new dependencies. Not breaking.

## Screenshots/Videos

_TBD_

## Testing
iOS: 9206
Android: 9207

**Dev Testing**

Happy path — Fast Stake restake:

1. Use a wallet (Fuji) that has a **completed** Fast Stake.
2. Go to the Stake tab — the completed card shows a **Restake** button; open the card's details — a **Restake** CTA shows at the bottom.
3. Tap Restake (either entry point).
4. Verify the review screen opens directly with the **original amount** and a duration equal to the original stake's duration (end time = now + original whole-day duration).
5. Verify the node: if the original node still qualifies, its NodeID is shown; otherwise a qualifying node is auto-selected.
6. Slide to stake and verify the delegation succeeds.

Happy path — Delegation restake:

1. Use a wallet (Fuji) that has a **completed** advanced delegation.
2. Tap Restake on the card or in details.
3. Verify the review screen opens directly with the **original node, amount, and duration**.
4. Slide to stake and verify the delegation succeeds.

Edge cases:

- Completed delegation whose validator has **left the active set** → tapping Restake shows a "Node unavailable" alert; OK drops into the node picker (only nodes with enough capacity for the original amount are listed); after picking a node, the amount and duration screens open **prefilled** with the original values.
- Active or pending stakes → no Restake button/CTA anywhere.
- Filter chips: `Fast stakes` shows only fee-escrow stakes, `Delegation` shows all delegation-type stakes (including fast stakes); scrolling the chip row right and selecting a chip keeps the scroll position.
- Abandon a restake mid-flow, then start a normal Fast Stake / Delegate → amounts and durations start fresh (no prefill leakage).

**QA Testing**

- Restake must only be offered on completed stakes and must reuse the original node/amount/duration, matching core-web's behavior on the same wallet.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14187]: https://ava-labs.atlassian.net/browse/CP-14187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ