### PR TITLE
CP-13913: Fix empty network list when adding a custom token

### DIFF
--- a/packages/core-mobile/app/new/features/tokenManagement/screens/SelectCustomTokenNetworkScreen.tsx
+++ b/packages/core-mobile/app/new/features/tokenManagement/screens/SelectCustomTokenNetworkScreen.tsx
@@ -35,8 +35,9 @@ export const SelectCustomTokenNetworkScreen = (): JSX.Element => {
   )
 
   const availableNetworks = useMemo(() => {
+    const enabledChainIds = new Set(enabledNetworks.map(n => n.chainId))
     const enabled = Object.values(networks).filter(n =>
-      enabledNetworks.includes(n)
+      enabledChainIds.has(n.chainId)
     )
 
     const filteredEnabled = enabled.filter(
@@ -47,7 +48,7 @@ export const SelectCustomTokenNetworkScreen = (): JSX.Element => {
     )
 
     const custom = Object.values(customNetworks).filter(
-      n => !enabled.includes(n)
+      n => !enabledChainIds.has(n.chainId)
     )
     return [...filteredEnabled, ...custom].sort(sortPrimaryNetworks)
   }, [customNetworks, enabledNetworks, networks])


### PR DESCRIPTION
## Description

**Ticket: [CP-13913](https://ava-labs.atlassian.net/browse/CP-13913)**

The network selection list in the Add Custom Token flow (Portfolio → Manage List → + → Network) was completely empty, showing "No results, Try a different search." — making it impossible to add a custom token.

**Root cause:** `SelectCustomTokenNetworkScreen` filtered networks with `enabledNetworks.includes(n)`, relying on object reference equality between the `networks` map values and the `enabledNetworks` array returned by `useNetworks()`. That assumption broke in #3574 (CP-13005), which changed both memos to spread-copy each network to attach `caip2ChainId` — the two collections now hold distinct object instances, so the reference-based `includes` always returned false and the list ended up empty. The regression shipped in 1.0.24-rc1 and affects all releases since.

**Fix:** Compare by `chainId` instead of object identity, using a `Set` for O(1) lookups. The second filter (`!enabled.includes(n)` for custom networks) relied on the same assumption and is fixed the same way — this also prevents enabled custom networks from being listed twice.

No dependencies introduced, no breaking changes.

## Screenshots/Videos

N/A — logic-only fix. Before: empty network list on the Select Network screen; after: enabled networks (minus P/X-Chain and Bitcoin) plus custom networks are listed.

## Testing

**Dev Testing (if applicable)**

Happy path:
1. From Portfolio, tap View → Manage List
2. Tap + to add a custom token
3. Tap Network → the list should show all enabled networks (excluding P-Chain, X-Chain, Bitcoin) and any custom networks
4. Select a network, enter a valid contract address, and confirm the token can be added

Edge cases:
- Search by network name and chain ID still filters correctly
- With a custom network added: it appears once (not duplicated) whether enabled or not
- Toggle developer mode: list shows testnet networks only

**QA Testing (if applicable)**

Verify the Add Custom Token flow end to end on both platforms. Expected: the network picker is populated and a custom token can be added successfully (regression from 1.0.24).

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CP-13913]: https://ava-labs.atlassian.net/browse/CP-13913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ