### PR TITLE
CP-14710: fix Android modal swipe-to-dismiss broken by nestedScrollEnabled

### DIFF
--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -482,12 +482,13 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
             keyboardDismissMode="interactive"
             keyboardShouldPersistTaps="handled"
             showsVerticalScrollIndicator={false}
-            // On Android, `nestedScrollEnabled` lets the scroll view participate in a
-            // parent form sheet's nested scrolling so a vertical swipe scrolls the
-            // content instead of being captured by the sheet's drag-to-dismiss gesture.
-            // Without it, scrolling down inside a modal dismisses the whole sheet.
+            // Do NOT set `nestedScrollEnabled` here. On Android, explicitly passing
+            // it (true OR false) to the gesture-handler ScrollView disables its
+            // default nested-scroll participation, so the parent form sheet never
+            // receives the vertical drag and swipe-to-dismiss stops working
+            // (CP-14710). Leaving it unset keeps content scrolling AND sheet
+            // dismissal both working.
             {...props}
-            nestedScrollEnabled={Platform.OS === 'android'}
             style={{
               flex: 1
             }}
@@ -529,11 +530,12 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
           showsVerticalScrollIndicator={false}
           keyboardDismissMode="interactive"
           keyboardShouldPersistTaps="handled"
-          // On Android, `nestedScrollEnabled` lets the scroll view participate in a
-          // parent form sheet's nested scrolling so a vertical swipe scrolls the
-          // content instead of being captured by the sheet's drag-to-dismiss gesture.
-          // Without it, scrolling down inside a modal dismisses the whole sheet.
-          nestedScrollEnabled={Platform.OS === 'android'}
+          // Do NOT set `nestedScrollEnabled` here. On Android, explicitly passing
+          // it (true OR false) to the gesture-handler ScrollView disables its
+          // default nested-scroll participation, so the parent form sheet never
+          // receives the vertical drag and swipe-to-dismiss stops working
+          // (CP-14710). Leaving it unset keeps content scrolling AND sheet
+          // dismissal both working.
           {...props}
           contentContainerStyle={[
             props?.contentContainerStyle,


### PR DESCRIPTION
iOS: 9159
Android: 9160

## Description

**Ticket: [CP-14710]**

On Android (1.0.34, rc6+), form-sheet modals could no longer be dismissed by swiping down on the modal body — users had to tap outside the sheet to close it. Swipe-to-dismiss worked in rc1–rc5.

### Root cause

`ScrollScreen`'s scroll containers set `nestedScrollEnabled={Platform.OS === 'android'}`. On Android, explicitly setting `nestedScrollEnabled` (**`true` OR `false`**) on the gesture-handler `ScrollView` disables its default nested-scroll participation, so the parent form sheet's `BottomSheetBehavior` never receives the vertical drag and swipe-to-dismiss stops working. Leaving the prop **unset** falls back to gesture-handler's default nested behavior, which correctly lets the content scroll *and* the sheet dismiss.

The prop was added in CP-14655 to stop a downward scroll from dismissing scrollable sheets (e.g. Swap), but it was never confirmed on device and over-corrected — killing dismissal entirely.

### Fix

Remove `nestedScrollEnabled` from both scroll paths in `ScrollScreen`. The CP-14631/CP-14632 fading-header CPU fix in the same component is preserved. `nestedScrollEnabled` is an Android-only RN prop and was `false` on iOS, so this is a no-op on iOS.

`ListScreenV2` uses a similar-looking prop but on a `FlashList` + `KeyboardAwareScrollView` scroller — verified on-device that its modals (swap token selector) still dismiss correctly, so it is intentionally left unchanged.

## Testing

Verified on-device (Galaxy S25, Android 16):

- Open a scrollable form-sheet modal (e.g. **Send** intro, or a token's list) → swipe **down on the body** → the sheet **dismisses**.
- Open the **Swap** modal, scroll **down through the content** → content **scrolls**, the sheet does **not** accidentally dismiss.
- From the **top** of a scrollable modal, swipe down → the sheet **dismisses**.
- Open **Swap → token selector** (SelectSwapToken) → swipe down → still **dismisses** (regression check for `ListScreenV2`).

[CP-14710]: https://ava-labs.atlassian.net/browse/CP-14710
