### PR TITLE
fix: allow swipe-down to dismiss modal on ScrollScreen with short content

### DIFF
--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -482,12 +482,7 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
             keyboardDismissMode="interactive"
             keyboardShouldPersistTaps="handled"
             showsVerticalScrollIndicator={false}
-            // On Android, `nestedScrollEnabled` lets the scroll view participate in a
-            // parent form sheet's nested scrolling so a vertical swipe scrolls the
-            // content instead of being captured by the sheet's drag-to-dismiss gesture.
-            // Without it, scrolling down inside a modal dismisses the whole sheet.
             {...props}
-            nestedScrollEnabled={Platform.OS === 'android'}
             style={{
               flex: 1
             }}

--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -529,11 +529,6 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
           showsVerticalScrollIndicator={false}
           keyboardDismissMode="interactive"
           keyboardShouldPersistTaps="handled"
-          // On Android, `nestedScrollEnabled` lets the scroll view participate in a
-          // parent form sheet's nested scrolling so a vertical swipe scrolls the
-          // content instead of being captured by the sheet's drag-to-dismiss gesture.
-          // Without it, scrolling down inside a modal dismisses the whole sheet.
-          nestedScrollEnabled={Platform.OS === 'android'}
           {...props}
           contentContainerStyle={[
             props?.contentContainerStyle,


### PR DESCRIPTION
## Description

**Ticket: [CP-]**

Modals presented as native form/page sheets could not be dismissed by swiping down when their content did not fill the viewport (e.g. the transaction/send onboarding screen, which is just an icon + title + subtitle).

`ScrollScreen`'s non-keyboard branch set `nestedScrollEnabled={Platform.OS === 'android'}`, which makes the scroll view consume the vertical drag instead of handing it to the native sheet's drag-to-dismiss gesture. Removing it lets a downward swipe fall through to the sheet, so the modal dismisses as expected. Screens with tall/scrollable content are unaffected — they still scroll normally.

## Screenshots/Videos

N/A

## Testing

**Dev Testing (if applicable)**

- Open a modal that uses `ScrollScreen` with short content (e.g. **Send → onboarding** screen) and swipe down anywhere on the screen — the modal sheet should dismiss.
- Open a modal that uses `ScrollScreen` with long/scrollable content and confirm normal scrolling still works and it can also be dismissed by swiping down from the top.
- Verify on both iOS and Android.

## Bitrise Build
iOS: 9168
Android: 9169
https://app.bitrise.io/app/7d7ca5af7066e290/pipelines/9790d954-e5c4-4984-b2de-83c126ac3710

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation
