### PR TITLE
CP-14711: Restore whatwg-fetch as global fetch over broken expo/fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "react-native-is-edge-to-edge": "1.2.1",
     "react-native-reanimated": "4.5.1",
     "react-native-worklets": "0.10.1",
-    "react-native-ble-plx": "3.5.1"
+    "react-native-ble-plx": "3.5.1",
+    "whatwg-fetch": "3.6.20"
   },
   "engines": {
     "node": ">=20.18.0",

--- a/packages/core-mobile/index.js
+++ b/packages/core-mobile/index.js
@@ -3,6 +3,7 @@ import { enableFreeze } from 'react-native-screens'
 enableFreeze(true)
 
 import { AppRegistry, LogBox, Platform, UIManager } from 'react-native'
+import { fetch as whatwgFetch } from 'whatwg-fetch'
 import './polyfills'
 import Big from 'big.js'
 import FCMService from 'services/fcm/FCMService'
@@ -44,6 +45,16 @@ if (__DEV__) {
   // eslint-disable-next-line no-console
   console.reportErrorsAsExceptions = false
 }
+
+// Expo SDK 56's winter runtime replaces globalThis.fetch with expo/fetch,
+// whose Android response-body handling can corrupt payloads (surfaces as
+// "JSON Parse error: Unexpected character" in avalanchejs P-Chain RPC calls
+// during staking — see expo/expo#46398, not yet backported to SDK 56).
+// Restore React Native's whatwg-fetch for global consumers until the upstream
+// fix ships. Explicit `expo/fetch` imports (streaming) are unaffected. This
+// must run after the import graph above (where the winter runtime installs
+// its fetch) and before setupDeBankCaching() below (which wraps global.fetch).
+global.fetch = whatwgFetch
 
 // TODO: remove this once we integrate with the new balance service
 setupDeBankCaching()

--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -255,6 +255,7 @@
     "vm-browserify": "1.1.2",
     "web-streams-polyfill": "4.1.0",
     "web3": "4.16.0",
+    "whatwg-fetch": "3.6.20",
     "xss": "1.0.15",
     "zeego": "3.0.6",
     "zod": "4.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -781,6 +781,7 @@ __metadata:
     web-streams-polyfill: 4.1.0
     web3: 4.16.0
     webdriverio: 9.19.2
+    whatwg-fetch: 3.6.20
     xss: 1.0.15
     zeego: 3.0.6
     zod: 4.1.12
@@ -42922,14 +42923,7 @@ react-native-webview@ava-labs/react-native-webview:
   languageName: node
   linkType: hard
 
-"whatwg-fetch@npm:^3.0.0":
-  version: 3.6.19
-  resolution: "whatwg-fetch@npm:3.6.19"
-  checksum: 2896bc9ca867ea514392c73e2a272f65d5c4916248fe0837a9df5b1b92f247047bc76cf7c29c28a01ac6c5fb4314021d2718958c8a08292a96d56f72b2f56806
-  languageName: node
-  linkType: hard
-
-"whatwg-fetch@npm:^3.4.1":
+"whatwg-fetch@npm:3.6.20":
   version: 3.6.20
   resolution: "whatwg-fetch@npm:3.6.20"
   checksum: c58851ea2c4efe5c2235f13450f426824cf0253c1d45da28f45900290ae602a20aff2ab43346f16ec58917d5562e159cd691efa368354b2e82918c2146a519c5


### PR DESCRIPTION
## Description

**Ticket: [CP-14711](https://ava-labs.atlassian.net/browse/CP-14711)**

Fixes the "Stake Failed — JSON Parse error: Unexpected character" errors in production ([Sentry issue](https://ava-labs.sentry.io/issues/7560604997/)) by restoring React Native's whatwg-fetch as the global fetch implementation.

**Root cause:** The Expo SDK 56 / RN 0.85 upgrade silently swapped `globalThis.fetch` — Expo's winter runtime installs `expo/fetch` as the default global (`expo/src/winter/runtime.native.ts`). Its new Android response-body handling (gzip/brotli/zstd decompression added in expo/expo#45458) can corrupt payloads, which surfaces as raw JSON parse errors from avalanchejs P-Chain RPC calls during stake delegation. The Sentry issue's first-seen release matches the first RN 0.85 build, and the stack trace points at `expo/src/winter/fetch/FetchResponse.ts` on `index.android.bundle`.

**Fix:**

- Restore `global.fetch = whatwg-fetch` in `index.js` — after the import graph (where the winter runtime installs its fetch) and before `setupDeBankCaching()` (which wraps global fetch). This returns all global-fetch consumers (avalanchejs RPC, vm-modules, third-party libs) to the exact implementation they used before the upgrade.
- Declare `whatwg-fetch@3.6.20` as a direct dependency (previously transitive via react-native) and pin it in root `resolutions`, collapsing the pre-existing 3.6.19/3.6.20 split into a single copy shared with RN's own polyfill.

Explicit `expo/fetch` imports (swap quote streaming via `appCheckStreamingFetch` / `fetchAdapter`) are intentionally untouched — they need ReadableStream support that whatwg-fetch lacks.

**Removal condition:** revert this (index.js assignment + direct dependency + resolutions entry) once the upstream fix (expo/expo#46398, currently unreleased for SDK 56) ships in an SDK 56 patch, or when we upgrade to Expo 57 which includes it.

Pure-JS change — no pod install / native rebuild required.

## Screenshots/Videos

N/A (no UI change). Verified on device via temporary logging:

```
fetch before restore, is whatwg? false   ← winter fetch was active
fetch after restore, is whatwg? true     ← whatwg-fetch restored
```

## Testing

**Dev Testing (if applicable)**

1. Reload the app (Metro restart is enough; no native rebuild)
2. Confirm normal app networking works (portfolio balances, stake list)
3. Run a stake confirm flow — the "JSON Parse error: Unexpected character" alert should no longer occur
4. Confirm swap quote streaming still works (it uses explicit expo/fetch, unaffected)

Note: the corruption is intermittent (Android chunk/compression timing), so the definitive verification is the Sentry issue's event rate dropping to zero on releases containing this fix.

**QA Testing (if applicable)**

- Smoke test staking (delegate, claim) on Android and iOS
- Smoke test swap including quote streaming
- General networking smoke (portfolio, watchlist, browser)

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CP-14711]: https://ava-labs.atlassian.net/browse/CP-14711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ