### PR TITLE
CP-14726: keep swap form scroll position when editing recurring setup on Android

### DIFF
--- a/packages/core-mobile/app/new/features/recurringSwap/components/RecurringDetailsRows.test.tsx
+++ b/packages/core-mobile/app/new/features/recurringSwap/components/RecurringDetailsRows.test.tsx
@@ -113,6 +113,7 @@ jest.mock('../contexts/RecurringSwapContext', () => ({
 
 // Import after mocks are registered.
 
+import { Keyboard, Platform } from 'react-native'
 import {
   RecurringDetailsRows,
   ordersChipsForToken
@@ -268,6 +269,70 @@ describe('<RecurringDetailsRows />', () => {
 
     expect(containsText(json, 'Unlimited')).toBe(true)
     expect(containsText(json, 'Estimated total spend')).toBe(false)
+  })
+})
+
+describe('recurring prompt keyboard handling', () => {
+  const originalOS = Platform.OS
+
+  const setPlatform = (os: 'ios' | 'android'): void => {
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: os })
+  }
+
+  // Invoke the "custom" orders chip, which routes to `promptCustomOrders`
+  // (the guarded `Keyboard.dismiss()` site). The chips only mount once the
+  // "Number of orders" row is expanded, so toggle it open first.
+  const triggerCustomOrders = async (): Promise<void> => {
+    let instance!: renderer.ReactTestRenderer
+    await act(async () => {
+      instance = renderer.create(<RecurringDetailsRows {...baseProps} />)
+    })
+    await act(async () => {
+      const row = instance.root
+        .findAllByProps({ testID: 'recurring_row__orders' })
+        .find(node => typeof node.props.onPress === 'function')
+      expect(row).toBeDefined()
+      row?.props.onPress()
+    })
+    const chips = instance.root
+      .findAllByProps({ testID: 'orders_chips' })
+      .find(node => typeof node.props.onSelect === 'function')
+    expect(chips).toBeDefined()
+    await act(async () => {
+      chips?.props.onSelect('custom')
+    })
+  }
+
+  afterEach(() => {
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      value: originalOS
+    })
+    jest.restoreAllMocks()
+  })
+
+  it('dismisses the keyboard before opening the prompt on Android', async () => {
+    setPlatform('android')
+    const dismissSpy = jest
+      .spyOn(Keyboard, 'dismiss')
+      .mockImplementation(() => undefined)
+
+    await triggerCustomOrders()
+
+    // Blurs the swap form's focused input so its KeyboardAwareScrollView has no
+    // child to snap back to when the inline alert opens. (CP-14726)
+    expect(dismissSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not dismiss the keyboard on iOS (prompt is isolated in a FullWindowOverlay)', async () => {
+    setPlatform('ios')
+    const dismissSpy = jest
+      .spyOn(Keyboard, 'dismiss')
+      .mockImplementation(() => undefined)
+
+    await triggerCustomOrders()
+
+    expect(dismissSpy).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/core-mobile/app/new/features/recurringSwap/components/RecurringDetailsRows.test.tsx
+++ b/packages/core-mobile/app/new/features/recurringSwap/components/RecurringDetailsRows.test.tsx
@@ -303,6 +303,41 @@ describe('recurring prompt keyboard handling', () => {
     })
   }
 
+  // Drive the Android custom-frequency path: expand the row, pick the custom
+  // chip (opens the Android unit picker), then select a unit — which routes to
+  // `promptCustomFrequencyValue` (the other guarded `Keyboard.dismiss()` site).
+  const triggerCustomFrequencyAndroid = async (): Promise<void> => {
+    let instance!: renderer.ReactTestRenderer
+    await act(async () => {
+      instance = renderer.create(<RecurringDetailsRows {...baseProps} />)
+    })
+    await act(async () => {
+      const row = instance.root
+        .findAllByProps({ testID: 'recurring_row__frequency' })
+        .find(node => typeof node.props.onPress === 'function')
+      expect(row).toBeDefined()
+      row?.props.onPress()
+    })
+    await act(async () => {
+      const chips = instance.root
+        .findAllByProps({ testID: 'frequency_chips' })
+        .find(node => typeof node.props.onSelect === 'function')
+      expect(chips).toBeDefined()
+      chips?.props.onSelect('custom')
+    })
+    // The Android unit-picker dialog is the element exposing both onSelect and
+    // onDismiss; selecting a unit routes to the value prompt.
+    await act(async () => {
+      const dialog = instance.root.findAll(
+        node =>
+          typeof node.props.onSelect === 'function' &&
+          typeof node.props.onDismiss === 'function'
+      )[0]
+      expect(dialog).toBeDefined()
+      dialog?.props.onSelect('day')
+    })
+  }
+
   afterEach(() => {
     Object.defineProperty(Platform, 'OS', {
       configurable: true,
@@ -333,6 +368,17 @@ describe('recurring prompt keyboard handling', () => {
     await triggerCustomOrders()
 
     expect(dismissSpy).not.toHaveBeenCalled()
+  })
+
+  it('dismisses the keyboard on the Android custom-frequency path (unit picker → value prompt)', async () => {
+    setPlatform('android')
+    const dismissSpy = jest
+      .spyOn(Keyboard, 'dismiss')
+      .mockImplementation(() => undefined)
+
+    await triggerCustomFrequencyAndroid()
+
+    expect(dismissSpy).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/core-mobile/app/new/features/recurringSwap/components/RecurringDetailsRows.tsx
+++ b/packages/core-mobile/app/new/features/recurringSwap/components/RecurringDetailsRows.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { Modal, Platform, Pressable } from 'react-native'
+import { Keyboard, Modal, Platform, Pressable } from 'react-native'
 import {
   Icons,
   Separator,
@@ -238,6 +238,13 @@ export function RecurringDetailsRows({
 
   const promptCustomFrequencyValue = useCallback(
     (unit: FrequencyUnit) => {
+      // Android: this alert renders inline in the swap window and autofocuses
+      // its own input. If "You pay" is still focused with the keyboard up, the
+      // swap KeyboardAwareScrollView snaps back to it on the keyboard frame
+      // change (a show/refresh, not a hide — so `disableScrollOnKeyboardHide`
+      // on SwapScreen doesn't cover it). Blur first so KAS has no child to
+      // scroll to; the alert then shows its own keyboard. (CP-14726)
+      if (Platform.OS === 'android') Keyboard.dismiss()
       const min = MIN_FREQ_VALUE[unit]
       const max = MAX_FREQ_VALUE[unit]
       const seed =
@@ -352,6 +359,9 @@ export function RecurringDetailsRows({
   )
 
   const promptCustomOrders = useCallback(() => {
+    // See `promptCustomFrequencyValue`: blur the swap form's focused input on
+    // Android before opening this inline alert so KAS doesn't snap back to it.
+    if (Platform.OS === 'android') Keyboard.dismiss()
     const seed =
       typeof numberOfOrders === 'number' &&
       numberOfOrders !== UNLIMITED_ORDERS &&

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -1730,6 +1730,19 @@ export const SwapScreen = (): JSX.Element => {
       // the content instead of being captured by the sheet's drag-to-dismiss.
       // Passed through to the underlying ScrollView via ScrollScreen's props.
       nestedScrollEnabled={Platform.OS === 'android'}
+      // Android + recurring only: the custom frequency / number-of-orders
+      // inputs (rendered only while recurring is on) open a react-native-dialog
+      // text-input alert (autofocused → keyboard). On Android that alert
+      // renders inline in this window (iOS isolates it in a FullWindowOverlay),
+      // so this KeyboardAwareScrollView sees the keyboard hide and, by default,
+      // auto-scrolls back to its initial position — snapping the form to the top
+      // and hiding the recurring setup the user was just editing. Keeping the
+      // position on keyboard-hide fixes that without affecting iOS (which never
+      // sees the alert's keyboard) or the plain one-time swap flow, which has no
+      // such dialog and should keep its normal restore-on-dismiss. (CP-14726)
+      disableScrollOnKeyboardHide={
+        Platform.OS === 'android' && recurring.isRecurring
+      }
       contentContainerStyle={{ flexGrow: 1, padding: 16 }}>
       {/* Stuck-funds banner — surfaces AVAX stranded in atomic memory from an
           incomplete cross-chain transfer. Self-hides (and reserves no space)


### PR DESCRIPTION
## Description

**Ticket: [CP-14726](https://ava-labs.atlassian.net/browse/CP-14726)**

Keeps the Swap form's scroll position stable while editing the recurring-swap setup on **Android**, so the form no longer snaps back to the "You pay" input.

The custom frequency / number-of-orders controls open a `react-native-dialog` text-input alert (autofocused → keyboard). On Android that alert renders **inline in the swap window** (iOS isolates it in a `FullWindowOverlay`), so the Swap screen's `KeyboardAwareScrollView` reacts to its keyboard and scroll-to-focused behavior and snaps the form to the top — hiding the recurring setup the user was just editing.

Two complementary fixes, both Android-only (iOS is unaffected — it never sees the inline alert's keyboard):

1. **`disableScrollOnKeyboardHide` on the Swap `ScrollScreen`** — suppresses the auto-scroll-to-initial-position when the alert's keyboard hides. Scoped to `Platform.OS === 'android' && recurring.isRecurring` so the plain one-time swap flow (which has no such dialog) keeps its normal restore-on-dismiss behavior.
2. **Blur the focused input before opening the recurring prompts** (`Keyboard.dismiss()` in `promptCustomFrequencyValue` / `promptCustomOrders`) — covers the edge case where the keyboard was already up the whole time (e.g. "You pay" focused): the snap there comes from a keyboard frame/focus change (not a hide), so `disableScrollOnKeyboardHide` alone doesn't catch it. Blurring first leaves `KeyboardAwareScrollView` with no child to scroll back to.

## Screenshots/Videos

_To be added._

## Testing

**QA Testing (Android)**

1. Open Swap, focus **You pay**, enter an amount (keyboard up).
2. Turn on recurring and scroll down to the recurring setup **without dismissing the keyboard**.
3. Tap the custom frequency chip → pick a unit → the number prompt opens; enter a value and Save.
4. Tap the custom number-of-orders chip → enter a value and Save.
5. **Expected:** the form stays put at the recurring setup throughout — it does **not** snap back to the "You pay" input, during or after each prompt.
6. Also verify the general flow (keyboard down before opening a prompt) still behaves — no snap on dismiss.
7. Also verify a **plain one-time swap** (recurring off): focus "You pay", enter an amount, dismiss the keyboard — the form still restores to its normal position (this fix does not change that flow).

**iOS**

- Unchanged: the prompts are isolated in a `FullWindowOverlay`, so scroll position is unaffected.

## Build Numbers

`build-apps-internal` pipeline (iOS + Android) — build **#9226** (commit `515705c`)
→ https://app.bitrise.io/app/7d7ca5af7066e290/pipelines/61bcee5d-7df8-4c32-bb70-33ccce8ca436

- iOS: 9226
- Android: 9227

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14726]: https://ava-labs.atlassian.net/browse/CP-14726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
