### PR TITLE
CP-14737: stop expired-wc pairing toast spam from in-app browser tabs

### DIFF
--- a/packages/core-mobile/app/new/features/browser/components/BrowserTab.tsx
+++ b/packages/core-mobile/app/new/features/browser/components/BrowserTab.tsx
@@ -528,7 +528,15 @@ export const BrowserTab = forwardRef<BrowserTabRef, { tabId: string }>(
         // is the root cause of the "Failed to pair with dApp" spam
         // (CORE-REACT-NATIVE-62P). Genuine load errors still fall through to
         // `setError` below, so the app's error UI keeps working for any tab.
-        if (disabled) return
+        if (disabled) {
+          // Suppress the WebView's error overlay so a background tab isn't left
+          // on an error page when the user returns to it. We deliberately skip
+          // the goBack/goToDiscover recovery here: `goToDiscover` is a global
+          // dispatch (would move the *active* view) and `lastNavStateRef` isn't
+          // maintained for inactive tabs.
+          event.preventDefault()
+          return
+        }
         setPendingDeepLink({
           url: failedUrl,
           origin: DeepLinkOrigin.ORIGIN_IN_APP_BROWSER

--- a/packages/core-mobile/app/new/features/browser/components/BrowserTab.tsx
+++ b/packages/core-mobile/app/new/features/browser/components/BrowserTab.tsx
@@ -62,6 +62,12 @@ export interface BrowserTabRef {
   }
 }
 
+// http/https keep normal browsing working; `wc:` is added so WalletConnect
+// navigations reach our `onShouldStartLoadWithRequest` (see the WebView usage).
+// Module-scoped for a stable reference so the WebView's memoized handlers don't
+// churn each render.
+const WC_BROWSER_ORIGIN_WHITELIST = ['http://*', 'https://*', 'wc:*']
+
 export const BrowserTab = forwardRef<BrowserTabRef, { tabId: string }>(
   // eslint-disable-next-line sonarjs/cognitive-complexity
   ({ tabId }, ref): JSX.Element => {
@@ -517,6 +523,12 @@ export const BrowserTab = forwardRef<BrowserTabRef, { tabId: string }>(
         description.includes('ERR_UNKNOWN_URL_SCHEME') &&
         isDeepLinkUrl(failedUrl)
       ) {
+        // Only the active tab may turn a failed custom-scheme navigation into a
+        // deeplink/pairing. Inactive/background tabs must not — that re-dispatch
+        // is the root cause of the "Failed to pair with dApp" spam
+        // (CORE-REACT-NATIVE-62P). Genuine load errors still fall through to
+        // `setError` below, so the app's error UI keeps working for any tab.
+        if (disabled) return
         setPendingDeepLink({
           url: failedUrl,
           origin: DeepLinkOrigin.ORIGIN_IN_APP_BROWSER
@@ -615,6 +627,15 @@ export const BrowserTab = forwardRef<BrowserTabRef, { tabId: string }>(
             onLoad={onLoad}
             onNavigationStateChange={onNavigationStateChange}
             onMessage={onMessageHandler}
+            // Whitelist `wc:` (only) alongside http/https so WalletConnect
+            // navigations pass the whitelist and reach `onShouldStartLoadWithRequest`
+            // instead of the library's blind `Linking.openURL` round-trip. That lets
+            // the existing `if (disabled) return false` guard block reconnect
+            // attempts from background/inactive tabs — the root cause of the
+            // "Failed to pair with dApp" spam (CORE-REACT-NATIVE-62P). `core:` is
+            // intentionally NOT whitelisted: it maps to many internal deeplink
+            // routes a page could reach with no Android gesture signal.
+            originWhitelist={WC_BROWSER_ORIGIN_WHITELIST}
             onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
             nestedScrollEnabled
             pullToRefreshEnabled

--- a/packages/core-mobile/app/store/walletConnectV2/listeners/index.test.ts
+++ b/packages/core-mobile/app/store/walletConnectV2/listeners/index.test.ts
@@ -184,7 +184,7 @@ describe('walletConnect - listeners', () => {
       // the in-app browser can re-surface such a stale uri on every navigation,
       // which previously spammed "Failed to pair with dApp" toasts (CORE-REACT-NATIVE-62P).
       const expiredUri =
-        'wc:1111111111111111111111111111111111111111111111111111111111111111@2?relay-protocol=irn&symKey=2222222222222222222222222222222222222222222222222222222222222222&expiryTimestamp=1'
+        'wc:1111111111111111111111111111111111111111111111111111111111111111@2?relay-protocol=irn&symKey=2222222222222222222222222222222222222222222222222222222222222222&expiryTimestamp=0'
       store.dispatch(newSession(expiredUri))
 
       expect(mockWCPair).not.toHaveBeenCalled()
@@ -195,7 +195,7 @@ describe('walletConnect - listeners', () => {
       // a distinct expired uri (not reused elsewhere) so the per-uri toast dedupe
       // isn't affected by other tests in this file.
       const expiredUri =
-        'wc:3333333333333333333333333333333333333333333333333333333333333333@2?relay-protocol=irn&symKey=4444444444444444444444444444444444444444444444444444444444444444&expiryTimestamp=1'
+        'wc:3333333333333333333333333333333333333333333333333333333333333333@2?relay-protocol=irn&symKey=4444444444444444444444444444444444444444444444444444444444444444&expiryTimestamp=0'
       store.dispatch(newSession(expiredUri))
       store.dispatch(newSession(expiredUri))
 

--- a/packages/core-mobile/app/store/walletConnectV2/listeners/index.test.ts
+++ b/packages/core-mobile/app/store/walletConnectV2/listeners/index.test.ts
@@ -179,6 +179,32 @@ describe('walletConnect - listeners', () => {
       expect(mockWCPair).toHaveBeenCalledWith(uri)
     })
 
+    it('should not pair or show an error when the wc uri has already expired', () => {
+      // a syntactically valid v2 uri whose expiryTimestamp is in the past.
+      // the in-app browser can re-surface such a stale uri on every navigation,
+      // which previously spammed "Failed to pair with dApp" toasts (CORE-REACT-NATIVE-62P).
+      const expiredUri =
+        'wc:1111111111111111111111111111111111111111111111111111111111111111@2?relay-protocol=irn&symKey=2222222222222222222222222222222222222222222222222222222222222222&expiryTimestamp=1'
+      store.dispatch(newSession(expiredUri))
+
+      expect(mockWCPair).not.toHaveBeenCalled()
+      expect(transactionSnackbar.error).not.toHaveBeenCalled()
+    })
+
+    it('should show a single informative snackbar for an expired uri, even when re-delivered', () => {
+      // a distinct expired uri (not reused elsewhere) so the per-uri toast dedupe
+      // isn't affected by other tests in this file.
+      const expiredUri =
+        'wc:3333333333333333333333333333333333333333333333333333333333333333@2?relay-protocol=irn&symKey=4444444444444444444444444444444444444444444444444444444444444444&expiryTimestamp=1'
+      store.dispatch(newSession(expiredUri))
+      store.dispatch(newSession(expiredUri))
+
+      expect(mockWCPair).not.toHaveBeenCalled()
+      expect(transactionSnackbar.error).not.toHaveBeenCalled()
+      // friendly, deduped feedback: one toast for the same expired link, not spam
+      expect(showSnackbar).toHaveBeenCalledTimes(1)
+    })
+
     it('should show error message when failed to start a new session', () => {
       const testError = new Error('test error')
       mockWCPair.mockImplementationOnce(() => {

--- a/packages/core-mobile/app/store/walletConnectV2/listeners/sessions.ts
+++ b/packages/core-mobile/app/store/walletConnectV2/listeners/sessions.ts
@@ -109,15 +109,16 @@ export const updateSessions = async ({
  * absent on legacy/v1 uris. The in-app browser re-surfaces stored `wc:` links
  * on navigation, so an already-expired uri can be re-delivered here many times.
  * Pairing with an expired uri throws and previously spammed "Failed to pair
- * with dApp" toasts (CORE-REACT-NATIVE-62P), so we short-circuit it silently.
+ * with dApp" toasts (CORE-REACT-NATIVE-62P), so we short-circuit it and show a
+ * single deduped, friendly snackbar instead of the generic error toast.
  */
 const isExpiredWcUri = (uri: string): boolean => {
   try {
     const { expiryTimestamp } = parseUri(uri)
     // `expiryTimestamp` is unix seconds. Treat at-or-past expiry as expired
     // (`<=`) — marginally more conservative than the SDK's strict `<`, so a
-    // just-expired uri is skipped rather than attempted; they differ only at
-    // exact-millisecond equality.
+    // just-expired uri is skipped rather than attempted; the two only disagree
+    // when `Date.now()` lands exactly on the expiry-second boundary.
     return expiryTimestamp !== undefined && expiryTimestamp * 1000 <= Date.now()
   } catch {
     // if the uri can't be parsed, let WalletConnectService.pair validate it as before
@@ -127,8 +128,19 @@ const isExpiredWcUri = (uri: string): boolean => {
 
 // Tracks expired uris we've already surfaced a toast for, so a background dapp
 // tab replaying the same stale uri can inform the user at most once instead of
-// spamming (CORE-REACT-NATIVE-62P).
+// spamming (CORE-REACT-NATIVE-62P). Bounded so a page that mints many distinct
+// expired uris can't grow it unbounded across a session; oldest entries evict
+// first (insertion-ordered Set), and it's cleared entirely on logout.
+const EXPIRED_URI_TOAST_CACHE_LIMIT = 100
 const expiredUrisToasted = new Set<string>()
+
+const markExpiredUriToasted = (uri: string): void => {
+  if (expiredUrisToasted.size >= EXPIRED_URI_TOAST_CACHE_LIMIT) {
+    const oldest = expiredUrisToasted.values().next().value
+    if (oldest !== undefined) expiredUrisToasted.delete(oldest)
+  }
+  expiredUrisToasted.add(uri)
+}
 
 export const startSession = async (
   action: ReturnType<typeof newSession>
@@ -138,7 +150,7 @@ export const startSession = async (
   if (isExpiredWcUri(uri)) {
     Logger.info('skipping pair for expired wallet connect uri')
     if (!expiredUrisToasted.has(uri)) {
-      expiredUrisToasted.add(uri)
+      markExpiredUriToasted(uri)
       showSnackbar(
         'This connection link has expired. Please try connecting again.'
       )

--- a/packages/core-mobile/app/store/walletConnectV2/listeners/sessions.ts
+++ b/packages/core-mobile/app/store/walletConnectV2/listeners/sessions.ts
@@ -1,6 +1,7 @@
 import { AppListenerEffectAPI } from 'store/types'
 import WalletConnectService from 'services/walletconnectv2/WalletConnectService'
 import { InteractionManager } from 'react-native'
+import { parseUri } from '@walletconnect/utils'
 import Logger from 'utils/Logger'
 import {
   onRehydrationComplete,
@@ -103,10 +104,47 @@ export const updateSessions = async ({
   }
 }
 
+/**
+ * A wc:v2 pairing uri carries its own `expiryTimestamp` (unix seconds); it is
+ * absent on legacy/v1 uris. The in-app browser re-surfaces stored `wc:` links
+ * on navigation, so an already-expired uri can be re-delivered here many times.
+ * Pairing with an expired uri throws and previously spammed "Failed to pair
+ * with dApp" toasts (CORE-REACT-NATIVE-62P), so we short-circuit it silently.
+ */
+const isExpiredWcUri = (uri: string): boolean => {
+  try {
+    const { expiryTimestamp } = parseUri(uri)
+    // `expiryTimestamp` is unix seconds. Treat at-or-past expiry as expired
+    // (`<=`) — marginally more conservative than the SDK's strict `<`, so a
+    // just-expired uri is skipped rather than attempted; they differ only at
+    // exact-millisecond equality.
+    return expiryTimestamp !== undefined && expiryTimestamp * 1000 <= Date.now()
+  } catch {
+    // if the uri can't be parsed, let WalletConnectService.pair validate it as before
+    return false
+  }
+}
+
+// Tracks expired uris we've already surfaced a toast for, so a background dapp
+// tab replaying the same stale uri can inform the user at most once instead of
+// spamming (CORE-REACT-NATIVE-62P).
+const expiredUrisToasted = new Set<string>()
+
 export const startSession = async (
   action: ReturnType<typeof newSession>
 ): Promise<void> => {
   const uri = action.payload
+
+  if (isExpiredWcUri(uri)) {
+    Logger.info('skipping pair for expired wallet connect uri')
+    if (!expiredUrisToasted.has(uri)) {
+      expiredUrisToasted.add(uri)
+      showSnackbar(
+        'This connection link has expired. Please try connecting again.'
+      )
+    }
+    return
+  }
 
   try {
     await WalletConnectService.pair(uri)
@@ -119,8 +157,11 @@ export const startSession = async (
   }
 }
 
-export const killAllSessions = async (): Promise<void> =>
-  WalletConnectService.killAllSessions()
+export const killAllSessions = async (): Promise<void> => {
+  // forget expired-uri toast history on logout so it can't grow across accounts
+  expiredUrisToasted.clear()
+  return WalletConnectService.killAllSessions()
+}
 
 export const killSomeSessions = async (
   action: ReturnType<typeof killSessions>

--- a/packages/core-mobile/app/store/walletConnectV2/listeners/sessions.ts
+++ b/packages/core-mobile/app/store/walletConnectV2/listeners/sessions.ts
@@ -126,20 +126,28 @@ const isExpiredWcUri = (uri: string): boolean => {
   }
 }
 
-// Tracks expired uris we've already surfaced a toast for, so a background dapp
-// tab replaying the same stale uri can inform the user at most once instead of
-// spamming (CORE-REACT-NATIVE-62P). Bounded so a page that mints many distinct
-// expired uris can't grow it unbounded across a session; oldest entries evict
-// first (insertion-ordered Set), and it's cleared entirely on logout.
-const EXPIRED_URI_TOAST_CACHE_LIMIT = 100
-const expiredUrisToasted = new Set<string>()
-
-const markExpiredUriToasted = (uri: string): void => {
-  if (expiredUrisToasted.size >= EXPIRED_URI_TOAST_CACHE_LIMIT) {
-    const oldest = expiredUrisToasted.values().next().value
-    if (oldest !== undefined) expiredUrisToasted.delete(oldest)
+const getWcTopic = (uri: string): string | undefined => {
+  try {
+    return parseUri(uri).topic
+  } catch {
+    return undefined
   }
-  expiredUrisToasted.add(uri)
+}
+
+// Tracks the pairing TOPICS of expired uris we've already toasted, so a background
+// dapp tab replaying the same stale uri informs the user at most once instead of
+// spamming (CORE-REACT-NATIVE-62P). We key on the topic — never the full uri, which
+// embeds the v2 `symKey` secret — and keep it bounded (oldest evicts first) and
+// cleared on logout so it can't grow across a session.
+const EXPIRED_TOPIC_TOAST_CACHE_LIMIT = 100
+const toastedExpiredTopics = new Set<string>()
+
+const markExpiredTopicToasted = (topic: string): void => {
+  if (toastedExpiredTopics.size >= EXPIRED_TOPIC_TOAST_CACHE_LIMIT) {
+    const oldest = toastedExpiredTopics.values().next().value
+    if (oldest !== undefined) toastedExpiredTopics.delete(oldest)
+  }
+  toastedExpiredTopics.add(topic)
 }
 
 export const startSession = async (
@@ -149,8 +157,9 @@ export const startSession = async (
 
   if (isExpiredWcUri(uri)) {
     Logger.info('skipping pair for expired wallet connect uri')
-    if (!expiredUrisToasted.has(uri)) {
-      markExpiredUriToasted(uri)
+    const topic = getWcTopic(uri)
+    if (topic !== undefined && !toastedExpiredTopics.has(topic)) {
+      markExpiredTopicToasted(topic)
       showSnackbar(
         'This connection link has expired. Please try connecting again.'
       )
@@ -170,8 +179,8 @@ export const startSession = async (
 }
 
 export const killAllSessions = async (): Promise<void> => {
-  // forget expired-uri toast history on logout so it can't grow across accounts
-  expiredUrisToasted.clear()
+  // forget expired-topic toast history on logout so it can't grow across accounts
+  toastedExpiredTopics.clear()
   return WalletConnectService.killAllSessions()
 }
 


### PR DESCRIPTION
## Description

**Ticket: [CP-14737](https://ava-labs.atlassian.net/browse/CP-14737)**

The in-app browser spams `Failed to pair with dApp` toasts for some users, with no user action.

**Root cause:** a forgotten/persisted browser tab holds a dApp page that auto-reconnects on every load using a cached, now-**expired** WalletConnect `wc:` URI. The browser WebView can't load the `wc:` scheme (no `originWhitelist` → default `http/https` only), so react-native-webview blindly `Linking.openURL('wc:...')`s it, which round-trips through the OS back into Core → `handleDeeplink` → `newSession` → `startSession` → `pair()` → throws `pair() URI has expired` → toast. Because the tab keeps firing (even in the **background**, where the user doesn't know it's open), it loops. Confirmed by the reporting user: closing the offending tab stops it, and Connected Sites was empty (so it's the browser round-trip, not a live WC session). Reproduces on both 1.0.33 and 1.0.34 (Sentry `CORE-REACT-NATIVE-62P`: ~81 users, 4,300+ events).

**Fix (two parts):**
1. `store/walletConnectV2/listeners/sessions.ts` — `startSession` short-circuits an already-expired `wc:` URI (via `parseUri().expiryTimestamp`): no `pair()`, no error toast. Surfaces a single, friendly, **per-URI-deduped** "connection link has expired" snackbar instead of the error spam.
2. `features/browser/components/BrowserTab.tsx` — add `wc:` (only) to the WebView `originWhitelist` so `wc:` navigations reach our `onShouldStartLoadWithRequest`, whose existing `if (disabled) return false` blocks reconnect attempts from **background/inactive** tabs (the actual cause). Also scopes the `onError` deep-link re-dispatch to the active tab. `core:` is intentionally **not** whitelisted (it maps to many internal deeplink routes).

**Dependencies:** none (uses existing `@walletconnect/utils`).
**Breaking:** no.

**Known residual (follow-up):** an *active/foreground* tab that mints *fresh* (non-expired) `wc:` URIs each attempt could still raise WalletConnect approval prompts — background tabs are fully covered. A separate mobile UX ticket will add a **tab-count badge** so users can find/close forgotten tabs.

## Screenshots/Videos

Verified on iOS simulator (dev client) via the local HTTPS harness below:
- **Before (guard off):** in-app browser round-trips the expired `wc:` → repeated `Failed to pair with dApp` toasts.
- **After (guard on):** active tab → one "link expired" snackbar, no error spam; **background tab → navigations blocked, zero pairing attempts** (harness fired 8× while backgrounded; app dispatched 0).

_(iOS recordings attached; Android to be verified on a build — the fix is shared JS and the mechanism is Android-originated.)_

## Testing

### Test harness (reproduces the exact mechanism)

The bug needs a page that auto-navigates to an **already-expired** `wc:` v2 URI. WalletConnect reads `expiryTimestamp` straight from the URI, so a forged URI with `expiryTimestamp=1` (1970) is always expired — no relay/network needed.

**1. Save this as `index.html`:**

```html
<!doctype html>
<html><head><meta name="viewport" content="width=device-width, initial-scale=1"><title>WC expired-pair repro</title></head>
<body>
<div id="status">starting…</div><pre id="log"></pre>
<script>
  var URI = "wc:1111111111111111111111111111111111111111111111111111111111111111@2"
    + "?relay-protocol=irn"
    + "&symKey=2222222222222222222222222222222222222222222222222222222222222222"
    + "&expiryTimestamp=1";
  var n = 0, MAX = 8;
  function log(m){ document.getElementById('log').textContent += m + "\n"; }
  function fire(){ n++; document.getElementById('status').textContent = "wc: navigation attempt #" + n;
                  log("attempt #" + n + " -> navigate to expired wc: uri"); window.location.href = URI; }
  log("auto-firing expired wc: navigation");
  var t = setInterval(function(){ if (n >= MAX){ clearInterval(t); log("done (" + MAX + " attempts)"); return; } fire(); }, 1500);
</script>
</body></html>
```

**2. Serve it over HTTPS with a cert the device trusts.** Core's in-app browser forces HTTPS and strips non-default ports, so it must be on **:443** with a trusted cert.

```bash
# one-time cert setup (mkcert)
brew install mkcert && mkcert -install
mkcert localhost 127.0.0.1                 # -> localhost+1.pem / localhost+1-key.pem
xcrun simctl keychain booted add-root-cert "$(mkcert -CAROOT)/rootCA.pem"   # iOS sim

# serve the folder containing index.html on 443 (needs sudo for the privileged port)
sudo python3 -c '
import http.server, ssl
h = http.server.SimpleHTTPRequestHandler
s = http.server.HTTPServer(("0.0.0.0", 443), h)
c = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER); c.load_cert_chain("localhost+1.pem", "localhost+1-key.pem")
s.socket = c.wrap_socket(s.socket, server_side=True)
print("serving on https://127.0.0.1:443"); s.serve_forever()'
```

(Android: `adb reverse tcp:443 tcp:443` and trust the mkcert root CA on the emulator, then use the same URL.)

**3. Repro steps + expected results**

| Step | Expected (with this fix) |
|---|---|
| Open `https://127.0.0.1` in Core's in-app browser (active tab) | **One** "This connection link has expired…" snackbar. **No** `Failed to pair with dApp` spam. |
| Open a second browser tab so the harness tab is **backgrounded** | Backgrounded page keeps firing (`attempt #N` on screen), but **no toasts and no pairing attempts** — blocked at the browser layer. |
| Connect to a real dApp via WalletConnect from the **active** tab | Still works normally. |

To see the **"before"** for comparison, temporarily neutralize the guard in `startSession` (`if (false && isExpiredWcUri(uri))`) and reload — step 1 then spams `Failed to pair with dApp`.

**Dev Testing**
- Run the harness above; confirm the table's expected results.
- Trigger a Bitrise build and reference it here. Move the ticket to the "Testing" column.

**QA Testing**
- Repro requires a dApp tab that auto-reconnects with a stale WC session, or the harness above.
- Acceptance: no `Failed to pair with dApp` toast loop; forgotten/background tabs never trigger pairing; a genuinely expired link scanned/opened shows a single friendly snackbar.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14737]: https://ava-labs.atlassian.net/browse/CP-14737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ