### PR TITLE
CP-14744: fix Swap "You pay" auto-scroll offset under header on Android

### DIFF
--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -538,10 +538,18 @@ export const SwapScreen = (): JSX.Element => {
   const [keyboardHeight, setKeyboardHeight] = useState(0)
   const scrollYouPayIntoView = useCallback(
     (animated: boolean) => {
+      // On the Android form sheet, ScrollScreen offsets the scroll view below
+      // the header via `marginTop: headerHeight` (CP-14679), so the scroll
+      // content already starts under the header — don't subtract headerHeight
+      // again or the card lands a full header-height too low (CP-14744). iOS
+      // insets the content under the transparent header (paddingTop), so the
+      // subtraction still applies there. This screen is always `isModal`, so
+      // the Android condition matches ScrollScreen's `scrollBelowHeader`.
+      const headerOffset = Platform.OS === 'android' ? 0 : headerHeight
       scrollRef.current?.scrollTo({
         y: Math.max(
           0,
-          fromSectionYRef.current - headerHeight - YOU_PAY_SCROLL_TOP_MARGIN
+          fromSectionYRef.current - headerOffset - YOU_PAY_SCROLL_TOP_MARGIN
         ),
         animated
       })


### PR DESCRIPTION
## Description

**Ticket: [CP-14744](https://ava-labs.atlassian.net/browse/CP-14744)**

On the Swap screen, after entering an amount the auto-scroll no longer positioned the "You pay" input directly under the header on Android — it landed offset lower on the screen. This was a regression from [CP-14679 / #3966](https://github.com/ava-labs/core-mobile/pull/3966), which changed the Android form-sheet keyboard-aware branch of `ScrollScreen` to offset the scroll view itself with `marginTop: headerHeight` (and `paddingTop: 0`) instead of insetting the content with `paddingTop: headerHeight`.

That shifted the scroll content's coordinate origin down by one header-height: the `onLayout` y that `SwapScreen` measures for the "You pay" card no longer includes the header offset, but `scrollYouPayIntoView` still subtracted `headerHeight` when scrolling — so on Android it scrolled a full header-height short, leaving the card offset below the header.

**Fix:** On the Android form-sheet path, don't subtract `headerHeight` again — the scroll view already starts below the header. Since the Swap screen is always `isModal`, the condition matches `ScrollScreen`'s internal `scrollBelowHeader` (`Platform.OS === 'android' && isModal`). iOS is unchanged (it still insets content under the transparent header, so the subtraction still applies).

- No dependencies introduced.
- Not breaking.

## Screenshots/Videos

_To be attached from the build (Android before/after; iOS unchanged)._

## Testing

**Dev Testing**

- Android: open the Swap screen and tap into the "You pay" input. Confirm the swap card auto-scrolls so the "You pay" input sits directly under the header (with a small ~8px gap), not offset lower on the screen.
- Android: with the stuck-funds and/or recurring-schedules banners visible above the card, focus "You pay" again and confirm it still lands just under the header.
- Android: confirm swipe-to-dismiss on the header/grabber still works and the body still scrolls (no regression to the CP-14679 behavior).
- iOS: repeat the focus-"You pay" flow and confirm the position is unchanged from before this PR.

**Build Numbers**

- iOS: 9240
- Android: 9241
- Pipeline: https://app.bitrise.io/app/7d7ca5af7066e290/pipelines/3caf7006-5599-46be-ad2b-f8fb3d56f299

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14744]: https://ava-labs.atlassian.net/browse/CP-14744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ