### PR TITLE
CP-14617: suppress Invalid environment toast for dApp-automated background read methods

### DIFF
--- a/packages/core-mobile/app/store/rpc/listeners/index.test.ts
+++ b/packages/core-mobile/app/store/rpc/listeners/index.test.ts
@@ -278,6 +278,29 @@ describe('rpc - listeners', () => {
         )
       })
 
+      it('should reject a dApp-automated read method on developer mode mismatch without showing an error toast (CP-14617)', async () => {
+        mockSelectIsDeveloperMode.mockImplementation(() => true)
+
+        const testRequest = createRequest(
+          'wallet_getNetworkState' as RpcMethod.WALLET_GET_NETWORK_STATE,
+          [false]
+        )
+
+        store.dispatch(onRequest(testRequest))
+
+        await jest.runOnlyPendingTimersAsync()
+
+        expect(transactionSnackbar.error).not.toHaveBeenCalled()
+
+        expect(mockWCRejectRequest).toHaveBeenCalledWith(
+          '3a094bf511357e0f48ff266f0b8d5b846fd3f7de4bd0824d976fdf4c5279b261',
+          1677366383831712,
+          rpcErrors.internal(
+            'Invalid environment. Please turn off developer mode and try again'
+          )
+        )
+      })
+
       it('should not reject request when requested chain does not match developer mode for a chain agnostic method', async () => {
         mockSelectIsDeveloperMode.mockImplementation(() => true)
 

--- a/packages/core-mobile/app/store/rpc/listeners/index.test.ts
+++ b/packages/core-mobile/app/store/rpc/listeners/index.test.ts
@@ -281,10 +281,9 @@ describe('rpc - listeners', () => {
       it('should reject a dApp-automated read method on developer mode mismatch without showing an error toast (CP-14617)', async () => {
         mockSelectIsDeveloperMode.mockImplementation(() => true)
 
-        const testRequest = createRequest(
-          'wallet_getNetworkState' as RpcMethod.WALLET_GET_NETWORK_STATE,
-          [false]
-        )
+        const testRequest = createRequest(RpcMethod.WALLET_GET_NETWORK_STATE, [
+          false
+        ])
 
         store.dispatch(onRequest(testRequest))
 

--- a/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.test.ts
+++ b/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.test.ts
@@ -7,6 +7,8 @@ import {
 } from '@avalabs/core-chains-sdk'
 import mockAccounts from 'tests/fixtures/accounts.json'
 import { AppListenerEffectAPI } from 'store/types'
+import { providerErrors, rpcErrors } from '@metamask/rpc-errors'
+import { transactionSnackbar } from 'new/common/utils/toast'
 import { RpcMethod, RpcProvider } from '../../types'
 import { walletConnectProvider } from './walletConnect'
 
@@ -382,6 +384,77 @@ describe('walletConnectProvider', () => {
           '0xtxhash'
         )
       })
+    })
+  })
+
+  describe('onError — toast suppression for dapp-automated read methods', () => {
+    beforeEach(() => {
+      jest.clearAllMocks()
+      jest
+        .spyOn(WalletConnectService, 'rejectRequest')
+        .mockResolvedValue(undefined)
+    })
+
+    const invalidEnvironmentError = rpcErrors.internal(
+      'Invalid environment. Please turn on developer mode and try again'
+    )
+
+    it.each([
+      RpcMethod.WALLET_GET_NETWORK_STATE,
+      RpcMethod.WALLET_GET_ETHEREUM_CHAIN,
+      RpcMethod.AVALANCHE_GET_ADDRESSES_IN_RANGE,
+      RpcMethod.AVALANCHE_GET_BRIDGE_STATE
+    ])('rejects %s without showing an error toast (CP-14617)', async method => {
+      const request = makeMockRequest(method, 'eip155:43114')
+
+      await walletConnectProvider.onError({
+        request,
+        error: invalidEnvironmentError,
+        listenerApi: mockListenerApi
+      })
+
+      expect(WalletConnectService.rejectRequest).toHaveBeenCalledWith(
+        'test-topic',
+        1,
+        invalidEnvironmentError
+      )
+      expect(transactionSnackbar.error).not.toHaveBeenCalled()
+    })
+
+    it('still shows an error toast for user-initiated signing methods', async () => {
+      const request = makeMockRequest(
+        RpcMethod.ETH_SEND_TRANSACTION,
+        'eip155:43114'
+      )
+
+      await walletConnectProvider.onError({
+        request,
+        error: invalidEnvironmentError,
+        listenerApi: mockListenerApi
+      })
+
+      expect(WalletConnectService.rejectRequest).toHaveBeenCalledWith(
+        'test-topic',
+        1,
+        invalidEnvironmentError
+      )
+      expect(transactionSnackbar.error).toHaveBeenCalled()
+    })
+
+    it('does not show an error toast for user-rejected errors', async () => {
+      const request = makeMockRequest(
+        RpcMethod.ETH_SEND_TRANSACTION,
+        'eip155:43114'
+      )
+
+      await walletConnectProvider.onError({
+        request,
+        error: providerErrors.userRejectedRequest(),
+        listenerApi: mockListenerApi
+      })
+
+      expect(WalletConnectService.rejectRequest).toHaveBeenCalled()
+      expect(transactionSnackbar.error).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.ts
+++ b/packages/core-mobile/app/store/rpc/providers/walletConnect/walletConnect.ts
@@ -50,12 +50,32 @@ const chainAgnosticMethods = [
   RpcMethod.AVALANCHE_RENAME_ACCOUNT
 ]
 
+// Read-only methods that dApps fire automatically, not from a user action —
+// e.g. core.app polls wallet_getNetworkState every ~3s while connected. Their
+// failures must still be returned to the dApp (it recovers on its own), but
+// never surfaced as an error toast: after a testnet/mainnet switch there is an
+// inherent propagation window (session update + chainChanged over the relay)
+// during which these background requests keep arriving scoped to the previous
+// environment, and validateRequest rejects each one — toasting every rejection
+// showed the user 1-2 "Invalid environment" snackbars per toggle. User-initiated
+// methods (signing etc.) keep the toast so the user learns why their action
+// failed. CP-14617.
+const dappAutomatedReadMethods: RpcMethod[] = [
+  RpcMethod.WALLET_GET_NETWORK_STATE,
+  RpcMethod.WALLET_GET_ETHEREUM_CHAIN,
+  RpcMethod.AVALANCHE_GET_ADDRESSES_IN_RANGE,
+  RpcMethod.AVALANCHE_GET_BRIDGE_STATE
+]
+
 class WalletConnectProvider implements AgnosticRpcProvider {
   provider = RpcProvider.WALLET_CONNECT
 
   onError: AgnosticRpcProvider['onError'] = async ({ request, error }) => {
-    // only show error toast if it is not a user rejected error
-    const shouldShowErrorToast = !isUserRejectedError(error)
+    // only show error toast if it is not a user rejected error and the request
+    // was user-initiated (background dApp polls must not toast — CP-14617)
+    const shouldShowErrorToast =
+      !isUserRejectedError(error) &&
+      !dappAutomatedReadMethods.includes(request.method)
 
     if (isSessionProposal(request)) {
       shouldShowErrorToast &&


### PR DESCRIPTION
## Description

**Ticket: [CP-14617](https://ava-labs.atlassian.net/browse/CP-14617)**

- After toggling testnet/mainnet, users always saw the "Invalid environment. Please turn on/off developer mode and try again" snackbar 1–2 times without doing anything.
- Root cause: core.app connected over WalletConnect polls `wallet_getNetworkState` every ~3s (`useWalletNetworks` in core-web). When developer mode flips, there is an inherent propagation window (session update + `chainChanged` over the relay) during which those background polls still arrive scoped to the previous environment's chainId. `WalletConnectProvider.validateRequest` correctly rejects each one, but `onError` surfaced **every** rejection as an error toast — one per poll tick until core.app catches up.
- Fix: introduce a `dappAutomatedReadMethods` list (`wallet_getNetworkState`, `wallet_getEthereumChain`, `avalanche_getAddressesInRange`, `avalanche_getBridgeState`) whose failures are still rejected back to the dApp (it recovers on its own) but never toasted. User-initiated methods (signing etc.) keep the toast so the user learns why their action failed.
- No dependencies introduced; not breaking. Rejection semantics toward dApps are unchanged — only the wallet-side toast side-effect is gated.
- Possible follow-up (out of scope here): `wallet_getEthereumChain`'s handler ignores the request chainId, so it could arguably join `chainAgnosticMethods` and succeed during the transition window, letting dApps resync faster.

## Screenshots/Videos

N/A — the change removes transient snackbars for background dApp requests; no UI otherwise. Repro/verification steps below.

## Testing

**Dev Testing (if applicable)**

iOS: 9249
Android: 9250

- Happy path: connect core.app to Core Mobile via WalletConnect (Connect → Core Mobile → scan QR), then toggle testnet mode in Settings → Advanced. Previously 1–2 "Invalid environment" snackbars appeared within a few seconds of the toggle; now none appear, and core.app recovers on its own once `chainChanged` propagates.
- Error state kept: with core.app still on the stale environment (immediately after toggle), initiate a signing request (e.g. a transfer) — the "Invalid environment" toast still appears, since that failure is user-initiated feedback.
- Unit tests: `walletConnect.test.ts` covers the `onError` gate per method (suppressed for the four read methods, kept for `eth_sendTransaction`, user-rejected errors unchanged); `listeners/index.test.ts` adds an end-to-end `processRequest` test asserting a `wallet_getNetworkState` env mismatch rejects without toasting.

**QA Testing (if applicable)**

- Connect core.app to Core Mobile through WalletConnect, switch between testnet and mainnet several times (both directions), and confirm no "Invalid environment" snackbar appears on its own.
- Confirm signing from a dApp whose environment mismatches still shows the "Invalid environment. Please turn on/off developer mode and try again" snackbar.
- Expected: no unprompted environment error toasts after switching environments; dApp connection keeps working after the switch.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14617]: https://ava-labs.atlassian.net/browse/CP-14617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ