### PR TITLE
CP-14189: Staking polish, analytics and flag-driven convenience fees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,8 @@
       "Bash(npx tsc:*)",
       "Bash(node_modules/.bin/tsc --noEmit --project e2e-appium/tsconfig.json)",
       "Bash(node packages/core-mobile/node_modules/.bin/tsc --noEmit --project packages/core-mobile/e2e-appium/tsconfig.json)",
-      "Bash(echo \"EXIT: $?\")"
+      "Bash(echo \"EXIT: $?\")",
+      "mcp__ide__getDiagnostics"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,9 +13,7 @@
       "Bash(npx tsc:*)",
       "Bash(node_modules/.bin/tsc --noEmit --project e2e-appium/tsconfig.json)",
       "Bash(node packages/core-mobile/node_modules/.bin/tsc --noEmit --project packages/core-mobile/e2e-appium/tsconfig.json)",
-      "Bash(echo \"EXIT: $?\")",
-      "mcp__ide__getDiagnostics",
-      "mcp__7db7d402-74f0-49b8-921b-d14b5dc57cef__getJiraIssue"
+      "Bash(echo \"EXIT: $?\")"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -14,7 +14,8 @@
       "Bash(node_modules/.bin/tsc --noEmit --project e2e-appium/tsconfig.json)",
       "Bash(node packages/core-mobile/node_modules/.bin/tsc --noEmit --project packages/core-mobile/e2e-appium/tsconfig.json)",
       "Bash(echo \"EXIT: $?\")",
-      "mcp__ide__getDiagnostics"
+      "mcp__ide__getDiagnostics",
+      "mcp__7db7d402-74f0-49b8-921b-d14b5dc57cef__getJiraIssue"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ packages/*/coverage/
 
 /docs/local/
 /.codex/config.toml
+
+# Claude Code personal settings (team-shared settings live in .claude/settings.json)
+.claude/settings.local.json

--- a/packages/core-mobile/app/contexts/DeeplinkContext/DeeplinkContext.tsx
+++ b/packages/core-mobile/app/contexts/DeeplinkContext/DeeplinkContext.tsx
@@ -14,8 +14,12 @@ import Logger from 'utils/Logger'
 import {
   selectIsEarnBlocked,
   selectIsAllNotificationsBlocked,
-  selectIsInAppDefiBlocked
+  selectIsInAppDefiBlocked,
+  selectIsFusionAvalancheCctEnabled,
+  selectIsFusionEnabled
 } from 'store/posthog'
+import { selectIsDeveloperMode } from 'store/settings/advanced'
+import { ViewOnceKey, selectHasBeenViewedOnce } from 'store/viewOnce'
 import { FIDO_CALLBACK_URL } from 'services/passkey/consts'
 import { processNotificationData } from 'store/notifications'
 import { useCoreBrowser } from 'common/hooks/useCoreBrowser'
@@ -45,6 +49,19 @@ export const DeeplinkContextProvider = ({
   const isEarnBlocked = useSelector(selectIsEarnBlocked)
   const isInAppDefiBlocked = useSelector(selectIsInAppDefiBlocked)
   const isIdled = useSelector(selectIsIdled)
+  // Stake-complete deeplinks redirect to the CCT swap (P → C AVAX) only when
+  // the whole swap surface is usable: the Fusion gate covers the swap screen
+  // itself, the CCT gate covers the Avalanche cross-chain pair.
+  const isFusionEnabled = useSelector(selectIsFusionEnabled)
+  const isFusionAvalancheCctEnabled = useSelector(
+    selectIsFusionAvalancheCctEnabled
+  )
+  const shouldRedirectStakeCompleteToCct =
+    isFusionEnabled && isFusionAvalancheCctEnabled
+  const isDeveloperMode = useSelector(selectIsDeveloperMode)
+  const hasSeenSwapOnboarding = useSelector(
+    selectHasBeenViewedOnce(ViewOnceKey.SWAP_ONBOARDING)
+  )
   const [pendingDeepLink, setPendingDeepLink] = useState<DeepLink>()
   const { openUrl } = useCoreBrowser()
 
@@ -157,6 +174,9 @@ export const DeeplinkContextProvider = ({
         dispatch,
         isEarnBlocked,
         isInAppDefiBlocked,
+        shouldRedirectStakeCompleteToCct,
+        isDeveloperMode,
+        shouldShowSwapOnboarding: !hasSeenSwapOnboarding,
         openUrl
       })
       // once we used the url, we can expire it
@@ -168,6 +188,9 @@ export const DeeplinkContextProvider = ({
     dispatch,
     isEarnBlocked,
     isInAppDefiBlocked,
+    shouldRedirectStakeCompleteToCct,
+    isDeveloperMode,
+    hasSeenSwapOnboarding,
     openUrl,
     isIdled
   ])

--- a/packages/core-mobile/app/contexts/DeeplinkContext/utils/handleDeeplink.test.ts
+++ b/packages/core-mobile/app/contexts/DeeplinkContext/utils/handleDeeplink.test.ts
@@ -31,9 +31,75 @@
 //   .spyOn(navigationUtils, 'navigateToWatchlist')
 //   .mockImplementation(mockNavigateToWatchlist)
 
-describe('handleDeeplink', () => {
-  it('should handle deeplink', () => {
-    expect(true).toBe(true)
+import * as navigateFromDeeplink from 'utils/navigateFromDeeplink'
+import { DeepLink, DeepLinkOrigin } from '../types'
+import { handleDeeplink } from './handleDeeplink'
+
+const mockNavigate = jest
+  .spyOn(navigateFromDeeplink, 'navigateFromDeeplinkUrl')
+  .mockImplementation(jest.fn())
+
+const stakeCompleteDeeplink = {
+  url: 'core://stakecomplete',
+  origin: DeepLinkOrigin.ORIGIN_NOTIFICATION
+} as DeepLink
+
+const baseArgs = {
+  deeplink: stakeCompleteDeeplink,
+  dispatch: jest.fn(),
+  isEarnBlocked: false,
+  isInAppDefiBlocked: false,
+  shouldRedirectStakeCompleteToCct: true,
+  isDeveloperMode: false,
+  shouldShowSwapOnboarding: false,
+  openUrl: jest.fn()
+}
+
+describe('handleDeeplink — stakecomplete', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('redirects to the CCT swap prefilled with the P → C AVAX pair', () => {
+    handleDeeplink(baseArgs)
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: '/swap/swap',
+      params: {
+        initialTokenIdFrom: 'NATIVE-avax',
+        initialFromCaip2Id: 'avax:Rr9hnPVPxuUvrdCul-vjEsU1zmqKqRDo',
+        initialTokenIdTo: 'NATIVE-avax',
+        initialToCaip2Id: 'eip155:43114'
+      }
+    })
+  })
+
+  it('routes through the swap onboarding for first-time swappers', () => {
+    handleDeeplink({ ...baseArgs, shouldShowSwapOnboarding: true })
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ pathname: '/swap/onboarding' })
+    )
+  })
+
+  it('uses the Fuji P-Chain and C-Chain ids in developer mode', () => {
+    handleDeeplink({ ...baseArgs, isDeveloperMode: true })
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          initialFromCaip2Id: 'avax:Sj7NVE3jXTbJvwFAiu7OEUo_8g8ctXMG',
+          initialToCaip2Id: 'eip155:43113'
+        })
+      })
+    )
+  })
+
+  it('falls back to the legacy claim screen while CCT is unavailable', () => {
+    handleDeeplink({ ...baseArgs, shouldRedirectStakeCompleteToCct: false })
+    expect(mockNavigate).toHaveBeenCalledWith('/claimStakeReward')
+  })
+
+  it('does nothing when earn is blocked', () => {
+    handleDeeplink({ ...baseArgs, isEarnBlocked: true })
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 })
 // describe('handleDeeplink', () => {

--- a/packages/core-mobile/app/contexts/DeeplinkContext/utils/handleDeeplink.ts
+++ b/packages/core-mobile/app/contexts/DeeplinkContext/utils/handleDeeplink.ts
@@ -10,6 +10,10 @@ import { navigateFromDeeplinkUrl } from 'utils/navigateFromDeeplink'
 import { dismissMeldStack } from 'features/meld/utils'
 import { offrampSend } from 'store/meld/slice'
 import { closeInAppBrowser } from 'utils/openInAppBrowser'
+import { Href } from 'expo-router'
+import { caip2ChainIds } from 'consts/caip2ChainIds'
+import { tokenIds } from 'consts/tokenIds'
+import { getAvalancheChainAliasCaip2 } from 'utils/caip2ChainIds'
 import { ACTIONS, DeepLink, PROTOCOLS } from '../types'
 import { DEEPLINK_WHITELIST } from '../consts'
 
@@ -17,17 +21,57 @@ const lowercasedDeeplinkWhitelist = DEEPLINK_WHITELIST.map(url =>
   url.toLowerCase()
 )
 
+/**
+ * Where the stake-complete deeplink (a tapped stake-complete notification)
+ * lands. Claim rewards are P-Chain AVAX; with Avalanche CCT available the
+ * canonical way to move them back to C-Chain is a cross-chain swap, so the
+ * deeplink opens the swap screen prefilled with the P → C AVAX pair —
+ * mirroring the portfolio P-Chain AVAX detail's Swap action. While CCT is
+ * unavailable it falls back to the legacy claim screen. First-time swappers
+ * route through the swap onboarding, which forwards the prefill params to
+ * the swap screen.
+ */
+const getStakeCompleteHref = ({
+  shouldRedirectToCct,
+  isDeveloperMode,
+  shouldShowSwapOnboarding
+}: {
+  shouldRedirectToCct: boolean
+  isDeveloperMode: boolean
+  shouldShowSwapOnboarding: boolean
+}): Href => {
+  if (!shouldRedirectToCct) return '/claimStakeReward' as Href
+  return {
+    pathname: shouldShowSwapOnboarding ? '/swap/onboarding' : '/swap/swap',
+    params: {
+      initialTokenIdFrom: tokenIds.AVAX,
+      initialFromCaip2Id: getAvalancheChainAliasCaip2('P', isDeveloperMode),
+      initialTokenIdTo: tokenIds.AVAX,
+      initialToCaip2Id: isDeveloperMode
+        ? caip2ChainIds.FUJI
+        : caip2ChainIds.C_CHAIN
+    }
+  } as Href
+}
+
 export const handleDeeplink = ({
   deeplink,
   dispatch,
   isEarnBlocked,
   isInAppDefiBlocked,
+  shouldRedirectStakeCompleteToCct,
+  isDeveloperMode,
+  shouldShowSwapOnboarding,
   openUrl
 }: {
   deeplink: DeepLink
   dispatch: Dispatch
   isEarnBlocked: boolean
   isInAppDefiBlocked: boolean
+  /** Fusion + Avalanche CCT flags both on — see `getStakeCompleteHref`. */
+  shouldRedirectStakeCompleteToCct: boolean
+  isDeveloperMode: boolean
+  shouldShowSwapOnboarding: boolean
   openUrl: (history: Pick<History, 'url' | 'title'>) => void
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }): void => {
@@ -68,7 +112,13 @@ export const handleDeeplink = ({
       } else if (action === ACTIONS.StakeComplete) {
         if (isEarnBlocked) return
         deeplink.callback?.()
-        navigateFromDeeplinkUrl('/claimStakeReward')
+        navigateFromDeeplinkUrl(
+          getStakeCompleteHref({
+            shouldRedirectToCct: shouldRedirectStakeCompleteToCct,
+            isDeveloperMode,
+            shouldShowSwapOnboarding
+          })
+        )
       } else if (action === ACTIONS.WatchList) {
         const tokenId = pathname.split('/')[1]
         if (tokenId) {

--- a/packages/core-mobile/app/new/common/hooks/useFadingHeaderNavigation.tsx
+++ b/packages/core-mobile/app/new/common/hooks/useFadingHeaderNavigation.tsx
@@ -85,31 +85,40 @@ export const useFadingHeaderNavigation = ({
     )
   }, [])
 
-  const handleScroll = (
-    event: NativeSyntheticEvent<NativeScrollEvent> | NativeScrollEvent | number
-  ): void => {
-    let contentOffsetY: number | undefined
+  // Stable identity (it only touches refs and shared values): consumers put
+  // this in effect dep lists (e.g. StakeCardList's remount resync), where a
+  // new function per render would re-fire their effects on every re-render.
+  const handleScroll = useCallback(
+    (
+      event:
+        | NativeSyntheticEvent<NativeScrollEvent>
+        | NativeScrollEvent
+        | number
+    ): void => {
+      let contentOffsetY: number | undefined
 
-    if (typeof event === 'number') {
-      // If event is just a numeric value, use it directly
-      contentOffsetY = event
-    } else if ('nativeEvent' in event) {
-      // If event is a NativeSyntheticEvent<NativeScrollEvent>
-      contentOffsetY = event.nativeEvent.contentOffset.y
-    } else {
-      // If event is a NativeScrollEvent
-      contentOffsetY = event.contentOffset.y
-    }
+      if (typeof event === 'number') {
+        // If event is just a numeric value, use it directly
+        contentOffsetY = event
+      } else if ('nativeEvent' in event) {
+        // If event is a NativeSyntheticEvent<NativeScrollEvent>
+        contentOffsetY = event.nativeEvent.contentOffset.y
+      } else {
+        // If event is a NativeScrollEvent
+        contentOffsetY = event.contentOffset.y
+      }
 
-    const latestTargetLayout = targetLayoutRef.current
+      const latestTargetLayout = targetLayoutRef.current
 
-    if (latestTargetLayout && contentOffsetY !== undefined) {
-      const h = latestTargetLayout.height
-      // Avoid divide-by-zero: 0 height makes progress NaN/Infinity and forces full-opacity separator (Android).
-      targetHiddenProgress.value = h > 0 ? clamp(contentOffsetY / h, 0, 1) : 0
-      scrollY.value = contentOffsetY
-    }
-  }
+      if (latestTargetLayout && contentOffsetY !== undefined) {
+        const h = latestTargetLayout.height
+        // Avoid divide-by-zero: 0 height makes progress NaN/Infinity and forces full-opacity separator (Android).
+        targetHiddenProgress.value = h > 0 ? clamp(contentOffsetY / h, 0, 1) : 0
+        scrollY.value = contentOffsetY
+      }
+    },
+    [targetHiddenProgress, scrollY]
+  )
 
   const animatedHeaderStyle = useAnimatedStyle(() => {
     const headerHeight =

--- a/packages/core-mobile/app/new/features/notifications/screens/NotificationsScreen.tsx
+++ b/packages/core-mobile/app/new/features/notifications/screens/NotificationsScreen.tsx
@@ -12,8 +12,11 @@ import { DeepLinkOrigin } from 'contexts/DeeplinkContext/types'
 import {
   selectIsEarnBlocked,
   selectIsInAppDefiBlocked,
-  selectIsFusionEnabled
+  selectIsFusionEnabled,
+  selectIsFusionAvalancheCctEnabled
 } from 'store/posthog'
+import { selectIsDeveloperMode } from 'store/settings/advanced'
+import { ViewOnceKey, selectHasBeenViewedOnce } from 'store/viewOnce'
 import { selectAccounts, selectActiveAccount } from 'store/account'
 import { selectWallets } from 'store/wallet/slice'
 import { ScrollScreen } from 'common/components/ScrollScreen'
@@ -156,6 +159,13 @@ export const NotificationsScreen = (): JSX.Element => {
   const isEarnBlocked = useSelector(selectIsEarnBlocked)
   const isInAppDefiBlocked = useSelector(selectIsInAppDefiBlocked)
   const isFusionEnabled = useSelector(selectIsFusionEnabled)
+  const isFusionAvalancheCctEnabled = useSelector(
+    selectIsFusionAvalancheCctEnabled
+  )
+  const isDeveloperMode = useSelector(selectIsDeveloperMode)
+  const hasSeenSwapOnboarding = useSelector(
+    selectHasBeenViewedOnce(ViewOnceKey.SWAP_ONBOARDING)
+  )
   const accounts = useSelector(selectAccounts)
   const wallets = useSelector(selectWallets)
   const activeAccount = useSelector(selectActiveAccount)
@@ -303,11 +313,23 @@ export const NotificationsScreen = (): JSX.Element => {
           dispatch: action => action,
           isEarnBlocked,
           isInAppDefiBlocked,
+          shouldRedirectStakeCompleteToCct:
+            isFusionEnabled && isFusionAvalancheCctEnabled,
+          isDeveloperMode,
+          shouldShowSwapOnboarding: !hasSeenSwapOnboarding,
           openUrl
         })
       }
     },
-    [openUrl, isEarnBlocked, isInAppDefiBlocked]
+    [
+      openUrl,
+      isEarnBlocked,
+      isInAppDefiBlocked,
+      isFusionEnabled,
+      isFusionAvalancheCctEnabled,
+      isDeveloperMode,
+      hasSeenSwapOnboarding
+    ]
   )
 
   const renderFooter = useCallback(() => {

--- a/packages/core-mobile/app/new/features/stake/components/DurationOptions.tsx
+++ b/packages/core-mobile/app/new/features/stake/components/DurationOptions.tsx
@@ -6,6 +6,7 @@ import {
   View
 } from '@avalabs/k2-alpine'
 import { differenceInDays } from 'date-fns'
+import { formatDurationInDays } from 'features/stake/utils'
 import React, { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import {
@@ -89,10 +90,10 @@ export const DurationOptions = ({
                       color: selectedTheme.colors.$textPrimary
                     }}>
                     {'numberOfDays' in item
-                      ? `${item.numberOfDays} days`
+                      ? formatDurationInDays(item.numberOfDays)
                       : item.stakeDurationFormat ===
                           StakeDurationFormat.Custom && customDurationInDays
-                      ? `${customDurationInDays} days`
+                      ? formatDurationInDays(customDurationInDays)
                       : 'Set'}
                   </Text>
                 </View>

--- a/packages/core-mobile/app/new/features/stake/utils/index.ts
+++ b/packages/core-mobile/app/new/features/stake/utils/index.ts
@@ -143,3 +143,10 @@ export const convertToDurationInSeconds = (date: UTCDate): Seconds => {
 
   return convertToSeconds(BigInt(stakeDurationMs) as MilliSeconds)
 }
+
+/**
+ * Formats a whole-day count with the correctly pluralized unit
+ * ("1 day", "14 days") — several staking surfaces used to render "1 days".
+ */
+export const formatDurationInDays = (numberOfDays: number): string =>
+  `${numberOfDays} ${numberOfDays === 1 ? 'day' : 'days'}`

--- a/packages/core-mobile/app/new/features/stake/v2/components/StakeCardList.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/components/StakeCardList.tsx
@@ -181,12 +181,20 @@ export const StakeCardList = ({
   // the stake home) would otherwise stay stuck at the pre-remount offset —
   // small title pinned in the navigation bar, large title never fading back
   // in. Re-sync it to the top manually whenever the remount key changes.
+  // Guarded by the previous key rather than the effect's dep list alone:
+  // `onScroll`'s identity is not guaranteed stable across parent re-renders,
+  // and resyncing outside an actual remount would wrongly report "top" while
+  // the user is scrolled down.
+  const listRemountKey = `${filter.selected}-${sort.selected}`
+  const prevListRemountKeyRef = useRef(listRemountKey)
   useEffect(() => {
+    if (prevListRemountKeyRef.current === listRemountKey) return
+    prevListRemountKeyRef.current = listRemountKey
     if (scrollOffsetRef.current.y !== 0) {
       scrollOffsetRef.current = { x: 0, y: 0 }
       onScroll?.(0)
     }
-  }, [filter.selected, sort.selected, onScroll])
+  }, [listRemountKey, onScroll])
 
   // Pass the header as a JSX element rather than a component reference.
   // FlashList instantiates a function passed to `ListHeaderComponent` as
@@ -214,7 +222,7 @@ export const StakeCardList = ({
       // gives each ordering a fresh layout pass (matches the v1 StakeCardList
       // and StakeSearchScreen approach). It stays stable per selection so it
       // doesn't thrash on background stake refreshes.
-      key={`stake-card-list-${filter.selected}-${sort.selected}`}
+      key={`stake-card-list-${listRemountKey}`}
       onScroll={handleScroll}
       overrideProps={overrideProps}
       data={data}

--- a/packages/core-mobile/app/new/features/stake/v2/components/StakeCardList.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/components/StakeCardList.tsx
@@ -7,13 +7,18 @@ import {
   useTheme
 } from '@avalabs/k2-alpine'
 import { useIsFocused } from 'expo-router'
-import { FlashList, ListRenderItemInfo } from '@shopify/flash-list'
+import {
+  FlashList,
+  FlashListRef,
+  ListRenderItemInfo
+} from '@shopify/flash-list'
 import { LoadingState } from 'common/components/LoadingState'
 import { useRouter } from 'expo-router'
 import { useStakes } from 'hooks/earn/useStakes'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   AppState,
+  LayoutChangeEvent,
   NativeScrollEvent,
   NativeSyntheticEvent,
   Platform,
@@ -177,24 +182,52 @@ export const StakeCardList = ({
 
   // Changing the filter/sort selection remounts the FlashList (see the `key`
   // below), which resets the native scroll offset to 0 WITHOUT emitting a
-  // scroll event. Scroll-driven header state (the fading navigation title on
-  // the stake home) would otherwise stay stuck at the pre-remount offset —
-  // small title pinned in the navigation bar, large title never fading back
-  // in. Re-sync it to the top manually whenever the remount key changes.
-  // Guarded by the previous key rather than the effect's dep list alone:
-  // `onScroll`'s identity is not guaranteed stable across parent re-renders,
-  // and resyncing outside an actual remount would wrongly report "top" while
-  // the user is scrolled down.
+  // scroll event. Two problems fall out of that: the scroll position is lost
+  // even when the new selection has plenty of content, and scroll-driven
+  // header state (the fading navigation title on the stake home) stays stuck
+  // at the pre-remount offset. So on every remount we restore the previous
+  // offset — clamped to the fresh list's scrollable range, so a selection
+  // with less content lands as far down as it can (the top, when it doesn't
+  // scroll at all) — and re-sync the header to wherever we actually landed.
+  //
+  // The remount is detected during render (ref compare, not an effect dep
+  // list): `onScroll`'s identity is not guaranteed stable across parent
+  // re-renders, and restoring outside an actual remount would fight the
+  // user's live scrolling.
+  const listRef = useRef<FlashListRef<StakeCardType>>(null)
+  const listLayoutHeightRef = useRef(0)
+  const pendingRestoreOffsetRef = useRef<number | null>(null)
   const listRemountKey = `${filter.selected}-${sort.selected}`
   const prevListRemountKeyRef = useRef(listRemountKey)
-  useEffect(() => {
-    if (prevListRemountKeyRef.current === listRemountKey) return
+  if (prevListRemountKeyRef.current !== listRemountKey) {
     prevListRemountKeyRef.current = listRemountKey
-    if (scrollOffsetRef.current.y !== 0) {
-      scrollOffsetRef.current = { x: 0, y: 0 }
-      onScroll?.(0)
-    }
-  }, [listRemountKey, onScroll])
+    pendingRestoreOffsetRef.current = scrollOffsetRef.current.y
+  }
+
+  const handleLayout = useCallback((event: LayoutChangeEvent): void => {
+    listLayoutHeightRef.current = event.nativeEvent.layout.height
+  }, [])
+
+  // Fires once the freshly mounted list has measured its content — the
+  // earliest point where the scrollable range (and thus the clamp) is known.
+  // Restores are one-shot; ordinary content-size changes (background stake
+  // refreshes) leave the user's position alone.
+  const handleContentSizeChange = useCallback(
+    (_width: number, height: number): void => {
+      const target = pendingRestoreOffsetRef.current
+      if (target === null) return
+      pendingRestoreOffsetRef.current = null
+      if (target === 0) return
+      const maxOffset = Math.max(0, height - listLayoutHeightRef.current)
+      const clamped = Math.min(target, maxOffset)
+      listRef.current?.scrollToOffset({ offset: clamped, animated: false })
+      // Sync the shared header state ourselves — the imperative scroll isn't
+      // guaranteed to emit a scroll event (notably when clamped to 0).
+      scrollOffsetRef.current = { x: 0, y: clamped }
+      onScroll?.(clamped)
+    },
+    [onScroll]
+  )
 
   // Pass the header as a JSX element rather than a component reference.
   // FlashList instantiates a function passed to `ListHeaderComponent` as
@@ -223,6 +256,9 @@ export const StakeCardList = ({
       // and StakeSearchScreen approach). It stays stable per selection so it
       // doesn't thrash on background stake refreshes.
       key={`stake-card-list-${listRemountKey}`}
+      ref={listRef}
+      onLayout={handleLayout}
+      onContentSizeChange={handleContentSizeChange}
       onScroll={handleScroll}
       overrideProps={overrideProps}
       data={data}

--- a/packages/core-mobile/app/new/features/stake/v2/components/StakeCardList.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/components/StakeCardList.tsx
@@ -175,6 +175,19 @@ export const StakeCardList = ({
     setSelectedSort(sort.selected as SortOrder)
   }, [sort.selected])
 
+  // Changing the filter/sort selection remounts the FlashList (see the `key`
+  // below), which resets the native scroll offset to 0 WITHOUT emitting a
+  // scroll event. Scroll-driven header state (the fading navigation title on
+  // the stake home) would otherwise stay stuck at the pre-remount offset —
+  // small title pinned in the navigation bar, large title never fading back
+  // in. Re-sync it to the top manually whenever the remount key changes.
+  useEffect(() => {
+    if (scrollOffsetRef.current.y !== 0) {
+      scrollOffsetRef.current = { x: 0, y: 0 }
+      onScroll?.(0)
+    }
+  }, [filter.selected, sort.selected, onScroll])
+
   // Pass the header as a JSX element rather than a component reference.
   // FlashList instantiates a function passed to `ListHeaderComponent` as
   // `<HeaderComponent />`, so a new function identity (which happens every

--- a/packages/core-mobile/app/new/features/stake/v2/components/StakeCardList.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/components/StakeCardList.tsx
@@ -88,7 +88,8 @@ export const StakeCardList = ({
 
   const handlePressStake = useCallback(
     (txHash: string) => {
-      navigate({ pathname: '/stakeDetail', params: { txHash } })
+      // `source` feeds StakeDetailViewed's entry-point attribution.
+      navigate({ pathname: '/stakeDetail', params: { txHash, source: 'home' } })
     },
     [navigate]
   )

--- a/packages/core-mobile/app/new/features/stake/v2/constants.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/constants.ts
@@ -1,11 +1,10 @@
-/**
- * 10% of the net estimated delegation rewards (after the validator's own
- * delegation fee) charged as a convenience fee for Fast Stake transactions.
- * Mirrors the rate and basis used by core-web (see
- * `apps/core/app/components/Stake/constants.ts`) so both clients quote the
- * user the same effective APY.
- */
-export const FAST_STAKE_FEE_RATE = 0.1
+// The convenience-fee rates are no longer compiled in here: the
+// `fast-stake-fee-enabled` / `delegation-fee-enabled` gates are multivariate
+// and their variant string carries the rate in basis points. See
+// `selectFastStakeFeeRate` / `selectDelegationFeeRate` in `store/posthog`
+// (both default to 10%, the rate core-web still hardcodes). The fee basis is
+// unchanged: the rate applies to the NET estimated rewards, after the
+// validator's own delegation fee.
 
 /**
  * Core-owned, P-Chain escrow address the convenience fee is paid to on
@@ -33,15 +32,6 @@ export const getFastStakeFeeEscrowAddress = (isTestnet: boolean): string =>
   isTestnet
     ? FAST_STAKE_FEE_ESCROW_ADDRESS_FUJI
     : FAST_STAKE_FEE_ESCROW_ADDRESS_MAINNET
-
-/**
- * 10% of the net estimated delegation rewards (after the validator's own
- * delegation fee) charged as a service fee for the advanced delegate flow.
- * Mirrors core-web's `DELEGATION_FEE_RATE`; same rate and basis as Fast Stake
- * but gated behind a separate flag/escrow so the two programs can be tuned
- * independently.
- */
-export const DELEGATION_FEE_RATE = 0.1
 
 /**
  * Core-owned, P-Chain escrow address the advanced delegate service fee is paid

--- a/packages/core-mobile/app/new/features/stake/v2/constants.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/constants.ts
@@ -2,8 +2,8 @@
 // `fast-stake-fee-enabled` / `delegation-fee-enabled` gates are multivariate
 // and their variant string carries the rate in basis points. See
 // `selectFastStakeFeeRate` / `selectDelegationFeeRate` in `store/posthog`
-// (both default to 10%, the rate core-web still hardcodes). The fee basis is
-// unchanged: the rate applies to the NET estimated rewards, after the
+// (no variant means no fee; core-web still hardcodes its 10%). The fee basis
+// is unchanged: the rate applies to the NET estimated rewards, after the
 // validator's own delegation fee.
 
 /**

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useAdvancedReviewSource.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useAdvancedReviewSource.ts
@@ -165,8 +165,8 @@ export const useAdvancedReviewSource = (): StakeReviewSource => {
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const isDelegationFeeBlocked = useSelector(selectIsDelegationFeeBlocked)
   const isDelegationFeeEnabled = !isDelegationFeeBlocked
-  // Flag-driven (multivariate variant in bps, 10% fallback) — see
-  // `selectDelegationFeeRate`.
+  // Flag-driven (multivariate variant in bps; no variant → 0 → fee off)
+  // — see `selectDelegationFeeRate`.
   const delegationFeeRate = useSelector(selectDelegationFeeRate)
 
   // Restake only: the node's remaining delegation capacity must still cover

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useAdvancedReviewSource.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useAdvancedReviewSource.ts
@@ -6,12 +6,12 @@ import { useNow } from 'hooks/time/useNow'
 import { useEffect, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { getMinimumStakeDurationMs } from 'services/earn/utils'
-import { selectIsDelegationFeeBlocked } from 'store/posthog'
-import { selectIsDeveloperMode } from 'store/settings/advanced'
 import {
-  DELEGATION_FEE_RATE,
-  getDelegationFeeEscrowAddress
-} from '../constants'
+  selectDelegationFeeRate,
+  selectIsDelegationFeeBlocked
+} from 'store/posthog'
+import { selectIsDeveloperMode } from 'store/settings/advanced'
+import { getDelegationFeeEscrowAddress } from '../constants'
 import { StakeReviewSource } from '../types'
 import { useDelegateNodeSelection } from '../store'
 import { getDelegateNodeLimits } from './useSelectedDelegateNodeLimits'
@@ -165,6 +165,9 @@ export const useAdvancedReviewSource = (): StakeReviewSource => {
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const isDelegationFeeBlocked = useSelector(selectIsDelegationFeeBlocked)
   const isDelegationFeeEnabled = !isDelegationFeeBlocked
+  // Flag-driven (multivariate variant in bps, 10% fallback) — see
+  // `selectDelegationFeeRate`.
+  const delegationFeeRate = useSelector(selectDelegationFeeRate)
 
   // Restake only: the node's remaining delegation capacity must still cover
   // the original amount (the seeded shared amount). The normal flow enforces
@@ -228,7 +231,7 @@ export const useAdvancedReviewSource = (): StakeReviewSource => {
       error,
       feePolicy: isDelegationFeeEnabled
         ? {
-            rate: DELEGATION_FEE_RATE,
+            rate: delegationFeeRate,
             recipientAddresses: [getDelegationFeeEscrowAddress(isDeveloperMode)]
           }
         : null
@@ -241,6 +244,7 @@ export const useAdvancedReviewSource = (): StakeReviewSource => {
     isFetchingValidators,
     validatorsError,
     isDelegationFeeEnabled,
+    delegationFeeRate,
     isDeveloperMode
   ])
 }

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useFastStakeReviewSource.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useFastStakeReviewSource.ts
@@ -51,8 +51,8 @@ export const useFastStakeReviewSource = (): StakeReviewSource => {
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const isFastStakeFeeBlocked = useSelector(selectIsFastStakeFeeBlocked)
   const isFastStakeFeeEnabled = !isFastStakeFeeBlocked
-  // Flag-driven (multivariate variant in bps, 10% fallback) — see
-  // `selectFastStakeFeeRate`.
+  // Flag-driven (multivariate variant in bps; no variant → 0 → fee off)
+  // — see `selectFastStakeFeeRate`.
   const fastStakeFeeRate = useSelector(selectFastStakeFeeRate)
 
   // `useFastStakeNode` already treats `undefined` `stakingEndTime` as the

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useFastStakeReviewSource.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useFastStakeReviewSource.ts
@@ -2,9 +2,12 @@ import { useLocalSearchParams } from 'expo-router'
 import { useStakeAmount } from 'hooks/earn/useStakeAmount'
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
-import { selectIsFastStakeFeeBlocked } from 'store/posthog'
+import {
+  selectFastStakeFeeRate,
+  selectIsFastStakeFeeBlocked
+} from 'store/posthog'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
-import { FAST_STAKE_FEE_RATE, getFastStakeFeeEscrowAddress } from '../constants'
+import { getFastStakeFeeEscrowAddress } from '../constants'
 import { StakeReviewSource } from '../types'
 import { parseStakeEndTimeParam } from '../utils/parseStakeEndTimeParam'
 import { useFastStakeNode } from './useFastStakeNode'
@@ -48,6 +51,9 @@ export const useFastStakeReviewSource = (): StakeReviewSource => {
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const isFastStakeFeeBlocked = useSelector(selectIsFastStakeFeeBlocked)
   const isFastStakeFeeEnabled = !isFastStakeFeeBlocked
+  // Flag-driven (multivariate variant in bps, 10% fallback) — see
+  // `selectFastStakeFeeRate`.
+  const fastStakeFeeRate = useSelector(selectFastStakeFeeRate)
 
   // `useFastStakeNode` already treats `undefined` `stakingEndTime` as the
   // "skip query" signal, so this guards against doing a useless Glacier
@@ -73,7 +79,7 @@ export const useFastStakeReviewSource = (): StakeReviewSource => {
       error,
       feePolicy: isFastStakeFeeEnabled
         ? {
-            rate: FAST_STAKE_FEE_RATE,
+            rate: fastStakeFeeRate,
             recipientAddresses: [getFastStakeFeeEscrowAddress(isDeveloperMode)]
           }
         : null
@@ -84,6 +90,7 @@ export const useFastStakeReviewSource = (): StakeReviewSource => {
     isFetching,
     error,
     isFastStakeFeeEnabled,
+    fastStakeFeeRate,
     isDeveloperMode
   ])
 }

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.test.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.test.ts
@@ -46,6 +46,12 @@ jest.mock('utils/mmkv', () => ({
   zustandPersistStorage: {}
 }))
 
+const mockCapture = jest.fn()
+jest.mock('services/analytics/AnalyticsService', () => ({
+  __esModule: true,
+  default: { capture: (...args: unknown[]) => mockCapture(...args) }
+}))
+
 // The real module drags in EarnService → WalletService → ModuleManager (native
 // deps); the hook only reads two static staking-config fields. Mainnet values.
 jest.mock('services/earn/utils', () => ({
@@ -84,6 +90,7 @@ describe('useRestake', () => {
   beforeEach(() => {
     jest.useFakeTimers().setSystemTime(FIXED_NOW)
     mockNavigate.mockReset()
+    mockCapture.mockReset()
     mockIsFastStakeTx.mockReset().mockReturnValue(false)
     mockIsDelegationTx.mockReset().mockReturnValue(false)
     mockIsDeveloperMode = false
@@ -101,22 +108,24 @@ describe('useRestake', () => {
 
   it('returns undefined for stakes that are not completed', () => {
     mockIsFastStakeTx.mockReturnValue(true)
-    expect(getOnRestake()(makeTx(), false)).toBeUndefined()
+    expect(getOnRestake()(makeTx(), false, 'card')).toBeUndefined()
   })
 
   it('returns undefined when the tx cannot seed restake params', () => {
     mockIsFastStakeTx.mockReturnValue(true)
-    expect(getOnRestake()(makeTx({ nodeId: undefined }), true)).toBeUndefined()
+    expect(
+      getOnRestake()(makeTx({ nodeId: undefined }), true, 'card')
+    ).toBeUndefined()
   })
 
   it('returns undefined when the tx is neither fast stake nor delegation', () => {
-    expect(getOnRestake()(makeTx(), true)).toBeUndefined()
+    expect(getOnRestake()(makeTx(), true, 'card')).toBeUndefined()
   })
 
   it('fast stake: seeds amount/prefill/entry flag and navigates to the fast confirm', () => {
     mockIsFastStakeTx.mockReturnValue(true)
 
-    const handler = getOnRestake()(makeTx(), true)
+    const handler = getOnRestake()(makeTx(), true, 'card')
     expect(handler).toBeDefined()
     handler?.()
 
@@ -129,6 +138,10 @@ describe('useRestake', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       `/addStakeV2/fastStake/confirm?stakeEndTime=${expectedStakeEndTime}&preferredNodeId=NodeID-A`
     )
+    expect(mockCapture).toHaveBeenCalledWith('StakeRestakeStarted', {
+      isAdvanced: false,
+      source: 'card'
+    })
   })
 
   it('delegation: seeds stores, resets the node selection and navigates to the delegate confirm', () => {
@@ -136,7 +149,7 @@ describe('useRestake', () => {
     // Simulate a stale selection from a previous delegate flow.
     setDelegateNodeSelection([{ nodeID: 'NodeID-STALE' }] as never[], 0)
 
-    const handler = getOnRestake()(makeTx(), true)
+    const handler = getOnRestake()(makeTx(), true, 'card')
     expect(handler).toBeDefined()
     handler?.()
 
@@ -155,6 +168,17 @@ describe('useRestake', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       `/addStakeV2/delegate/confirm?stakeEndTime=${expectedStakeEndTime}&restakeNodeId=NodeID-A`
     )
+    expect(mockCapture).toHaveBeenCalledWith('StakeRestakeStarted', {
+      isAdvanced: true,
+      source: 'card'
+    })
+  })
+
+  it('does not capture the restake start until the handler actually runs', () => {
+    mockIsFastStakeTx.mockReturnValue(true)
+    getOnRestake()(makeTx(), true, 'detail')
+    // Building the handler (rendering a card / the detail CTA) is not a tap.
+    expect(mockCapture).not.toHaveBeenCalled()
   })
 
   it('sums multiple staked assets into the seeded amount', () => {
@@ -166,7 +190,8 @@ describe('useRestake', () => {
           { amount: '5000000000' }
         ] as PChainTransaction['amountStaked']
       }),
-      true
+      true,
+      'card'
     )
     handler?.()
     expect(useStakeAmount.getState().toSubUnit()).toBe(30_000_000_000n)

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.ts
@@ -5,6 +5,7 @@ import { Href, useRouter } from 'expo-router'
 import { useStakeAmount } from 'hooks/earn/useStakeAmount'
 import { useCallback } from 'react'
 import { useSelector } from 'react-redux'
+import AnalyticsService from 'services/analytics/AnalyticsService'
 import { getStakingConfig } from 'services/earn/utils'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import {
@@ -51,7 +52,9 @@ const SECONDS_PER_DAY = 24 * 60 * 60
 export const useRestake = (): {
   getOnRestake: (
     stake: PChainTransaction,
-    isCompleted: boolean
+    isCompleted: boolean,
+    /** Which Restake entry point the handler is wired to (analytics). */
+    source: 'card' | 'detail'
   ) => (() => void) | undefined
 } => {
   const { navigate } = useRouter()
@@ -60,7 +63,8 @@ export const useRestake = (): {
   const getOnRestake = useCallback(
     (
       stake: PChainTransaction,
-      isCompleted: boolean
+      isCompleted: boolean,
+      source: 'card' | 'detail'
     ): (() => void) | undefined => {
       if (!isCompleted) return undefined
 
@@ -71,6 +75,13 @@ export const useRestake = (): {
       if (!isFastStake && !isDelegationTx(stake)) return undefined
 
       return () => {
+        // Restakes get their own funnel start (deliberately NOT
+        // `StakeFlowStarted`); the downstream lifecycle reuses the
+        // delegation events with `isRestake` set by the confirm screen.
+        AnalyticsService.capture('StakeRestakeStarted', {
+          isAdvanced: !isFastStake,
+          source
+        })
         beginRestakeEntry()
         useStakeAmount.setState(new TokenUnit(params.amountNAvax, 9, 'AVAX'))
         // Set for BOTH branches: the delegate node-gone fallback consumes it

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useStakeCardRenderer.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useStakeCardRenderer.tsx
@@ -117,7 +117,7 @@ export const useStakeCardRenderer = ({
           // Undefined for active stakes and for txs that can't seed a
           // restake, hiding the card's Restake button (web parity: only
           // completed stakes offer Restake).
-          onRestake={getOnRestake(stake, stakeIsCompleted)}
+          onRestake={getOnRestake(stake, stakeIsCompleted, 'card')}
         />
       )
     },

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useStakeFundingPreflight.test.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useStakeFundingPreflight.test.ts
@@ -137,4 +137,49 @@ describe('useStakeFundingPreflight', () => {
       expect(result.current.hasInsufficientFunds).toBe(false)
     })
   })
+
+  describe('CTA flicker (CP-14717)', () => {
+    it('reports checking synchronously on the first enabled render', () => {
+      // Never resolves — this asserts the value BEFORE any effect settles. The
+      // old implementation set `isCheckingFunding` from the effect, which left
+      // the first painted frame reading `false` and let the slide button flash
+      // enabled while the check had not even started.
+      mockComputeSteps.mockReturnValue(new Promise(() => undefined))
+      const { result } = renderPreflight()
+      expect(result.current.isCheckingFunding).toBe(true)
+    })
+
+    it('re-enters checking in the same render the inputs change', async () => {
+      const { result, rerender } = renderPreflight()
+      await flush()
+      expect(result.current.isCheckingFunding).toBe(false)
+
+      // Amount changes (e.g. fee output resolves) — pending must be true in
+      // the very render that carries the new inputs, not one effect-tick later.
+      rerender({ ...defaultProps, stakeAmountNanoAvax: 2_000_000_000n })
+      expect(result.current.isCheckingFunding).toBe(true)
+
+      await flush()
+      expect(result.current.isCheckingFunding).toBe(false)
+      expect(mockComputeSteps).toHaveBeenLastCalledWith(2_000_000_000n, 0n)
+    })
+
+    it('re-runs the check after the preflight is disabled and re-enabled', async () => {
+      const { result, rerender } = renderPreflight()
+      await flush()
+      expect(mockComputeSteps).toHaveBeenCalledTimes(1)
+
+      // Disabled (e.g. reward estimate refetching) — idle, not pending.
+      rerender({ ...defaultProps, enabled: false })
+      expect(result.current.isCheckingFunding).toBe(false)
+
+      // Re-enabled: the balance may have moved meanwhile, so the completed
+      // check is invalidated and runs again (held as pending synchronously).
+      rerender(defaultProps)
+      expect(result.current.isCheckingFunding).toBe(true)
+      await flush()
+      expect(mockComputeSteps).toHaveBeenCalledTimes(2)
+      expect(result.current.isCheckingFunding).toBe(false)
+    })
+  })
 })

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useStakeFundingPreflight.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useStakeFundingPreflight.ts
@@ -16,6 +16,13 @@ import { isInsufficientFundsError } from '../utils/isInsufficientFundsError'
  * errors (network, etc.) are ignored here so they don't strand the user — the
  * normal submit + error-alert path handles those.
  *
+ * `isCheckingFunding` is DERIVED, not set from the effect: it's true whenever
+ * the check is enabled but the current inputs haven't completed a check yet.
+ * Setting it from the effect left a rendered frame between "the other CTA
+ * gates opened" and "the effect flipped the flag" in which the slide button
+ * flashed enabled — the flicker in CP-14717. Deriving it keeps the CTA held
+ * in the very same render the inputs change.
+ *
  * The check counts as complete only once `computeSteps` had all of its async
  * inputs (`isComputeReady`) and returned actual steps. Before that,
  * `computeSteps` resolves to an empty list without validating anything, which
@@ -23,8 +30,8 @@ import { isInsufficientFundsError } from '../utils/isInsufficientFundsError'
  * with a cached validator, so the pre-flight can fire before the fee-state /
  * base-fee queries resolve — treating that empty result as "funded" let an
  * unaffordable stake through with no inline error (it then failed after the
- * slide). While the inputs are still loading we report `isCheckingFunding`
- * and re-run the real check when `isComputeReady` flips true.
+ * slide). While the inputs are still loading the check stays pending and the
+ * real check runs when `isComputeReady` flips true.
  */
 export const useStakeFundingPreflight = ({
   enabled,
@@ -39,13 +46,21 @@ export const useStakeFundingPreflight = ({
 }): { isCheckingFunding: boolean; hasInsufficientFunds: boolean } => {
   const { computeSteps, isComputeReady } = useDelegationContext()
   const [fundingError, setFundingError] = useState<Error | null>(null)
-  const [isCheckingFunding, setIsCheckingFunding] = useState(false)
+  // The input snapshot the last completed check validated — null when nothing
+  // has been validated yet (or the preflight was disabled in between).
+  const [checkedKey, setCheckedKey] = useState<string | null>(null)
 
   const additionalOutputAmount = useMemo(
     () =>
       additionalOutputs?.reduce((sum, output) => sum + output.amount, 0n) ?? 0n,
     [additionalOutputs]
   )
+
+  const inputsKey = `${stakeAmountNanoAvax}:${additionalOutputAmount}`
+  // Synchronous by design (see the flicker note in the JSDoc): the moment the
+  // inputs change — or the check becomes enabled — this reads pending in the
+  // same render, with no effect-timing gap for the CTA to flash enabled in.
+  const isCheckingFunding = enabled && checkedKey !== inputsKey
 
   // Keep `computeSteps` in a ref so the effect doesn't re-run (and re-toggle
   // the CTA) just because `computeSteps` got a new identity. It's recreated
@@ -61,23 +76,20 @@ export const useStakeFundingPreflight = ({
 
   useEffect(() => {
     if (!enabled) {
-      // No check should be running while the preflight is disabled. Clear the
-      // flag here so a check that was cancelled mid-flight (e.g. `enabled`
-      // flipped off when the reward estimate started a background refetch)
-      // doesn't strand `isCheckingFunding` at `true` and leave the CTA
-      // permanently disabled — its `.finally` is skipped once `cancelled` is set.
-      setIsCheckingFunding(false)
+      // Invalidate the completed check so re-enabling re-runs it — the
+      // balance may have moved while the preflight was disabled (e.g. during
+      // a reward-estimate refetch).
+      setCheckedKey(null)
       return
     }
-    if (!isComputeReady) {
-      // `computeSteps` would resolve to an empty list without validating
-      // anything. Hold the CTA as "checking" until the inputs are ready; the
-      // dep below re-runs the real check the moment they are.
-      setIsCheckingFunding(true)
-      return
-    }
+    // Current inputs already validated — nothing to do.
+    if (checkedKey === inputsKey) return
+    // `computeSteps` would resolve to an empty list without validating
+    // anything. The derived pending state above already holds the CTA; the
+    // dep below re-runs the real check the moment the inputs are ready.
+    if (!isComputeReady) return
+
     let cancelled = false
-    setIsCheckingFunding(true)
     computeStepsRef
       .current(stakeAmountNanoAvax, additionalOutputAmount)
       .then(steps => {
@@ -90,17 +102,24 @@ export const useStakeFundingPreflight = ({
           return
         }
         setFundingError(null)
-        setIsCheckingFunding(false)
+        setCheckedKey(inputsKey)
       })
       .catch((e: unknown) => {
         if (cancelled) return
         setFundingError(e as Error)
-        setIsCheckingFunding(false)
+        setCheckedKey(inputsKey)
       })
     return () => {
       cancelled = true
     }
-  }, [enabled, isComputeReady, stakeAmountNanoAvax, additionalOutputAmount])
+  }, [
+    enabled,
+    isComputeReady,
+    checkedKey,
+    inputsKey,
+    stakeAmountNanoAvax,
+    additionalOutputAmount
+  ])
 
   return {
     isCheckingFunding,

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useStartStaking.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useStartStaking.ts
@@ -10,6 +10,7 @@ import { useStakeAmount } from 'hooks/earn/useStakeAmount'
 import useStakingParams from 'hooks/earn/useStakingParams'
 import { useCallback } from 'react'
 import { useSelector } from 'react-redux'
+import AnalyticsService from 'services/analytics/AnalyticsService'
 import { getStakingConfig } from 'services/earn/utils'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 
@@ -63,6 +64,9 @@ export const useStartStaking = (): {
     if (!canAddStake) return
 
     if (hasEnoughAvax) {
+      // Fired only when the flow actually starts — a balance-blocked tap
+      // shows the Buy/Swap alert instead and must not enter the funnel.
+      AnalyticsService.capture('StakeFlowStarted', { isAdvanced: false })
       clearRestakeLeftovers()
       navigate({ pathname: '/addStakeV2/fastStake/amount' })
     } else {
@@ -81,6 +85,8 @@ export const useStartStaking = (): {
     if (!canAddStake) return
 
     if (hasEnoughAvax) {
+      // Same gating rationale as `startFastStake` above.
+      AnalyticsService.capture('StakeFlowStarted', { isAdvanced: true })
       clearRestakeLeftovers()
       // Seed the same default filters core-web applies on entry (uptime ≥ 75%,
       // fee ≤ network min, remaining time ≥ min stake duration) so the node

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeAmountScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeAmountScreen.tsx
@@ -34,13 +34,16 @@ import { FAST_STAKE_FEE_RATE } from '../constants'
 // we stake 99.99% of the balance so there's room to cover fees.
 const STAKING_MAX_BALANCE_PERCENTAGE = 0.9999
 
-// Dial granularity, matched to the 2-decimal input precision. Passing this
-// explicitly is important: without a `step` the dial floors it to
-// `max(0.1, max/1000)` = 0.1 for small balances, which both snaps the amount
-// to coarse 0.1 increments AND widens the preset-highlight tolerance
-// (`step / max`) to ~5% of the arc — wide enough that the minimum stake (~47%
-// of a ~2 AVAX max) lights up the "50%" chip. 0.01 keeps both tight.
-const STAKING_DIAL_STEP = 0.01
+// Dial granularity. 0.1 keeps swiping controllable — at 0.01 every pixel of
+// drag crossed several steps, making it hard to land on an intended amount.
+// Manual input is NOT snapped to this (typed values keep their 2-decimal
+// precision; only drag/preset values snap). Passing `step` explicitly still
+// matters: without it the dial derives `max(0.1, max/1000)`, which grows
+// coarser than 0.1 on large balances. Known trade-off on small balances
+// (~2 AVAX): the preset-highlight tolerance (`step / max`) widens to ~5% of
+// the arc, so a value near a chip's fraction can light the chip up slightly
+// early.
+const STAKING_DIAL_STEP = 0.1
 
 // P-chain AVAX has 9 decimals; used to convert the dial's plain number back
 // into a TokenUnit (the rest of the stake flow speaks TokenUnit). We bridge

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeAmountScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeAmountScreen.tsx
@@ -107,8 +107,8 @@ const StakeAmountScreen = ({
 
   const isFastStakeFeeBlocked = useSelector(selectIsFastStakeFeeBlocked)
   const isFastStakeFeeEnabled = !isFastStakeFeeBlocked
-  // Flag-driven (multivariate variant in bps, 10% fallback) — see
-  // `selectFastStakeFeeRate`.
+  // Flag-driven (multivariate variant in bps; no variant → 0 → fee off)
+  // — see `selectFastStakeFeeRate`.
   const fastStakeFeeRate = useSelector(selectFastStakeFeeRate)
 
   // This screen doesn't know the stake duration yet (it's picked on the next

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeAmountScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeAmountScreen.tsx
@@ -24,11 +24,13 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import AnalyticsService from 'services/analytics/AnalyticsService'
 import { getMaximumStakeEndDate } from 'services/earn/utils'
-import { selectIsFastStakeFeeBlocked } from 'store/posthog'
+import {
+  selectFastStakeFeeRate,
+  selectIsFastStakeFeeBlocked
+} from 'store/posthog'
 import { Seconds } from 'types/siUnits'
 import { stringToBigint } from 'utils/bigNumbers/stringToBigint'
 import { xpChainToken } from 'utils/units/knownTokens'
-import { FAST_STAKE_FEE_RATE } from '../constants'
 
 // we can't stake the full amount because of fees; when the user maxes out
 // we stake 99.99% of the balance so there's room to cover fees.
@@ -105,6 +107,9 @@ const StakeAmountScreen = ({
 
   const isFastStakeFeeBlocked = useSelector(selectIsFastStakeFeeBlocked)
   const isFastStakeFeeEnabled = !isFastStakeFeeBlocked
+  // Flag-driven (multivariate variant in bps, 10% fallback) — see
+  // `selectFastStakeFeeRate`.
+  const fastStakeFeeRate = useSelector(selectFastStakeFeeRate)
 
   // This screen doesn't know the stake duration yet (it's picked on the next
   // screen), so reserve room for the fee at the MAX duration (1y) — the
@@ -134,10 +139,8 @@ const StakeAmountScreen = ({
     const reward = referenceReward?.estimatedTokenReward
     const minStake = minStakeAmount.toDisplay({ asNumber: true })
     if (!reward || minStake <= 0) return 0
-    return (
-      (reward.toDisplay({ asNumber: true }) * FAST_STAKE_FEE_RATE) / minStake
-    )
-  }, [isFastStakeFeeEnabled, referenceReward, minStakeAmount])
+    return (reward.toDisplay({ asNumber: true }) * fastStakeFeeRate) / minStake
+  }, [isFastStakeFeeEnabled, fastStakeFeeRate, referenceReward, minStakeAmount])
 
   const formatInCurrency = useCallback(
     (amount: TokenUnit): string => {

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeConfirmScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeConfirmScreen.tsx
@@ -18,7 +18,12 @@ import {
   OnDelegationProgress
 } from 'contexts/DelegationContext'
 import { differenceInDays, format, getUnixTime } from 'date-fns'
-import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router'
+import {
+  Href,
+  useLocalSearchParams,
+  useNavigation,
+  useRouter
+} from 'expo-router'
 import { StakeTokenUnitValue } from 'features/stake/components/StakeTokenUnitValue'
 import { useLedgerStaking } from 'features/stake/hooks/useLedgerStaking'
 import { useEarnCalcEstimatedRewards } from 'hooks/earn/useEarnCalcEstimatedRewards'
@@ -170,7 +175,7 @@ const StakeConfirmScreen = ({
    */
   isAdvanced: boolean
 }): JSX.Element => {
-  const { back, dismissAll } = useRouter()
+  const { back, dismissAll, dismissTo } = useRouter()
   const navigation = useNavigation()
   const dispatch = useDispatch()
   // Drives the post-slide screens. `isSubmitting` latches when the user
@@ -746,17 +751,23 @@ const StakeConfirmScreen = ({
     )
   }, [phase, navigation])
 
-  // Auto-close the entire stake flow shortly after success. Going back on
-  // the parent navigator pops the whole addStakeV2 modal and returns to
-  // wherever the flow was opened from. (`dismissAll()` only pops the inner
-  // stack back to the chooser/start screen, which we don't want.)
+  // Auto-close the entire stake flow shortly after success, always landing
+  // on the stake home. Popping just the add-stake modal (the parent
+  // navigator's `goBack()`) would return to wherever the flow was opened
+  // from — for a restake that can be the stake detail or search modal
+  // stacked beneath, both now-stale surfaces. `dismissTo` POPs back to the
+  // existing stake tab route instead, dismissing every modal above it in
+  // one action. (`navigate` is wrong here: since React Navigation 7 it
+  // pushes a fresh route instead of popping to the existing one, which
+  // presented a second stake home as a modal. `dismissAll()` is also
+  // wrong: it only pops the inner stack back to the chooser/start screen.)
   useEffect(() => {
     if (phase !== 'success') return
     const timeout = setTimeout(() => {
-      navigation.getParent()?.goBack()
+      dismissTo('/stake' as Href)
     }, SUCCESS_DISMISS_DELAY_MS)
     return () => clearTimeout(timeout)
-  }, [phase, navigation])
+  }, [phase, dismissTo])
 
   // Invalid `stakeEndTime` route param (deep link / state restoration with
   // a missing or NaN value). We can't proceed with a fake duration, so

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeConfirmScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeConfirmScreen.tsx
@@ -135,6 +135,16 @@ const toEstimationFeePercent = (
 ): number => Number(validator?.delegationFee ?? 0)
 
 /**
+ * A restake is the only flow that sets either node param (`useRestake`'s
+ * fast / delegate branches). Module-level so the `||` stays out of the
+ * component's cognitive-complexity budget.
+ */
+const isRestakeEntry = (
+  preferredNodeId: string | undefined,
+  restakeNodeId: string | undefined
+): boolean => Boolean(preferredNodeId || restakeNodeId)
+
+/**
  * V2 "Almost done, review your stake..." screen.
  *
  * Designed to be shared across staking flows (Fast Stake today; the
@@ -175,9 +185,17 @@ const StakeConfirmScreen = ({
   const { steps } = useDelegationContext()
   const { annualPercentageYieldBPS } = useStakingParams()
   // Optional in the type because deep links / state restoration can land here
-  // without the param — the defensive parsing below relies on it being
-  // possibly `undefined`, so the type must reflect that too.
-  const { stakeEndTime } = useLocalSearchParams<{ stakeEndTime?: string }>()
+  // without the params — the defensive parsing below relies on them being
+  // possibly `undefined`, so the type must reflect that too. The node params
+  // are only ever set by `useRestake` (fast path / delegate path), so their
+  // presence identifies a restake for analytics.
+  const { stakeEndTime, preferredNodeId, restakeNodeId } =
+    useLocalSearchParams<{
+      stakeEndTime?: string
+      preferredNodeId?: string
+      restakeNodeId?: string
+    }>()
+  const isRestake = isRestakeEntry(preferredNodeId, restakeNodeId)
   // Defensive parse — deep links / state restoration could land us here
   // with a missing or non-numeric `stakeEndTime`. Falling through with a
   // NaN would produce an Invalid Date and later crash inside `format()` /
@@ -292,13 +310,15 @@ const StakeConfirmScreen = ({
     ]
   }, [convenienceFee, feePolicy])
 
-  // Per-event analytics built from the route's `isAdvanced` flag and the
-  // runtime-computed fee amount. `convenienceFeeAvax` is only added when
-  // the flow actually applies a fee — keeps the "fee not paid" vs
-  // "fee not applicable" distinction the analytics contract promises.
+  // Per-event analytics built from the route's `isAdvanced` flag, the
+  // restake marker, and the runtime-computed fee amount.
+  // `convenienceFeeAvax` is only added when the flow actually applies a
+  // fee — keeps the "fee not paid" vs "fee not applicable" distinction the
+  // analytics contract promises.
   const delegationAnalyticsProps = useMemo(
     () => ({
       isAdvanced,
+      isRestake,
       ...(feePolicy
         ? {
             convenienceFeeAvax: convenienceFee
@@ -307,20 +327,25 @@ const StakeConfirmScreen = ({
           }
         : {})
     }),
-    [isAdvanced, feePolicy, convenienceFee]
+    [isAdvanced, isRestake, feePolicy, convenienceFee]
   )
 
   // Bundle captured on `StakeIssueDelegation`, which has a stricter shape
-  // (no `isAdvanced`) than the success/fail events. Undefined when the
-  // flow doesn't charge a fee, matching the analytics type's union arm.
-  const issueDelegationAnalyticsProps = useMemo(() => {
-    if (!feePolicy) return undefined
-    return {
-      convenienceFeeAvax: convenienceFee
-        ? convenienceFee.toDisplay({ asNumber: true })
-        : 0
-    }
-  }, [feePolicy, convenienceFee])
+  // (no `isAdvanced`) than the success/fail events. Always carries the
+  // restake marker; the fee is added only when one applies.
+  const issueDelegationAnalyticsProps = useMemo(
+    () => ({
+      isRestake,
+      ...(feePolicy
+        ? {
+            convenienceFeeAvax: convenienceFee
+              ? convenienceFee.toDisplay({ asNumber: true })
+              : 0
+          }
+        : {})
+    }),
+    [isRestake, feePolicy, convenienceFee]
+  )
 
   // Percentage form of the fee rate, formatted for display so that
   // floating-point artifacts (e.g. `0.07 * 100 = 7.000000000000001`) don't

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeConfirmScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeConfirmScreen.tsx
@@ -48,6 +48,7 @@ import { AdditionalDelegatorOutput } from 'services/wallet/types'
 import { getExplorerAddressByNetwork } from 'utils/getExplorerAddressByNetwork'
 import { StakeTargetValidator } from 'types/earn'
 import { truncateNodeId } from 'utils/Utils'
+import { formatDurationInDays } from 'features/stake/utils'
 import { StakeStatusScreen } from '../components/StakeStatusScreen'
 import { useStakeFundingPreflight } from '../hooks/useStakeFundingPreflight'
 import { StakeReviewSource } from '../types'
@@ -420,7 +421,7 @@ const StakeConfirmScreen = ({
         value: isResolvingValidator ? (
           <ActivityIndicator />
         ) : (
-          `${differenceInDays(validatedStakingEndTime, now)} days`
+          formatDurationInDays(differenceInDays(validatedStakingEndTime, now))
         )
       },
       {

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeDetailScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeDetailScreen.tsx
@@ -26,7 +26,7 @@ import {
 } from 'features/stake/utils'
 import { useStake } from 'hooks/earn/useStake'
 import { clamp, round } from 'lodash'
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useSelector } from 'react-redux'
 import AnalyticsService from 'services/analytics/AnalyticsService'
 import NetworkService from 'services/network/NetworkService'
@@ -43,7 +43,11 @@ import { isFastStakeTx } from '../utils/isFastStakeTx'
 const HASH_LENGTH = 14
 
 export const StakeDetailScreen = (): React.JSX.Element => {
-  const { txHash } = useLocalSearchParams<{ txHash: string }>()
+  const { txHash, source } = useLocalSearchParams<{
+    txHash: string
+    /** Entry-point attribution for StakeDetailViewed; in-app navigations set it. */
+    source?: 'home' | 'search'
+  }>()
   const stake = useStake(txHash)
   const isDevMode = useSelector(selectIsDeveloperMode)
   const apyBps = useSelector(selectStakeAnnualPercentageYieldBPS)
@@ -65,13 +69,31 @@ export const StakeDetailScreen = (): React.JSX.Element => {
     return isOnGoing(stake, now)
   }, [stake, now])
 
+  // Once per visit, and only after the stake has resolved so the variant is
+  // known — firing on mount would either drop the variant or mislabel it
+  // while `useStake` is still loading. Entries without a `source` param
+  // reached this screen from outside the in-app navigations that set it
+  // (e.g. a push-notification deep link), hence the fallback.
+  const hasCapturedViewRef = useRef(false)
+  useEffect(() => {
+    if (!stake || hasCapturedViewRef.current) return
+    hasCapturedViewRef.current = true
+    AnalyticsService.capture('StakeDetailViewed', {
+      variant: isActive ? 'active' : 'completed',
+      source: source ?? 'deeplink'
+    })
+  }, [stake, isActive, source])
+
   // Restake CTA — completed stakes only (web parity), and only when the tx
   // carries enough data to seed a restake (see `useRestake`). Note completed
   // is checked explicitly rather than as `!isActive`, so pending stakes don't
   // offer it either.
   const { getOnRestake } = useRestake()
   const onRestake = useMemo(
-    () => (stake ? getOnRestake(stake, isCompleted(stake, now)) : undefined),
+    () =>
+      stake
+        ? getOnRestake(stake, isCompleted(stake, now), 'detail')
+        : undefined,
     [stake, getOnRestake, now]
   )
 

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
@@ -29,7 +29,10 @@ import { StakeCustomEndDatePicker } from 'features/stake/components/StakeCustomE
 import { StakeTokenUnitValue } from 'features/stake/components/StakeTokenUnitValue'
 import { useStakeEstimatedReward } from 'features/stake/hooks/useStakeEstimatedReward'
 import { useStakeEstimatedRewards } from 'features/stake/hooks/useStakeEstimatedRewards'
-import { convertToDurationInSeconds } from 'features/stake/utils'
+import {
+  convertToDurationInSeconds,
+  formatDurationInDays
+} from 'features/stake/utils'
 import { useStakeAmount } from 'hooks/earn/useStakeAmount'
 import { useNow } from 'hooks/time/useNow'
 import { useDebounce } from 'hooks/useDebounce'
@@ -187,7 +190,7 @@ const StakeDurationScreen = ({
     return (estimatedRewards ?? []).map((item, index) => {
       return {
         value: item.estimatedTokenReward.toDisplay({ asNumber: true }),
-        duration: `${item.duration.numberOfDays} days`,
+        duration: formatDurationInDays(item.duration.numberOfDays),
         index
       }
     })
@@ -335,7 +338,7 @@ const StakeDurationScreen = ({
         title: 'Duration',
         value:
           selectedDurationInDays !== undefined
-            ? `${selectedDurationInDays} days`
+            ? formatDurationInDays(selectedDurationInDays)
             : '',
         accordion: (
           <DurationOptions

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeHomeScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeHomeScreen.tsx
@@ -13,7 +13,7 @@ import { useEffectiveHeaderHeight } from 'common/hooks/useEffectiveHeaderHeight'
 import BlurredBarsContentLayout from 'common/components/BlurredBarsContentLayout'
 import { useFadingHeaderNavigation } from 'common/hooks/useFadingHeaderNavigation'
 import { LinearGradient } from 'expo-linear-gradient'
-import { useRouter } from 'expo-router'
+import { useFocusEffect, useRouter } from 'expo-router'
 import React, { useCallback, useMemo, useRef, useState } from 'react'
 import {
   LayoutChangeEvent,
@@ -26,6 +26,7 @@ import Animated, { useAnimatedStyle } from 'react-native-reanimated'
 import { useSafeAreaFrame } from 'react-native-safe-area-context'
 import { useBottomTabBarHeight } from 'common/hooks/useBottomTabBarHeight'
 import { StuckFundsBanner } from 'features/swap/components/StuckFundsBanner'
+import AnalyticsService from 'services/analytics/AnalyticsService'
 import {
   StakeCardList,
   StakeCardListHeaderProps
@@ -44,6 +45,16 @@ export const StakeHomeScreen = (): JSX.Element => {
   const tabBarHeight = useBottomTabBarHeight()
   const { theme } = useTheme()
   const { navigate } = useRouter()
+
+  // Focus (not mount): tab screens stay mounted across tab switches, so a
+  // mount effect would count only the first visit per session. Firing on
+  // focus matches the legacy `StakeOpened` tab-press semantics (and the
+  // `EarnOpened` pattern on the Earn home).
+  useFocusEffect(
+    useCallback(() => {
+      AnalyticsService.capture('StakeHomeViewed')
+    }, [])
+  )
 
   const [headerLayout, setHeaderLayout] = useState<
     LayoutRectangle | undefined

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeSearchScreen.tsx
@@ -23,6 +23,7 @@ import {
 import { dismissKeyboardIfNeeded } from 'common/utils/dismissKeyboardIfNeeded'
 import { useRouter } from 'expo-router'
 import { useStakes } from 'hooks/earn/useStakes'
+import AnalyticsService from 'services/analytics/AnalyticsService'
 import React, {
   useCallback,
   useDeferredValue,
@@ -120,6 +121,23 @@ export const StakeSearchScreen = (): JSX.Element => {
   const trimmedQuery = deferredSearchText.trim()
   const hasQuery = trimmedQuery.length > 0
 
+  // Mount-once (NOT focus): returning from a stake detail pushed on top
+  // re-focuses this screen but is still the same search session, so it must
+  // not count as another "opened".
+  useEffect(() => {
+    AnalyticsService.capture('StakeSearchOpened')
+  }, [])
+
+  // Once per visit, on the first non-empty (deferred) query — measures how
+  // many openers actually search. Deliberately payload-free: the query text
+  // is node IDs and stays out of analytics.
+  const hasCapturedQueryRef = useRef(false)
+  useEffect(() => {
+    if (!hasQuery || hasCapturedQueryRef.current) return
+    hasCapturedQueryRef.current = true
+    AnalyticsService.capture('StakeSearchQueryEntered')
+  }, [hasQuery])
+
   const filteredStakes = useMemo(() => {
     if (!hasQuery) return []
     const q = trimmedQuery.toLowerCase()
@@ -169,7 +187,11 @@ export const StakeSearchScreen = (): JSX.Element => {
       await dismissKeyboardIfNeeded()
       // Push the detail onto this search modal's own stack (slides in over the
       // results) rather than opening the global /stakeDetail modal.
-      navigate({ pathname: '/stakeSearch/stakeDetail', params: { txHash } })
+      // `source` feeds StakeDetailViewed's entry-point attribution.
+      navigate({
+        pathname: '/stakeSearch/stakeDetail',
+        params: { txHash, source: 'search' }
+      })
     },
     [navigate]
   )

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/addStakeV2/_layout.tsx
@@ -76,6 +76,25 @@ export default function StakeLayoutV2(): JSX.Element {
             headerBackVisible: false
           }}
         />
+        {/*
+         * The confirm screens host the left-to-right "slide to stake"
+         * button. On iOS 26 the back-pop gesture works across the whole
+         * screen content by default (`fullScreenGestureEnabled` maps to
+         * react-native-screens' `interactiveContentPopGestureRecognizer`
+         * handling and defaults to true there), so sliding the button
+         * reads as a back swipe and pops to the duration step mid-slide.
+         * Disable the content-wide gesture on these screens only — the
+         * edge swipe-back and the header back button still work, and the
+         * other steps keep the convenient full-screen back swipe.
+         */}
+        <Stack.Screen
+          name="fastStake/confirm"
+          options={{ fullScreenGestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="delegate/confirm"
+          options={{ fullScreenGestureEnabled: false }}
+        />
       </Stack>
     </DelegationContextProvider>
   )

--- a/packages/core-mobile/app/services/fcm/FCMService.ts
+++ b/packages/core-mobile/app/services/fcm/FCMService.ts
@@ -289,6 +289,12 @@ class FCMService {
         dispatch: action => action,
         isEarnBlocked: false,
         isInAppDefiBlocked: false,
+        // Stake-complete is a Notifee local notification routed through
+        // DeeplinkContext, never an FCM push, so this handler keeps the
+        // legacy claim target (consistent with the hardcoded flags above).
+        shouldRedirectStakeCompleteToCct: false,
+        isDeveloperMode: false,
+        shouldShowSwapOnboarding: false,
         openUrl: link =>
           router.navigate({
             pathname: '/browser',

--- a/packages/core-mobile/app/services/posthog/sanitizeFeatureFlags.test.ts
+++ b/packages/core-mobile/app/services/posthog/sanitizeFeatureFlags.test.ts
@@ -16,6 +16,54 @@ describe('app/contexts/posthogUtils.ts', () => {
       })
     })
 
+    describe('multivariate fee gates', () => {
+      it('accepts a variant string (fee rate in bps) alongside plain booleans', () => {
+        expect(
+          sanitizeFeatureFlags({
+            featureFlags: {
+              [FeatureGates.FAST_STAKE_FEE_ENABLED]: '1000',
+              [FeatureGates.DELEGATION_FEE_ENABLED]: true
+            }
+          })
+        ).toStrictEqual({
+          [FeatureGates.FAST_STAKE_FEE_ENABLED]: '1000',
+          [FeatureGates.DELEGATION_FEE_ENABLED]: true
+        })
+      })
+
+      it('still drops variant strings served for regular boolean gates', () => {
+        expect(
+          sanitizeFeatureFlags({
+            featureFlags: {
+              [FeatureGates.FUSION]: '1000'
+            }
+          })
+        ).toStrictEqual({})
+      })
+
+      it('preserves the variant through version-payload gating', () => {
+        const featureFlags = sanitizeFeatureFlags(
+          {
+            featureFlags: {
+              [FeatureGates.FAST_STAKE_FEE_ENABLED]: '1000',
+              [FeatureGates.DELEGATION_FEE_ENABLED]: '250'
+            },
+            featureFlagPayloads: {
+              [FeatureGates.FAST_STAKE_FEE_ENABLED]: JSON.stringify('^1.32'),
+              [FeatureGates.DELEGATION_FEE_ENABLED]: JSON.stringify('^2')
+            }
+          },
+          '1.32.8'
+        )
+
+        // Version satisfied: the variant value survives instead of being
+        // collapsed to boolean `true`.
+        expect(featureFlags[FeatureGates.FAST_STAKE_FEE_ENABLED]).toBe('1000')
+        // Version not satisfied: the gate is disabled outright.
+        expect(featureFlags[FeatureGates.DELEGATION_FEE_ENABLED]).toBe(false)
+      })
+    })
+
     it('returns empty object if server returns empty featureFlags object', () => {
       expect(
         sanitizeFeatureFlags({

--- a/packages/core-mobile/app/services/posthog/sanitizeFeatureFlags.ts
+++ b/packages/core-mobile/app/services/posthog/sanitizeFeatureFlags.ts
@@ -14,6 +14,14 @@ const allowedKeys: (FeatureGates | FeatureVars)[] = [
 const featureVars = Object.values(FeatureVars) as string[]
 const featureGates = Object.values(FeatureGates) as string[]
 
+// Gates that may arrive as a multivariate variant string instead of a plain
+// boolean — the variant carries a value (convenience-fee rate in basis
+// points) on top of acting as the on/off switch. See `FeatureGates`.
+const variantGates: string[] = [
+  FeatureGates.FAST_STAKE_FEE_ENABLED,
+  FeatureGates.DELEGATION_FEE_ENABLED
+]
+
 function isFeatureGate(key: string): key is FeatureGates {
   return featureGates.includes(key)
 }
@@ -43,7 +51,9 @@ export const sanitizeFeatureFlags = (
   const rawFlags = allowedKeys.reduce((acc, k) => {
     if (
       (featureVars.includes(k) && typeof value.featureFlags[k] === 'string') ||
-      (featureGates.includes(k) && typeof value.featureFlags[k] === 'boolean')
+      (featureGates.includes(k) &&
+        typeof value.featureFlags[k] === 'boolean') ||
+      (variantGates.includes(k) && typeof value.featureFlags[k] === 'string')
     ) {
       acc[k] = value.featureFlags[k]
     }
@@ -77,7 +87,14 @@ export const sanitizeFeatureFlags = (
               return [flagName, false]
             }
 
-            return [flagName, satisfies(version, versionRange)]
+            // Preserve the raw flag value (a variant string for the
+            // multivariate gates, `true` otherwise) when the version
+            // qualifies — collapsing it to a boolean would drop the value
+            // the variant carries.
+            return [
+              flagName,
+              satisfies(version, versionRange) && rawFlags[flagName]
+            ]
           } catch {
             return [flagName, false]
           }

--- a/packages/core-mobile/app/services/posthog/types.ts
+++ b/packages/core-mobile/app/services/posthog/types.ts
@@ -47,12 +47,11 @@ export enum FeatureGates {
   PRICE_CHART = 'price-chart',
   PERPETUALS = 'perpetuals',
   FAST_STAKE_ENABLED = 'fast-stake-enabled',
-  // The two fee gates below are multivariate: besides plain boolean `true`,
-  // PostHog may serve a variant string carrying the convenience-fee rate in
-  // basis points (e.g. '1000' = 10%). The rate selectors in `store/posthog`
-  // parse it and fall back to the compiled-in default when the flag is a
-  // plain boolean; a variant of '0' behaves exactly like the flag being off
-  // (see `selectIs*FeeBlocked`).
+  // The two fee gates below are multivariate: enabling a fee requires a
+  // variant string carrying the rate in basis points (e.g. '1000' = 10%).
+  // Anything without a positive parsable rate — a plain boolean `true`, a
+  // '0' variant, or an unparsable variant — behaves exactly like the flag
+  // being off (see `selectIs*FeeBlocked` in `store/posthog`).
   FAST_STAKE_FEE_ENABLED = 'fast-stake-fee-enabled',
   DELEGATION_FEE_ENABLED = 'delegation-fee-enabled'
 }

--- a/packages/core-mobile/app/services/posthog/types.ts
+++ b/packages/core-mobile/app/services/posthog/types.ts
@@ -47,6 +47,12 @@ export enum FeatureGates {
   PRICE_CHART = 'price-chart',
   PERPETUALS = 'perpetuals',
   FAST_STAKE_ENABLED = 'fast-stake-enabled',
+  // The two fee gates below are multivariate: besides plain boolean `true`,
+  // PostHog may serve a variant string carrying the convenience-fee rate in
+  // basis points (e.g. '1000' = 10%). The rate selectors in `store/posthog`
+  // parse it and fall back to the compiled-in default when the flag is a
+  // plain boolean; a variant of '0' behaves exactly like the flag being off
+  // (see `selectIs*FeeBlocked`).
   FAST_STAKE_FEE_ENABLED = 'fast-stake-fee-enabled',
   DELEGATION_FEE_ENABLED = 'delegation-fee-enabled'
 }

--- a/packages/core-mobile/app/store/posthog/slice.test.ts
+++ b/packages/core-mobile/app/store/posthog/slice.test.ts
@@ -14,6 +14,10 @@ import {
   selectMarkrSwapMaxRetries,
   selectSentrySampleRate,
   selectStakeAnnualPercentageYieldBPS,
+  selectFastStakeFeeRate,
+  selectDelegationFeeRate,
+  selectIsFastStakeFeeBlocked,
+  selectIsDelegationFeeBlocked,
   posthogSlice
 } from './slice'
 import { DefaultFeatureFlagConfig, initialState } from './types'
@@ -349,5 +353,80 @@ describe('selectIsFusionEnabled', () => {
       }
     })
     expect(selectIsFusionEnabled(state)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Stake convenience-fee rate selectors (multivariate fee gates)
+// ---------------------------------------------------------------------------
+
+describe('selectFastStakeFeeRate / selectDelegationFeeRate', () => {
+  it('parses the variant string as basis points', () => {
+    const state = stateWithFlags({
+      [FeatureGates.FAST_STAKE_FEE_ENABLED]: '1000',
+      [FeatureGates.DELEGATION_FEE_ENABLED]: '250'
+    })
+    expect(selectFastStakeFeeRate(state)).toBe(0.1)
+    expect(selectDelegationFeeRate(state)).toBe(0.025)
+  })
+
+  it('treats a variant of "0" as a valid zero rate (no fallback)', () => {
+    const state = stateWithFlags({
+      [FeatureGates.FAST_STAKE_FEE_ENABLED]: '0'
+    })
+    expect(selectFastStakeFeeRate(state)).toBe(0)
+  })
+
+  it('falls back to the 10% default when the gate is a plain boolean', () => {
+    const state = stateWithFlags({
+      [FeatureGates.FAST_STAKE_FEE_ENABLED]: true,
+      [FeatureGates.DELEGATION_FEE_ENABLED]: true
+    })
+    expect(selectFastStakeFeeRate(state)).toBe(0.1)
+    expect(selectDelegationFeeRate(state)).toBe(0.1)
+  })
+
+  it('falls back to the 10% default when the flag is absent', () => {
+    const state = stateWithFlags({})
+    expect(selectFastStakeFeeRate(state)).toBe(0.1)
+    expect(selectDelegationFeeRate(state)).toBe(0.1)
+  })
+})
+
+describe('selectIsFastStakeFeeBlocked / selectIsDelegationFeeBlocked with variants', () => {
+  it('reports enabled for a positive-rate variant', () => {
+    const state = stateWithFlags({
+      [FeatureGates.EVERYTHING]: true,
+      [FeatureGates.FAST_STAKE_FEE_ENABLED]: '250',
+      [FeatureGates.DELEGATION_FEE_ENABLED]: '1000'
+    })
+    expect(selectIsFastStakeFeeBlocked(state)).toBe(false)
+    expect(selectIsDelegationFeeBlocked(state)).toBe(false)
+  })
+
+  it('treats a variant of "0" exactly like the flag being off', () => {
+    const state = stateWithFlags({
+      [FeatureGates.EVERYTHING]: true,
+      [FeatureGates.FAST_STAKE_FEE_ENABLED]: '0',
+      [FeatureGates.DELEGATION_FEE_ENABLED]: '0'
+    })
+    expect(selectIsFastStakeFeeBlocked(state)).toBe(true)
+    expect(selectIsDelegationFeeBlocked(state)).toBe(true)
+  })
+
+  it('treats a negative-rate misconfiguration as off', () => {
+    const state = stateWithFlags({
+      [FeatureGates.EVERYTHING]: true,
+      [FeatureGates.FAST_STAKE_FEE_ENABLED]: '-100'
+    })
+    expect(selectIsFastStakeFeeBlocked(state)).toBe(true)
+  })
+
+  it('keeps a plain boolean gate enabled (10% fallback is positive)', () => {
+    const state = stateWithFlags({
+      [FeatureGates.EVERYTHING]: true,
+      [FeatureGates.FAST_STAKE_FEE_ENABLED]: true
+    })
+    expect(selectIsFastStakeFeeBlocked(state)).toBe(false)
   })
 })

--- a/packages/core-mobile/app/store/posthog/slice.test.ts
+++ b/packages/core-mobile/app/store/posthog/slice.test.ts
@@ -377,6 +377,18 @@ describe('selectFastStakeFeeRate / selectDelegationFeeRate', () => {
     expect(selectFastStakeFeeRate(state)).toBe(0)
   })
 
+  it('rejects partially numeric variants outright (strict parse)', () => {
+    const state = stateWithFlags({
+      [FeatureGates.EVERYTHING]: true,
+      [FeatureGates.FAST_STAKE_FEE_ENABLED]: '1000abc',
+      [FeatureGates.DELEGATION_FEE_ENABLED]: '10.5'
+    })
+    expect(selectFastStakeFeeRate(state)).toBe(0)
+    expect(selectDelegationFeeRate(state)).toBe(0)
+    expect(selectIsFastStakeFeeBlocked(state)).toBe(true)
+    expect(selectIsDelegationFeeBlocked(state)).toBe(true)
+  })
+
   it('yields 0 (fee off) when the gate is a plain boolean with no variant', () => {
     const state = stateWithFlags({
       [FeatureGates.FAST_STAKE_FEE_ENABLED]: true,

--- a/packages/core-mobile/app/store/posthog/slice.test.ts
+++ b/packages/core-mobile/app/store/posthog/slice.test.ts
@@ -377,19 +377,19 @@ describe('selectFastStakeFeeRate / selectDelegationFeeRate', () => {
     expect(selectFastStakeFeeRate(state)).toBe(0)
   })
 
-  it('falls back to the 10% default when the gate is a plain boolean', () => {
+  it('yields 0 (fee off) when the gate is a plain boolean with no variant', () => {
     const state = stateWithFlags({
       [FeatureGates.FAST_STAKE_FEE_ENABLED]: true,
       [FeatureGates.DELEGATION_FEE_ENABLED]: true
     })
-    expect(selectFastStakeFeeRate(state)).toBe(0.1)
-    expect(selectDelegationFeeRate(state)).toBe(0.1)
+    expect(selectFastStakeFeeRate(state)).toBe(0)
+    expect(selectDelegationFeeRate(state)).toBe(0)
   })
 
-  it('falls back to the 10% default when the flag is absent', () => {
+  it('yields 0 (fee off) when the flag is absent', () => {
     const state = stateWithFlags({})
-    expect(selectFastStakeFeeRate(state)).toBe(0.1)
-    expect(selectDelegationFeeRate(state)).toBe(0.1)
+    expect(selectFastStakeFeeRate(state)).toBe(0)
+    expect(selectDelegationFeeRate(state)).toBe(0)
   })
 })
 
@@ -422,11 +422,11 @@ describe('selectIsFastStakeFeeBlocked / selectIsDelegationFeeBlocked with varian
     expect(selectIsFastStakeFeeBlocked(state)).toBe(true)
   })
 
-  it('keeps a plain boolean gate enabled (10% fallback is positive)', () => {
+  it('treats a plain boolean gate (no rate variant) as blocked', () => {
     const state = stateWithFlags({
       [FeatureGates.EVERYTHING]: true,
       [FeatureGates.FAST_STAKE_FEE_ENABLED]: true
     })
-    expect(selectIsFastStakeFeeBlocked(state)).toBe(false)
+    expect(selectIsFastStakeFeeBlocked(state)).toBe(true)
   })
 })

--- a/packages/core-mobile/app/store/posthog/slice.test.ts
+++ b/packages/core-mobile/app/store/posthog/slice.test.ts
@@ -377,6 +377,13 @@ describe('selectFastStakeFeeRate / selectDelegationFeeRate', () => {
     expect(selectFastStakeFeeRate(state)).toBe(0)
   })
 
+  it('caps the rate at 10,000 bps (100% of the reward)', () => {
+    const state = stateWithFlags({
+      [FeatureGates.FAST_STAKE_FEE_ENABLED]: '500000'
+    })
+    expect(selectFastStakeFeeRate(state)).toBe(1)
+  })
+
   it('rejects partially numeric variants outright (strict parse)', () => {
     const state = stateWithFlags({
       [FeatureGates.EVERYTHING]: true,

--- a/packages/core-mobile/app/store/posthog/slice.ts
+++ b/packages/core-mobile/app/store/posthog/slice.ts
@@ -661,16 +661,21 @@ export const selectIsFastStakeBlocked = (state: RootState): boolean => {
 // explicit rate from PostHog.
 const BPS_PER_UNIT = 10_000
 
+// Strict integer parse for the fee-rate variants — deliberately NOT
+// `parseIntFlag`, whose `parseInt` accepts partially numeric strings
+// ('1000abc' → 1000). This value charges users, so anything that isn't a
+// pure digit string reads as 0 and the fee stays off.
+const parseBpsFlag = (raw: unknown): number =>
+  typeof raw === 'string' && /^\d+$/.test(raw) ? parseInt(raw) : 0
+
 export const selectFastStakeFeeRate = (state: RootState): number =>
-  parseIntFlag(
-    state.posthog.featureFlags[FeatureGates.FAST_STAKE_FEE_ENABLED],
-    '0'
+  parseBpsFlag(
+    state.posthog.featureFlags[FeatureGates.FAST_STAKE_FEE_ENABLED]
   ) / BPS_PER_UNIT
 
 export const selectDelegationFeeRate = (state: RootState): number =>
-  parseIntFlag(
-    state.posthog.featureFlags[FeatureGates.DELEGATION_FEE_ENABLED],
-    '0'
+  parseBpsFlag(
+    state.posthog.featureFlags[FeatureGates.DELEGATION_FEE_ENABLED]
   ) / BPS_PER_UNIT
 
 export const selectIsFastStakeFeeBlocked = (state: RootState): boolean => {

--- a/packages/core-mobile/app/store/posthog/slice.ts
+++ b/packages/core-mobile/app/store/posthog/slice.ts
@@ -664,9 +664,13 @@ const BPS_PER_UNIT = 10_000
 // Strict integer parse for the fee-rate variants — deliberately NOT
 // `parseIntFlag`, whose `parseInt` accepts partially numeric strings
 // ('1000abc' → 1000). This value charges users, so anything that isn't a
-// pure digit string reads as 0 and the fee stays off.
+// pure digit string reads as 0 and the fee stays off, and the result is
+// capped at 10,000 bps (100% of the reward) so no misconfigured variant can
+// ever charge more than the reward itself.
 const parseBpsFlag = (raw: unknown): number =>
-  typeof raw === 'string' && /^\d+$/.test(raw) ? parseInt(raw) : 0
+  typeof raw === 'string' && /^\d+$/.test(raw)
+    ? Math.min(parseInt(raw, 10), BPS_PER_UNIT)
+    : 0
 
 export const selectFastStakeFeeRate = (state: RootState): number =>
   parseBpsFlag(

--- a/packages/core-mobile/app/store/posthog/slice.ts
+++ b/packages/core-mobile/app/store/posthog/slice.ts
@@ -652,11 +652,37 @@ export const selectIsFastStakeBlocked = (state: RootState): boolean => {
   )
 }
 
+// The two fee gates are multivariate: their variant string carries the
+// convenience-fee rate in basis points (e.g. '1000' = 10%), so the same flag
+// both enables the fee and tunes its rate without a release. A gate served as
+// a plain boolean `true` (no variant) falls back to the compiled-in 10%,
+// matching core-web's hardcoded rate. Only meaningful while the corresponding
+// `selectIs*FeeBlocked` selector reports the fee as enabled.
+const STAKE_FEE_RATE_FALLBACK_BPS = '1000' // 10%
+const BPS_PER_UNIT = 10_000
+
+export const selectFastStakeFeeRate = (state: RootState): number =>
+  parseIntFlag(
+    state.posthog.featureFlags[FeatureGates.FAST_STAKE_FEE_ENABLED],
+    STAKE_FEE_RATE_FALLBACK_BPS
+  ) / BPS_PER_UNIT
+
+export const selectDelegationFeeRate = (state: RootState): number =>
+  parseIntFlag(
+    state.posthog.featureFlags[FeatureGates.DELEGATION_FEE_ENABLED],
+    STAKE_FEE_RATE_FALLBACK_BPS
+  ) / BPS_PER_UNIT
+
 export const selectIsFastStakeFeeBlocked = (state: RootState): boolean => {
   const { featureFlags } = state.posthog
   return (
     !featureFlags[FeatureGates.FAST_STAKE_FEE_ENABLED] ||
-    !featureFlags[FeatureGates.EVERYTHING]
+    !featureFlags[FeatureGates.EVERYTHING] ||
+    // A variant of '0' (or a negative misconfiguration) means "charge
+    // nothing" — report the fee as blocked outright so the flows take the
+    // fee-off path instead of advertising a 0% fee and holding the CTA on
+    // the reward estimate for a fee that never materialises.
+    selectFastStakeFeeRate(state) <= 0
   )
 }
 
@@ -664,7 +690,9 @@ export const selectIsDelegationFeeBlocked = (state: RootState): boolean => {
   const { featureFlags } = state.posthog
   return (
     !featureFlags[FeatureGates.DELEGATION_FEE_ENABLED] ||
-    !featureFlags[FeatureGates.EVERYTHING]
+    !featureFlags[FeatureGates.EVERYTHING] ||
+    // Same zero-rate treatment as `selectIsFastStakeFeeBlocked`.
+    selectDelegationFeeRate(state) <= 0
   )
 }
 

--- a/packages/core-mobile/app/store/posthog/slice.ts
+++ b/packages/core-mobile/app/store/posthog/slice.ts
@@ -654,23 +654,23 @@ export const selectIsFastStakeBlocked = (state: RootState): boolean => {
 
 // The two fee gates are multivariate: their variant string carries the
 // convenience-fee rate in basis points (e.g. '1000' = 10%), so the same flag
-// both enables the fee and tunes its rate without a release. A gate served as
-// a plain boolean `true` (no variant) falls back to the compiled-in 10%,
-// matching core-web's hardcoded rate. Only meaningful while the corresponding
-// `selectIs*FeeBlocked` selector reports the fee as enabled.
-const STAKE_FEE_RATE_FALLBACK_BPS = '1000' // 10%
+// both enables the fee and tunes its rate without a release. There is no
+// compiled-in rate on purpose — a gate served as a plain boolean `true` (no
+// variant) or with an unparsable variant yields 0, which
+// `selectIs*FeeBlocked` treats as off. Charging a fee always requires an
+// explicit rate from PostHog.
 const BPS_PER_UNIT = 10_000
 
 export const selectFastStakeFeeRate = (state: RootState): number =>
   parseIntFlag(
     state.posthog.featureFlags[FeatureGates.FAST_STAKE_FEE_ENABLED],
-    STAKE_FEE_RATE_FALLBACK_BPS
+    '0'
   ) / BPS_PER_UNIT
 
 export const selectDelegationFeeRate = (state: RootState): number =>
   parseIntFlag(
     state.posthog.featureFlags[FeatureGates.DELEGATION_FEE_ENABLED],
-    STAKE_FEE_RATE_FALLBACK_BPS
+    '0'
   ) / BPS_PER_UNIT
 
 export const selectIsFastStakeFeeBlocked = (state: RootState): boolean => {
@@ -678,10 +678,11 @@ export const selectIsFastStakeFeeBlocked = (state: RootState): boolean => {
   return (
     !featureFlags[FeatureGates.FAST_STAKE_FEE_ENABLED] ||
     !featureFlags[FeatureGates.EVERYTHING] ||
-    // A variant of '0' (or a negative misconfiguration) means "charge
-    // nothing" — report the fee as blocked outright so the flows take the
-    // fee-off path instead of advertising a 0% fee and holding the CTA on
-    // the reward estimate for a fee that never materialises.
+    // No positive rate, no fee: a '0' variant, a negative misconfiguration,
+    // a plain boolean gate, or an unparsable variant all report as blocked
+    // outright, so the flows take the fee-off path instead of advertising a
+    // 0% fee and holding the CTA on the reward estimate for a fee that
+    // never materialises.
     selectFastStakeFeeRate(state) <= 0
   )
 }

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -147,15 +147,70 @@ export type AnalyticsEvents = {
      * from "fee not applicable".
      */
     convenienceFeeAvax?: number
+    /**
+     * True when the stake was reached via Restake on a completed stake
+     * (see `StakeRestakeStarted`). Only the V2 confirm sends this.
+     */
+    isRestake?: boolean
   }
   StakeDelegationFail: {
     isAdvanced: boolean
     convenienceFeeAvax?: number
+    isRestake?: boolean
   }
+  /**
+   * Stake detail screen viewed, once per visit. Fired when the stake has
+   * resolved so the variant is known. `source` attributes the entry point;
+   * in-app navigations pass it explicitly, anything unattributed (e.g. a
+   * push-notification deep link) falls back to `deeplink`.
+   */
+  StakeDetailViewed: {
+    variant: 'active' | 'completed'
+    source: 'home' | 'search' | 'deeplink'
+  }
+  /**
+   * User started a staking flow from the chooser ("Choose a way to start
+   * staking"). Mirrors the PRD's `staking_flow_started` (entry CTA tap).
+   * Fired only when the flow actually begins — a tap blocked by the AVAX
+   * balance guard does not count, so funnel conversion isn't diluted by
+   * users who never entered the flow. Restake entries bypass the chooser
+   * and are intentionally NOT counted here (they get their own events).
+   */
+  StakeFlowStarted: {
+    /** `false` = Fast Stake, `true` = advanced Delegate (matches `StakeDelegationSuccess`). */
+    isAdvanced: boolean
+  }
+  /**
+   * Stake home screen gained focus (tab switch or navigation). Successor to
+   * the legacy `StakeOpened`, which fired on the old-gen Stake tab press and
+   * was dropped with the old navigation code (#2621) without a replacement.
+   */
+  StakeHomeViewed: undefined
   StakeIssueClaim: undefined
-  StakeIssueDelegation: undefined | { convenienceFeeAvax: number }
-  StakeOpened: undefined
+  /** V1 sends no payload; the V2 confirm always sends `isRestake` and adds the fee when one applies. */
+  StakeIssueDelegation:
+    | undefined
+    | { convenienceFeeAvax?: number; isRestake?: boolean }
   StakeOpenDurationSelect: undefined
+  /**
+   * User tapped Restake on a completed stake (the card button or the detail
+   * CTA) and the flow actually started. Deliberately separate from
+   * `StakeFlowStarted` so restakes don't dilute the fresh-stake funnel; the
+   * downstream lifecycle reuses the delegation events with `isRestake`.
+   */
+  StakeRestakeStarted: {
+    /** `false` = original stake was a Fast Stake, `true` = advanced delegation. */
+    isAdvanced: boolean
+    /** Which Restake entry point was tapped. */
+    source: 'card' | 'detail'
+  }
+  /** Stake search screen opened (once per open, not re-fired on back-focus). */
+  StakeSearchOpened: undefined
+  /**
+   * User actually typed a search query, once per search-screen visit. No
+   * payload by design — the query text (node IDs) stays out of analytics.
+   */
+  StakeSearchQueryEntered: undefined
   StakeTransactionStarted: {
     encrypted: { txHash: string; chainId: number }
   }

--- a/packages/k2-alpine/src/components/CircularDial/DialReadout.tsx
+++ b/packages/k2-alpine/src/components/CircularDial/DialReadout.tsx
@@ -453,9 +453,16 @@ export const DialReadout = forwardRef<DialReadoutHandle, DialReadoutProps>(
               amountStyle,
               animatedDigitStyle,
               {
-                // Width is intrinsic; font auto-fit shrinks the
-                // digits before width hits `maxWidth`.
-                maxWidth: AMOUNT_CANVAS_WIDTH,
+                // Fixed width, NOT intrinsic: mid-drag the digits are written
+                // imperatively on the UI thread (`animatedProps.text`), which
+                // does not trigger a Yoga relayout — an intrinsic box keeps
+                // the width of the last laid-out text, so when the value
+                // grows a character (e.g. "9" → "9.1") the tail is clipped
+                // and renders as "9.". A fixed box spanning the readout area
+                // can't be outgrown; the font auto-fit (which targets
+                // `AMOUNT_FIT_WIDTH`) still shrinks long numbers before they
+                // reach the edges.
+                width: AMOUNT_CANVAS_WIDTH,
                 textAlign: 'center',
                 padding: 0,
                 paddingHorizontal: 8,

--- a/packages/k2-alpine/src/components/CircularDial/useDialValue.ts
+++ b/packages/k2-alpine/src/components/CircularDial/useDialValue.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { SharedValue, useSharedValue } from 'react-native-reanimated'
 import { shouldSyncExternalValue, valueToProgress } from './helpers'
 
@@ -23,7 +23,29 @@ export const useDialValue = ({
   // gesture's onEnd / preset completion in CircularDial.
   const isSettling = useSharedValue(false)
 
+  // Last range the progress was mapped against. `shouldSyncExternalValue`'s
+  // step-sized tolerance exists to damp the dial's own onChange echoes — but
+  // when `max` changes (e.g. staking's available-to-stake shrinking once the
+  // async fee reservation resolves), the drift it produces is NOT an echo:
+  // progress is simply mapped against a stale range, so the displayed number
+  // (progress × new max) silently disagrees with the controlled `value`
+  // (1 AVAX rendering as "0.99"). Range changes must always remap.
+  const lastRangeRef = useRef({ max, step })
+
   useEffect(() => {
+    const rangeChanged =
+      lastRangeRef.current.max !== max || lastRangeRef.current.step !== step
+    lastRangeRef.current = { max, step }
+
+    if (rangeChanged) {
+      // Skip only while a gesture owns the dial (same ownership rule the
+      // echo path uses); the next value/range change re-syncs after release.
+      if (!isActive.value && !isSettling.value) {
+        progressSv.value = valueToProgress(value, max)
+      }
+      return
+    }
+
     const currentValue = progressSv.value * max
     const decision = shouldSyncExternalValue({
       value,

--- a/packages/k2-alpine/src/components/CircularDial/useDialValue.ts
+++ b/packages/k2-alpine/src/components/CircularDial/useDialValue.ts
@@ -1,5 +1,10 @@
-import { useEffect, useRef } from 'react'
-import { SharedValue, useSharedValue } from 'react-native-reanimated'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  SharedValue,
+  useAnimatedReaction,
+  useSharedValue
+} from 'react-native-reanimated'
+import { scheduleOnRN } from 'react-native-worklets'
 import { shouldSyncExternalValue, valueToProgress } from './helpers'
 
 export const useDialValue = ({
@@ -32,16 +37,40 @@ export const useDialValue = ({
   // (1 AVAX rendering as "0.99"). Range changes must always remap.
   const lastRangeRef = useRef({ max, step })
 
+  // A range change that arrives while a gesture owns the dial is deferred —
+  // but the effect below only re-runs on prop changes, and the props may
+  // never change again after release (e.g. `max` shrinks during the settle
+  // window and the settled value equals the previous one). `hasPendingRemap`
+  // bridges that gap: the UI-thread reaction below watches ownership end and
+  // bumps `remapRetryTick` so the effect re-runs and applies the deferred
+  // remap.
+  const hasPendingRemap = useSharedValue(false)
+  const [remapRetryTick, setRemapRetryTick] = useState(0)
+  const bumpRemapRetryTick = useCallback(
+    () => setRemapRetryTick(tick => tick + 1),
+    []
+  )
+  useAnimatedReaction(
+    () => isActive.value || isSettling.value,
+    (owned, previouslyOwned) => {
+      if (!owned && previouslyOwned === true && hasPendingRemap.value) {
+        hasPendingRemap.value = false
+        scheduleOnRN(bumpRemapRetryTick)
+      }
+    }
+  )
+
   useEffect(() => {
     const rangeChanged =
       lastRangeRef.current.max !== max || lastRangeRef.current.step !== step
 
     if (rangeChanged) {
       // Defer while a gesture owns the dial (same ownership rule the echo
-      // path uses) — and leave `lastRangeRef` stale so the remap is retried
-      // on the next effect run (the release propagates a fresh `value`)
-      // instead of being dropped.
+      // path uses) — leaving `lastRangeRef` stale and flagging the pending
+      // remap so the ownership-end reaction above retries it even when no
+      // prop changes again after release.
       if (isActive.value || isSettling.value) {
+        hasPendingRemap.value = true
         return
       }
       lastRangeRef.current = { max, step }
@@ -62,7 +91,7 @@ export const useDialValue = ({
       progressSv.value = valueToProgress(decision.target, max)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value, max, step])
+  }, [value, max, step, remapRetryTick])
 
   return { progressSv, isActive, isSettling }
 }

--- a/packages/k2-alpine/src/components/CircularDial/useDialValue.ts
+++ b/packages/k2-alpine/src/components/CircularDial/useDialValue.ts
@@ -35,14 +35,17 @@ export const useDialValue = ({
   useEffect(() => {
     const rangeChanged =
       lastRangeRef.current.max !== max || lastRangeRef.current.step !== step
-    lastRangeRef.current = { max, step }
 
     if (rangeChanged) {
-      // Skip only while a gesture owns the dial (same ownership rule the
-      // echo path uses); the next value/range change re-syncs after release.
-      if (!isActive.value && !isSettling.value) {
-        progressSv.value = valueToProgress(value, max)
+      // Defer while a gesture owns the dial (same ownership rule the echo
+      // path uses) — and leave `lastRangeRef` stale so the remap is retried
+      // on the next effect run (the release propagates a fresh `value`)
+      // instead of being dropped.
+      if (isActive.value || isSettling.value) {
+        return
       }
+      lastRangeRef.current = { max, step }
+      progressSv.value = valueToProgress(value, max)
       return
     }
 

--- a/packages/k2-alpine/src/components/Staking/StakingRewardChart/index.tsx
+++ b/packages/k2-alpine/src/components/Staking/StakingRewardChart/index.tsx
@@ -13,6 +13,7 @@ import React, {
   useEffect,
   useImperativeHandle,
   useMemo,
+  useRef,
   useState
 } from 'react'
 import { InteractionManager, LayoutChangeEvent, ViewStyle } from 'react-native'
@@ -115,12 +116,28 @@ export const StakeRewardChart = forwardRef<
       }
     )
 
+    // `selectionX` is in pixels, so it must be (re)anchored whenever the
+    // geometry (`graphSize`/`gridWidth`, baked into `selectIndex`) changes.
+    // Only the very first anchoring applies `initialIndex`; later re-runs
+    // re-anchor whatever is CURRENTLY selected — including `undefined`
+    // (custom selection cleared via the ref) — because a layout pass or a
+    // data refresh must not override a selection the user has since changed
+    // (it used to snap a custom stake duration back to the initial preset,
+    // CP-14721).
+    const hasAnchoredRef = useRef(false)
     useEffect(() => {
       InteractionManager.runAfterInteractions(() => {
         if (graphSize.width > 0 && graphSize.height > 0) {
-          selectIndex(initialIndex, 0)
+          selectIndex(
+            hasAnchoredRef.current ? animatedSelectedIndex.value : initialIndex,
+            0
+          )
+          hasAnchoredRef.current = true
         }
       })
+      // `animatedSelectedIndex` is a stable SharedValue ref; its `.value` is
+      // read on purpose only when the geometry changes.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [initialIndex, selectIndex, graphSize])
 
     const {
@@ -218,7 +235,14 @@ export const StakeRewardChart = forwardRef<
                 marginHorizontal: 36
               }}
               onLayout={({ nativeEvent: { layout } }) =>
-                setGraphSize({ width: layout.width, height: layout.height })
+                // Only commit when the rect actually changed: a fresh object
+                // per event would re-run the anchoring effect above on every
+                // redundant layout pass.
+                setGraphSize(prev =>
+                  prev.width === layout.width && prev.height === layout.height
+                    ? prev
+                    : { width: layout.width, height: layout.height }
+                )
               }>
               <Canvas
                 style={{ width: graphSize.width, height: graphSize.height }}>


### PR DESCRIPTION
## Description

**Ticket: [CP-14189](https://ava-labs.atlassian.net/browse/CP-14189)**

Cross-cutting polish + analytics pass for the Staking 2.0 Phase 1 flows. Also fixes [CP-14717](https://ava-labs.atlassian.net/browse/CP-14717), [CP-14721](https://ava-labs.atlassian.net/browse/CP-14721) / [CP-14003](https://ava-labs.atlassian.net/browse/CP-14003), and the two issues reported in the CP-14189 comments (dial step, slide-to-stake back swipe).

### Analytics (reusing the existing v1 PascalCase taxonomy)

- `StakeHomeViewed` (focus), `StakeFlowStarted { isAdvanced }` (chooser, balance-blocked taps excluded), `StakeDetailViewed { variant, source: home|search|deeplink }`, `StakeSearchOpened` / `StakeSearchQueryEntered` (payload-free by design), `StakeRestakeStarted { isAdvanced, source: card|detail }`
- `isRestake` stamped on `StakeIssueDelegation` / `StakeDelegationSuccess` / `StakeDelegationFail` so the restake lifecycle reuses the existing delegation events

### Dynamic convenience fee via multivariate feature flags

- `fast-stake-fee-enabled` / `delegation-fee-enabled` now accept a variant string carrying the fee rate in **basis points** (`'1000'` = 10%); the hardcoded 10% constants are removed
- **A plain boolean `true` (no variant) now behaves as fee OFF** — charging a fee requires an explicit rate from PostHog. `'0'` / unparsable variants are also treated as off (no 0% caption, no reward-estimate CTA hold)
- Version-payload gating preserves the variant instead of collapsing it to a boolean

### Polish / fixes

- **CP-14717**: funding preflight pending state is derived synchronously (`checkedKey`), killing the slide-to-stake CTA enable flicker
- **CP-14721 / CP-14003**: k2 `StakingRewardChart` re-anchors the *current* selection on relayout instead of resetting to `initialIndex` — custom stake durations no longer silently revert to the default preset (1 day on Fuji / 90 days on mainnet, Android). Also "1 days" → "1 day" pluralization
- Dial: step coarsened to 0.1 (comment issue 1), readout clipping fixed (fixed-width imperative text), progress remapped when the range changes (0.99 desync)
- Slide-to-stake area no longer triggers the iOS 26 content-wide back-pop gesture (comment issue 2)
- Stake success always lands on the stake home via `dismissTo` (RN7 `navigate` pushes instead of popping)
- Stake-complete deeplink redirects to the CCT swap prefilled with P→C AVAX
- Filter/sort chip switches keep the scroll position (clamped to the new content's range) and keep the fading header in sync across the FlashList remount

## Screenshots/Videos

N/A — flows are visually unchanged; the fixes are behavioral (see testing steps).

## Testing
iOS: 9258
Android: 9259

**Dev Testing**

- Fee flags: set a `2000` variant on `fast-stake-fee-enabled` in the dev PostHog project → amount screen reserves a 20% fee, confirm shows "20% Core fee" caption and a 20% escrow output.
- CP-14721: staking flow → duration → Custom → pick a date (Android) → selection stays on the custom date; presets/chart drag still work
- Restake from home card / detail / search → success returns to stake home
- Analytics (watch the PostHog live events / debug log while driving the flows):
  - Stake tab focus → `StakeHomeViewed` (re-fires on every tab return, not just first mount)
  - Chooser → Fast stake / Delegate with enough AVAX → `StakeFlowStarted { isAdvanced: false / true }`; a balance-blocked tap (Buy/Swap alert) must NOT fire it
  - Open a stake from home / search results / a stake-complete notification → `StakeDetailViewed { variant: active|completed, source: home|search|deeplink }`, once per visit
  - Open search → `StakeSearchOpened` once (returning from a detail pushed on top must not re-fire); type a first query → `StakeSearchQueryEntered` once per visit, with no query text in the payload
  - Tap Restake on a card / on the detail CTA → `StakeRestakeStarted { isAdvanced, source: card|detail }`, and NO `StakeFlowStarted`
  - Slide to stake → `StakeIssueDelegation` then `StakeDelegationSuccess`/`Fail`, each carrying `isRestake` (true only for restake entries) and `convenienceFeeAvax` only when a fee applies
- `core://stakecomplete` deeplink → CCT swap prefilled P-Chain AVAX → C-Chain AVAX; with `fusion-avalanche-cct` off → legacy claim screen
- Stake home: scroll down on Completed → switch to Active → position preserved (clamped when shorter); header title state matches

**QA Testing**

- Regression: fast stake + advanced delegate happy paths, restake from all three entry points, custom duration on Android (mainnet defaults to 90d — CP-14003 scenario)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14189]: https://ava-labs.atlassian.net/browse/CP-14189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-14717]: https://ava-labs.atlassian.net/browse/CP-14717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-14721]: https://ava-labs.atlassian.net/browse/CP-14721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-14003]: https://ava-labs.atlassian.net/browse/CP-14003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ