### PR TITLE
CP-14753: reduce Sentry noise - ignore expected field errors, downgrade handled NFT/WebView failures to warn

### DIFF
--- a/packages/core-mobile/app/new/features/browser/components/Webview.tsx
+++ b/packages/core-mobile/app/new/features/browser/components/Webview.tsx
@@ -43,7 +43,10 @@ export const WebView = ({
       setSupportMultipleWindows={false}
       onError={event => {
         onError?.(event)
-        Logger.error('WebView onError', event.nativeEvent.description)
+        // Load failures are external (site down, connection lost, bad cert)
+        // and already surfaced to the user by the WebView error view — warn
+        // so they don't reach Sentry.
+        Logger.warn('WebView onError', event.nativeEvent.description)
       }}
       onLoadEnd={() => {
         Logger.trace('------> onLoadEnd')

--- a/packages/core-mobile/app/new/features/portfolio/collectibles/CollectiblesContext.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/collectibles/CollectiblesContext.tsx
@@ -130,7 +130,10 @@ export const CollectiblesProvider = ({
             ...prevData,
             [localId]: NftLocalStatus.Unprocessable
           }))
-          Logger.error(e)
+          // Expected in the field (dead/overloaded IPFS gateways, bad URIs,
+          // device offline) and already handled by marking the collectible
+          // unprocessable — not worth a Sentry error.
+          Logger.warn('[CollectiblesContext] failed to process NFT image', e)
         })
     },
     []
@@ -160,7 +163,13 @@ export const CollectiblesProvider = ({
               ...prevData,
               [localId]: NftLocalStatus.Unprocessable
             }))
-            Logger.error(e)
+            // Same failure class as processImageData above — expected in the
+            // field and already handled by marking the collectible
+            // unprocessable.
+            Logger.warn(
+              '[CollectiblesContext] failed to process NFT metadata',
+              e
+            )
           })
       else
         setStatusData(prevData => ({

--- a/packages/core-mobile/app/services/sentry/SentryService.test.ts
+++ b/packages/core-mobile/app/services/sentry/SentryService.test.ts
@@ -111,6 +111,23 @@ describe('SentryService', () => {
     })
 
     // -----------------------------------------------------------------------
+    describe('init', () => {
+      it('ignores expected field errors that carry no actionable signal', () => {
+        service.init()
+
+        expect(Sentry.init).toHaveBeenCalledWith(
+          expect.objectContaining({
+            ignoreErrors: expect.arrayContaining([
+              'Network request failed',
+              '[appCheck/token-error]',
+              '[messaging/unregistered]'
+            ])
+          })
+        )
+      })
+    })
+
+    // -----------------------------------------------------------------------
     describe('captureException', () => {
       it('passes an Error directly with message as extra', () => {
         const error = new Error('original error')

--- a/packages/core-mobile/app/services/sentry/SentryService.ts
+++ b/packages/core-mobile/app/services/sentry/SentryService.ts
@@ -65,6 +65,22 @@ const init = (): void => {
       environment: Config.ENVIRONMENT,
       debug: false,
       spotlight: DevDebuggingConfig.SENTRY_SPOTLIGHT,
+      // Expected field conditions that carry no actionable signal. Entries
+      // are substring-matched against the event message by Sentry's inbound
+      // filter, so one entry covers every capture site.
+      ignoreErrors: [
+        // Generic whatwg-fetch failure whenever the device is offline or a
+        // request is interrupted.
+        'Network request failed',
+        // Firebase AppCheck attestation failing in the field (offline,
+        // rooted device, attestation outage) — thrown by getToken() and
+        // reported by every appCheckFetch caller with its own prefix.
+        '[appCheck/token-error]',
+        // iOS APNs registration hasn't completed yet (e.g. app woken in the
+        // background) when a notification listener asks for an FCM token —
+        // resolves itself on the next foreground token fetch.
+        '[messaging/unregistered]'
+      ],
       beforeSend: scrubSentryData,
       beforeSendTransaction: scrubSentryData,
       beforeBreadcrumb: breadcrumb => {


### PR DESCRIPTION
## Description

**Ticket: [CP-14753](https://ava-labs.atlassian.net/browse/CP-14753)**

A sweep of the `core-react-native` Sentry project showed most of the 30-day error volume is expected field conditions reported as errors (~28k events/30d combined). This PR cuts that noise so real issues stand out:

- **Add `ignoreErrors` to Sentry init** (`SentryService.ts`):
  - `Network request failed` — whatwg-fetch's generic device-offline error ([CORE-REACT-NATIVE-4WW](https://ava-labs.sentry.io/issues/CORE-REACT-NATIVE-4WW), ~12.6k events / 1,692 users per 30d). **Accepted tradeoff:** this also hides fetch failures during a genuine backend outage. The event carries no URL or request context, so it was unactionable even as an outage signal — real incidents still surface via HTTP-status and feature-level errors.
  - `[appCheck/token-error]` — Firebase AppCheck attestation failing in the field (offline, rooted devices, attestation outages). One root cause currently fans out into three Sentry issues because each caller wraps it with its own prefix; the substring filter covers every site ([72Y](https://ava-labs.sentry.io/issues/CORE-REACT-NATIVE-72Y), [5RJ](https://ava-labs.sentry.io/issues/CORE-REACT-NATIVE-5RJ), [5RG](https://ava-labs.sentry.io/issues/CORE-REACT-NATIVE-5RG), ~2.9k events/30d).
  - `[messaging/unregistered]` — iOS APNs registration race when a notification listener requests an FCM token while the app is backgrounded; resolves itself on next foreground fetch ([AN5](https://ava-labs.sentry.io/issues/CORE-REACT-NATIVE-AN5), ~4.3k events/30d).
- **`CollectiblesContext.tsx`**: NFT image and metadata fetch failures (flaky public IPFS gateways, bad URIs) downgraded from `Logger.error` to `Logger.warn` — the failure is already handled by marking the collectible unprocessable ([AN8](https://ava-labs.sentry.io/issues/CORE-REACT-NATIVE-AN8), ~6k events/30d).
- **`Webview.tsx`**: page-load failures downgraded to `Logger.warn` — causes are external (site down, connection lost) and the user already sees the WebView error view ([APD](https://ava-labs.sentry.io/issues/CORE-REACT-NATIVE-APD), ~2.4k events/30d).

No dependencies introduced, no breaking changes. Verified against the installed `@sentry/core` source that passing `integrations: [navigationIntegration]` merges with (not replaces) default integrations, so the `inboundFilters` integration that applies `ignoreErrors` stays active, and that `ignoreErrors` entries substring-match the exception value.

## Screenshots/Videos

N/A — no UI changes (logging/reporting only).

## Testing

**Dev Testing (if applicable)**

- `yarn jest app/services/sentry app/services/nft` — 31 tests pass, including a new test asserting the `ignoreErrors` config passed to `Sentry.init`.
- Airplane-mode the device and pull-to-refresh portfolio: `Network request failed` no longer produces Sentry events (visible in Spotlight / debug builds).
- Open the in-app browser and load a page while offline: error view shows, no Sentry event.
- After release: confirm event counts on the six linked Sentry issues drop to ~0 and resolve them.

**QA Testing (if applicable)**

- No behavior change expected anywhere in the app — error handling paths are unchanged; only what gets reported to Sentry differs. Regression-level pass on portfolio collectibles and in-app browser is sufficient.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14753]: https://ava-labs.atlassian.net/browse/CP-14753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ