### PR TITLE
CP-14758: include HTTP status in defiMarket gqlQuery errors

### DIFF
--- a/packages/core-mobile/app/new/features/defiMarket/utils/gqlQuery.test.ts
+++ b/packages/core-mobile/app/new/features/defiMarket/utils/gqlQuery.test.ts
@@ -1,0 +1,50 @@
+import { gqlQuery } from './gqlQuery'
+
+const mockFetchResponse = (response: Partial<Response>): void => {
+  jest.spyOn(global, 'fetch').mockResolvedValue(response as unknown as Response)
+}
+
+describe('gqlQuery', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('returns the parsed json on success', async () => {
+    mockFetchResponse({
+      ok: true,
+      json: () => Promise.resolve({ data: { markets: [] } })
+    })
+
+    await expect(
+      gqlQuery('https://example.com/gql', '{ markets }')
+    ).resolves.toEqual({
+      data: { markets: [] }
+    })
+  })
+
+  it('includes the http status in the error on non-ok responses', async () => {
+    // React Native's fetch returns an empty statusText, so the status code
+    // is the only signal that distinguishes a 429 from a 500 in Sentry.
+    mockFetchResponse({
+      ok: false,
+      status: 429,
+      statusText: ''
+    })
+
+    await expect(
+      gqlQuery('https://example.com/gql', '{ markets }')
+    ).rejects.toThrow('GraphQL error: HTTP 429')
+  })
+
+  it('appends statusText when the platform provides one', async () => {
+    mockFetchResponse({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable'
+    })
+
+    await expect(
+      gqlQuery('https://example.com/gql', '{ markets }')
+    ).rejects.toThrow('GraphQL error: HTTP 503 Service Unavailable')
+  })
+})

--- a/packages/core-mobile/app/new/features/defiMarket/utils/gqlQuery.ts
+++ b/packages/core-mobile/app/new/features/defiMarket/utils/gqlQuery.ts
@@ -16,7 +16,14 @@ export async function gqlQuery(
   })
 
   if (!response.ok) {
-    throw new Error(`GraphQL error: ${response.statusText}`)
+    // React Native's fetch returns an empty statusText, so include the
+    // status code — otherwise the error reads "GraphQL error: " and a 429
+    // is indistinguishable from a 500.
+    throw new Error(
+      `GraphQL error: HTTP ${response.status}${
+        response.statusText ? ` ${response.statusText}` : ''
+      }`
+    )
   }
 
   return response.json()


### PR DESCRIPTION
## Description

**Ticket: [CP-14758](https://ava-labs.atlassian.net/browse/CP-14758)**

Follow-up from the CP-14753 Sentry noise sweep. `gqlQuery` (defiMarket) throws `` `GraphQL error: ${response.statusText}` `` on non-OK responses, but React Native's fetch returns an empty `statusText` — so Sentry issue [CORE-REACT-NATIVE-9MH](https://ava-labs.sentry.io/issues/CORE-REACT-NATIVE-9MH) reads "GraphQL error: " with no way to tell a 429 from a 500.

The error now includes the HTTP status code (and `statusText` when the platform provides one): `GraphQL error: HTTP 429`. Verified the only caller (`fetchAaveApyHistory.ts`) propagates the error without matching on the message string, so the format change is safe.

No dependencies introduced, no breaking changes.

## Screenshots/Videos

N/A — error-message change only, no UI.

## Testing

**Dev Testing (if applicable)**

- New unit tests in `gqlQuery.test.ts` cover success, empty-`statusText` failure (429), and populated-`statusText` failure (503) — `yarn jest app/new/features/defiMarket/utils/gqlQuery.test.ts`.

**QA Testing (if applicable)**

- No behavior change — DeFi market data loading is unchanged; only the thrown error message differs when the GraphQL endpoint returns a non-OK response.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14758]: https://ava-labs.atlassian.net/browse/CP-14758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ