### PR TITLE
CP-14756: fix P-chain burned-amount validation (never ran; unhandled rejection on every P-chain tx)

### DIFF
--- a/packages/core-mobile/app/hooks/earn/useClaimFees.ts
+++ b/packages/core-mobile/app/hooks/earn/useClaimFees.ts
@@ -201,6 +201,8 @@ const getExportPFee = async ({
       isTestnet: Boolean(avaxXPNetwork.isTestnet),
       destinationAddress: activeAccount.addressPVM,
       destinationChain: 'C',
+      // fee-estimation only — this tx is never submitted
+      shouldValidateBurnedAmount: false,
       feeState,
       xpAddresses
     })
@@ -245,6 +247,8 @@ const getExportPFee = async ({
       isTestnet: Boolean(avaxXPNetwork.isTestnet),
       destinationAddress: activeAccount.addressPVM,
       destinationChain: 'C',
+      // fee-estimation only — this tx is never submitted
+      shouldValidateBurnedAmount: false,
       feeState,
       xpAddresses
     })

--- a/packages/core-mobile/app/services/earn/computeDelegationSteps/utils.ts
+++ b/packages/core-mobile/app/services/earn/computeDelegationSteps/utils.ts
@@ -57,7 +57,7 @@ export const getDelegationFee = async ({
     endDate: getUnixTime(new Date()) + 60 * 60 * 24 * 30,
     rewardAddress,
     isTestnet,
-    shouldValidateBurnedAmount: true,
+    shouldValidateBurnedAmount: false,
     feeState,
     pFeeAdjustmentThreshold,
     xpAddresses
@@ -264,7 +264,7 @@ export const getImportPFee = async ({
     isTestnet,
     sourceChain: 'C',
     destinationAddress,
-    shouldValidateBurnedAmount: true,
+    shouldValidateBurnedAmount: false,
     feeState,
     xpAddresses
   })
@@ -366,7 +366,7 @@ export const getExportCFee = async ({
     isTestnet,
     destinationChain: 'P',
     destinationAddress: addressPVM,
-    shouldValidateBurnedAmount: true,
+    shouldValidateBurnedAmount: false,
     avalancheEvmProvider,
     xpAddresses
   })

--- a/packages/core-mobile/app/services/wallet/AvalancheWalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/AvalancheWalletService.test.ts
@@ -1,11 +1,25 @@
 import { AddDelegatorProps } from 'services/wallet/types'
 import { add, getUnixTime, sub } from 'date-fns'
-import { Utxo } from '@avalabs/avalanchejs'
+import { pvm, Utxo } from '@avalabs/avalanchejs'
 import { PChainId } from '@avalabs/glacier-sdk'
 import BiometricsSDK from 'utils/BiometricsSDK'
 import mockMnemonic from 'tests/fixtures/mockMnemonic.json'
 import { Account } from 'store/account'
+import NetworkService from 'services/network/NetworkService'
 import AvalancheWalletService from './AvalancheWalletService'
+
+const mockValidateBurnedAmount = jest.fn()
+jest.mock('@avalabs/avalanchejs', () => {
+  const actual = jest.requireActual('@avalabs/avalanchejs')
+  return {
+    ...actual,
+    utils: {
+      ...actual.utils,
+      validateBurnedAmount: (...args: unknown[]) =>
+        mockValidateBurnedAmount(...args)
+    }
+  }
+})
 
 jest.mock('@avalabs/core-wallets-sdk', () => ({
   ...jest.requireActual('@avalabs/core-wallets-sdk'),
@@ -155,13 +169,34 @@ describe('WalletService', () => {
         isTestnet: true
       } as AddDelegatorProps
 
-      mockValidateFee.mockImplementationOnce(() => {
-        throw new Error('test fee validation error')
-      })
+      // Async rejection (not a sync throw) so this only passes when the
+      // call site actually awaits validateFee.
+      mockValidateFee.mockRejectedValueOnce(
+        new Error('test fee validation error')
+      )
 
       await expect(async () => {
         await AvalancheWalletService.createAddDelegatorTx(params)
       }).rejects.toThrow('test fee validation error')
+    })
+
+    it('should forward the P-chain fee price from feeState to validateFee', async () => {
+      const params = {
+        account: { index: 0 } as Account,
+        nodeId: validNodeId,
+        stakeAmountInNAvax: fujiValidStakeAmount,
+        startDate: validStartDate,
+        endDate: validEndDateFuji,
+        rewardAddress: validRewardAddress,
+        isTestnet: true,
+        feeState: { price: 7n } as pvm.FeeState
+      } as AddDelegatorProps
+
+      await AvalancheWalletService.createAddDelegatorTx(params)
+
+      expect(mockValidateFee).toHaveBeenCalledWith(
+        expect.objectContaining({ pChainFeePriceInNAvax: 7n })
+      )
     })
 
     it('should not throw if failed to validate fee when shouldValidateBurnedAmount is false', async () => {
@@ -209,6 +244,120 @@ describe('WalletService', () => {
         rewardAddresses: [validRewardAddress]
       })
       expect(unsignedTx).toStrictEqual(mockUnsignedTx)
+    })
+  })
+
+  describe('validateFee', () => {
+    const mockGetFeeState = jest.fn()
+    const mockProvider = {
+      getContext: () => ({}),
+      getApiP: () => ({ getFeeState: mockGetFeeState })
+    }
+
+    let providerSpy: jest.SpyInstance
+
+    const callValidateFee = (args: {
+      isTestnet: boolean
+      unsignedTx: unknown
+      evmBaseFeeInNAvax?: bigint
+      pChainFeePriceInNAvax?: bigint
+    }): Promise<void> =>
+      (
+        AvalancheWalletService as unknown as {
+          validateFee: (a: typeof args) => Promise<void>
+        }
+      ).validateFee(args)
+
+    const evmTx = { getVM: () => 'EVM', getTx: jest.fn() }
+    const pvmTx = { getVM: () => 'PVM', getTx: jest.fn() }
+
+    beforeAll(() => {
+      // The createAddDelegatorTx describe above replaces validateFee with a
+      // mock and never restores it — undo that so we test the real method.
+      const maybeMocked = (
+        AvalancheWalletService as unknown as Record<
+          'validateFee',
+          { mockRestore?: () => void }
+        >
+      ).validateFee
+      maybeMocked.mockRestore?.()
+
+      providerSpy = jest
+        .spyOn(NetworkService, 'getAvalancheProviderXP')
+        // @ts-ignore
+        .mockResolvedValue(mockProvider)
+    })
+
+    beforeEach(() => {
+      mockGetFeeState.mockReset().mockResolvedValue({ price: 5n })
+      mockValidateBurnedAmount.mockReset()
+      mockValidateBurnedAmount.mockReturnValue({ isValid: true, txFee: 1n })
+    })
+
+    afterAll(() => {
+      providerSpy.mockRestore()
+    })
+
+    it('throws for EVM txs when the evm base fee is missing', async () => {
+      await expect(
+        callValidateFee({ isTestnet: true, unsignedTx: evmTx })
+      ).rejects.toThrow('Missing evm fee data')
+      expect(mockValidateBurnedAmount).not.toHaveBeenCalled()
+    })
+
+    it('uses the evm base fee for EVM txs', async () => {
+      await callValidateFee({
+        isTestnet: true,
+        unsignedTx: evmTx,
+        evmBaseFeeInNAvax: 3n
+      })
+
+      expect(mockValidateBurnedAmount).toHaveBeenCalledWith(
+        expect.objectContaining({ baseFee: 3n })
+      )
+    })
+
+    it('uses the caller-provided P-chain fee price for PVM txs', async () => {
+      await callValidateFee({
+        isTestnet: true,
+        unsignedTx: pvmTx,
+        pChainFeePriceInNAvax: 7n
+      })
+
+      expect(mockValidateBurnedAmount).toHaveBeenCalledWith(
+        expect.objectContaining({ baseFee: 7n })
+      )
+      expect(mockGetFeeState).not.toHaveBeenCalled()
+    })
+
+    it('fetches the fee state for PVM txs when no price is provided', async () => {
+      await callValidateFee({ isTestnet: true, unsignedTx: pvmTx })
+
+      expect(mockGetFeeState).toHaveBeenCalled()
+      expect(mockValidateBurnedAmount).toHaveBeenCalledWith(
+        expect.objectContaining({ baseFee: 5n })
+      )
+    })
+
+    it('skips validation when the fee-state fetch fails for PVM txs', async () => {
+      mockGetFeeState.mockRejectedValue(new Error('rpc down'))
+
+      await expect(
+        callValidateFee({ isTestnet: true, unsignedTx: pvmTx })
+      ).resolves.toBeUndefined()
+      expect(mockValidateBurnedAmount).not.toHaveBeenCalled()
+    })
+
+    it('throws when the burned amount is invalid', async () => {
+      mockValidateBurnedAmount.mockReturnValue({ isValid: false, txFee: 9n })
+
+      await expect(
+        callValidateFee({
+          isTestnet: true,
+          unsignedTx: pvmTx,
+          pChainFeePriceInNAvax: 7n
+        })
+      ).rejects.toThrow('Excessive burn amount')
     })
   })
 

--- a/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
+++ b/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
@@ -199,12 +199,13 @@ class AvalancheWalletService {
       destinationAddress
     )
 
-    shouldValidateBurnedAmount &&
-      this.validateFee({
+    if (shouldValidateBurnedAmount) {
+      await this.validateFee({
         isTestnet,
         unsignedTx,
         evmBaseFeeInNAvax: baseFeeInNAvax
       })
+    }
 
     return unsignedTx
   }
@@ -233,11 +234,13 @@ class AvalancheWalletService {
       feeState
     })
 
-    shouldValidateBurnedAmount &&
-      this.validateFee({
+    if (shouldValidateBurnedAmount) {
+      await this.validateFee({
         isTestnet,
-        unsignedTx
+        unsignedTx,
+        pChainFeePriceInNAvax: feeState?.price
       })
+    }
 
     return unsignedTx
   }
@@ -268,11 +271,13 @@ class AvalancheWalletService {
       feeState
     })
 
-    shouldValidateBurnedAmount &&
-      this.validateFee({
+    if (shouldValidateBurnedAmount) {
+      await this.validateFee({
         isTestnet,
-        unsignedTx
+        unsignedTx,
+        pChainFeePriceInNAvax: feeState?.price
       })
+    }
 
     return unsignedTx
   }
@@ -467,12 +472,13 @@ class AvalancheWalletService {
       destinationAddress
     )
 
-    shouldValidateBurnedAmount &&
-      this.validateFee({
+    if (shouldValidateBurnedAmount) {
+      await this.validateFee({
         isTestnet,
         unsignedTx,
         evmBaseFeeInNAvax: baseFeeInNAvax
       })
+    }
 
     return unsignedTx
   }
@@ -554,11 +560,13 @@ class AvalancheWalletService {
       throw error
     }
 
-    shouldValidateBurnedAmount &&
-      this.validateFee({
+    if (shouldValidateBurnedAmount) {
+      await this.validateFee({
         isTestnet,
-        unsignedTx
+        unsignedTx,
+        pChainFeePriceInNAvax: feeState?.price
       })
+    }
 
     return unsignedTx
   }
@@ -661,26 +669,56 @@ class AvalancheWalletService {
   private async validateFee({
     isTestnet,
     unsignedTx,
-    evmBaseFeeInNAvax
+    evmBaseFeeInNAvax,
+    pChainFeePriceInNAvax
   }: {
     isTestnet: boolean
     unsignedTx: UnsignedTx
     evmBaseFeeInNAvax?: bigint
+    pChainFeePriceInNAvax?: bigint
   }): Promise<void> {
-    if (evmBaseFeeInNAvax === undefined) {
-      throw new Error('Missing evm fee data')
-    }
-
-    Logger.info('validating burned amount')
-
     const avalancheProvider = await NetworkService.getAvalancheProviderXP(
       isTestnet
     )
 
+    // validateBurnedAmount interprets `baseFee` per VM: the EVM base fee for
+    // C-chain atomic txs, the P-chain dynamic fee price for PVM txs. The
+    // static X-chain path ignores it.
+    let baseFee: bigint
+    const vm = unsignedTx.getVM()
+    if (vm === 'EVM') {
+      if (evmBaseFeeInNAvax === undefined) {
+        throw new Error('Missing evm fee data')
+      }
+      baseFee = evmBaseFeeInNAvax
+    } else if (vm === 'PVM') {
+      let price = pChainFeePriceInNAvax
+      if (price === undefined) {
+        try {
+          price = (await avalancheProvider.getApiP().getFeeState()).price
+        } catch (error) {
+          // Fail open: without a reference price the check can't run, and a
+          // transient RPC failure must not block staking/claim actions.
+          // (Substituting 0 would be worse — a zero expected fee makes any
+          // real burn look excessive and fails the validation.)
+          Logger.warn(
+            'skipping burned amount validation, unable to fetch P-Chain fee state',
+            error
+          )
+          return
+        }
+      }
+      baseFee = price
+    } else {
+      baseFee = 0n
+    }
+
+    Logger.info('validating burned amount')
+
     const { isValid, txFee } = utils.validateBurnedAmount({
       unsignedTx,
       context: avalancheProvider.getContext(),
-      baseFee: evmBaseFeeInNAvax,
+      baseFee,
       feeTolerance: EVM_FEE_TOLERANCE
     })
 


### PR DESCRIPTION
## Description

**Ticket: [CP-14756](https://ava-labs.atlassian.net/browse/CP-14756)**

Fixes the largest error issue in the core-react-native Sentry project ([CORE-REACT-NATIVE-8Z2](https://ava-labs.sentry.io/issues/CORE-REACT-NATIVE-8Z2), 19.6k events / 1,134 users since Dec 2025) — and more importantly, resurrects a dead safety check.

**The bug:** `validateFee` threw `Missing evm fee data` whenever `evmBaseFeeInNAvax` was `undefined`. The three P-chain call sites (`createExportPTx`, `createImportPTx`, `createAddDelegatorTx`) never passed it — for P-chain txs there is no EVM base fee — so validation threw unconditionally. And because all five call sites invoked it fire-and-forget (`shouldValidateBurnedAmount && this.validateFee({...})`), the rejection was unobserved: every P-chain export/import/delegation logged an unhandled rejection to Sentry, and burned-amount validation **never actually ran** on any path (even the C-chain sites could not block a bad tx, since nothing awaited the result).

**The fix**, following the SDK's own canonical per-VM baseFee sourcing (the compiled validate helper in `@avalabs/core-wallets-sdk`):

- `validateFee` now branches on `unsignedTx.getVM()`:
  - `EVM` (C-chain atomic txs) → requires `evmBaseFeeInNAvax`, as before.
  - `PVM` → uses the new optional `pChainFeePriceInNAvax` (call sites pass `feeState?.price` — the same fee state the tx builder used), falling back to a fresh `provider.getApiP().getFeeState().price` when absent. If that fallback fetch fails, validation is **skipped with a warning** (fail-open): a transient RPC failure must not block staking/claim actions, and substituting a zero price would make any real burn look excessive.
  - other VMs → `baseFee: 0n` (the static validation path ignores it).
- All five call sites now `await` inside `if (shouldValidateBurnedAmount) { ... }`, so an excessive-burn tx fails creation instead of throwing into the void. This matches the intent already pinned by the existing test `'should throw if failed to validate fee'`, which only passed before because its mock threw synchronously.
- **Fee-estimation call sites opt out**: the delegation planner's dummy txs (`computeDelegationSteps/utils.ts` — literally `NodeID-1` and dummy amounts) and `useClaimFees`' preflight `createExportPTx` calls now pass `shouldValidateBurnedAmount: false`, matching the existing convention at `useClaimFees.ts` (import estimation). These txs are never submitted, and a validation rejection inside estimation would be misclassified by the planner as a balance failure. Real issuance paths (`EarnService`, `exportP.ts`, `importP.ts`) keep validation enforced.

No dependencies introduced. Behavior notes:

- Fee validation is now actually enforced on issuance — the existing 50% `feeTolerance` and the fact that validation uses the same `feeState` the builder burned against keep legitimate txs passing.
- The 50% tolerance is generous for P-chain (fees there are deterministic `price × gas`), so this catches catastrophic overburn bugs rather than small ones. Deliberately not tightened in the same PR that revives a dead check — a per-VM tolerance is a possible follow-up.

## Screenshots/Videos

N/A — no UI changes.

## Testing

**Dev Testing (if applicable)**

- `yarn jest app/services/wallet/AvalancheWalletService.test.ts` — 17 tests, including new coverage: the fee-failure test now uses an **async** rejection (proves the `await`), `feeState.price` forwarding, and five direct `validateFee` cases (EVM missing-fee throw, EVM fee used, P-chain caller price used, P-chain fetch fallback, excessive-burn throw).
- `yarn jest app/services/earn app/hooks/earn` — 84 tests pass (delegation flows, claim fees, import/export P).
- On-device happy path: stake on Fuji (Stake → Add Delegation), claim rewards, and confirm no `Missing evm fee data` events in Sentry Spotlight; txs proceed normally.

**QA Testing (if applicable)**

- Regression pass on staking flows (delegate, claim, cross-chain transfer C↔P). Expected: identical UX; the only new user-visible behavior is that a transaction whose burned fee exceeds the expected fee by >50% now fails with "Excessive burn amount" instead of being submitted.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14756]: https://ava-labs.atlassian.net/browse/CP-14756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ