### PR TITLE
CP-14761: fix CCT export/import approval modal card spacing

### DIFF
--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
@@ -446,11 +446,16 @@ const ApprovalScreenInner = ({
     return (
       // `Details` no longer carries its own top margin (removed so it doesn't
       // double-space against the spend-limit block on the batch screen), so the
-      // 12px gap above the details card is supplied here at the composition
-      // level to keep it separated from the preceding card.
-      <View sx={{ marginTop: 12 }}>
+      // 12px gap is supplied here at the composition level. It must sit on each
+      // section — not just the wrapper — otherwise multi-section approvals (e.g.
+      // an Avalanche CCT export/import, which emits Source/Target, Amount and
+      // Network Fee cards) render flush against one another. This restores the
+      // pre-batch-screen behaviour where every section card was 12px apart.
+      <View>
         {filteredSections.map((detailSection, index) => (
-          <Details key={index} detailSection={detailSection} symbol={symbol} />
+          <View key={index} sx={{ marginTop: 12 }}>
+            <Details detailSection={detailSection} symbol={symbol} />
+          </View>
         ))}
       </View>
     )


### PR DESCRIPTION
## Description

**Ticket: [CP-14761](https://ava-labs.atlassian.net/browse/CP-14761)**

The CCT (cross-chain transfer) **Export/Import approval modal** rendered its detail cards flush against each other with no spacing between them.

**Root cause:** the batch-approval PR ([#3938](https://github.com/ava-labs/core-mobile/pull/3938)) removed the built-in `marginTop: 12` from the `Details` component (correct — it was double-spacing against the spend-limit block on the new batch screen) but replaced it in `ApprovalScreen` with a **single** `marginTop` on the wrapping `<View>` instead of a per-section margin. The Avalanche module emits **multiple** detail sections for an export/import (Source/Target Chain, Transaction Type/Amount, Network Fee), so they all collapsed together.

**Fix:** move the `12px` gap back onto each section in `renderDetails` — exactly reproducing the pre-batch layout for the regular approval modal — while leaving `Details` margin-free so the batch approval screen's spacing (and thus the batch approval UI) is unaffected.

- One-file change: `ApprovalScreen.tsx` → `renderDetails`.
- No dependencies introduced. Not breaking.

## Screenshots/Videos

Screenshots are rendered from the real approval components (`Details` / `Account` / `Network` / `SpendLimits` / `BalanceChange`) driven through the exact `renderDetails` composition. The change is a shared React Native layout tweak, so behavior is identical on Android.

### Before → After (Avalanche Export — the regression case)

| Before (cards flush / no gap) | After (12px gap per card) |
|---|---|
| <img src="https://raw.githubusercontent.com/ava-labs/core-mobile/cp-14761-screenshots/packages/core-mobile/cp-14761-approval-screenshots/00-avalancheExport-BEFORE-bug.png" width="280"> | <img src="https://raw.githubusercontent.com/ava-labs/core-mobile/cp-14761-screenshots/packages/core-mobile/cp-14761-approval-screenshots/03-avalancheExport.png" width="280"> |

### After — spacing verified across every approval type

| EVM send | ERC-20 approval | Avalanche Import |
|---|---|---|
| <img src="https://raw.githubusercontent.com/ava-labs/core-mobile/cp-14761-screenshots/packages/core-mobile/cp-14761-approval-screenshots/01-evmSend.png" width="240"> | <img src="https://raw.githubusercontent.com/ava-labs/core-mobile/cp-14761-screenshots/packages/core-mobile/cp-14761-approval-screenshots/02-erc20Approve.png" width="240"> | <img src="https://raw.githubusercontent.com/ava-labs/core-mobile/cp-14761-screenshots/packages/core-mobile/cp-14761-approval-screenshots/04-avalancheImport.png" width="240"> |

| Staking (add delegator) | Swap (balance change) | Stress: 4 stacked sections |
|---|---|---|
| <img src="https://raw.githubusercontent.com/ava-labs/core-mobile/cp-14761-screenshots/packages/core-mobile/cp-14761-approval-screenshots/05-avalancheStake.png" width="240"> | <img src="https://raw.githubusercontent.com/ava-labs/core-mobile/cp-14761-screenshots/packages/core-mobile/cp-14761-approval-screenshots/06-swapBalanceChange.png" width="240"> | <img src="https://raw.githubusercontent.com/ava-labs/core-mobile/cp-14761-screenshots/packages/core-mobile/cp-14761-approval-screenshots/07-manySections.png" width="240"> |

> Note: "undefined USDC" in the ERC-20 shot is a preview mock-data artifact (unlimited allowance), not a product change — only the card spacing is relevant here.

## Testing

**Dev Testing**

- Start a Swap that routes through Avalanche cross-chain (C↔P), advance to the **Export/Import approval modal**.
- Verify the detail cards — **Source/Target Chain**, **Transaction Type/Amount**, **Network Fee** — are separated by consistent spacing and no longer touch each other.
- Confirm a plain EVM send and an ERC-20 approval approval sheet still show the account/network card and details with the same spacing as before.
- Confirm a **batch (recurring swap) approval** is unchanged — its per-step spacing is unaffected by this change.
- Build: iOS/Android below.

**QA Testing**

- Acceptance: on the CCT export/import approval, every detail section card has a visible, uniform gap between it and the adjacent cards (matches pre-batch-approval behavior). Regular single-section approvals and the batch approval flow are visually unchanged.

## Build Numbers

- iOS: 9259
- Android: 9260
- Pipeline: https://app.bitrise.io/app/7d7ca5af7066e290/pipelines/26c76ee1-2d1f-4536-a7b4-71537ac57787

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14761]: https://ava-labs.atlassian.net/browse/CP-14761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ