### PR TITLE
CP-14759: stop supported-chains Sentry flood (207k events) - dedupe query errors, add HTTP status, fix CancelledError source

### DIFF
--- a/packages/core-mobile/app/contexts/ReactQueryProvider.test.ts
+++ b/packages/core-mobile/app/contexts/ReactQueryProvider.test.ts
@@ -27,8 +27,9 @@ jest.mock('@react-native-community/netinfo', () => ({
 }))
 
 jest.mock('@tanstack/react-query', () => {
-  mockInvalidateQueries = jest.fn()
+  mockInvalidateQueries = jest.fn().mockResolvedValue(undefined)
   return {
+    isCancelledError: jest.fn().mockReturnValue(false),
     QueryClient: jest.fn().mockImplementation(() => ({
       invalidateQueries: mockInvalidateQueries,
       setQueryData: jest.fn(),

--- a/packages/core-mobile/app/contexts/ReactQueryProvider.tsx
+++ b/packages/core-mobile/app/contexts/ReactQueryProvider.tsx
@@ -10,7 +10,7 @@ import {
   removeOldestQuery
 } from '@tanstack/react-query-persist-client'
 import NetInfo from '@react-native-community/netinfo'
-import { onlineManager } from '@tanstack/react-query'
+import { isCancelledError, onlineManager } from '@tanstack/react-query'
 import { AppState, AppStateStatus } from 'react-native'
 import { queryStorage } from 'utils/mmkv'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
@@ -18,6 +18,7 @@ import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persist
 import { useNetworksListener } from 'hooks/networks/useNetworksListener'
 import { useWatchlistListener } from 'hooks/watchlist/useWatchlistListener'
 import Logger from 'utils/Logger'
+import { onQueryError } from './reactQueryErrorHandler'
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -27,9 +28,7 @@ export const queryClient = new QueryClient({
     }
   },
   queryCache: new QueryCache({
-    onError: (error: unknown) => {
-      Logger.error('[ReactQueryProvider] Query error', error)
-    }
+    onError: onQueryError
   })
 })
 
@@ -94,7 +93,16 @@ onlineManager.setEventListener(setOnline => {
       // (null = cold start, false = was offline), invalidate all queries
       // so active observers refetch fresh data.
       if (state.isInternetReachable && wasReachable !== true) {
-        queryClient.invalidateQueries()
+        // The returned promise rejects with CancelledError when an
+        // in-flight refetch gets cancelled (e.g. connectivity flaps
+        // mid-refetch) — routine, but unhandled it lands in Sentry
+        // (CORE-REACT-NATIVE-ABX). Real refetch failures are already
+        // reported by the QueryCache onError handler.
+        queryClient.invalidateQueries().catch(error => {
+          if (!isCancelledError(error)) {
+            Logger.warn('[ReactQueryProvider] invalidateQueries failed', error)
+          }
+        })
       }
     } else if (state.isConnected === false) {
       lastReachable = false

--- a/packages/core-mobile/app/contexts/ReactQueryProvider.tsx
+++ b/packages/core-mobile/app/contexts/ReactQueryProvider.tsx
@@ -1,5 +1,7 @@
 import React, { PropsWithChildren, useEffect } from 'react'
 import {
+  isCancelledError,
+  onlineManager,
   Query,
   QueryCache,
   QueryClient,
@@ -10,7 +12,6 @@ import {
   removeOldestQuery
 } from '@tanstack/react-query-persist-client'
 import NetInfo from '@react-native-community/netinfo'
-import { isCancelledError, onlineManager } from '@tanstack/react-query'
 import { AppState, AppStateStatus } from 'react-native'
 import { queryStorage } from 'utils/mmkv'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'

--- a/packages/core-mobile/app/contexts/reactQueryErrorHandler.test.ts
+++ b/packages/core-mobile/app/contexts/reactQueryErrorHandler.test.ts
@@ -72,11 +72,10 @@ describe('onQueryError', () => {
     expect(Logger.warn).not.toHaveBeenCalled()
   })
 
-  it('handles non-Error rejection values despite the typed signature', () => {
+  it('handles non-Error rejection values', () => {
     const query = queryWithHash('["chains"]')
-    const nonError = 'string failure' as unknown as Error
-    onQueryError(nonError, query)
-    onQueryError(nonError, query)
+    onQueryError('string failure', query)
+    onQueryError('string failure', query)
 
     expect(Logger.error).toHaveBeenCalledTimes(1)
     expect(Logger.warn).toHaveBeenCalledTimes(1)

--- a/packages/core-mobile/app/contexts/reactQueryErrorHandler.test.ts
+++ b/packages/core-mobile/app/contexts/reactQueryErrorHandler.test.ts
@@ -20,11 +20,24 @@ describe('onQueryError', () => {
     resetReportedQueryErrors()
   })
 
-  it('reports the first occurrence of an error at error level', () => {
-    onQueryError(new Error('boom'), queryWithHash('["chains"]'))
+  it('reports the first occurrence of an error at error level with the query hash as a tag', () => {
+    const error = new Error('boom')
+    onQueryError(error, queryWithHash('["chains"]'))
 
     expect(Logger.error).toHaveBeenCalledTimes(1)
+    expect(Logger.error).toHaveBeenCalledWith(
+      '[ReactQueryProvider] Query error',
+      error,
+      { queryHash: '["chains"]' }
+    )
     expect(Logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('truncates long query hashes to the sentry tag value limit', () => {
+    onQueryError(new Error('boom'), queryWithHash('x'.repeat(300)))
+
+    const tags = (Logger.error as jest.Mock).mock.calls[0][2]
+    expect(tags.queryHash).toHaveLength(200)
   })
 
   it('downgrades repeats of the same query error to warn', () => {

--- a/packages/core-mobile/app/contexts/reactQueryErrorHandler.test.ts
+++ b/packages/core-mobile/app/contexts/reactQueryErrorHandler.test.ts
@@ -1,0 +1,71 @@
+import { CancelledError } from '@tanstack/query-core'
+import Logger from 'utils/Logger'
+import {
+  onQueryError,
+  resetReportedQueryErrors
+} from './reactQueryErrorHandler'
+
+jest.mock('utils/Logger', () => ({
+  error: jest.fn(),
+  warn: jest.fn()
+}))
+
+const queryWithHash = (queryHash: string): { queryHash: string } => ({
+  queryHash
+})
+
+describe('onQueryError', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetReportedQueryErrors()
+  })
+
+  it('reports the first occurrence of an error at error level', () => {
+    onQueryError(new Error('boom'), queryWithHash('["chains"]'))
+
+    expect(Logger.error).toHaveBeenCalledTimes(1)
+    expect(Logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('downgrades repeats of the same query error to warn', () => {
+    const query = queryWithHash('["chains"]')
+    onQueryError(new Error('boom'), query)
+    onQueryError(new Error('boom'), query)
+    onQueryError(new Error('boom'), query)
+
+    expect(Logger.error).toHaveBeenCalledTimes(1)
+    expect(Logger.warn).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports again when the same query fails with a different message', () => {
+    const query = queryWithHash('["chains"]')
+    onQueryError(new Error('HTTP 500'), query)
+    onQueryError(new Error('HTTP 403'), query)
+
+    expect(Logger.error).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports the same error message for different queries independently', () => {
+    onQueryError(new Error('boom'), queryWithHash('["a"]'))
+    onQueryError(new Error('boom'), queryWithHash('["b"]'))
+
+    expect(Logger.error).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores React Query cancellations entirely', () => {
+    onQueryError(new CancelledError(), queryWithHash('["chains"]'))
+
+    expect(Logger.error).not.toHaveBeenCalled()
+    expect(Logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('handles non-Error rejection values despite the typed signature', () => {
+    const query = queryWithHash('["chains"]')
+    const nonError = 'string failure' as unknown as Error
+    onQueryError(nonError, query)
+    onQueryError(nonError, query)
+
+    expect(Logger.error).toHaveBeenCalledTimes(1)
+    expect(Logger.warn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core-mobile/app/contexts/reactQueryErrorHandler.ts
+++ b/packages/core-mobile/app/contexts/reactQueryErrorHandler.ts
@@ -44,7 +44,12 @@ export const onQueryError = (
     reportedErrors.add(key)
   }
 
-  Logger.error('[ReactQueryProvider] Query error', error)
+  // Tag with the query hash so Sentry can be searched/faceted by which
+  // query failed (truncated to Sentry's 200-char tag value limit; the
+  // beforeSend scrubber covers any sensitive values embedded in keys).
+  Logger.error('[ReactQueryProvider] Query error', error, {
+    queryHash: query.queryHash.slice(0, 200)
+  })
 }
 
 /**

--- a/packages/core-mobile/app/contexts/reactQueryErrorHandler.ts
+++ b/packages/core-mobile/app/contexts/reactQueryErrorHandler.ts
@@ -1,0 +1,55 @@
+import { isCancelledError } from '@tanstack/react-query'
+import Logger from 'utils/Logger'
+
+/**
+ * Bounded so a pathological session (e.g. hundreds of distinct failing
+ * queries) can't grow memory unbounded; beyond the cap every failure is
+ * reported, which simply reverts to the pre-dedupe behavior.
+ */
+const MAX_TRACKED_ERRORS = 200
+
+const reportedErrors = new Set<string>()
+
+/**
+ * Global QueryCache error handler.
+ *
+ * Reports each unique (query, error message) pair once per session at error
+ * level (which reaches Sentry via Logger.error) and downgrades repeats to
+ * warn. Recurring background polls against a persistently failing endpoint
+ * otherwise emit an identical Sentry event on every poll cycle — the
+ * "Failed to fetch supported chains" issue accumulated 200k+ events this
+ * way (CP-14759).
+ *
+ * The CancelledError guard is defensive only: in the current react-query
+ * version the query filters cancellations before invoking QueryCache
+ * onError, but that's an internal detail a version bump could change —
+ * and this handler is the gateway to Sentry.
+ */
+export const onQueryError = (
+  error: Error,
+  query: { queryHash: string }
+): void => {
+  if (isCancelledError(error)) return
+
+  // Defensive: queryFns can reject with non-Error values despite the type.
+  const message = error instanceof Error ? error.message : String(error)
+  const key = `${query.queryHash}:${message}`
+
+  if (reportedErrors.has(key)) {
+    Logger.warn('[ReactQueryProvider] Query error (repeat)', error)
+    return
+  }
+
+  if (reportedErrors.size < MAX_TRACKED_ERRORS) {
+    reportedErrors.add(key)
+  }
+
+  Logger.error('[ReactQueryProvider] Query error', error)
+}
+
+/**
+ * Test-only: clears the once-per-session dedupe state.
+ */
+export const resetReportedQueryErrors = (): void => {
+  reportedErrors.clear()
+}

--- a/packages/core-mobile/app/contexts/reactQueryErrorHandler.ts
+++ b/packages/core-mobile/app/contexts/reactQueryErrorHandler.ts
@@ -26,12 +26,11 @@ const reportedErrors = new Set<string>()
  * and this handler is the gateway to Sentry.
  */
 export const onQueryError = (
-  error: Error,
+  error: unknown,
   query: { queryHash: string }
 ): void => {
   if (isCancelledError(error)) return
 
-  // Defensive: queryFns can reject with non-Error values despite the type.
   const message = error instanceof Error ? error.message : String(error)
   const key = `${query.queryHash}:${message}`
 

--- a/packages/core-mobile/app/hooks/balance/useSupportedChains.test.ts
+++ b/packages/core-mobile/app/hooks/balance/useSupportedChains.test.ts
@@ -1,0 +1,52 @@
+import { fetchSupportedChains } from './useSupportedChains'
+
+jest.mock('contexts/ReactQueryProvider', () => ({
+  queryClient: { fetchQuery: jest.fn() }
+}))
+
+jest.mock('utils/api/clients/balanceApiClient', () => ({
+  balanceApiClient: {}
+}))
+
+const mockGetSupportedChains = jest.fn()
+jest.mock('utils/api/generated/balanceApi.client', () => ({
+  getV1BalanceGetSupportedChains: (...args: unknown[]) =>
+    mockGetSupportedChains(...args)
+}))
+
+describe('fetchSupportedChains', () => {
+  beforeEach(() => {
+    mockGetSupportedChains.mockReset()
+  })
+
+  it('returns the caip2 ids on success', async () => {
+    mockGetSupportedChains.mockResolvedValue({
+      data: { caip2Ids: ['eip155:43114', 'bip122:000000000019d6689c085ae1'] },
+      response: { status: 200 }
+    })
+
+    await expect(fetchSupportedChains()).resolves.toEqual([
+      'eip155:43114',
+      'bip122:000000000019d6689c085ae1'
+    ])
+  })
+
+  it('includes the http status in the error when the api fails', async () => {
+    mockGetSupportedChains.mockResolvedValue({
+      error: { message: 'forbidden' },
+      response: { status: 403 }
+    })
+
+    await expect(fetchSupportedChains()).rejects.toThrow(
+      'Failed to fetch supported chains (HTTP 403)'
+    )
+  })
+
+  it('reports an unknown status when no response is available', async () => {
+    mockGetSupportedChains.mockResolvedValue({})
+
+    await expect(fetchSupportedChains()).rejects.toThrow(
+      'Failed to fetch supported chains (HTTP unknown)'
+    )
+  })
+})

--- a/packages/core-mobile/app/hooks/balance/useSupportedChains.ts
+++ b/packages/core-mobile/app/hooks/balance/useSupportedChains.ts
@@ -7,15 +7,22 @@ import { balanceApiClient } from 'utils/api/clients/balanceApiClient'
 const STALE_TIME = 5 * 60 * 1000 // 5 minutes
 
 /**
- * Fetches supported chain IDs from the balance API
+ * Fetches supported chain IDs from the balance API.
+ * Exported for tests.
  */
-const fetchSupportedChains = async (): Promise<string[]> => {
+export const fetchSupportedChains = async (): Promise<string[]> => {
   const result = await getV1BalanceGetSupportedChains({
     client: balanceApiClient
   })
 
   if (result.error || !result.data) {
-    throw new Error('Failed to fetch supported chains')
+    // Include the status so a 403 (e.g. region blocking) is distinguishable
+    // from a 5xx in Sentry — the bare message hid this for 200k+ events.
+    throw new Error(
+      `Failed to fetch supported chains (HTTP ${
+        result.response?.status ?? 'unknown'
+      })`
+    )
   }
 
   return result.data.caip2Ids


### PR DESCRIPTION
## Description

**Ticket: [CP-14759](https://ava-labs.atlassian.net/browse/CP-14759)**

Fixes the two remaining flood sources in the core-react-native Sentry project, both traced to `ReactQueryProvider`:

**1. "Failed to fetch supported chains" — [CORE-REACT-NATIVE-9JE](https://ava-labs.sentry.io/issues/CORE-REACT-NATIVE-9JE), 207k events / 750 users since Feb.**
The global `QueryCache.onError` reported every failed query at error level, and `BalanceService` polls the supported-chains query constantly — so a user whose balance-API requests persistently fail (sample events include backgrounded Mac Catalyst instances polling for hours) emitted an identical Sentry event on every poll cycle.

- New `reactQueryErrorHandler.ts`: reports each unique `(queryHash, error message)` pair **once per session** at error level; repeats downgrade to warn (console only). Bounded at 200 tracked keys (beyond the cap, behavior reverts to report-everything). Outage visibility is preserved — every distinct failure still reports once per app launch.
- `fetchSupportedChains` now includes the HTTP status in the thrown error (`Failed to fetch supported chains (HTTP 403)`), so region-blocking vs server errors becomes distinguishable. The hey-api client returns `response: undefined` when fetch itself throws — handled with `?? 'unknown'` (and raw network `TypeError`s are already dropped by CP-14753's `ignoreErrors`).

**2. `CancelledError` — [CORE-REACT-NATIVE-ABX](https://ava-labs.sentry.io/issues/CORE-REACT-NATIVE-ABX), ~500 events/30d.**
Review of the installed react-query source showed `QueryCache.onError` never receives cancellations (the query filters them upstream) — the real source is the **un-awaited `queryClient.invalidateQueries()`** in the NetInfo reconnect listener, whose promise rejects with `CancelledError` when connectivity flaps mid-refetch. Now caught at that site: cancellations ignored, genuine invalidation failures logged at warn (real refetch failures already report via the query cache handler). The handler also keeps a defensive `isCancelledError` guard in case a react-query upgrade changes the upstream filtering.

No dependencies introduced, no behavior change to data fetching — only what gets reported to Sentry.

## Screenshots/Videos

N/A — logging/reporting only.

## Testing

**Dev Testing (if applicable)**

- `yarn jest app/contexts app/hooks/balance` — 16 tests: new `onQueryError` suite (first-occurrence reporting, repeat downgrade, per-message and per-query independence, cancellation skip, non-Error values) and new `fetchSupportedChains` suite (success, status-in-message, missing-response fallback). Existing provider connectivity tests still pass.
- `yarn jest app/services/balance` — 55 tests pass.
- After release: CORE-REACT-NATIVE-9JE event volume should drop from ~1.5k/day to roughly one event per affected user per app launch, with statuses visible in the message; CORE-REACT-NATIVE-ABX should stop entirely.

**QA Testing (if applicable)**

- No user-facing behavior change. Regression-level sanity on portfolio load and offline→online recovery (queries refetch on reconnect as before).

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14759]: https://ava-labs.atlassian.net/browse/CP-14759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ