### PR TITLE
CP-13903: [Settings] Add toggle to filter out small UTXOs

### DIFF
--- a/packages/core-mobile/app/consts/reactQueryKeys.ts
+++ b/packages/core-mobile/app/consts/reactQueryKeys.ts
@@ -3,6 +3,7 @@ export enum ReactQueryKeys {
   ACCOUNTS_BALANCES = 'accountsBalances',
   BALANCE_SUPPORTED_CHAINS = 'balanceSupportedChains',
   XP_ADDRESSES = 'xpAddresses',
+  SPENDABLE_XP_BALANCE = 'spendableXpBalance',
 
   // defi
   DEFI_EXCHANGE_RATES = 'defiExchangeRates',

--- a/packages/core-mobile/app/hooks/earn/useRefreshStakingBalances.ts
+++ b/packages/core-mobile/app/hooks/earn/useRefreshStakingBalances.ts
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux'
 import { selectActiveAccount } from 'store/account'
 import { selectEnabledNetworks } from 'store/network'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
+import { selectIsFilterSmallUtxosActive } from 'store/settings/advanced/filterSmallUtxosActive'
 import { useXPAddresses } from 'hooks/useXPAddresses/useXPAddresses'
 
 export const useRefreshStakingBalances = (
@@ -15,6 +16,7 @@ export const useRefreshStakingBalances = (
   const activeAccount = useSelector(selectActiveAccount)
   const { xpAddresses } = useXPAddresses(activeAccount)
   const enabledNetworks = useSelector(selectEnabledNetworks)
+  const filterOutDustUtxos = useSelector(selectIsFilterSmallUtxosActive)
 
   return useCallback(
     ({ shouldRefreshStakes }: { shouldRefreshStakes: boolean }) => {
@@ -25,7 +27,11 @@ export const useRefreshStakingBalances = (
           })
         }
         queryClient.invalidateQueries({
-          queryKey: balanceKey(activeAccount, Object.values(enabledNetworks))
+          queryKey: balanceKey(
+            activeAccount,
+            Object.values(enabledNetworks),
+            filterOutDustUtxos
+          )
         })
       }, timeout)
     },
@@ -35,7 +41,8 @@ export const useRefreshStakingBalances = (
       activeAccount,
       isDeveloperMode,
       enabledNetworks,
-      xpAddresses
+      xpAddresses,
+      filterOutDustUtxos
     ]
   )
 }

--- a/packages/core-mobile/app/new/common/hooks/send/useAVMSend.ts
+++ b/packages/core-mobile/app/new/common/hooks/send/useAVMSend.ts
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useSelector } from 'react-redux'
+import { selectIsFilterSmallUtxosActive } from 'store/settings/advanced/filterSmallUtxosActive'
 import { useInAppRequest } from 'hooks/useInAppRequest'
 import { TokenWithBalanceAVM } from '@avalabs/vm-module-types'
 import { assertNotUndefined } from 'utils/assertions'
@@ -9,6 +11,7 @@ import Logger from 'utils/Logger'
 import { useSendContext } from 'new/features/send/context/sendContext'
 import { useSendSelectedToken } from 'new/features/send/store'
 import { useXPAddresses } from 'hooks/useXPAddresses/useXPAddresses'
+import AvalancheWalletService from 'services/wallet/AvalancheWalletService'
 import { SendAdapterAVM, SendErrorMessage } from './utils/types'
 import { send as sendAVM } from './utils/avm/send'
 import { validate as validateAVMSend } from './utils/avm/validate'
@@ -30,6 +33,38 @@ const useAVMSend: SendAdapterAVM = ({
   } = useSendContext()
   const [selectedToken] = useSendSelectedToken()
   const { xpAddresses, xpAddressDictionary } = useXPAddresses(account)
+  const filterSmallUtxos = useSelector(selectIsFilterSmallUtxosActive)
+
+  // CP-13903: the Balance API only honors the dust filter on P-Chain, so
+  // the displayed X balance stays dust-inclusive while createSendXTx
+  // filters its spend set. Max and validation must use the spendable
+  // balance derived from the same filtered UTXO set instead.
+  const [spendableBalance, setSpendableBalance] = useState<bigint>()
+
+  useEffect(() => {
+    // Any dep change means the previous value may describe a different
+    // account/network — drop it so Max/validation never gate on a stale
+    // balance while the refetch is in flight.
+    setSpendableBalance(undefined)
+    if (!filterSmallUtxos || network === undefined) {
+      return
+    }
+    let cancelled = false
+    AvalancheWalletService.getSpendableAvaxBalance({
+      chain: 'X',
+      account,
+      isTestnet: Boolean(network.isTestnet),
+      xpAddresses,
+      filterSmallUtxos
+    })
+      .then(balance => {
+        if (!cancelled) setSpendableBalance(balance)
+      })
+      .catch(Logger.error)
+    return () => {
+      cancelled = true
+    }
+  }, [filterSmallUtxos, network, account, xpAddresses])
 
   const tokenProps = useMemo(() => {
     if (!selectedToken || !isTokenWithBalanceAVM(selectedToken)) {
@@ -54,7 +89,8 @@ const useAVMSend: SendAdapterAVM = ({
         toAddress: addressToSend,
         amount: amount.toSubUnit(),
         xpAddresses,
-        xpAddressDictionary
+        xpAddressDictionary,
+        filterSmallUtxos
       })
     } finally {
       setIsSending(false)
@@ -68,7 +104,8 @@ const useAVMSend: SendAdapterAVM = ({
     fromAddress,
     account,
     xpAddresses,
-    xpAddressDictionary
+    xpAddressDictionary,
+    filterSmallUtxos
   ])
 
   const handleError = useCallback(
@@ -89,14 +126,29 @@ const useAVMSend: SendAdapterAVM = ({
         amount: amount?.toSubUnit(),
         address: addressToSend,
         maxFee,
-        token: selectedToken as TokenWithBalanceAVM
+        token: selectedToken as TokenWithBalanceAVM,
+        // While the spendable balance is loading (or if its fetch failed),
+        // this is undefined and validation deliberately degrades to the
+        // displayed balance — same as pre-filter behavior: worst case the
+        // send fails at build instead of validation. Max (getMaxAmount)
+        // never degrades this way.
+        spendableBalance: filterSmallUtxos ? spendableBalance : undefined
       })
 
       setError(undefined)
     } catch (err) {
       handleError(err)
     }
-  }, [maxFee, setError, handleError, addressToSend, amount, selectedToken])
+  }, [
+    maxFee,
+    setError,
+    handleError,
+    addressToSend,
+    amount,
+    selectedToken,
+    filterSmallUtxos,
+    spendableBalance
+  ])
 
   const getMaxAmount = useCallback(async () => {
     if (!selectedToken || !isTokenWithBalanceAVM(selectedToken)) {
@@ -105,7 +157,14 @@ const useAVMSend: SendAdapterAVM = ({
 
     const fee = maxFee ? BigInt(GAS_LIMIT_FOR_X_CHAIN) * maxFee : 0n
 
-    const balance = selectedToken.available ?? 0n
+    // With the filter on, wait for the spendable balance — a Max derived
+    // from the dust-inclusive displayed balance would build an over-spend.
+    const balance = filterSmallUtxos
+      ? spendableBalance
+      : selectedToken.available ?? 0n
+    if (balance === undefined) {
+      return
+    }
     const maxAmountValue = balance - fee
     const maxAmount = maxAmountValue > 0n ? maxAmountValue : 0n
     return new TokenUnit(
@@ -113,7 +172,7 @@ const useAVMSend: SendAdapterAVM = ({
       selectedToken.decimals,
       selectedToken.symbol
     )
-  }, [maxFee, selectedToken])
+  }, [maxFee, selectedToken, filterSmallUtxos, spendableBalance])
 
   useEffect(() => {
     if (canValidate) {

--- a/packages/core-mobile/app/new/common/hooks/send/usePVMSend.ts
+++ b/packages/core-mobile/app/new/common/hooks/send/usePVMSend.ts
@@ -58,7 +58,12 @@ const usePVMSend: SendAdapterPVM = ({
     // account/network/fee state — drop it so Max/validation never gate on
     // a stale balance while the refetch is in flight.
     setSpendableBalance(undefined)
-    if (!filterSmallUtxos || network === undefined) {
+    // P needs a loaded feeState: getMaximumUtxoSet builds txs to measure
+    // size, and an undefined feeState makes every build fail — the "capped"
+    // set comes back empty and Max/validation would gate on a bogus 0.
+    // getFeeState's identity changes when defaults load, re-firing this.
+    const feeState = getFeeState(gasPrice)
+    if (!filterSmallUtxos || network === undefined || feeState === undefined) {
       return
     }
     let cancelled = false
@@ -67,7 +72,7 @@ const usePVMSend: SendAdapterPVM = ({
       account,
       isTestnet: Boolean(network.isTestnet),
       xpAddresses,
-      feeState: getFeeState(gasPrice),
+      feeState,
       filterSmallUtxos
     })
       .then(balance => {

--- a/packages/core-mobile/app/new/common/hooks/send/usePVMSend.ts
+++ b/packages/core-mobile/app/new/common/hooks/send/usePVMSend.ts
@@ -46,6 +46,39 @@ const usePVMSend: SendAdapterPVM = ({
   const { xpAddresses, xpAddressDictionary } = useXPAddresses(account)
   const filterSmallUtxos = useSelector(selectIsFilterSmallUtxosActive)
 
+  // CP-13903: with the small-UTXO filter on, the displayed balance can
+  // include dust the send tx builder will refuse to spend (and the
+  // VM-module balance fallback never filters), so Max and validation must
+  // use the spendable balance from the same filtered UTXO set
+  // createSendPTx consumes.
+  const [spendableBalance, setSpendableBalance] = useState<bigint>()
+
+  useEffect(() => {
+    // Any dep change means the previous value may describe a different
+    // account/network/fee state — drop it so Max/validation never gate on
+    // a stale balance while the refetch is in flight.
+    setSpendableBalance(undefined)
+    if (!filterSmallUtxos || network === undefined) {
+      return
+    }
+    let cancelled = false
+    AvalancheWalletService.getSpendableAvaxBalance({
+      chain: 'P',
+      account,
+      isTestnet: Boolean(network.isTestnet),
+      xpAddresses,
+      feeState: getFeeState(gasPrice),
+      filterSmallUtxos
+    })
+      .then(balance => {
+        if (!cancelled) setSpendableBalance(balance)
+      })
+      .catch(Logger.error)
+    return () => {
+      cancelled = true
+    }
+  }, [filterSmallUtxos, network, account, xpAddresses, getFeeState, gasPrice])
+
   const createSendPTx = useCallback(
     async (amountInNAvax: bigint, price?: bigint): Promise<UnsignedTx> => {
       assertNotUndefined(network)
@@ -161,7 +194,13 @@ const usePVMSend: SendAdapterPVM = ({
         maxFee,
         token: selectedToken as TokenWithBalancePVM,
         gasPrice,
-        estimatedFee
+        estimatedFee,
+        // While the spendable balance is loading (or if its fetch failed),
+        // this is undefined and validation deliberately degrades to the
+        // displayed balance — same as pre-filter behavior: worst case the
+        // send fails at build instead of validation. Max (getMaxAmount)
+        // never degrades this way.
+        spendableBalance: filterSmallUtxos ? spendableBalance : undefined
       })
 
       setError(undefined)
@@ -176,7 +215,9 @@ const usePVMSend: SendAdapterPVM = ({
     gasPrice,
     estimatedFee,
     setError,
-    handleError
+    handleError,
+    filterSmallUtxos,
+    spendableBalance
   ])
 
   // P-Chain uses dynamic fees
@@ -188,7 +229,14 @@ const usePVMSend: SendAdapterPVM = ({
       return
     }
 
-    const balance = selectedToken.available ?? 0n
+    // With the filter on, wait for the spendable balance — a Max derived
+    // from the dust-inclusive displayed balance would build an over-spend.
+    const balance = filterSmallUtxos
+      ? spendableBalance
+      : selectedToken.available ?? 0n
+    if (balance === undefined) {
+      return
+    }
     const estimatedFeePercent = balance / 100n
     const maxAmountValue = balance - estimatedFeePercent
     const maxAmount = maxAmountValue > 0n ? maxAmountValue : 0n
@@ -198,7 +246,7 @@ const usePVMSend: SendAdapterPVM = ({
       selectedToken.decimals,
       selectedToken.symbol
     )
-  }, [selectedToken])
+  }, [selectedToken, filterSmallUtxos, spendableBalance])
 
   useEffect(() => {
     if (canValidate) {

--- a/packages/core-mobile/app/new/common/hooks/send/usePVMSend.ts
+++ b/packages/core-mobile/app/new/common/hooks/send/usePVMSend.ts
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
+import { useSelector } from 'react-redux'
+import { selectIsFilterSmallUtxosActive } from 'store/settings/advanced/filterSmallUtxosActive'
 import { useInAppRequest } from 'hooks/useInAppRequest'
 import { TokenWithBalancePVM } from '@avalabs/vm-module-types'
 import { isTokenWithBalancePVM } from '@avalabs/avalanche-module'
@@ -42,6 +44,7 @@ const usePVMSend: SendAdapterPVM = ({
   const provider = useAvalancheXpProvider()
   const wallet = useActiveWallet()
   const { xpAddresses, xpAddressDictionary } = useXPAddresses(account)
+  const filterSmallUtxos = useSelector(selectIsFilterSmallUtxosActive)
 
   const createSendPTx = useCallback(
     async (amountInNAvax: bigint, price?: bigint): Promise<UnsignedTx> => {
@@ -55,10 +58,19 @@ const usePVMSend: SendAdapterPVM = ({
         destinationAddress,
         sourceAddress: fromAddress,
         feeState: getFeeState(price),
-        xpAddresses
+        xpAddresses,
+        filterSmallUtxos
       })
     },
-    [addressToSend, account, network, fromAddress, getFeeState, xpAddresses]
+    [
+      addressToSend,
+      account,
+      network,
+      fromAddress,
+      getFeeState,
+      xpAddresses,
+      filterSmallUtxos
+    ]
   )
 
   useEffect(() => {
@@ -106,7 +118,8 @@ const usePVMSend: SendAdapterPVM = ({
         toAddress: addressToSend,
         feeState: getFeeState(gasPrice),
         xpAddresses,
-        xpAddressDictionary
+        xpAddressDictionary,
+        filterSmallUtxos
       })
     } finally {
       setIsSending(false)
@@ -124,7 +137,8 @@ const usePVMSend: SendAdapterPVM = ({
     gasPrice,
     wallet,
     xpAddresses,
-    xpAddressDictionary
+    xpAddressDictionary,
+    filterSmallUtxos
   ])
 
   const handleError = useCallback(

--- a/packages/core-mobile/app/new/common/hooks/send/utils/avm/send.ts
+++ b/packages/core-mobile/app/new/common/hooks/send/utils/avm/send.ts
@@ -23,7 +23,8 @@ export const send = async ({
   toAddress,
   amount,
   xpAddresses,
-  xpAddressDictionary
+  xpAddressDictionary,
+  filterSmallUtxos
 }: {
   request: Request
   fromAddress: string
@@ -33,6 +34,7 @@ export const send = async ({
   amount: bigint
   xpAddresses: string[]
   xpAddressDictionary: XPAddressDictionary
+  filterSmallUtxos: boolean
 }): Promise<string> => {
   const sentrySpanName = 'send-token'
   return SentryWrapper.startSpan(
@@ -47,7 +49,8 @@ export const send = async ({
           isTestnet,
           destinationAddress: destinationAddress,
           sourceAddress: fromAddress,
-          xpAddresses
+          xpAddresses,
+          filterSmallUtxos
         })
 
         const txRequest = await getTransactionRequest({

--- a/packages/core-mobile/app/new/common/hooks/send/utils/avm/validate.test.ts
+++ b/packages/core-mobile/app/new/common/hooks/send/utils/avm/validate.test.ts
@@ -84,4 +84,16 @@ describe('validate avm send', () => {
       })
     ).toThrow(SendErrorMessage.INSUFFICIENT_BALANCE)
   })
+
+  it('should validate against spendableBalance instead of available when provided (CP-13903)', async () => {
+    expect(() =>
+      validate({
+        address: mockActiveAccount.addressAVM,
+        amount: 1000n,
+        maxFee: 1n,
+        token: mockNativeTokenWithBalance, // available: 10000n
+        spendableBalance: 100n
+      })
+    ).toThrow(SendErrorMessage.INSUFFICIENT_BALANCE)
+  })
 })

--- a/packages/core-mobile/app/new/common/hooks/send/utils/avm/validate.ts
+++ b/packages/core-mobile/app/new/common/hooks/send/utils/avm/validate.ts
@@ -7,18 +7,25 @@ export const validate = ({
   amount,
   address,
   maxFee,
-  token
+  token,
+  spendableBalance
 }: {
   amount: bigint | undefined
   address: string | undefined
   maxFee: bigint
   token: TokenWithBalanceAVM
+  /**
+   * CP-13903: dust-filtered spendable balance. When set it replaces the
+   * displayed balance, which can include dust the send tx builder will
+   * refuse to spend.
+   */
+  spendableBalance?: bigint
 }): void => {
   if (!address) throw new Error(SendErrorMessage.ADDRESS_REQUIRED)
 
   const fee = maxFee ? BigInt(GAS_LIMIT_FOR_X_CHAIN) * maxFee : 0n
 
-  const balance = token.available ?? 0n
+  const balance = spendableBalance ?? token.available ?? 0n
   const maxAmountValue = balance - fee
 
   if (

--- a/packages/core-mobile/app/new/common/hooks/send/utils/pvm/send.ts
+++ b/packages/core-mobile/app/new/common/hooks/send/utils/pvm/send.ts
@@ -24,7 +24,8 @@ export const send = async ({
   feeState,
   account,
   xpAddresses,
-  xpAddressDictionary
+  xpAddressDictionary,
+  filterSmallUtxos
 }: {
   walletId: string
   walletType: WalletType
@@ -37,6 +38,7 @@ export const send = async ({
   account: Account
   xpAddresses: string[]
   xpAddressDictionary: XPAddressDictionary
+  filterSmallUtxos: boolean
 }): Promise<string> => {
   const sentrySpanName = 'send-token'
 
@@ -53,7 +55,8 @@ export const send = async ({
           destinationAddress,
           sourceAddress: fromAddress,
           feeState,
-          xpAddresses
+          xpAddresses,
+          filterSmallUtxos
         })
         const txRequest = await getTransactionRequest({
           unsignedTx,

--- a/packages/core-mobile/app/new/common/hooks/send/utils/pvm/validate.test.ts
+++ b/packages/core-mobile/app/new/common/hooks/send/utils/pvm/validate.test.ts
@@ -87,4 +87,16 @@ describe('validate pvm send', () => {
       })
     ).toThrow(SendErrorMessage.INSUFFICIENT_BALANCE)
   })
+
+  it('should validate against spendableBalance instead of available when provided (CP-13903)', async () => {
+    expect(() =>
+      validate({
+        address: mockActiveAccount.addressPVM,
+        amount: 1000n,
+        maxFee: 1n,
+        token: mockNativeTokenWithBalance, // available: 10000n
+        spendableBalance: 100n
+      })
+    ).toThrow(SendErrorMessage.INSUFFICIENT_BALANCE)
+  })
 })

--- a/packages/core-mobile/app/new/common/hooks/send/utils/pvm/validate.ts
+++ b/packages/core-mobile/app/new/common/hooks/send/utils/pvm/validate.ts
@@ -9,7 +9,8 @@ export const validate = ({
   maxFee,
   token,
   estimatedFee,
-  gasPrice
+  gasPrice,
+  spendableBalance
 }: {
   amount: bigint
   address: string | undefined
@@ -17,12 +18,18 @@ export const validate = ({
   token: TokenWithBalancePVM
   estimatedFee?: bigint
   gasPrice?: bigint
+  /**
+   * CP-13903: dust-filtered spendable balance. When set it replaces the
+   * displayed balance, which can include dust the send tx builder will
+   * refuse to spend.
+   */
+  spendableBalance?: bigint
 }): void => {
   if (!address) throw new Error(SendErrorMessage.ADDRESS_REQUIRED)
   // TODO: use correct gas limit for P-chain
   const fee = estimatedFee ?? BigInt(GAS_LIMIT_FOR_X_CHAIN) * maxFee
 
-  const balance = token.available ?? 0n
+  const balance = spendableBalance ?? token.available ?? 0n
   const maxAmountValue = balance - fee
 
   if (

--- a/packages/core-mobile/app/new/features/accountSettings/screens/advancedSettings/AdvancedSettingsScreen.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/screens/advancedSettings/AdvancedSettingsScreen.tsx
@@ -1,6 +1,7 @@
 import { Text, View } from '@avalabs/k2-alpine'
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import React from 'react'
+import { FilterSmallUtxos } from './components/FilterSmallUtxos'
 import { QuickSwaps } from './components/QuickSwaps'
 
 export const AdvancedSettingsScreen = (): React.JSX.Element | null => {
@@ -11,7 +12,8 @@ export const AdvancedSettingsScreen = (): React.JSX.Element | null => {
       contentContainerStyle={{ padding: 16, flex: 1 }}>
       <Text variant="heading2">Advanced settings</Text>
       <Text variant="subtitle1">Tools and settings for power users</Text>
-      <View sx={{ marginTop: 36 }}>
+      <View sx={{ marginTop: 36, gap: 24 }}>
+        <FilterSmallUtxos />
         <QuickSwaps />
       </View>
     </ScrollScreen>

--- a/packages/core-mobile/app/new/features/accountSettings/screens/advancedSettings/components/FilterSmallUtxos.tsx
+++ b/packages/core-mobile/app/new/features/accountSettings/screens/advancedSettings/components/FilterSmallUtxos.tsx
@@ -1,0 +1,65 @@
+import { GroupList, Text, Toggle, View, useTheme } from '@avalabs/k2-alpine'
+import React, { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import AnalyticsService from 'services/analytics/AnalyticsService'
+import { selectIsFilterSmallUtxosAvailable } from 'store/posthog'
+import {
+  selectFilterSmallUtxos,
+  setFilterSmallUtxos
+} from 'store/settings/advanced/slice'
+
+export const FilterSmallUtxos = (): React.JSX.Element => {
+  const { theme } = useTheme()
+  const dispatch = useDispatch()
+  const flagOn = useSelector(selectIsFilterSmallUtxosAvailable)
+  const isEnabled = useSelector(selectFilterSmallUtxos)
+
+  const onToggle = useCallback(
+    (value: boolean) => {
+      dispatch(setFilterSmallUtxos(value))
+      AnalyticsService.capture('FilterSmallUtxosToggled', { isEnabled: value })
+    },
+    [dispatch]
+  )
+
+  if (!flagOn) return <></>
+
+  return (
+    <View sx={{ gap: 4 }}>
+      <GroupList
+        data={[
+          {
+            title: 'Filter out small UTXOs',
+            disableRowAccessibility: true,
+            value: (
+              <Toggle
+                testID={
+                  isEnabled
+                    ? 'filter_small_utxos_enabled'
+                    : 'filter_small_utxos_disabled'
+                }
+                value={isEnabled}
+                onValueChange={onToggle}
+              />
+            )
+          }
+        ]}
+        titleSx={{
+          fontSize: 16,
+          lineHeight: 22,
+          fontFamily: 'Inter-Regular'
+        }}
+      />
+      <Text
+        variant="caption"
+        sx={{
+          fontFamily: 'Inter-Medium',
+          color: theme.colors.$textSecondary,
+          paddingRight: 32
+        }}>
+        Improves loading performance by removing UTXOs with a value less than
+        0.002 AVAX from the wallet. Total balances may be inaccurate.
+      </Text>
+    </View>
+  )
+}

--- a/packages/core-mobile/app/new/features/portfolio/hooks/getCachedBalancesWithFlagFallback.test.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/getCachedBalancesWithFlagFallback.test.ts
@@ -1,0 +1,84 @@
+import { QueryClient } from '@tanstack/react-query'
+import { Account } from 'store/account/types'
+import { Network } from '@avalabs/core-chains-sdk'
+import { AdjustedNormalizedBalancesForAccount } from 'services/balance/types'
+import {
+  balanceKey,
+  getCachedBalancesWithFlagFallback
+} from './useAccountBalances'
+
+const account = { id: 'account-1' } as Account
+const networks = [
+  { chainId: 43114 },
+  { chainId: 4503599627370475 }
+] as Network[]
+
+const balances = (marker: string): AdjustedNormalizedBalancesForAccount[] =>
+  [{ accountId: 'account-1', chainId: 43114, marker }] as never
+
+describe('getCachedBalancesWithFlagFallback', () => {
+  let client: QueryClient
+
+  beforeEach(() => {
+    client = new QueryClient()
+  })
+
+  afterEach(() => {
+    client.clear()
+  })
+
+  it('returns the exact-key data when present', () => {
+    client.setQueryData(balanceKey(account, networks, true), balances('exact'))
+    client.setQueryData(balanceKey(account, networks, false), balances('other'))
+
+    expect(
+      getCachedBalancesWithFlagFallback({
+        client,
+        account,
+        networks,
+        filterOutDustUtxos: true
+      })
+    ).toEqual(balances('exact'))
+  })
+
+  it('falls back to the opposite-flag key when the exact key is empty (toggle-flip window)', () => {
+    client.setQueryData(
+      balanceKey(account, networks, false),
+      balances('pre-toggle')
+    )
+
+    expect(
+      getCachedBalancesWithFlagFallback({
+        client,
+        account,
+        networks,
+        filterOutDustUtxos: true
+      })
+    ).toEqual(balances('pre-toggle'))
+  })
+
+  it('prefers an exact-key empty array (completed fetch) over the fallback', () => {
+    client.setQueryData(balanceKey(account, networks, true), [])
+    client.setQueryData(balanceKey(account, networks, false), balances('stale'))
+
+    expect(
+      getCachedBalancesWithFlagFallback({
+        client,
+        account,
+        networks,
+        filterOutDustUtxos: true
+      })
+    ).toEqual([])
+  })
+
+  it('returns undefined when neither key has data', () => {
+    expect(
+      getCachedBalancesWithFlagFallback({
+        client,
+        account,
+        networks,
+        filterOutDustUtxos: true
+      })
+    ).toBeUndefined()
+  })
+})

--- a/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalances.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalances.ts
@@ -12,6 +12,7 @@ import { useXPAddresses } from 'hooks/useXPAddresses/useXPAddresses'
 import { selectWalletById } from 'store/wallet/slice'
 import { getXpubXPIfAvailable } from 'utils/getAddressesFromXpubXP/getAddressesFromXpubXP'
 import { useOnlineStatus } from 'common/hooks/useOnlineStatus'
+import { selectIsFilterSmallUtxosActive } from 'store/settings/advanced/filterSmallUtxosActive'
 import * as store from '../store'
 
 /**
@@ -26,14 +27,19 @@ const staleTime = 20_000
  */
 const refetchInterval = __DEV__ ? 30_000 : 5_000
 
-export const balanceKey = (account: Account | undefined, network?: Network[]) =>
+export const balanceKey = (
+  account: Account | undefined,
+  network: Network[] | undefined,
+  filterOutDustUtxos: boolean
+) =>
   [
     ReactQueryKeys.ACCOUNT_BALANCE,
     account?.id,
     network
       ?.map(n => n.chainId)
       .sort()
-      .join(',')
+      .join(','),
+    filterOutDustUtxos
   ] as const
 
 /**
@@ -64,6 +70,7 @@ export function useAccountBalances(
   const currency = useSelector(selectSelectedCurrency)
   const { xpAddresses } = useXPAddresses(account)
   const wallet = useSelector(selectWalletById(account?.walletId ?? ''))
+  const filterOutDustUtxos = useSelector(selectIsFilterSmallUtxosActive)
 
   const isNotReady = !account || enabledNetworks.length === 0 || !wallet
 
@@ -77,7 +84,7 @@ export function useAccountBalances(
     refetch: refetchFn
   } = useQuery({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
-    queryKey: balanceKey(account, enabledNetworks),
+    queryKey: balanceKey(account, enabledNetworks, filterOutDustUtxos),
     enabled,
     refetchInterval: options?.refetchInterval ?? refetchInterval,
     staleTime,
@@ -96,9 +103,10 @@ export function useAccountBalances(
         currency: currency.toLowerCase(),
         xpAddresses,
         xpub,
+        filterOutDustUtxos,
         onBalanceLoaded: balance => {
           queryClient.setQueryData(
-            balanceKey(account, enabledNetworks),
+            balanceKey(account, enabledNetworks, filterOutDustUtxos),
             (prev: AdjustedNormalizedBalancesForAccount[] | undefined) => {
               if (!prev) return [balance]
               const filtered = prev.filter(p => p.chainId !== balance.chainId)

--- a/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalances.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalances.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { QueryClient, useQuery, useQueryClient } from '@tanstack/react-query'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import { useCallback, useMemo } from 'react'
 import { useSelector } from 'react-redux'
@@ -41,6 +41,37 @@ export const balanceKey = (
       .join(','),
     filterOutDustUtxos
   ] as const
+
+/**
+ * Cache read with flag fallback. When the small-UTXO filter setting (or its
+ * PostHog gate) flips, `balanceKey` changes and the new key stays empty until
+ * the next refetch lands. Cache-only readers (meld off-ramp,
+ * wallet_getNetworkState) should serve the previous flag variant's data for
+ * that window rather than nothing — momentarily stale dust totals beat an
+ * empty token list. An exact-key hit (including a legitimately empty array
+ * from a completed fetch) always wins; the fallback is read-only and never
+ * written back.
+ */
+export const getCachedBalancesWithFlagFallback = ({
+  client,
+  account,
+  networks,
+  filterOutDustUtxos
+}: {
+  client: QueryClient
+  account: Account | undefined
+  networks: Network[] | undefined
+  filterOutDustUtxos: boolean
+}): AdjustedNormalizedBalancesForAccount[] | undefined => {
+  const exact = client.getQueryData(
+    balanceKey(account, networks, filterOutDustUtxos)
+  ) as AdjustedNormalizedBalancesForAccount[] | undefined
+  if (exact !== undefined) return exact
+
+  return client.getQueryData(
+    balanceKey(account, networks, !filterOutDustUtxos)
+  ) as AdjustedNormalizedBalancesForAccount[] | undefined
+}
 
 /**
  * Fetches balances for the specified account across all enabled networks (C-Chain, X-Chain, P-Chain, other EVMs, BTC, SOL, etc.)

--- a/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalances.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalances.ts
@@ -1,4 +1,8 @@
-import { QueryClient, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  type QueryClient,
+  useQuery,
+  useQueryClient
+} from '@tanstack/react-query'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import { useCallback, useMemo } from 'react'
 import { useSelector } from 'react-redux'

--- a/packages/core-mobile/app/new/features/portfolio/hooks/useAccountsBalances.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/useAccountsBalances.ts
@@ -16,6 +16,7 @@ import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { getCachedXPAddresses } from 'hooks/useXPAddresses/useXPAddresses'
 import { getXpubXPIfAvailable } from 'utils/getAddressesFromXpubXP/getAddressesFromXpubXP'
 import Logger from 'utils/Logger'
+import { selectIsFilterSmallUtxosActive } from 'store/settings/advanced/filterSmallUtxosActive'
 
 /**
  * Stale time in milliseconds
@@ -32,11 +33,13 @@ const refetchInterval = __DEV__ ? 30_000 : 5_000
 export const balancesKey = (params: {
   currency: string
   enabledChainIdsKey: string
+  filterOutDustUtxos: boolean
 }) =>
   [
     ReactQueryKeys.ACCOUNTS_BALANCES,
     params.currency.toLowerCase(),
-    params.enabledChainIdsKey
+    params.enabledChainIdsKey,
+    params.filterOutDustUtxos
   ] as const
 
 /**
@@ -61,6 +64,7 @@ export function useAccountsBalances(
   const currency = useSelector(selectSelectedCurrency)
   const wallets = useSelector(selectWallets)
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
+  const filterOutDustUtxos = useSelector(selectIsFilterSmallUtxosActive)
 
   const enabledChainIdsKey = useMemo(() => {
     // Stable + order-independent key
@@ -74,9 +78,10 @@ export function useAccountsBalances(
     () =>
       balancesKey({
         currency,
-        enabledChainIdsKey
+        enabledChainIdsKey,
+        filterOutDustUtxos
       }),
-    [currency, enabledChainIdsKey]
+    [currency, enabledChainIdsKey, filterOutDustUtxos]
   )
 
   const isNotReady = accounts.length === 0 || enabledNetworks.length === 0
@@ -150,6 +155,7 @@ export function useAccountsBalances(
         currency: currency.toLowerCase(),
         xpAddressesByAccountId,
         xpubByAccountId,
+        filterOutDustUtxos,
         onBalanceLoaded: balance => {
           queryClient.setQueryData(
             queryKey,

--- a/packages/core-mobile/app/new/features/portfolio/hooks/useTokensWithBalanceForAccount.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/useTokensWithBalanceForAccount.ts
@@ -79,18 +79,20 @@ export function useTokensWithBalanceForAccount({
 export function getTokensWithBalanceForAccountFromCache({
   account,
   networks,
-  isDeveloperMode
+  isDeveloperMode,
+  filterOutDustUtxos
 }: {
   account?: Account
   networks: Networks
   isDeveloperMode: boolean
+  filterOutDustUtxos: boolean
 }): AdjustedLocalTokenWithBalance[] {
   if (!account) return []
 
   const results = (
-    queryClient.getQueryData(balanceKey(account, Object.values(networks))) as
-      | AdjustedNormalizedBalancesForAccount[]
-      | undefined
+    queryClient.getQueryData(
+      balanceKey(account, Object.values(networks), filterOutDustUtxos)
+    ) as AdjustedNormalizedBalancesForAccount[] | undefined
   )?.filter(balance => balance.accountId === account.id)
 
   if (!results) return []

--- a/packages/core-mobile/app/new/features/portfolio/hooks/useTokensWithBalanceForAccount.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/useTokensWithBalanceForAccount.ts
@@ -11,7 +11,10 @@ import {
   AdjustedNormalizedBalancesForAccount
 } from 'services/balance/types'
 import { Networks } from 'store/network'
-import { balanceKey, useAccountBalances } from './useAccountBalances'
+import {
+  getCachedBalancesWithFlagFallback,
+  useAccountBalances
+} from './useAccountBalances'
 
 /**
  * Returns token balances for a specific account.
@@ -89,11 +92,12 @@ export function getTokensWithBalanceForAccountFromCache({
 }): AdjustedLocalTokenWithBalance[] {
   if (!account) return []
 
-  const results = (
-    queryClient.getQueryData(
-      balanceKey(account, Object.values(networks), filterOutDustUtxos)
-    ) as AdjustedNormalizedBalancesForAccount[] | undefined
-  )?.filter(balance => balance.accountId === account.id)
+  const results = getCachedBalancesWithFlagFallback({
+    client: queryClient,
+    account,
+    networks: Object.values(networks),
+    filterOutDustUtxos
+  })?.filter(balance => balance.accountId === account.id)
 
   if (!results) return []
 

--- a/packages/core-mobile/app/new/features/portfolio/hooks/useWalletBalances.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/useWalletBalances.ts
@@ -7,6 +7,7 @@ import {
 } from 'services/balance/types'
 import { selectEnabledNetworks } from 'store/network/slice'
 import { selectSelectedCurrency } from 'store/settings/currency/slice'
+import { selectIsFilterSmallUtxosActive } from 'store/settings/advanced/filterSmallUtxosActive'
 import { balancesKey } from './useAccountsBalances'
 
 const emptyBalances: AdjustedNormalizedBalancesForAccount[] = []
@@ -24,6 +25,7 @@ export function useWalletBalances(accountIds: string[]): {
 } {
   const enabledNetworks = useSelector(selectEnabledNetworks)
   const currency = useSelector(selectSelectedCurrency)
+  const filterOutDustUtxos = useSelector(selectIsFilterSmallUtxosActive)
 
   const enabledChainIdsKey = useMemo(
     () =>
@@ -35,8 +37,8 @@ export function useWalletBalances(accountIds: string[]): {
   )
 
   const queryKey = useMemo(
-    () => balancesKey({ currency, enabledChainIdsKey }),
-    [currency, enabledChainIdsKey]
+    () => balancesKey({ currency, enabledChainIdsKey, filterOutDustUtxos }),
+    [currency, enabledChainIdsKey, filterOutDustUtxos]
   )
 
   const select = useCallback(

--- a/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/index.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/index.ts
@@ -18,6 +18,7 @@ import {
   getTotalAdditiveNativeFee
 } from '../../utils/getTotalAdditiveSourceFee'
 import { usePreQuote } from './usePreQuote'
+import { useSpendableXpBalance } from './useSpendableXpBalance'
 import {
   computeMaxAmount,
   getPreQuoteAmount,
@@ -157,14 +158,26 @@ export const useMaxSwapAmount = ({
     bufferedAdditiveFee
   )
 
+  const { spendableBalance, isSpendableBalanceRequired } =
+    useSpendableXpBalance({ fromToken, fromNetwork })
+
   const max = useMemo(() => {
+    // CP-13903: a native X/P Max must come from the dust-filtered UTXO set
+    // the CCT callbacks spend. Until it loads, keep Max disabled — falling
+    // back to the displayed balance could build an over-spend.
+    if (isSpendableBalanceRequired && spendableBalance === undefined) {
+      return undefined
+    }
     return computeMaxAmount({
       fromToken,
       isNative,
       bufferedGas: bufferedFee,
       additiveFee: additiveFeeForMax,
       hasEstimationError:
-        (!!feeEstimationError && !isFeeEstimationFetching) || preQuoteFailed
+        (!!feeEstimationError && !isFeeEstimationFetching) || preQuoteFailed,
+      spendableBalance: isSpendableBalanceRequired
+        ? spendableBalance
+        : undefined
     })
   }, [
     fromToken,
@@ -173,7 +186,9 @@ export const useMaxSwapAmount = ({
     additiveFeeForMax,
     feeEstimationError,
     preQuoteFailed,
-    isFeeEstimationFetching
+    isFeeEstimationFetching,
+    isSpendableBalanceRequired,
+    spendableBalance
   ])
 
   return {

--- a/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/useSpendableXpBalance.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/useSpendableXpBalance.ts
@@ -57,12 +57,18 @@ export const useSpendableXpBalance = ({
     fromToken?.type === TokenType.NATIVE &&
     chain !== undefined
 
+  // P needs a loaded feeState: getMaximumUtxoSet builds txs to measure
+  // size, and an undefined feeState makes every build fail — the "capped"
+  // set comes back empty and a bogus 0 balance would be cached.
+  const feeState = chain === 'P' ? getFeeState() : undefined
+
   const enabled =
     isSpendableBalanceRequired &&
     activeAccount !== undefined &&
     fromNetwork !== undefined &&
     chain !== undefined &&
-    xpAddresses.length > 0
+    xpAddresses.length > 0 &&
+    (chain !== 'P' || feeState !== undefined)
 
   const { data } = useQuery({
     // chain and isTestnet are derived from chainId, and account identity is
@@ -81,7 +87,7 @@ export const useSpendableXpBalance = ({
             account: activeAccount,
             isTestnet: Boolean(fromNetwork.isTestnet),
             xpAddresses,
-            feeState: chain === 'P' ? getFeeState() : undefined,
+            feeState,
             filterSmallUtxos: true
           })
       : skipToken,

--- a/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/useSpendableXpBalance.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/useSpendableXpBalance.ts
@@ -1,0 +1,99 @@
+import { skipToken, useQuery } from '@tanstack/react-query'
+import { TokenType } from '@avalabs/vm-module-types'
+import { Network } from '@avalabs/core-chains-sdk'
+import { useSelector } from 'react-redux'
+import { ReactQueryKeys } from 'consts/reactQueryKeys'
+import { useGetFeeState } from 'hooks/earn/useGetFeeState'
+import { useXPAddresses } from 'hooks/useXPAddresses/useXPAddresses'
+import AvalancheWalletService from 'services/wallet/AvalancheWalletService'
+import { selectActiveAccount } from 'store/account'
+import { selectIsFilterSmallUtxosActive } from 'store/settings/advanced/filterSmallUtxosActive'
+import type { LocalTokenWithBalance } from 'store/balance'
+import { isPChain, isXChain } from 'utils/network/isAvalancheNetwork'
+
+/**
+ * CP-13903: spendable balance for a native X-/P-Chain swap source, derived
+ * from the dust-filtered UTXO set. Needed because the displayed balance can
+ * stay dust-inclusive (the Balance API only honors `filterOutDustUtxos` on
+ * P-Chain, and the VM-module fallback never filters), so a Max derived from
+ * it would exceed what the CCT `getUtxos` callback offers the SDK.
+ *
+ * On P this is a conservative subset of the CCT spend set: the service
+ * helper also applies the BaseP tx-size cap, which CCT `getUtxos` doesn't.
+ * Max can only ever be lower than truly spendable, never higher.
+ *
+ * Returns:
+ * - `spendableBalance` — filtered available balance in nAVAX, or undefined
+ *   while loading / on error (callers must NOT fall back to the displayed
+ *   balance in that case, or Max can exceed the spendable set)
+ * - `isSpendableBalanceRequired` — true when the source token is native X/P
+ *   AVAX and the small-UTXO filter is active
+ */
+export const useSpendableXpBalance = ({
+  fromToken,
+  fromNetwork
+}: {
+  fromToken: LocalTokenWithBalance | undefined
+  fromNetwork: Network | undefined
+}): {
+  spendableBalance: bigint | undefined
+  isSpendableBalanceRequired: boolean
+} => {
+  const activeAccount = useSelector(selectActiveAccount)
+  const filterSmallUtxos = useSelector(selectIsFilterSmallUtxosActive)
+  const { xpAddresses } = useXPAddresses(activeAccount)
+  const { getFeeState } = useGetFeeState()
+
+  const chain = fromNetwork
+    ? isPChain(fromNetwork.chainId)
+      ? ('P' as const)
+      : isXChain(fromNetwork.chainId)
+      ? ('X' as const)
+      : undefined
+    : undefined
+
+  const isSpendableBalanceRequired =
+    filterSmallUtxos &&
+    fromToken?.type === TokenType.NATIVE &&
+    chain !== undefined
+
+  const enabled =
+    isSpendableBalanceRequired &&
+    activeAccount !== undefined &&
+    fromNetwork !== undefined &&
+    chain !== undefined &&
+    xpAddresses.length > 0
+
+  const { data } = useQuery({
+    // chain and isTestnet are derived from chainId, and account identity is
+    // its id — the key below fully determines the fetch inputs.
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: [
+      ReactQueryKeys.SPENDABLE_XP_BALANCE,
+      activeAccount?.id,
+      fromNetwork?.chainId,
+      xpAddresses
+    ],
+    queryFn: enabled
+      ? () =>
+          AvalancheWalletService.getSpendableAvaxBalance({
+            chain,
+            account: activeAccount,
+            isTestnet: Boolean(fromNetwork.isTestnet),
+            xpAddresses,
+            feeState: chain === 'P' ? getFeeState() : undefined,
+            filterSmallUtxos: true
+          })
+      : skipToken,
+    // Spendable UTXOs move with every send/swap and the key fields don't
+    // (same account/network), so a cached value can describe a pre-spend
+    // set. Always refetch on mount; react-query still dedupes concurrent
+    // consumers within a render pass.
+    staleTime: 0
+  })
+
+  return {
+    spendableBalance: data,
+    isSpendableBalanceRequired
+  }
+}

--- a/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/useSpendableXpBalance.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/useSpendableXpBalance.ts
@@ -70,7 +70,7 @@ export const useSpendableXpBalance = ({
     xpAddresses.length > 0 &&
     (chain !== 'P' || feeState !== undefined)
 
-  const { data } = useQuery({
+  const { data, isFetching } = useQuery({
     // chain and isTestnet are derived from chainId, and account identity is
     // its id — the key below fully determines the fetch inputs.
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
@@ -99,7 +99,11 @@ export const useSpendableXpBalance = ({
   })
 
   return {
-    spendableBalance: data,
+    // Hide cached data while a refetch is in flight: react-query serves the
+    // previous value during background refetches, and a pre-spend balance
+    // must never re-enable Max after UTXOs moved. Max stays disabled until
+    // the current fetch lands.
+    spendableBalance: isFetching ? undefined : data,
     isSpendableBalanceRequired
   }
 }

--- a/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/utils.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/utils.test.ts
@@ -101,6 +101,32 @@ describe('computeMaxAmount', () => {
     expect(result).toBeUndefined()
   })
 
+  it('uses spendableBalance instead of the displayed balance when provided (CP-13903)', () => {
+    const token = makeToken(5000n)
+    const result = computeMaxAmount({
+      fromToken: token,
+      isNative: true,
+      bufferedGas: 1000n,
+      additiveFee: 0n,
+      hasEstimationError: false,
+      spendableBalance: 3000n
+    })
+    expect(result).toBe(2000n)
+  })
+
+  it('uses spendableBalance for the estimation-error fallback too (CP-13903)', () => {
+    const token = makeToken(5000n)
+    const result = computeMaxAmount({
+      fromToken: token,
+      isNative: true,
+      bufferedGas: undefined,
+      additiveFee: 0n,
+      hasEstimationError: true,
+      spendableBalance: 3000n
+    })
+    expect(result).toBe(3000n)
+  })
+
   it('returns balance minus gas for native token with no additive fees', () => {
     const token = makeToken(5000n)
     const result = computeMaxAmount({

--- a/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/utils.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/utils.ts
@@ -106,28 +106,37 @@ export const computeMaxAmount = ({
   isNative,
   bufferedGas,
   additiveFee,
-  hasEstimationError
+  hasEstimationError,
+  spendableBalance
 }: {
   fromToken: LocalTokenWithBalance | undefined
   isNative: boolean
   bufferedGas: bigint | undefined
   additiveFee: bigint | undefined
   hasEstimationError: boolean
+  /**
+   * CP-13903: dust-filtered spendable balance for native X/P sources.
+   * When set it replaces the displayed balance, which can include dust
+   * the CCT spend set excludes.
+   */
+  spendableBalance?: bigint
 }): bigint | undefined => {
   if (!fromToken) return undefined
 
   // Use the swappable balance (excludes P/X-chain staked/locked funds) as the
   // ceiling so Max can't select more than the user can actually swap (CP-14788).
-  const swappableBalance = getSwappableBalance(fromToken)
+  // For native X/P sources the dust-filtered spendable balance (CP-13903), when
+  // set, takes precedence since it reflects the CCT spend set exactly.
+  const balance = spendableBalance ?? getSwappableBalance(fromToken)
 
   if (isNative) {
-    // Fall back to full swappable balance if fee estimation failed
-    if (hasEstimationError) return swappableBalance
+    // Fall back to full balance if fee estimation failed
+    if (hasEstimationError) return balance
 
     // Wait for fee estimate before enabling Max button
     if (bufferedGas === undefined) return undefined
 
-    const max = swappableBalance - bufferedGas - (additiveFee ?? 0n)
+    const max = balance - bufferedGas - (additiveFee ?? 0n)
     return max > 0n ? max : undefined
   }
 
@@ -136,6 +145,6 @@ export const computeMaxAmount = ({
 
   // For non-native tokens (ERC20/SPL): gas is paid in the chain's native asset, but additive fees
   // denominated in the source token must be deducted.
-  const max = swappableBalance - additiveFee
+  const max = balance - additiveFee
   return max > 0n ? max : undefined
 }

--- a/packages/core-mobile/app/new/features/swap/services/cct/buildCctDependencies.ts
+++ b/packages/core-mobile/app/new/features/swap/services/cct/buildCctDependencies.ts
@@ -2,6 +2,7 @@ import { getCachedXPAddresses } from 'hooks/useXPAddresses/useXPAddresses'
 import { selectActiveAccount } from 'store/account/slice'
 import type { XPAddressDictionary } from 'store/account/types'
 import { selectIsDeveloperMode } from 'store/settings/advanced/slice'
+import { selectIsFilterSmallUtxosActive } from 'store/settings/advanced/filterSmallUtxosActive'
 import { selectWalletById } from 'store/wallet/slice'
 import type { AppListenerEffectAPI } from 'store/types'
 import { createInAppRequest } from 'store/rpc/utils/createInAppRequest'
@@ -48,5 +49,7 @@ export const buildCctDependencies = (
         isDeveloperMode: selectIsDeveloperMode(state)
       })
     },
-    request: createInAppRequest(listenerApi.dispatch, listenerApi.getState)
+    request: createInAppRequest(listenerApi.dispatch, listenerApi.getState),
+    getFilterSmallUtxos: () =>
+      selectIsFilterSmallUtxosActive(listenerApi.getState())
   })

--- a/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.test.ts
+++ b/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.test.ts
@@ -17,6 +17,10 @@ jest.mock('common/hooks/send/utils/getInternalExternalAddrs', () => ({
   getInternalExternalAddrs: jest.fn()
 }))
 
+jest.mock('services/wallet/utils', () => ({
+  getAvaxAssetId: () => 'FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z'
+}))
+
 jest.mock('@avalabs/avalanchejs', () => ({
   utils: {
     getManagerForVM: jest.fn(() => ({
@@ -24,7 +28,16 @@ jest.mock('@avalabs/avalanchejs', () => ({
     })),
     bufferToHex: jest.fn((bytes: unknown) =>
       typeof bytes === 'string' ? bytes : '0xmock'
-    )
+    ),
+    UtxoSet: class {
+      private readonly utxos: unknown[]
+      constructor(utxos: unknown[]) {
+        this.utxos = utxos
+      }
+      getUTXOs(): unknown[] {
+        return this.utxos
+      }
+    }
   }
 }))
 
@@ -60,6 +73,7 @@ const makeDeps = (
       } as any
     }),
     request: jest.fn(async () => 'mock-tx-hash') as any,
+    getFilterSmallUtxos: () => false,
     ...overrides
   }
 }
@@ -365,6 +379,57 @@ describe('createCctCallbacks', () => {
         )
       ).rejects.toThrow(/xpAddressDictionary empty/)
       expect(mockedRequest).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getUtxos small-UTXO filtering (CP-13903)', () => {
+    const avaxAssetId = 'FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z'
+    const mockUtxo = (assetId: string, amount: bigint) =>
+      ({
+        getAssetId: () => assetId,
+        output: { amount: () => amount }
+      } as never)
+
+    const dust = mockUtxo(avaxAssetId, 1_000n)
+    const big = mockUtxo(avaxAssetId, 5_000_000n)
+
+    const signer = {
+      getAtomicUTXOs: jest.fn(),
+      getUTXOs: jest.fn(),
+      getAddresses: jest.fn(),
+      getChangeAddress: jest.fn()
+    }
+
+    const originalUtxoSet = {
+      getUTXOs: () => [dust, big]
+    }
+
+    beforeEach(() => {
+      mockedGetReadOnlySigner.mockResolvedValue(signer)
+      signer.getUTXOs.mockResolvedValue(originalUtxoSet)
+    })
+
+    it('passes the original UtxoSet through untouched when the setting is off', async () => {
+      const { getUtxos } = createCctCallbacks(
+        makeDeps({
+          getFilterSmallUtxos: () => false
+        })
+      )
+      const result = await getUtxos('P')
+      // Reference identity: the SDK must receive the signer's own UtxoSet,
+      // not a rewrapped copy, when filtering is off.
+      expect(result).toBe(originalUtxoSet)
+      expect(result.getUTXOs()).toHaveLength(2)
+    })
+
+    it('drops dust UTXOs when the setting is on', async () => {
+      const { getUtxos } = createCctCallbacks(
+        makeDeps({
+          getFilterSmallUtxos: () => true
+        })
+      )
+      const result = await getUtxos('P')
+      expect(result.getUTXOs()).toEqual([big])
     })
   })
 })

--- a/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.ts
+++ b/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.ts
@@ -85,9 +85,14 @@ export const createCctCallbacks = (deps: CctCallbackDeps): CctCallbacks => {
     return account
   }
 
-  const getReadOnlySigner = async (): Promise<Avalanche.AddressWallet> => {
+  // `isTestnet` may be passed by callers that also need the value for
+  // network-dependent work (e.g. getUtxos' asset-id lookup), so the signer
+  // and that work are guaranteed to describe the same network. Defaults to
+  // a fresh read for everyone else.
+  const getReadOnlySigner = async (
+    isTestnet: boolean = deps.getIsDeveloperMode()
+  ): Promise<Avalanche.AddressWallet> => {
     const account = getRequiredAccount()
-    const isTestnet = deps.getIsDeveloperMode()
     const { xpAddresses } = await deps.getXpAddresses()
     if (xpAddresses.length === 0) {
       // Defensive: getCachedXPAddresses normally fetches on a cold cache, so
@@ -188,11 +193,11 @@ export const createCctCallbacks = (deps: CctCallbackDeps): CctCallbacks => {
   }
 
   const getUtxos: CctCallbacks['getUtxos'] = async chainAlias => {
-    // Read once, before any await: the asset id must describe the same
-    // network the signer was built for, even if developer mode flips
+    // Read once and thread into the signer: the asset id must describe the
+    // same network the signer was built for, even if developer mode flips
     // while the UTXO fetch is in flight.
     const isTestnet = deps.getIsDeveloperMode()
-    const signer = await getReadOnlySigner()
+    const signer = await getReadOnlySigner(isTestnet)
     const utxoSet = await signer.getUTXOs(chainAlias)
     if (!deps.getFilterSmallUtxos()) return utxoSet
     // CP-13903: drop dust from the spendable set, mirroring extension

--- a/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.ts
+++ b/packages/core-mobile/app/new/features/swap/services/cct/createCctCallbacks.ts
@@ -8,7 +8,9 @@ import { AvalancheSendTransactionParams } from '@avalabs/avalanche-module'
 import { RpcMethod } from '@avalabs/vm-module-types'
 import { getInternalExternalAddrs } from 'common/hooks/send/utils/getInternalExternalAddrs'
 import AvalancheWalletService from 'services/wallet/AvalancheWalletService'
+import { filterOutSmallUtxos } from 'services/wallet/filterSmallUtxos'
 import { WalletType } from 'services/wallet/types'
+import { getAvaxAssetId } from 'services/wallet/utils'
 import { Account, XPAddressDictionary } from 'store/account/types'
 import { Request } from 'store/rpc/utils/createInAppRequest'
 import { RequestContext } from 'store/rpc/types'
@@ -39,6 +41,10 @@ export type CctCallbackDeps = {
    * then import tx) — same path the X/P send flows use.
    */
   request: Request
+  // CP-13903: composite filter gate (PostHog flag AND user setting).
+  // Read lazily per call so mid-session toggles apply without rebuilding
+  // the TransferManager.
+  getFilterSmallUtxos: () => boolean
 }
 
 export type CctCallbacks = Pick<
@@ -182,8 +188,19 @@ export const createCctCallbacks = (deps: CctCallbackDeps): CctCallbacks => {
   }
 
   const getUtxos: CctCallbacks['getUtxos'] = async chainAlias => {
+    // Read once, before any await: the asset id must describe the same
+    // network the signer was built for, even if developer mode flips
+    // while the UTXO fetch is in flight.
+    const isTestnet = deps.getIsDeveloperMode()
     const signer = await getReadOnlySigner()
-    return signer.getUTXOs(chainAlias)
+    const utxoSet = await signer.getUTXOs(chainAlias)
+    if (!deps.getFilterSmallUtxos()) return utxoSet
+    // CP-13903: drop dust from the spendable set, mirroring extension
+    // Fusion's getMaxUtxoSet. getAtomicUtxos stays deliberately unfiltered —
+    // filtering imports would strand exported dust in atomic memory.
+    return new utils.UtxoSet(
+      filterOutSmallUtxos(utxoSet.getUTXOs(), getAvaxAssetId(isTestnet))
+    )
   }
 
   const getWalletAddressesForChainAlias: CctCallbacks['getWalletAddressesForChainAlias'] =

--- a/packages/core-mobile/app/services/balance/BalanceService.test.ts
+++ b/packages/core-mobile/app/services/balance/BalanceService.test.ts
@@ -203,6 +203,7 @@ describe('BalanceService', () => {
       const onBalanceLoaded = jest.fn()
 
       const result = await balanceService.getBalancesForAccount({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any],
         account: testAccount,
         currency: 'usd',
@@ -239,6 +240,7 @@ describe('BalanceService', () => {
       mockLoadModuleByNetwork.mockResolvedValue(mockModule)
 
       const result = await balanceService.getBalancesForAccount({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any],
         account: testAccount,
         currency: 'usd',
@@ -301,6 +303,7 @@ describe('BalanceService', () => {
       mockLoadModuleByNetwork.mockResolvedValue(mockModule)
 
       const result = await balanceService.getBalancesForAccount({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any, ethereumNetwork as any],
         account: testAccount,
         currency: 'usd',
@@ -354,6 +357,7 @@ describe('BalanceService', () => {
       mockLoadModuleByNetwork.mockResolvedValue(mockModule)
 
       await balanceService.getBalancesForAccount({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any, ethereumNetwork as any],
         account: testAccount,
         currency: 'usd',
@@ -405,6 +409,7 @@ describe('BalanceService', () => {
       mockLoadModuleByNetwork.mockResolvedValue(mockModule)
 
       const result = await balanceService.getBalancesForAccount({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any, ethereumNetwork as any],
         account: testAccount,
         currency: 'usd',
@@ -455,6 +460,7 @@ describe('BalanceService', () => {
       const onBalanceLoaded = jest.fn()
 
       const result = await balanceService.getBalancesForAccounts({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any],
         accounts: [testAccount, testAccount2],
         currency: 'usd',
@@ -504,6 +510,7 @@ describe('BalanceService', () => {
       mockLoadModuleByNetwork.mockResolvedValue(mockModule)
 
       const result = await balanceService.getBalancesForAccounts({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any],
         accounts: [testAccount, testAccount2],
         currency: 'usd',
@@ -565,6 +572,7 @@ describe('BalanceService', () => {
       mockLoadModuleByNetwork.mockResolvedValue(mockModule)
 
       await balanceService.getBalancesForAccounts({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any, ethereumNetwork as any],
         accounts: [testAccount],
         currency: 'usd',
@@ -612,6 +620,7 @@ describe('BalanceService', () => {
       mockLoadModuleByNetwork.mockResolvedValue(mockModule)
 
       const result = await balanceService.getBalancesForAccounts({
+        filterOutDustUtxos: false,
         networks: [ethereumNetwork as any],
         accounts: [testAccount],
         currency: 'usd',
@@ -651,6 +660,7 @@ describe('BalanceService', () => {
       const onBalanceLoaded = jest.fn()
 
       await balanceService.getBalancesForAccounts({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any],
         accounts: [testAccount],
         currency: 'usd',
@@ -794,6 +804,7 @@ describe('BalanceService', () => {
         const onBalanceLoaded = jest.fn()
 
         const result = await balanceService.getBalancesForAccounts({
+          filterOutDustUtxos: false,
           networks: [cChainNetwork as any],
           accounts: [testAccount, importedAccount],
           currency: 'usd',
@@ -850,6 +861,7 @@ describe('BalanceService', () => {
           })
 
         const result = await balanceService.getBalancesForAccounts({
+          filterOutDustUtxos: false,
           networks: [cChainNetwork as any],
           accounts: [testAccount, importedAccount],
           currency: 'usd',
@@ -889,6 +901,7 @@ describe('BalanceService', () => {
         })
 
         const result = await balanceService.getBalancesForAccounts({
+          filterOutDustUtxos: false,
           networks: [cChainNetwork as any],
           accounts: [testAccount, importedAccount],
           currency: 'usd',
@@ -909,7 +922,7 @@ describe('BalanceService', () => {
       it('should assign VM balance to both accounts sharing the same EVM address', async () => {
         const mockModule = {
           getBalances: jest.fn().mockResolvedValue({
-            [testAccount.addressC!]: {
+            [String(testAccount.addressC)]: {
               avax: {
                 name: 'Avalanche',
                 symbol: 'AVAX',
@@ -948,7 +961,7 @@ describe('BalanceService', () => {
       it('should handle VM error for both accounts sharing an address', async () => {
         const mockModule = {
           getBalances: jest.fn().mockResolvedValue({
-            [testAccount.addressC!]: {
+            [String(testAccount.addressC)]: {
               error: new Error('VM fetch failed')
             }
           })
@@ -983,7 +996,7 @@ describe('BalanceService', () => {
 
         const mockModule = {
           getBalances: jest.fn().mockResolvedValue({
-            [testAccount.addressC!]: {
+            [String(testAccount.addressC)]: {
               avax: {
                 name: 'Avalanche',
                 symbol: 'AVAX',
@@ -1019,6 +1032,7 @@ describe('BalanceService', () => {
   describe('edge cases', () => {
     it('should handle empty networks array', async () => {
       const result = await balanceService.getBalancesForAccount({
+        filterOutDustUtxos: false,
         networks: [],
         account: testAccount,
         currency: 'usd',
@@ -1032,6 +1046,7 @@ describe('BalanceService', () => {
 
     it('should handle empty accounts array for getBalancesForAccounts', async () => {
       const result = await balanceService.getBalancesForAccounts({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any],
         accounts: [],
         currency: 'usd',
@@ -1077,6 +1092,7 @@ describe('BalanceService', () => {
       const onBalanceLoaded = jest.fn()
 
       const result = await balanceService.getBalancesForAccount({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any],
         account: testAccount,
         currency: 'usd',
@@ -1113,6 +1129,7 @@ describe('BalanceService', () => {
 
       // No callback provided
       const result = await balanceService.getBalancesForAccount({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any],
         account: testAccount,
         currency: 'usd',
@@ -1133,6 +1150,7 @@ describe('BalanceService', () => {
       mockLoadModuleByNetwork.mockRejectedValue(new Error('VM module failed'))
 
       const result = await balanceService.getBalancesForAccount({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any],
         account: testAccount,
         currency: 'usd',
@@ -1168,6 +1186,7 @@ describe('BalanceService', () => {
       })
 
       const result = await balanceService.getBalancesForAccount({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any],
         account: testAccount,
         currency: 'usd',
@@ -1218,6 +1237,7 @@ describe('BalanceService', () => {
       const onBalanceLoaded = jest.fn()
 
       await balanceService.getBalancesForAccount({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any],
         account: testAccount,
         currency: 'usd',
@@ -1273,6 +1293,7 @@ describe('BalanceService', () => {
       mockLoadModuleByNetwork.mockResolvedValue(mockModule)
 
       await balanceService.getBalancesForAccount({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any, ethereumNetwork as any],
         account: testAccount,
         currency: 'usd',
@@ -1321,6 +1342,7 @@ describe('BalanceService', () => {
         })
 
       const result = await balanceService.getBalancesForAccount({
+        filterOutDustUtxos: false,
         networks: [cChainNetwork as any, btcNetwork as any],
         account: testAccount,
         currency: 'usd',

--- a/packages/core-mobile/app/services/balance/BalanceService.ts
+++ b/packages/core-mobile/app/services/balance/BalanceService.ts
@@ -328,7 +328,8 @@ export class BalanceService {
     currency,
     onBalanceLoaded,
     xpAddresses,
-    xpub
+    xpub,
+    filterOutDustUtxos
   }: {
     networks: Network[]
     account: Account
@@ -336,6 +337,7 @@ export class BalanceService {
     onBalanceLoaded?: (balance: AdjustedNormalizedBalancesForAccount) => void
     xpAddresses: string[]
     xpub?: string
+    filterOutDustUtxos: boolean
   }): Promise<AdjustedNormalizedBalancesForAccount[]> {
     // Final aggregated result
     const finalResults = new Map<number, AdjustedNormalizedBalancesForAccount>()
@@ -347,7 +349,8 @@ export class BalanceService {
       networks: supportedNetworks,
       accounts: [account],
       xpAddressesByAccountId: new Map([[account.id, xpAddresses]]),
-      xpubByAccountId: new Map([[account.id, xpub]])
+      xpubByAccountId: new Map([[account.id, xpub]]),
+      filterOutDustUtxos
     })
 
     const { balanceApiThrew, failedChainIds } =
@@ -415,7 +418,8 @@ export class BalanceService {
     currency,
     onBalanceLoaded,
     xpAddressesByAccountId,
-    xpubByAccountId
+    xpubByAccountId,
+    filterOutDustUtxos
   }: {
     networks: Network[]
     accounts: Account[]
@@ -423,6 +427,7 @@ export class BalanceService {
     onBalanceLoaded?: (balance: AdjustedNormalizedBalancesForAccount) => void
     xpAddressesByAccountId: Map<string, string[]>
     xpubByAccountId: Map<string, string | undefined>
+    filterOutDustUtxos: boolean
   }): Promise<AdjustedNormalizedBalancesForAccounts> {
     const finalResults: AdjustedNormalizedBalancesForAccounts = {}
 
@@ -437,7 +442,8 @@ export class BalanceService {
       networks: supportedNetworks,
       accounts,
       xpAddressesByAccountId,
-      xpubByAccountId
+      xpubByAccountId,
+      filterOutDustUtxos
     })
 
     const accountById = accounts.reduce((acc, a) => {
@@ -517,8 +523,9 @@ export class BalanceService {
             }
           }
 
-          if (matchedAccounts.length === 0 && accounts.length === 1) {
-            matchedAccounts.push(accounts[0]!)
+          const onlyAccount = accounts.length === 1 ? accounts[0] : undefined
+          if (matchedAccounts.length === 0 && onlyAccount) {
+            matchedAccounts.push(onlyAccount)
           }
 
           if (matchedAccounts.length === 0) {

--- a/packages/core-mobile/app/services/balance/getPChainBalance.ts
+++ b/packages/core-mobile/app/services/balance/getPChainBalance.ts
@@ -10,13 +10,15 @@ export const getPChainBalance = async ({
   currency,
   avaxXPNetwork,
   xpAddresses,
-  xpub
+  xpub,
+  filterOutDustUtxos
 }: {
   account: Account
   currency: string
   avaxXPNetwork: Network
   xpAddresses: string[]
   xpub?: string
+  filterOutDustUtxos: boolean
 }): Promise<TokenWithBalancePVM> => {
   try {
     const balances = await BalanceService.getBalancesForAccount({
@@ -24,7 +26,8 @@ export const getPChainBalance = async ({
       account,
       currency,
       xpAddresses,
-      xpub
+      xpub,
+      filterOutDustUtxos
     })
 
     const pChainBalance = balances

--- a/packages/core-mobile/app/services/balance/utils/buildRequestItemsForAccounts.test.ts
+++ b/packages/core-mobile/app/services/balance/utils/buildRequestItemsForAccounts.test.ts
@@ -74,7 +74,8 @@ describe('buildRequestItemsForAccounts', () => {
       networks,
       accounts,
       xpAddressesByAccountId,
-      xpubByAccountId
+      xpubByAccountId,
+      filterOutDustUtxos: false
     })
 
     const evmItems = batches
@@ -113,7 +114,8 @@ describe('buildRequestItemsForAccounts', () => {
       networks,
       accounts,
       xpAddressesByAccountId,
-      xpubByAccountId
+      xpubByAccountId,
+      filterOutDustUtxos: false
     })
     const btcItems = batches
       .flatMap(batch => batch)
@@ -151,7 +153,8 @@ describe('buildRequestItemsForAccounts', () => {
       networks,
       accounts,
       xpAddressesByAccountId,
-      xpubByAccountId
+      xpubByAccountId,
+      filterOutDustUtxos: false
     })
     const svmItems = batches
       .flatMap(batch => batch)
@@ -190,7 +193,8 @@ describe('buildRequestItemsForAccounts', () => {
       networks,
       accounts,
       xpAddressesByAccountId,
-      xpubByAccountId
+      xpubByAccountId,
+      filterOutDustUtxos: false
     })
     const avaxItems = batches
       .flatMap(batch => batch)
@@ -220,7 +224,8 @@ describe('buildRequestItemsForAccounts', () => {
       networks,
       accounts,
       xpAddressesByAccountId,
-      xpubByAccountId
+      xpubByAccountId,
+      filterOutDustUtxos: false
     })
     const avaxItems = batches
       .flatMap(batch => batch)
@@ -270,7 +275,8 @@ describe('buildRequestItemsForAccounts', () => {
       networks,
       accounts,
       xpAddressesByAccountId,
-      xpubByAccountId
+      xpubByAccountId,
+      filterOutDustUtxos: false
     })
     const allItems = batches.flatMap(batch => batch)
 
@@ -300,7 +306,8 @@ describe('buildRequestItemsForAccounts', () => {
       networks,
       accounts,
       xpAddressesByAccountId,
-      xpubByAccountId
+      xpubByAccountId,
+      filterOutDustUtxos: false
     })
     const evmItems = batches
       .flatMap(batch => batch)
@@ -339,7 +346,8 @@ describe('buildRequestItemsForAccounts', () => {
       networks,
       accounts,
       xpAddressesByAccountId,
-      xpubByAccountId
+      xpubByAccountId,
+      filterOutDustUtxos: false
     })
     const allItems = batches.flatMap(batch => batch)
 
@@ -377,7 +385,8 @@ describe('buildRequestItemsForAccounts', () => {
       networks,
       accounts,
       xpAddressesByAccountId,
-      xpubByAccountId
+      xpubByAccountId,
+      filterOutDustUtxos: false
     })
 
     const avaxItems = batches
@@ -432,7 +441,8 @@ describe('buildRequestItemsForAccounts', () => {
       networks,
       accounts,
       xpAddressesByAccountId,
-      xpubByAccountId
+      xpubByAccountId,
+      filterOutDustUtxos: false
     })
     const avaxItems = batches
       .flatMap(batch => batch)
@@ -466,7 +476,8 @@ describe('buildRequestItemsForAccounts', () => {
       networks,
       accounts,
       xpAddressesByAccountId,
-      xpubByAccountId
+      xpubByAccountId,
+      filterOutDustUtxos: false
     })
 
     const avaxItems = batches
@@ -500,6 +511,37 @@ describe('buildRequestItemsForAccounts', () => {
     )
     addressItems.forEach(item => {
       expect(item.extendedPublicKeyDetails).toBeUndefined()
+    })
+  })
+
+  describe('filterOutDustUtxos threading', () => {
+    const avaxNetwork = createMockNetwork(4503599627370465, NetworkVMType.AVM)
+    const account = createMockAccount()
+
+    const build = (filterOutDustUtxos: boolean) =>
+      buildRequestItemsForAccounts({
+        networks: [avaxNetwork],
+        accounts: [account],
+        xpAddressesByAccountId: new Map([
+          [account.id, [account.addressAVM as string]]
+        ]),
+        xpubByAccountId: new Map([[account.id, undefined]]),
+        filterOutDustUtxos
+      })
+
+    const avaxItemsOf = (batches: ReturnType<typeof build>) =>
+      batches.flat().filter((item: any) => item.namespace === 'avax')
+
+    it('emits filterOutDustUtxos: false on every avax item when false', () => {
+      const items = avaxItemsOf(build(false))
+      expect(items.length).toBeGreaterThan(0)
+      items.forEach((item: any) => expect(item.filterOutDustUtxos).toBe(false))
+    })
+
+    it('emits filterOutDustUtxos: true on every avax item when true', () => {
+      const items = avaxItemsOf(build(true))
+      expect(items.length).toBeGreaterThan(0)
+      items.forEach((item: any) => expect(item.filterOutDustUtxos).toBe(true))
     })
   })
 })

--- a/packages/core-mobile/app/services/balance/utils/buildRequestItemsForAccounts.ts
+++ b/packages/core-mobile/app/services/balance/utils/buildRequestItemsForAccounts.ts
@@ -74,12 +74,20 @@ export const buildRequestItemsForAccounts = ({
   networks,
   accounts,
   xpAddressesByAccountId,
-  xpubByAccountId
+  xpubByAccountId,
+  filterOutDustUtxos
 }: {
   networks: Network[]
   accounts: Account[]
   xpAddressesByAccountId: Map<string, string[]>
   xpubByAccountId: Map<string, string | undefined>
+  /**
+   * CP-13903: forwarded to the Balance API's avax-namespace items. The
+   * server default is `true`, so this must always be explicit. Pass
+   * `selectIsFilterSmallUtxosActive` for user-facing balances; pass `false`
+   * for account discovery (dust-only accounts must still be detected).
+   */
+  filterOutDustUtxos: boolean
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }): GetBalancesRequestBody['data'][] => {
   const evmReferences = new Set<string>()
@@ -258,7 +266,7 @@ export const buildRequestItemsForAccounts = ({
         avaxItems.push({
           namespace: BlockchainNamespace.AVAX,
           references: avaxRefs,
-          filterOutDustUtxos: false,
+          filterOutDustUtxos,
           extendedPublicKeyDetails: xpubChunk
         })
       }
@@ -277,7 +285,7 @@ export const buildRequestItemsForAccounts = ({
         avaxItems.push({
           namespace: BlockchainNamespace.AVAX,
           references: avaxRefs,
-          filterOutDustUtxos: false,
+          filterOutDustUtxos,
           addressDetails: addressChunk
         })
       }

--- a/packages/core-mobile/app/services/earn/importP.ts
+++ b/packages/core-mobile/app/services/earn/importP.ts
@@ -131,7 +131,12 @@ const getUnlockedUnstakedAmount = async ({
       currency: selectedCurrency,
       avaxXPNetwork: network,
       xpAddresses,
-      xpub
+      xpub,
+      // CP-13903: intentionally unfiltered. This is the import-completion
+      // delta check (polls unlockedUnstaked before/after importP) — dust is
+      // constant across the import, and unfiltered totals detect the landed
+      // amount most accurately. Not a user-facing balance.
+      filterOutDustUtxos: false
     })
 
     return pChainBalance.balancePerType.unlockedUnstaked

--- a/packages/core-mobile/app/services/posthog/types.ts
+++ b/packages/core-mobile/app/services/posthog/types.ts
@@ -53,7 +53,8 @@ export enum FeatureGates {
   // '0' variant, or an unparsable variant — behaves exactly like the flag
   // being off (see `selectIs*FeeBlocked` in `store/posthog`).
   FAST_STAKE_FEE_ENABLED = 'fast-stake-fee-enabled',
-  DELEGATION_FEE_ENABLED = 'delegation-fee-enabled'
+  DELEGATION_FEE_ENABLED = 'delegation-fee-enabled',
+  FILTER_SMALL_UTXOS = 'filter-small-utxos'
 }
 
 export enum FeatureVars {

--- a/packages/core-mobile/app/services/wallet/AvalancheWalletService.sendTx.test.ts
+++ b/packages/core-mobile/app/services/wallet/AvalancheWalletService.sendTx.test.ts
@@ -1,0 +1,119 @@
+import {
+  BigIntPr,
+  Id,
+  Int,
+  OutputOwners,
+  TransferOutput,
+  Utxo,
+  avaxSerial,
+  utils
+} from '@avalabs/avalanchejs'
+import { Avalanche } from '@avalabs/core-wallets-sdk'
+import { Account } from 'store/account'
+import AvalancheWalletService from './AvalancheWalletService'
+import { SMALL_UTXO_THRESHOLD_NAVAX } from './filterSmallUtxos'
+
+const AVAX_ASSET_ID = Avalanche.MainnetContext.avaxAssetID
+
+const bech32Address = utils.formatBech32('avax', new Uint8Array(20))
+
+let utxoCounter = 0
+const mockUtxo = (amount: bigint): Utxo =>
+  new Utxo(
+    new avaxSerial.UTXOID(Id.fromString(AVAX_ASSET_ID), new Int(utxoCounter++)),
+    Id.fromString(AVAX_ASSET_ID),
+    new TransferOutput(
+      new BigIntPr(amount),
+      OutputOwners.fromNative([new Uint8Array(20)])
+    )
+  )
+
+const account = {
+  addressC: '0x0000000000000000000000000000000000000000',
+  addressCoreEth: 'C-avax1x0000000000000000000000000000000000',
+  addressPVM: 'P-avax1x0000000000000000000000000000000000'
+} as Account
+
+const dust = mockUtxo(SMALL_UTXO_THRESHOLD_NAVAX - 1n)
+const spendable = mockUtxo(SMALL_UTXO_THRESHOLD_NAVAX)
+
+describe('createSendXTx', () => {
+  const baseTX = jest.fn().mockReturnValue('unsigned-tx')
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(AvalancheWalletService, 'getReadOnlySigner').mockResolvedValue({
+      getUTXOs: jest
+        .fn()
+        .mockResolvedValue(new utils.UtxoSet([dust, spendable])),
+      baseTX
+    } as unknown as Avalanche.AddressWallet)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  const params = {
+    amountInNAvax: 1n,
+    account,
+    isTestnet: false,
+    destinationAddress: `X-${bech32Address}`,
+    sourceAddress: `X-${bech32Address}`,
+    xpAddresses: [bech32Address]
+  }
+
+  it('drops small UTXOs from the spend set when filterSmallUtxos is true', async () => {
+    await AvalancheWalletService.createSendXTx({
+      ...params,
+      filterSmallUtxos: true
+    })
+
+    const { utxoSet } = baseTX.mock.calls[0][0]
+    expect(utxoSet.getUTXOs()).toEqual([spendable])
+  })
+
+  it('spends the full UTXO set when filterSmallUtxos is not set', async () => {
+    await AvalancheWalletService.createSendXTx(params)
+
+    const { utxoSet } = baseTX.mock.calls[0][0]
+    expect(utxoSet.getUTXOs()).toEqual([dust, spendable])
+  })
+})
+
+describe('getSpendableAvaxBalance (X-chain)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(AvalancheWalletService, 'getReadOnlySigner').mockResolvedValue({
+      getUTXOs: jest
+        .fn()
+        .mockResolvedValue(new utils.UtxoSet([dust, spendable]))
+    } as unknown as Avalanche.AddressWallet)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  const params = {
+    chain: 'X' as const,
+    account,
+    isTestnet: false,
+    xpAddresses: [bech32Address]
+  }
+
+  it('excludes dust from the spendable balance when filterSmallUtxos is true', async () => {
+    const available = await AvalancheWalletService.getSpendableAvaxBalance({
+      ...params,
+      filterSmallUtxos: true
+    })
+    expect(available).toBe(SMALL_UTXO_THRESHOLD_NAVAX)
+  })
+
+  it('sums the full set when filterSmallUtxos is not set', async () => {
+    const available = await AvalancheWalletService.getSpendableAvaxBalance(
+      params
+    )
+    expect(available).toBe(SMALL_UTXO_THRESHOLD_NAVAX * 2n - 1n)
+  })
+})

--- a/packages/core-mobile/app/services/wallet/AvalancheWalletService.sendTx.test.ts
+++ b/packages/core-mobile/app/services/wallet/AvalancheWalletService.sendTx.test.ts
@@ -13,6 +13,20 @@ import { Account } from 'store/account'
 import AvalancheWalletService from './AvalancheWalletService'
 import { SMALL_UTXO_THRESHOLD_NAVAX } from './filterSmallUtxos'
 
+// getMaximumUtxoSet builds real transactions to measure their size, which a
+// mocked signer can't support — replace it with a pass-through so the P
+// tests can pin that the dust filter runs on the size-capped output.
+jest.mock('@avalabs/core-wallets-sdk', () => {
+  const actual = jest.requireActual('@avalabs/core-wallets-sdk')
+  return {
+    ...actual,
+    Avalanche: {
+      ...actual.Avalanche,
+      getMaximumUtxoSet: jest.fn(({ utxos }) => utxos)
+    }
+  }
+})
+
 const AVAX_ASSET_ID = Avalanche.MainnetContext.avaxAssetID
 
 const bech32Address = utils.formatBech32('avax', new Uint8Array(20))
@@ -78,6 +92,86 @@ describe('createSendXTx', () => {
 
     const { utxoSet } = baseTX.mock.calls[0][0]
     expect(utxoSet.getUTXOs()).toEqual([dust, spendable])
+  })
+})
+
+describe('createSendPTx', () => {
+  const baseTX = jest.fn().mockReturnValue('unsigned-tx')
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(Avalanche.getMaximumUtxoSet as jest.Mock).mockImplementation(
+      ({ utxos }) => utxos
+    )
+    jest.spyOn(AvalancheWalletService, 'getReadOnlySigner').mockResolvedValue({
+      getUTXOs: jest
+        .fn()
+        .mockResolvedValue(new utils.UtxoSet([dust, spendable])),
+      baseTX
+    } as unknown as Avalanche.AddressWallet)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  const params = {
+    amountInNAvax: 1n,
+    account,
+    isTestnet: false,
+    destinationAddress: `P-${bech32Address}`,
+    sourceAddress: `P-${bech32Address}`,
+    xpAddresses: [bech32Address]
+  }
+
+  it('applies the size cap first, then drops dust from the P spend set', async () => {
+    await AvalancheWalletService.createSendPTx({
+      ...params,
+      filterSmallUtxos: true
+    })
+
+    // the size cap sees the full set; the dust filter runs on its output
+    expect(Avalanche.getMaximumUtxoSet).toHaveBeenCalledWith(
+      expect.objectContaining({ utxos: [dust, spendable] })
+    )
+    const { utxoSet } = baseTX.mock.calls[0][0]
+    expect(utxoSet.getUTXOs()).toEqual([spendable])
+  })
+
+  it('spends the full size-capped set when filterSmallUtxos is not set', async () => {
+    await AvalancheWalletService.createSendPTx(params)
+
+    const { utxoSet } = baseTX.mock.calls[0][0]
+    expect(utxoSet.getUTXOs()).toEqual([dust, spendable])
+  })
+})
+
+describe('getSpendableAvaxBalance (P-chain)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(Avalanche.getMaximumUtxoSet as jest.Mock).mockImplementation(
+      ({ utxos }) => utxos
+    )
+    jest.spyOn(AvalancheWalletService, 'getReadOnlySigner').mockResolvedValue({
+      getUTXOs: jest
+        .fn()
+        .mockResolvedValue(new utils.UtxoSet([dust, spendable]))
+    } as unknown as Avalanche.AddressWallet)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('excludes dust from the size-capped P spendable balance', async () => {
+    const available = await AvalancheWalletService.getSpendableAvaxBalance({
+      chain: 'P',
+      account,
+      isTestnet: false,
+      xpAddresses: [bech32Address],
+      filterSmallUtxos: true
+    })
+    expect(available).toBe(SMALL_UTXO_THRESHOLD_NAVAX)
   })
 })
 

--- a/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
+++ b/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
@@ -16,7 +16,8 @@ import {
   CreateExportPTxParams,
   CreateImportCTxParams,
   CreateImportPTxParams,
-  CreateSendPTxParams
+  CreateSendPTxParams,
+  CreateSendXTxParams
 } from './types'
 import { getAvaxAssetId } from './utils'
 import { filterOutSmallUtxos } from './filterSmallUtxos'
@@ -277,6 +278,83 @@ class AvalancheWalletService {
   }
 
   /**
+   * The exact UTXO set the send tx builders spend from: full set for X,
+   * size-capped for P (64KB tx limit), minus dust when the small-UTXO
+   * filter is on. Max-amount derivation MUST use this same set — deriving
+   * Max from the (unfiltered) displayed balance builds an over-spend.
+   */
+  private async getSendUtxoSet({
+    readOnlySigner,
+    chain,
+    isTestnet,
+    feeState,
+    filterSmallUtxos
+  }: {
+    readOnlySigner: Avalanche.AddressWallet
+    chain: 'P' | 'X'
+    isTestnet: boolean
+    feeState?: pvm.FeeState
+    filterSmallUtxos?: boolean
+  }): Promise<utils.UtxoSet> {
+    const utxoSet = await readOnlySigner.getUTXOs(chain)
+    let filteredUtxos = utxoSet.getUTXOs()
+    if (chain === 'P') {
+      // P-chain has a tx size limit of 64KB
+      filteredUtxos = Avalanche.getMaximumUtxoSet({
+        wallet: readOnlySigner,
+        utxos: filteredUtxos,
+        sizeSupportedTx: Avalanche.SizeSupportedTx.BaseP,
+        feeState
+      })
+    }
+    if (filterSmallUtxos === true) {
+      filteredUtxos = filterOutSmallUtxos(
+        filteredUtxos,
+        getAvaxAssetId(isTestnet)
+      )
+    }
+    return new utils.UtxoSet(filteredUtxos)
+  }
+
+  /**
+   * Spendable AVAX (nAVAX) computed from the same UTXO set
+   * createSendPTx/createSendXTx will spend, so Max amounts stay consistent
+   * with what a send can actually consume (CP-13903).
+   */
+  public async getSpendableAvaxBalance({
+    chain,
+    account,
+    isTestnet,
+    xpAddresses,
+    feeState,
+    filterSmallUtxos
+  }: {
+    chain: 'P' | 'X'
+    account: Account
+    isTestnet: boolean
+    xpAddresses: string[]
+    feeState?: pvm.FeeState
+    filterSmallUtxos?: boolean
+  }): Promise<bigint> {
+    const readOnlySigner = await this.getReadOnlySigner({
+      account,
+      isTestnet,
+      xpAddresses
+    })
+
+    const utxoSet = await this.getSendUtxoSet({
+      readOnlySigner,
+      chain,
+      isTestnet,
+      feeState,
+      filterSmallUtxos
+    })
+
+    return Avalanche.getAssetBalance(utxoSet, getAvaxAssetId(isTestnet))
+      .available
+  }
+
+  /**
    * Create UnsignedTx for sending on P-chain
    */
   public async createSendPTx({
@@ -299,21 +377,13 @@ class AvalancheWalletService {
       xpAddresses
     })
 
-    // P-chain has a tx size limit of 64KB
-    let utxoSet = await readOnlySigner.getUTXOs('P')
-    let filteredUtxos = Avalanche.getMaximumUtxoSet({
-      wallet: readOnlySigner,
-      utxos: utxoSet.getUTXOs(),
-      sizeSupportedTx: Avalanche.SizeSupportedTx.BaseP,
-      feeState
+    const utxoSet = await this.getSendUtxoSet({
+      readOnlySigner,
+      chain: 'P',
+      isTestnet,
+      feeState,
+      filterSmallUtxos
     })
-    if (filterSmallUtxos === true) {
-      filteredUtxos = filterOutSmallUtxos(
-        filteredUtxos,
-        getAvaxAssetId(isTestnet)
-      )
-    }
-    utxoSet = new utils.UtxoSet(filteredUtxos)
     const changeAddress = utils.parse(sourceAddress)[2]
 
     return readOnlySigner.baseTX({
@@ -339,8 +409,9 @@ class AvalancheWalletService {
     isTestnet,
     destinationAddress,
     sourceAddress,
-    xpAddresses
-  }: CreateSendPTxParams): Promise<UnsignedTx> {
+    xpAddresses,
+    filterSmallUtxos
+  }: CreateSendXTxParams): Promise<UnsignedTx> {
     if (!destinationAddress) {
       throw new Error('destination address must be set')
     }
@@ -351,8 +422,12 @@ class AvalancheWalletService {
       xpAddresses
     })
 
-    // P-chain has a tx size limit of 64KB
-    const utxoSet = await readOnlySigner.getUTXOs('X')
+    const utxoSet = await this.getSendUtxoSet({
+      readOnlySigner,
+      chain: 'X',
+      isTestnet,
+      filterSmallUtxos
+    })
     const changeAddress = utils.parse(sourceAddress)[2]
     return readOnlySigner.baseTX({
       utxoSet,

--- a/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
+++ b/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
@@ -19,6 +19,7 @@ import {
   CreateSendPTxParams
 } from './types'
 import { getAvaxAssetId } from './utils'
+import { filterOutSmallUtxos } from './filterSmallUtxos'
 class AvalancheWalletService {
   /**
    * Get atomic transactions that are in VM memory.
@@ -285,7 +286,8 @@ class AvalancheWalletService {
     destinationAddress,
     sourceAddress,
     feeState,
-    xpAddresses
+    xpAddresses,
+    filterSmallUtxos
   }: CreateSendPTxParams): Promise<UnsignedTx> {
     if (!destinationAddress) {
       throw new Error('destination address must be set')
@@ -299,12 +301,18 @@ class AvalancheWalletService {
 
     // P-chain has a tx size limit of 64KB
     let utxoSet = await readOnlySigner.getUTXOs('P')
-    const filteredUtxos = Avalanche.getMaximumUtxoSet({
+    let filteredUtxos = Avalanche.getMaximumUtxoSet({
       wallet: readOnlySigner,
       utxos: utxoSet.getUTXOs(),
       sizeSupportedTx: Avalanche.SizeSupportedTx.BaseP,
       feeState
     })
+    if (filterSmallUtxos === true) {
+      filteredUtxos = filterOutSmallUtxos(
+        filteredUtxos,
+        getAvaxAssetId(isTestnet)
+      )
+    }
     utxoSet = new utils.UtxoSet(filteredUtxos)
     const changeAddress = utils.parse(sourceAddress)[2]
 

--- a/packages/core-mobile/app/services/wallet/filterSmallUtxos.test.ts
+++ b/packages/core-mobile/app/services/wallet/filterSmallUtxos.test.ts
@@ -1,0 +1,44 @@
+import { Utxo } from '@avalabs/avalanchejs'
+import {
+  SMALL_UTXO_THRESHOLD_NAVAX,
+  filterOutSmallUtxos
+} from './filterSmallUtxos'
+
+const AVAX_ASSET_ID = 'FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z'
+const OTHER_ASSET_ID = '2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe'
+
+const mockUtxo = (assetId: string, amount: bigint): Utxo =>
+  ({
+    getAssetId: () => assetId,
+    output: { amount: () => amount }
+  } as unknown as Utxo)
+
+describe('filterOutSmallUtxos', () => {
+  it('exports the shared 0.002 AVAX threshold', () => {
+    expect(SMALL_UTXO_THRESHOLD_NAVAX).toBe(2_000_000n)
+  })
+
+  it('drops AVAX UTXOs below the threshold', () => {
+    const dust = mockUtxo(AVAX_ASSET_ID, 1_999_999n)
+    const keep = mockUtxo(AVAX_ASSET_ID, 2_000_001n)
+    expect(filterOutSmallUtxos([dust, keep], AVAX_ASSET_ID)).toEqual([keep])
+  })
+
+  it('keeps an AVAX UTXO of exactly the threshold (inclusive)', () => {
+    const boundary = mockUtxo(AVAX_ASSET_ID, 2_000_000n)
+    expect(filterOutSmallUtxos([boundary], AVAX_ASSET_ID)).toEqual([boundary])
+  })
+
+  it('never drops non-AVAX UTXOs, however small', () => {
+    const tinyOther = mockUtxo(OTHER_ASSET_ID, 1n)
+    expect(filterOutSmallUtxos([tinyOther], AVAX_ASSET_ID)).toEqual([tinyOther])
+  })
+
+  it('keeps UTXOs whose output has no amount() (non-transfer outputs)', () => {
+    const noAmount = {
+      getAssetId: () => AVAX_ASSET_ID,
+      output: {}
+    } as unknown as Utxo
+    expect(filterOutSmallUtxos([noAmount], AVAX_ASSET_ID)).toEqual([noAmount])
+  })
+})

--- a/packages/core-mobile/app/services/wallet/filterSmallUtxos.ts
+++ b/packages/core-mobile/app/services/wallet/filterSmallUtxos.ts
@@ -1,0 +1,28 @@
+import { Utxo } from '@avalabs/avalanchejs'
+
+/**
+ * Minimum UTXO value kept when "Filter out small UTXOs" is enabled
+ * (CP-13903). 0.002 AVAX in nAVAX (9 decimals). Matches core-web's
+ * SMALL_UTXO_THRESHOLD_NAVAX and core-extension's DUST_THRESHOLD
+ * (getMaxUtxos.ts) exactly — keep in lockstep if either ever changes.
+ */
+export const SMALL_UTXO_THRESHOLD_NAVAX = 2_000_000n
+
+/**
+ * Drops AVAX UTXOs strictly below SMALL_UTXO_THRESHOLD_NAVAX.
+ *
+ * Non-AVAX UTXOs always pass: other assets have their own denominations,
+ * so comparing their raw amounts against an AVAX threshold is meaningless.
+ * Outputs without an amount() (non-transfer outputs) also pass — only
+ * plain value UTXOs are ever considered dust.
+ */
+export const filterOutSmallUtxos = (
+  utxos: Utxo[],
+  avaxAssetId: string
+): Utxo[] =>
+  utxos.filter(utxo => {
+    if (utxo.getAssetId() !== avaxAssetId) return true
+    const output = utxo.output as unknown as { amount?: () => bigint }
+    if (typeof output.amount !== 'function') return true
+    return output.amount() >= SMALL_UTXO_THRESHOLD_NAVAX
+  })

--- a/packages/core-mobile/app/services/wallet/types.ts
+++ b/packages/core-mobile/app/services/wallet/types.ts
@@ -154,6 +154,12 @@ export type CreateSendPTxParams = CommonAvalancheTxParamsBase & {
   filterSmallUtxos?: boolean
 }
 
+/**
+ * X-chain send params: same shape as P minus the P-only feeState
+ * (X has fixed base fees; there is no pvm FeeState to thread).
+ */
+export type CreateSendXTxParams = Omit<CreateSendPTxParams, 'feeState'>
+
 //TODO: delete this enum
 export enum WalletType {
   UNSET = 'UNSET',

--- a/packages/core-mobile/app/services/wallet/types.ts
+++ b/packages/core-mobile/app/services/wallet/types.ts
@@ -146,6 +146,12 @@ export type CreateSendPTxParams = CommonAvalancheTxParamsBase & {
   amountInNAvax: bigint
   sourceAddress: string
   feeState?: pvm.FeeState
+  /**
+   * CP-13903: when true, drop AVAX UTXOs < SMALL_UTXO_THRESHOLD_NAVAX from
+   * the spendable set (after the tx-size cap), mirroring core-extension's
+   * getMaxUtxoSet. Callers pass selectIsFilterSmallUtxosActive.
+   */
+  filterSmallUtxos?: boolean
 }
 
 //TODO: delete this enum

--- a/packages/core-mobile/app/store/index.ts
+++ b/packages/core-mobile/app/store/index.ts
@@ -30,7 +30,7 @@ import { walletsReducer as wallet } from './wallet/slice'
 import { nestEggReducer as nestEgg } from './nestEgg/slice'
 import { chartPreferencesReducer as chartPreferences } from './chartPreferences/slice'
 
-const VERSION = 29
+const VERSION = 30
 const STORAGE_WRITE_THROTTLE = 200
 
 // list of reducers that don't need to be persisted

--- a/packages/core-mobile/app/store/meld/listeners.ts
+++ b/packages/core-mobile/app/store/meld/listeners.ts
@@ -41,6 +41,7 @@ import { onAppUnlocked } from 'store/app'
 import DeviceInfoService from 'services/deviceInfo/DeviceInfoService'
 import { getTokensWithBalanceForAccountFromCache } from 'features/portfolio/hooks/useTokensWithBalanceForAccount'
 import { AdjustedLocalTokenWithBalance } from 'services/balance/types'
+import { selectIsFilterSmallUtxosActive } from 'store/settings/advanced/filterSmallUtxosActive'
 import { offrampSend } from './slice'
 
 const handleOfframpSend = async (
@@ -110,7 +111,8 @@ const handleOfframpSend = async (
   const tokens = getTokensWithBalanceForAccountFromCache({
     account: activeAccount,
     networks: selectEnabledNetworksMap(state),
-    isDeveloperMode
+    isDeveloperMode,
+    filterOutDustUtxos: selectIsFilterSmallUtxosActive(state)
   })
 
   const token = tokens.find(

--- a/packages/core-mobile/app/store/posthog/slice.test.ts
+++ b/packages/core-mobile/app/store/posthog/slice.test.ts
@@ -18,6 +18,7 @@ import {
   selectDelegationFeeRate,
   selectIsFastStakeFeeBlocked,
   selectIsDelegationFeeBlocked,
+  selectIsFilterSmallUtxosAvailable,
   posthogSlice
 } from './slice'
 import { DefaultFeatureFlagConfig, initialState } from './types'
@@ -447,5 +448,23 @@ describe('selectIsFastStakeFeeBlocked / selectIsDelegationFeeBlocked with varian
       [FeatureGates.FAST_STAKE_FEE_ENABLED]: true
     })
     expect(selectIsFastStakeFeeBlocked(state)).toBe(true)
+  })
+})
+
+describe('selectIsFilterSmallUtxosAvailable', () => {
+  it('is false by default (flag defaults off)', () => {
+    expect(selectIsFilterSmallUtxosAvailable(createMockRootState({}))).toBe(
+      false
+    )
+  })
+
+  it('is true when FILTER_SMALL_UTXOS and EVERYTHING are on', () => {
+    const state = createMockRootState({
+      featureFlags: {
+        [FeatureGates.FILTER_SMALL_UTXOS]: true,
+        [FeatureGates.EVERYTHING]: true
+      }
+    })
+    expect(selectIsFilterSmallUtxosAvailable(state)).toBe(true)
   })
 })

--- a/packages/core-mobile/app/store/posthog/slice.ts
+++ b/packages/core-mobile/app/store/posthog/slice.ts
@@ -605,12 +605,22 @@ export const selectIsQuickSwapsAvailable = (state: RootState): boolean => {
   )
 }
 
+export const selectIsFilterSmallUtxosAvailable = (
+  state: RootState
+): boolean => {
+  const { featureFlags } = state.posthog
+  return (
+    featureFlags[FeatureGates.FILTER_SMALL_UTXOS] === true &&
+    featureFlags[FeatureGates.EVERYTHING] === true
+  )
+}
+
 // Composed selector — true when ANY feature on the Advanced Settings
 // screen is available. Drives the entry-row visibility on Account
 // Settings. Add new flags here as features are added to the Advanced
 // screen so the entry doesn't disappear when one specific flag flips off.
 export const selectIsAdvancedSettingsAvailable = (state: RootState): boolean =>
-  selectIsQuickSwapsAvailable(state)
+  selectIsQuickSwapsAvailable(state) || selectIsFilterSmallUtxosAvailable(state)
 
 export const selectIsAlternateAppIconsBlocked = (state: RootState): boolean => {
   const { featureFlags } = state.posthog

--- a/packages/core-mobile/app/store/posthog/types.ts
+++ b/packages/core-mobile/app/store/posthog/types.ts
@@ -60,7 +60,10 @@ export const DefaultFeatureFlagConfig = {
   [FeatureGates.PRICE_CHART]: false,
   [FeatureGates.FAST_STAKE_ENABLED]: false,
   [FeatureGates.FAST_STAKE_FEE_ENABLED]: false,
-  [FeatureGates.DELEGATION_FEE_ENABLED]: false
+  [FeatureGates.DELEGATION_FEE_ENABLED]: false,
+  // CP-13903 kill-switch. `false` = feature fully off: balance requests keep
+  // dust, tx building keeps dust, Settings row hidden.
+  [FeatureGates.FILTER_SMALL_UTXOS]: false
 }
 
 export const initialState = {

--- a/packages/core-mobile/app/store/rpc/handlers/wallet_getNetworkState/wallet_getNetworkState.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/wallet_getNetworkState/wallet_getNetworkState.ts
@@ -9,8 +9,7 @@ import { getCaip2ChainId } from 'utils/caip2ChainIds'
 import { selectTokenVisibility } from 'store/portfolio/slice'
 import { selectActiveAccount } from 'store/account'
 import { queryClient } from 'contexts/ReactQueryProvider'
-import { balanceKey } from 'features/portfolio/hooks/useAccountBalances'
-import { AdjustedNormalizedBalancesForAccount } from 'services/balance/types'
+import { getCachedBalancesWithFlagFallback } from 'features/portfolio/hooks/useAccountBalances'
 import { HandleResponse, RpcRequestHandler } from '../types'
 import { parseRequestParams } from './utils'
 import { getTokensByNetworkFromCache } from './getTokensByNetworkFromCache'
@@ -84,9 +83,12 @@ class WalletGetNetworkStateHandler
 
     const filterOutDustUtxos = selectIsFilterSmallUtxosActive(state)
 
-    const cachedBalancesForAccount = queryClient.getQueryData(
-      balanceKey(activeAccount, enabledNetworks, filterOutDustUtxos)
-    ) as AdjustedNormalizedBalancesForAccount[] | undefined
+    const cachedBalancesForAccount = getCachedBalancesWithFlagFallback({
+      client: queryClient,
+      account: activeAccount,
+      networks: enabledNetworks,
+      filterOutDustUtxos
+    })
 
     const networks = enabledNetworks.map(network => {
       const { enabledTokens, disabledTokens } = getTokensByNetworkFromCache({

--- a/packages/core-mobile/app/store/rpc/handlers/wallet_getNetworkState/wallet_getNetworkState.ts
+++ b/packages/core-mobile/app/store/rpc/handlers/wallet_getNetworkState/wallet_getNetworkState.ts
@@ -4,6 +4,7 @@ import { RpcMethod, RpcRequest } from 'store/rpc/types'
 import Logger from 'utils/Logger'
 import { selectEnabledNetworksByTestnet } from 'store/network/slice'
 import { selectIsDeveloperMode } from 'store/settings/advanced/slice'
+import { selectIsFilterSmallUtxosActive } from 'store/settings/advanced/filterSmallUtxosActive'
 import { getCaip2ChainId } from 'utils/caip2ChainIds'
 import { selectTokenVisibility } from 'store/portfolio/slice'
 import { selectActiveAccount } from 'store/account'
@@ -81,8 +82,10 @@ class WalletGetNetworkStateHandler
 
     const activeAccount = selectActiveAccount(state)
 
+    const filterOutDustUtxos = selectIsFilterSmallUtxosActive(state)
+
     const cachedBalancesForAccount = queryClient.getQueryData(
-      balanceKey(activeAccount, enabledNetworks)
+      balanceKey(activeAccount, enabledNetworks, filterOutDustUtxos)
     ) as AdjustedNormalizedBalancesForAccount[] | undefined
 
     const networks = enabledNetworks.map(network => {

--- a/packages/core-mobile/app/store/schemaMigration/schemaMigrations.test.ts
+++ b/packages/core-mobile/app/store/schemaMigration/schemaMigrations.test.ts
@@ -13,3 +13,23 @@ describe('migration 29 — quickSwaps default-fill', () => {
     expect(after.settings.advanced.isLeftHanded).toBe(false)
   })
 })
+
+describe('migration 30 — filterSmallUtxos default-fill', () => {
+  it('fills filterSmallUtxos with true when missing', () => {
+    const before = {
+      settings: { advanced: { developerMode: false, isLeftHanded: false } }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const after = (migrations as any)[30](before)
+    expect(after.settings.advanced.filterSmallUtxos).toBe(true)
+    // untouched siblings survive
+    expect(after.settings.advanced.developerMode).toBe(false)
+  })
+
+  it('preserves an existing false value', () => {
+    const before = { settings: { advanced: { filterSmallUtxos: false } } }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const after = (migrations as any)[30](before)
+    expect(after.settings.advanced.filterSmallUtxos).toBe(false)
+  })
+})

--- a/packages/core-mobile/app/store/schemaMigration/schemaMigrations.ts
+++ b/packages/core-mobile/app/store/schemaMigration/schemaMigrations.ts
@@ -31,7 +31,10 @@ import { getInitialState as browserTabsGetInitialState } from '../browser/slices
 import { initialState as browserGlobalHistoryInitialState } from '../browser/slices/globalHistory'
 import { ViewOnceKey } from '../viewOnce'
 import { CollectibleVisibility, TokenVisibility } from '../portfolio'
-import { QUICK_SWAPS_DEFAULT } from '../settings/advanced/types'
+import {
+  FILTER_SMALL_UTXOS_DEFAULT,
+  QUICK_SWAPS_DEFAULT
+} from '../settings/advanced/types'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const migrations = {
@@ -550,6 +553,23 @@ export const migrations = {
           ...state.settings?.advanced,
           quickSwaps:
             state.settings?.advanced?.quickSwaps ?? QUICK_SWAPS_DEFAULT
+        }
+      }
+    }
+  },
+  30: (state: any) => {
+    // CP-13903: introduce filterSmallUtxos on advanced settings. Filled from
+    // FILTER_SMALL_UTXOS_DEFAULT so the migration stays in sync with the
+    // slice initialState instead of drifting.
+    return {
+      ...state,
+      settings: {
+        ...state.settings,
+        advanced: {
+          ...state.settings?.advanced,
+          filterSmallUtxos:
+            state.settings?.advanced?.filterSmallUtxos ??
+            FILTER_SMALL_UTXOS_DEFAULT
         }
       }
     }

--- a/packages/core-mobile/app/store/settings/advanced/filterSmallUtxosActive.ts
+++ b/packages/core-mobile/app/store/settings/advanced/filterSmallUtxosActive.ts
@@ -1,4 +1,4 @@
-import { RootState } from 'store/types'
+import type { RootState } from 'store/types'
 import { selectIsFilterSmallUtxosAvailable } from 'store/posthog/slice'
 
 // Composite gate: PostHog kill-switch AND the user's saved toggle. Read this

--- a/packages/core-mobile/app/store/settings/advanced/filterSmallUtxosActive.ts
+++ b/packages/core-mobile/app/store/settings/advanced/filterSmallUtxosActive.ts
@@ -1,0 +1,15 @@
+import { RootState } from 'store/types'
+import { selectIsFilterSmallUtxosAvailable } from 'store/posthog/slice'
+
+// Composite gate: PostHog kill-switch AND the user's saved toggle. Read this
+// from every runtime decision point (balance requests, P-Chain send tx
+// building, CCT getUtxos) so the kill-switch can't drift between consumers.
+// A stale persisted `filterSmallUtxos: true` with the flag off must NOT
+// filter anything.
+//
+// Lives outside slice.ts because posthog's transitive imports are heavier
+// than the slice's own tests need to load (same reason as quickSwapsActive).
+export const selectIsFilterSmallUtxosActive = (state: RootState): boolean => {
+  if (!selectIsFilterSmallUtxosAvailable(state)) return false
+  return state.settings.advanced.filterSmallUtxos
+}

--- a/packages/core-mobile/app/store/settings/advanced/slice.test.ts
+++ b/packages/core-mobile/app/store/settings/advanced/slice.test.ts
@@ -1,8 +1,10 @@
 import type { RootState } from 'store/types'
 import {
+  advancedReducer,
   selectIsQuickSwapsEnabled,
   selectQuickSwapsFeeSetting,
-  selectQuickSwapsMaxBuy
+  selectQuickSwapsMaxBuy,
+  setFilterSmallUtxos
 } from './slice'
 import { initialState } from './types'
 
@@ -18,5 +20,18 @@ describe('advancedSlice — quickSwaps selectors', () => {
     expect(selectIsQuickSwapsEnabled(wrap(next))).toBe(true)
     expect(selectQuickSwapsFeeSetting(wrap(next))).toBe('low')
     expect(selectQuickSwapsMaxBuy(wrap(next))).toBe('10000')
+  })
+})
+
+describe('filterSmallUtxos', () => {
+  it('defaults to true', () => {
+    expect(initialState.filterSmallUtxos).toBe(true)
+  })
+
+  it('setFilterSmallUtxos updates the value', () => {
+    const next = advancedReducer(initialState, setFilterSmallUtxos(false))
+    expect(next.filterSmallUtxos).toBe(false)
+    const back = advancedReducer(next, setFilterSmallUtxos(true))
+    expect(back.filterSmallUtxos).toBe(true)
   })
 })

--- a/packages/core-mobile/app/store/settings/advanced/slice.ts
+++ b/packages/core-mobile/app/store/settings/advanced/slice.ts
@@ -25,6 +25,9 @@ export const advancedSlice = createSlice({
     },
     setQuickSwapsMaxBuy: (state, action: PayloadAction<QuickSwapMaxBuy>) => {
       state.quickSwaps.maxBuy = action.payload
+    },
+    setFilterSmallUtxos: (state, action: PayloadAction<boolean>) => {
+      state.filterSmallUtxos = action.payload
     }
   }
 })
@@ -46,13 +49,17 @@ export const selectQuickSwapsFeeSetting = (
 export const selectQuickSwapsMaxBuy = (state: RootState): QuickSwapMaxBuy =>
   state.settings.advanced.quickSwaps.maxBuy
 
+export const selectFilterSmallUtxos = (state: RootState): boolean =>
+  state.settings.advanced.filterSmallUtxos
+
 // actions
 export const {
   toggleDeveloperMode,
   toggleLeftHanded,
   setQuickSwapsEnabled,
   setQuickSwapsFeeSetting,
-  setQuickSwapsMaxBuy
+  setQuickSwapsMaxBuy,
+  setFilterSmallUtxos
 } = advancedSlice.actions
 
 export const advancedReducer = advancedSlice.reducer

--- a/packages/core-mobile/app/store/settings/advanced/types.ts
+++ b/packages/core-mobile/app/store/settings/advanced/types.ts
@@ -32,14 +32,20 @@ export const QUICK_SWAPS_DEFAULT: QuickSwapsSettings = {
   maxBuy: 'unlimited'
 }
 
+// Matches core-extension's default (SettingsService.ts: filterSmallUtxos: true)
+// and core-web's userPreferencesSchema prefault(true). CP-13903.
+export const FILTER_SMALL_UTXOS_DEFAULT = true
+
 export type AdvancedState = {
   developerMode: boolean
   isLeftHanded: boolean
   quickSwaps: QuickSwapsSettings
+  filterSmallUtxos: boolean
 }
 
 export const initialState: AdvancedState = {
   developerMode: false,
   isLeftHanded: false,
-  quickSwaps: QUICK_SWAPS_DEFAULT
+  quickSwaps: QUICK_SWAPS_DEFAULT,
+  filterSmallUtxos: FILTER_SMALL_UTXOS_DEFAULT
 }

--- a/packages/core-mobile/app/types/analytics.ts
+++ b/packages/core-mobile/app/types/analytics.ts
@@ -289,6 +289,7 @@ export type AnalyticsEvents = {
     caip2TargetChainId: string
   }
   QuickSwapsToggled: { isEnabled: boolean }
+  FilterSmallUtxosToggled: { isEnabled: boolean }
   QuickSwapsBypassFired: {
     caip2SourceChainId: string
     maxBuy: 'unlimited' | '1000' | '5000' | '10000' | '50000'


### PR DESCRIPTION
## Description

**Ticket: [CP-13903](https://ava-labs.atlassian.net/browse/CP-13903)**

Adds a "Filter out small UTXOs" setting (Advanced settings, default ON) that excludes P-Chain UTXOs smaller than 0.002 AVAX (2,000,000 nAVAX), mirroring the implementation already shipped in Core web and Core extension:

- **Balance layer:** the existing Balance-API field `filterOutDustUtxos` (previously hard-coded `false`) is now driven by the setting, so portfolio totals, token detail, send "available", claimable balance, and staking decision math all respect the toggle server-side. The flag is folded into the React Query balance keys so toggling refetches immediately. Account-discovery requests intentionally keep `false` so dust-only accounts are still detected.
- **Tx-building layer:** a shared `filterOutSmallUtxos` util (threshold `2_000_000n`, AVAX-asset-only, inclusive-keep at the boundary) is applied in P-Chain send tx building (after the existing tx-size cap, matching extension order) and in the swap/CCT `getUtxos` callback. `getAtomicUtxos`, staking/delegation, claim (export/import), and fee simulation are deliberately unfiltered (extension parity; avoids stranding dust in atomic memory and keeps fee-sim consistent with real builds).
- **Rollout:** everything is gated behind a new PostHog flag `filter-small-utxos` (default off = kill switch). Flag off ⇒ behavior byte-identical to today and the settings row is hidden. Persisted via redux migration 30 (VERSION 29→30).
- Analytics: `FilterSmallUtxosToggled { isEnabled }`.

Design doc: `docs/superpowers/specs/2026-07-14-cp13903-filter-small-utxos-design.md` (local, uncommitted).

**Known/accepted limitations (adversarially reviewed, accepted by design):**
- The VM-module fallback balance path (used only when the streaming Balance API fails) does not support the dust flag, so during an API outage a toggle-on user sees dust-inclusive balances while send still filters locally. Documented in the spec as out of scope; self-heals when the API recovers.
- Toggling the setting moves the balance query key; cache-only readers now fall back to the previous flag variant's cache for the seconds until refetch (`getCachedBalancesWithFlagFallback`), rather than transiently seeing empty data.
- Pre-existing send-flow races surfaced during review were ticketed separately: [CP-14762](https://ava-labs.atlassian.net/browse/CP-14762), [CP-14763](https://ava-labs.atlassian.net/browse/CP-14763).

No new dependencies. Not breaking; migration 30 default-fills the new setting.

## Screenshots/Videos

TODO before marking ready: iOS/Android screenshots of the Advanced settings toggle (Figma: Core-Mobile-Redesign-2025, node 16584-11892).

## Testing

**Dev Testing (if applicable)**

iOS: 9260
Android: 9261

Happy path:
1. Enable the `filter-small-utxos` PostHog flag (and `everything`).
2. Settings → Advanced settings → verify "Filter out small UTXOs" row appears above Quick swaps, toggle ON by default, caption warns totals may be inaccurate.
3. On a wallet with P-Chain dust (<0.002 AVAX UTXOs): toggle OFF → P-Chain balance increases after refetch; toggle ON → decreases.
4. P-Chain send: with toggle ON, build/send succeeds and consumes no dust UTXOs; max send matches displayed available.

Edge cases:
- Flag OFF in PostHog: row hidden, balances identical to production behavior regardless of the persisted setting.
- Upgrade path: install a build from `main`, then this branch — persisted settings migrate (VERSION 30) with the setting defaulting ON.
- Toggle flip while the Meld off-ramp or a connected dapp (`wallet_getNetworkState`) is active: no empty token lists (cache fallback covers the refetch window).
- Cross-chain swap (CCT) with dust: dust excluded from source UTXO set; stuck-funds import unaffected.

**QA Testing (if applicable)**

- AC1: toggle exists in Advanced settings and persists across app restarts.
- AC2: warning caption shown: "Improves loading performance by removing UTXOs with a value less than 0.002 AVAX from the wallet. Total balances may be inaccurate."
- AC3: with toggle ON, dust value is excluded from portfolio P-Chain balance, send available/max, claimable balance, staking flows, and swap; with toggle OFF everything includes dust.
- Regression: account import/discovery still finds accounts that hold only dust; staking/claim flows unaffected; testnet mode behaves consistently.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CP-13903]: https://ava-labs.atlassian.net/browse/CP-13903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-14762]: https://ava-labs.atlassian.net/browse/CP-14762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ