### PR TITLE
CP-14721: stop chart reaction from clobbering initial duration selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,11 +186,11 @@ High-performance crypto operations implemented in C++ using the Nitro Modules fr
 
 ## Key Dependencies
 
-- **React Native**: 0.79.5
-- **Expo**: 53.0.20
-- **React**: 19.0.0
+- **React Native**: 0.85
+- **Expo**: SDK 56
+- **React**: 19.2
 - **Avalanche SDKs**: Various `@avalabs/*` packages at 3.1.0-alpha.x
-- **Nitro Modules**: 0.32.0 for native module architecture
+- **Nitro Modules**: 0.35 for native module architecture
 
 ## Troubleshooting
 

--- a/packages/k2-alpine/CLAUDE.md
+++ b/packages/k2-alpine/CLAUDE.md
@@ -265,5 +265,5 @@ This package is consumed by `@avalabs/core-mobile` via `workspace:*` dependency:
 
 - **Font scaling**: Disabled globally for consistency across devices
 - **Theme switching**: Handled by `K2AlpineThemeProvider` based on system color scheme
-- **Expo SDK**: Version 53.0.20 (ensure compatibility with core-mobile)
+- **Expo SDK**: Version 56 (ensure compatibility with core-mobile)
 - **Private package**: Not published to npm, internal workspace use only

--- a/packages/k2-alpine/src/components/Staking/StakingRewardChart/index.tsx
+++ b/packages/k2-alpine/src/components/Staking/StakingRewardChart/index.tsx
@@ -16,7 +16,7 @@ import React, {
   useRef,
   useState
 } from 'react'
-import { InteractionManager, LayoutChangeEvent, ViewStyle } from 'react-native'
+import { LayoutChangeEvent, ViewStyle } from 'react-native'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import Animated, {
   Easing,
@@ -153,19 +153,21 @@ export const StakeRewardChart = forwardRef<
     // CP-14721).
     const hasAnchoredRef = useRef(false)
     useEffect(() => {
-      InteractionManager.runAfterInteractions(() => {
-        // Also require real data: anchoring against an empty/single-point
-        // grid would write garbage pixels (see the gridWidth note above).
-        // The effect re-runs once the data lands, since `selectIndex`'s
-        // identity changes with `gridWidth`.
-        if (graphSize.width > 0 && graphSize.height > 0 && data.length > 1) {
-          selectIndex(
-            hasAnchoredRef.current ? animatedSelectedIndex.value : initialIndex,
-            0
-          )
-          hasAnchoredRef.current = true
-        }
-      })
+      // Anchor synchronously the moment layout AND real data are available
+      // (an empty/single-point grid would produce garbage pixels — see the
+      // gridWidth note above; the effect re-runs once the data lands, since
+      // `selectIndex`'s identity changes with `gridWidth`). This used to be
+      // deferred via `InteractionManager.runAfterInteractions`, but on the
+      // New Architecture that API is a deprecated stub (plain `setImmediate`
+      // semantics), so the deferral bought nothing except a nondeterministic
+      // window in which consumers observed the not-yet-anchored selection.
+      if (graphSize.width > 0 && graphSize.height > 0 && data.length > 1) {
+        selectIndex(
+          hasAnchoredRef.current ? animatedSelectedIndex.value : initialIndex,
+          0
+        )
+        hasAnchoredRef.current = true
+      }
       // `animatedSelectedIndex` is a stable SharedValue ref; its `.value` is
       // read on purpose only when the geometry changes. `data.length` is
       // covered transitively by `selectIndex` (via `gridWidth`).

--- a/packages/k2-alpine/src/components/Staking/StakingRewardChart/index.tsx
+++ b/packages/k2-alpine/src/components/Staking/StakingRewardChart/index.tsx
@@ -98,7 +98,12 @@ export const StakeRewardChart = forwardRef<
     // `data` inside the worklet would clone the whole array into the UI
     // runtime on every closure rebuild.
     const lastDataIndex = data.length - 1
-    const isGridWidthValid = Number.isFinite(gridWidth) && gridWidth > 0
+    // Explicitly requires ≥ 2 data points: the formula alone is not enough
+    // (an unmeasured width with EMPTY data yields (0−stroke)/(0−1) = +stroke,
+    // a positive finite number that would pass the numeric checks while
+    // `lastDataIndex` is −1).
+    const isGridWidthValid =
+      data.length > 1 && Number.isFinite(gridWidth) && gridWidth > 0
     const selectionX = useSharedValue<number | undefined>(undefined)
 
     const selectIndex = useCallback(
@@ -117,27 +122,45 @@ export const StakeRewardChart = forwardRef<
           // feed animated styles). Record the INTENT instead, so a selection
           // made while the reward data is still loading isn't lost: the
           // anchor effect below turns it into pixels once the grid is real.
+          // Deliberately NOT clamped: it's intent against data that hasn't
+          // arrived yet (`lastDataIndex` may be −1 here); the pixel path
+          // below clamps once the real grid exists.
           animatedSelectedIndex.value = index
           return
         }
-        selectionX.value = withTiming(gridWidth * index, {
+        // Defensive clamp: an out-of-range index (e.g. a stale consumer
+        // `initialIndex` after a data refresh) would otherwise anchor pixels
+        // outside the grid — indicator drawn off the chart while the
+        // reaction reports a different, clamped index.
+        const clampedIndex = Math.min(Math.max(index, 0), lastDataIndex)
+        selectionX.value = withTiming(gridWidth * clampedIndex, {
           duration: duration
         })
       },
-      [gridWidth, isGridWidthValid, selectionX, animatedSelectedIndex]
+      [
+        gridWidth,
+        isGridWidthValid,
+        lastDataIndex,
+        selectionX,
+        animatedSelectedIndex
+      ]
     )
 
     // Pixel position → selected index. Guards, in order:
-    // - `previous === null` is the reaction's initial evaluation, which runs
-    //   on mount AND every time this closure is re-created (any render where
-    //   `gridWidth` changed: first layout, reward data arriving). It reflects
-    //   no actual `selectionX` change, and before the first anchor it would
-    //   read `undefined` / stale pixels and clobber the consumer-provided
-    //   initial index — the intermittently "Custom" initial duration on the
-    //   staking screens.
-    // - `undefined` never comes from a gesture (pan positions are clamped
-    //   pixels), only from `selectIndex(undefined)` — which writes the
-    //   cleared index itself above.
+    // - `x === undefined` is load-bearing for CP-14721: the mapper evaluates
+    //   eagerly on registration AND on every re-registration (any render
+    //   where a captured value like `gridWidth` changed — first layout,
+    //   reward data arriving), NOT only when `selectionX` actually moves.
+    //   Until the anchor effect below runs, `selectionX` is still
+    //   `undefined`, and writing that through would clobber the
+    //   consumer-provided initial index — the intermittently "Custom"
+    //   initial duration on the staking screens. It is safe to skip because
+    //   `undefined` never comes from a gesture (pan positions are clamped
+    //   pixels); clearing goes through `selectIndex(undefined)`, which
+    //   writes the cleared index itself above. (Note Reanimated's `previous`
+    //   argument can NOT stand in for this: it is a persistent shared value,
+    //   `null` only on the very first evaluation of the component's life,
+    //   not on re-registrations.)
     // - `gridWidth` is garbage until BOTH the graph has a measured width and
     //   the data has ≥ 2 points ((0−stroke)/(len−1) is negative or even
     //   positive nonsense for empty data); an `=== 0` check misses those.
@@ -145,8 +168,7 @@ export const StakeRewardChart = forwardRef<
     //   from ever emitting an out-of-range index.
     useAnimatedReaction(
       () => selectionX.value,
-      (x, previous) => {
-        if (previous === null) return
+      x => {
         if (x === undefined) return
         if (!isGridWidthValid) return
 

--- a/packages/k2-alpine/src/components/Staking/StakingRewardChart/index.tsx
+++ b/packages/k2-alpine/src/components/Staking/StakingRewardChart/index.tsx
@@ -98,21 +98,48 @@ export const StakeRewardChart = forwardRef<
 
     const selectIndex = useCallback(
       (index: number | undefined, duration = 300): void => {
-        selectionX.value =
-          index !== undefined
-            ? withTiming(gridWidth * index, { duration: duration })
-            : undefined
+        if (index === undefined) {
+          // Clearing is written to BOTH shared values here, explicitly — the
+          // reaction below deliberately ignores `undefined` (see there), so
+          // this is the only path that may clear the selected index.
+          selectionX.value = undefined
+          animatedSelectedIndex.value = undefined
+          return
+        }
+        selectionX.value = withTiming(gridWidth * index, {
+          duration: duration
+        })
       },
-      [gridWidth, selectionX]
+      [gridWidth, selectionX, animatedSelectedIndex]
     )
 
+    // Pixel position → selected index. Guards, in order:
+    // - `previous === null` is the reaction's initial evaluation, which runs
+    //   on mount AND every time this closure is re-created (any render where
+    //   `gridWidth` changed: first layout, reward data arriving). It reflects
+    //   no actual `selectionX` change, and before the first anchor it would
+    //   read `undefined` / stale pixels and clobber the consumer-provided
+    //   initial index — the intermittently "Custom" initial duration on the
+    //   staking screens.
+    // - `undefined` never comes from a gesture (pan positions are clamped
+    //   pixels), only from `selectIndex(undefined)` — which writes the
+    //   cleared index itself above.
+    // - `gridWidth` is garbage until BOTH the graph has a measured width and
+    //   the data has ≥ 2 points ((0−stroke)/(len−1) is negative or even
+    //   positive nonsense for empty data); an `=== 0` check misses those.
+    // - Clamping keeps a stale pixel value read against a fresh `gridWidth`
+    //   from ever emitting an out-of-range index.
     useAnimatedReaction(
       () => selectionX.value,
-      x => {
-        if (gridWidth === 0) return
+      (x, previous) => {
+        if (previous === null) return
+        if (x === undefined) return
+        if (!Number.isFinite(gridWidth) || gridWidth <= 0) return
 
-        animatedSelectedIndex.value =
-          x === undefined ? undefined : Math.round(x / gridWidth)
+        animatedSelectedIndex.value = Math.min(
+          Math.max(Math.round(x / gridWidth), 0),
+          data.length - 1
+        )
       }
     )
 
@@ -127,7 +154,11 @@ export const StakeRewardChart = forwardRef<
     const hasAnchoredRef = useRef(false)
     useEffect(() => {
       InteractionManager.runAfterInteractions(() => {
-        if (graphSize.width > 0 && graphSize.height > 0) {
+        // Also require real data: anchoring against an empty/single-point
+        // grid would write garbage pixels (see the gridWidth note above).
+        // The effect re-runs once the data lands, since `selectIndex`'s
+        // identity changes with `gridWidth`.
+        if (graphSize.width > 0 && graphSize.height > 0 && data.length > 1) {
           selectIndex(
             hasAnchoredRef.current ? animatedSelectedIndex.value : initialIndex,
             0
@@ -136,7 +167,8 @@ export const StakeRewardChart = forwardRef<
         }
       })
       // `animatedSelectedIndex` is a stable SharedValue ref; its `.value` is
-      // read on purpose only when the geometry changes.
+      // read on purpose only when the geometry changes. `data.length` is
+      // covered transitively by `selectIndex` (via `gridWidth`).
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [initialIndex, selectIndex, graphSize])
 

--- a/packages/k2-alpine/src/components/Staking/StakingRewardChart/index.tsx
+++ b/packages/k2-alpine/src/components/Staking/StakingRewardChart/index.tsx
@@ -94,6 +94,11 @@ export const StakeRewardChart = forwardRef<
 
     const gridWidth =
       (graphSize.width - GRAPH_STROKE_WIDTH * 2) / (data.length - 1)
+    // Captured as a plain number for the reaction worklet below: referencing
+    // `data` inside the worklet would clone the whole array into the UI
+    // runtime on every closure rebuild.
+    const lastDataIndex = data.length - 1
+    const isGridWidthValid = Number.isFinite(gridWidth) && gridWidth > 0
     const selectionX = useSharedValue<number | undefined>(undefined)
 
     const selectIndex = useCallback(
@@ -106,11 +111,20 @@ export const StakeRewardChart = forwardRef<
           animatedSelectedIndex.value = undefined
           return
         }
+        if (!isGridWidthValid) {
+          // The grid isn't measurable yet (no layout, or < 2 data points) —
+          // NaN/Infinity/negative pixels must never reach `selectionX` (they
+          // feed animated styles). Record the INTENT instead, so a selection
+          // made while the reward data is still loading isn't lost: the
+          // anchor effect below turns it into pixels once the grid is real.
+          animatedSelectedIndex.value = index
+          return
+        }
         selectionX.value = withTiming(gridWidth * index, {
           duration: duration
         })
       },
-      [gridWidth, selectionX, animatedSelectedIndex]
+      [gridWidth, isGridWidthValid, selectionX, animatedSelectedIndex]
     )
 
     // Pixel position → selected index. Guards, in order:
@@ -134,11 +148,11 @@ export const StakeRewardChart = forwardRef<
       (x, previous) => {
         if (previous === null) return
         if (x === undefined) return
-        if (!Number.isFinite(gridWidth) || gridWidth <= 0) return
+        if (!isGridWidthValid) return
 
         animatedSelectedIndex.value = Math.min(
           Math.max(Math.round(x / gridWidth), 0),
-          data.length - 1
+          lastDataIndex
         )
       }
     )
@@ -162,8 +176,17 @@ export const StakeRewardChart = forwardRef<
       // semantics), so the deferral bought nothing except a nondeterministic
       // window in which consumers observed the not-yet-anchored selection.
       if (graphSize.width > 0 && graphSize.height > 0 && data.length > 1) {
+        // First anchor: prefer whatever is already recorded on the shared
+        // value — a selection made through the ref while the reward data was
+        // still loading (see `selectIndex`'s intent path) — falling back to
+        // `initialIndex` for an unseeded value. Later anchors always re-apply
+        // the current selection, INCLUDING a deliberately cleared
+        // `undefined` (CP-14721), which is why the `??` fallback must not
+        // apply once anchored.
         selectIndex(
-          hasAnchoredRef.current ? animatedSelectedIndex.value : initialIndex,
+          hasAnchoredRef.current
+            ? animatedSelectedIndex.value
+            : animatedSelectedIndex.value ?? initialIndex,
           0
         )
         hasAnchoredRef.current = true


### PR DESCRIPTION
## Description

**Ticket: [CP-14721](https://ava-labs.atlassian.net/browse/CP-14721)** (follow-up hardening; also relevant to [CP-14003](https://ava-labs.atlassian.net/browse/CP-14003))

Fixes the intermittent bug where the staking duration screen (notably the Delegate flow on Android) opens with the Duration row empty and the **Custom** option selected instead of the default preset.

### Root cause

`StakingRewardChart`'s pixel→index `useAnimatedReaction` runs an initial evaluation on mount **and every time its closure is re-created** (any render where `gridWidth` changed: first layout, reward data arriving). Before the deferred anchor effect has positioned `selectionX`, that initial run reads `undefined` (or stale pixels against a fresh `gridWidth`) and **clobbers the consumer-provided initial index**. The old `gridWidth === 0` guard didn't help because an unmeasured/empty-data grid produces *negative or nonsense-positive* values, not 0.

The original CP-14721 fix (merged in #3976) made the anchor effect preserve the *current* selection instead of resetting to `initialIndex` — which turned this clobber from a brief flash into a **sticky** wrong state, because the anchor now faithfully preserved the clobbered `undefined`. Timing-dependent (screen-push transition vs the 300ms duration debounce vs reward-data arrival), hence intermittent and Android-biased.

### Fix (all inside the chart)

- The reaction ignores its initial evaluation (`previous === null`) — it reflects no actual `selectionX` change
- `undefined` is never written by the reaction; clearing goes through `selectIndex(undefined)`, which now writes both shared values explicitly (Custom selection still works)
- Proper garbage guard (`!Number.isFinite(gridWidth) || gridWidth <= 0`) and the computed index is clamped to `[0, data.length - 1]`
- The anchor effect additionally requires `data.length > 1`, so it never anchors pixels against a degenerate grid; it re-runs naturally when the data lands

With this, the consumer's initial index survives from the first frame; the chart only positions the pixel indicator once layout + data are ready.

## Screenshots/Videos

N/A — behavioral fix; see testing steps.

## Testing
iOS: 9274
Android: 9275

**Dev Testing**

- Delegate flow → "How long do you want to stake?" — repeat entry several times on Android (slow devices / heavy transitions are the trigger): the default preset must be selected every time, never Custom/empty
- Custom → pick a date → selection stays custom (no CP-14721 regression), including across background reward-data refreshes
- Chart drag and preset taps still drive the selection; Fast Stake duration screen unaffected

**QA Testing**

- Regression around CP-14721/CP-14003: custom duration selection persists on Android; initial selection is always the default preset (1 day on Fuji, 3 months on mainnet)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14721]: https://ava-labs.atlassian.net/browse/CP-14721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-14003]: https://ava-labs.atlassian.net/browse/CP-14003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ