### PR TITLE
CP-14723: define stake duration presets in whole days to match web

### DIFF
--- a/packages/core-mobile/app/new/features/stake/components/DurationOptions.tsx
+++ b/packages/core-mobile/app/new/features/stake/components/DurationOptions.tsx
@@ -5,8 +5,10 @@ import {
   useTheme,
   View
 } from '@avalabs/k2-alpine'
-import { differenceInDays } from 'date-fns'
-import { formatDurationInDays } from 'features/stake/utils'
+import {
+  formatDurationInDays,
+  getRoundedDurationInDays
+} from 'features/stake/utils'
 import React, { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import {
@@ -33,12 +35,6 @@ export const DurationOptions = ({
     () => (isDeveloperMode ? DURATION_OPTIONS_FUJI : DURATION_OPTIONS_MAINNET),
     [isDeveloperMode]
   )
-  const today = useMemo(() => {
-    const now = new Date()
-    now.setHours(0, 0, 0, 0)
-    return now
-  }, [])
-
   const rows = useMemo(() => {
     const chunks = []
     for (let i = 0; i < durations.length; i += 3) {
@@ -62,8 +58,11 @@ export const DurationOptions = ({
             const globalIndex = rowIndex * 3 + index
             const isSelected = globalIndex === selectedIndex
             const selectedTheme = isSelected ? inversedTheme : theme
+            // Anchored at NOW and rounded (not midnight + truncation) so
+            // the cell agrees with the Duration summary row and the confirm
+            // screen's "Time to unlock".
             const customDurationInDays = customEndDate
-              ? differenceInDays(customEndDate, today)
+              ? getRoundedDurationInDays(Date.now(), customEndDate)
               : undefined
 
             return (

--- a/packages/core-mobile/app/new/features/stake/components/DurationOptions.tsx
+++ b/packages/core-mobile/app/new/features/stake/components/DurationOptions.tsx
@@ -43,6 +43,14 @@ export const DurationOptions = ({
     return chunks
   }, [durations])
 
+  // Anchored at NOW and rounded (not midnight + truncation) so the Custom
+  // cell agrees with the Duration summary row and the confirm screen's
+  // "Time to unlock". Computed once per render — only the Custom cell
+  // renders it.
+  const customDurationInDays = customEndDate
+    ? getRoundedDurationInDays(Date.now(), customEndDate)
+    : undefined
+
   return (
     <View sx={{ padding: 16, gap: 8 }}>
       {rows.map((row, rowIndex) => (
@@ -58,12 +66,6 @@ export const DurationOptions = ({
             const globalIndex = rowIndex * 3 + index
             const isSelected = globalIndex === selectedIndex
             const selectedTheme = isSelected ? inversedTheme : theme
-            // Anchored at NOW and rounded (not midnight + truncation) so
-            // the cell agrees with the Duration summary row and the confirm
-            // screen's "Time to unlock".
-            const customDurationInDays = customEndDate
-              ? getRoundedDurationInDays(Date.now(), customEndDate)
-              : undefined
 
             return (
               <TouchableOpacity

--- a/packages/core-mobile/app/new/features/stake/utils/getRoundedDurationInDays.test.ts
+++ b/packages/core-mobile/app/new/features/stake/utils/getRoundedDurationInDays.test.ts
@@ -1,0 +1,32 @@
+import { getRoundedDurationInDays } from './index'
+
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+
+describe('getRoundedDurationInDays', () => {
+  const start = new Date('2026-07-15T14:30:00Z').getTime()
+
+  it('rounds a custom stake up when now has just passed its time-of-day', () => {
+    // 34d 23h 58m — truncation would read 34, one short of the selection.
+    const end = start + 35 * DAY_MS - 2 * 60 * 1000
+    expect(getRoundedDurationInDays(start, end)).toBe(35)
+  })
+
+  it('rounds the preset +1h slack back down to the labeled days', () => {
+    expect(
+      getRoundedDurationInDays(start, start + 180 * DAY_MS + HOUR_MS)
+    ).toBe(180)
+  })
+
+  it('rounds the 365-day preset (-1h backoff) back up to 365', () => {
+    expect(
+      getRoundedDurationInDays(start, start + 365 * DAY_MS - HOUR_MS)
+    ).toBe(365)
+  })
+
+  it('accepts Date instances as well as epoch millis', () => {
+    expect(
+      getRoundedDurationInDays(new Date(start), new Date(start + 14 * DAY_MS))
+    ).toBe(14)
+  })
+})

--- a/packages/core-mobile/app/new/features/stake/utils/index.ts
+++ b/packages/core-mobile/app/new/features/stake/utils/index.ts
@@ -150,3 +150,19 @@ export const convertToDurationInSeconds = (date: UTCDate): Seconds => {
  */
 export const formatDurationInDays = (numberOfDays: number): string =>
   `${numberOfDays} ${numberOfDays === 1 ? 'day' : 'days'}`
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * Day distance between two instants, rounded to the NEAREST whole day —
+ * deliberately not date-fns's `differenceInDays`, which truncates. Display
+ * surfaces anchored at "now" would otherwise read one day short the moment
+ * `now` passes the end date's time-of-day (a 34d 23h 59m custom stake
+ * showing "34 days"), while the presets' ±1h slack still rounds back to the
+ * labeled day count (180d + 1h → 180, 365d − 1h → 365).
+ */
+export const getRoundedDurationInDays = (
+  earlierDate: Date | number,
+  laterDate: Date | number
+): number =>
+  Math.round(differenceInMilliseconds(laterDate, earlierDate) / MS_PER_DAY)

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeConfirmScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeConfirmScreen.tsx
@@ -17,7 +17,7 @@ import {
   useDelegationContext,
   OnDelegationProgress
 } from 'contexts/DelegationContext'
-import { differenceInDays, format, getUnixTime } from 'date-fns'
+import { format, getUnixTime } from 'date-fns'
 import {
   Href,
   useLocalSearchParams,
@@ -48,7 +48,10 @@ import { AdditionalDelegatorOutput } from 'services/wallet/types'
 import { getExplorerAddressByNetwork } from 'utils/getExplorerAddressByNetwork'
 import { StakeTargetValidator } from 'types/earn'
 import { truncateNodeId } from 'utils/Utils'
-import { formatDurationInDays } from 'features/stake/utils'
+import {
+  formatDurationInDays,
+  getRoundedDurationInDays
+} from 'features/stake/utils'
 import { StakeStatusScreen } from '../components/StakeStatusScreen'
 import { useStakeFundingPreflight } from '../hooks/useStakeFundingPreflight'
 import { StakeReviewSource } from '../types'
@@ -205,7 +208,7 @@ const StakeConfirmScreen = ({
   // Defensive parse — deep links / state restoration could land us here
   // with a missing or non-numeric `stakeEndTime`. Falling through with a
   // NaN would produce an Invalid Date and later crash inside `format()` /
-  // `differenceInDays()`. When invalid we surface a dismiss-the-flow alert
+  // the duration math. When invalid we surface a dismiss-the-flow alert
   // below; the placeholder below keeps downstream date hooks running with
   // a finite value until the alert dismisses the modal.
   const parsedStakeEndTime = useMemo(
@@ -421,7 +424,13 @@ const StakeConfirmScreen = ({
         value: isResolvingValidator ? (
           <ActivityIndicator />
         ) : (
-          formatDurationInDays(differenceInDays(validatedStakingEndTime, now))
+          // Rounded, not truncated: a custom end date carries the
+          // time-of-day the picker was seeded with, so by review time `now`
+          // has passed it and truncation would read one day short of what
+          // the duration screen advertised.
+          formatDurationInDays(
+            getRoundedDurationInDays(now, validatedStakingEndTime)
+          )
         )
       },
       {

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
@@ -13,7 +13,6 @@ import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import {
   addDays,
   addHours,
-  differenceInDays,
   format,
   getUnixTime,
   millisecondsToSeconds
@@ -31,7 +30,8 @@ import { useStakeEstimatedReward } from 'features/stake/hooks/useStakeEstimatedR
 import { useStakeEstimatedRewards } from 'features/stake/hooks/useStakeEstimatedRewards'
 import {
   convertToDurationInSeconds,
-  formatDurationInDays
+  formatDurationInDays,
+  getRoundedDurationInDays
 } from 'features/stake/utils'
 import { useStakeAmount } from 'hooks/earn/useStakeAmount'
 import { useNow } from 'hooks/time/useNow'
@@ -227,9 +227,10 @@ const StakeDurationScreen = ({
     }
 
     if (customEndDate) {
-      const today = new Date()
-      today.setHours(0, 0, 0, 0)
-      return differenceInDays(customEndDate, today)
+      // Anchored at NOW and rounded, matching the confirm screen's
+      // "Time to unlock" — the previous midnight anchor made this row read
+      // one day higher than the review right after picking a date.
+      return getRoundedDurationInDays(Date.now(), customEndDate)
     }
   }, [
     durationsWithDays,

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
@@ -227,17 +227,19 @@ const StakeDurationScreen = ({
     }
 
     if (customEndDate) {
-      // Anchored at NOW and rounded, matching the confirm screen's
-      // "Time to unlock" — the previous midnight anchor made this row read
-      // one day higher than the review right after picking a date.
-      return getRoundedDurationInDays(Date.now(), customEndDate)
+      // Anchored at the reactive `now` (same clock the confirm screen's
+      // "Time to unlock" uses) and rounded — the previous midnight anchor
+      // made this row read one day higher than the review right after
+      // picking a date.
+      return getRoundedDurationInDays(now, customEndDate)
     }
   }, [
     durationsWithDays,
     selectedDurationIndex,
     estimatedRewards,
     defaultDurationIndex,
-    customEndDate
+    customEndDate,
+    now
   ])
 
   // Advanced delegate: the stake can't outlast the selected validator. The

--- a/packages/core-mobile/app/services/earn/getStakeEndDate.test.ts
+++ b/packages/core-mobile/app/services/earn/getStakeEndDate.test.ts
@@ -2,6 +2,7 @@ import { fromUnixTime, addDays, getUnixTime } from 'date-fns'
 import {
   DURATION_OPTIONS_MAINNET,
   DURATION_OPTIONS_FUJI,
+  DurationOptionWithDays,
   getStakeEndDate,
   StakeDurationFormat,
   StakeDurationTitle
@@ -52,12 +53,14 @@ describe('getStakeEndDate', () => {
   it('defines every preset in whole days matching its label (web parity)', () => {
     const presets = [...DURATION_OPTIONS_MAINNET, ...DURATION_OPTIONS_FUJI]
     presets
-      .filter(option => option.title !== StakeDurationTitle.CUSTOM)
+      // Type guard (not a plain predicate) so `numberOfDays` narrows below.
+      .filter(
+        (option): option is DurationOptionWithDays =>
+          option.title !== StakeDurationTitle.CUSTOM
+      )
       .forEach(option => {
         expect(option.stakeDurationFormat).toBe(StakeDurationFormat.Day)
-        expect(option.stakeDurationValue).toBe(
-          'numberOfDays' in option ? option.numberOfDays : undefined
-        )
+        expect(option.stakeDurationValue).toBe(option.numberOfDays)
       })
   })
 

--- a/packages/core-mobile/app/services/earn/getStakeEndDate.test.ts
+++ b/packages/core-mobile/app/services/earn/getStakeEndDate.test.ts
@@ -1,7 +1,10 @@
 import { fromUnixTime, addDays, getUnixTime } from 'date-fns'
 import {
+  DURATION_OPTIONS_MAINNET,
+  DURATION_OPTIONS_FUJI,
   getStakeEndDate,
-  StakeDurationFormat
+  StakeDurationFormat,
+  StakeDurationTitle
 } from 'services/earn/getStakeEndDate'
 import { getMinimumStakeEndTime } from 'services/earn/utils'
 
@@ -14,14 +17,48 @@ describe('getStakeEndDate', () => {
   const startDateUnix = 1729807200 // Thu Oct 24 2024 22:00:00 UTC
   const currentDate = fromUnixTime(startDateUnix) // Date representation in UTC
 
-  it('calculates end date in days', () => {
+  it('calculates end date in days with +1h of submit-drift slack', () => {
     const result = getStakeEndDate({
       startDateUnix,
       stakeDurationFormat: StakeDurationFormat.Day,
       stakeDurationValue: 1,
       isDeveloperMode: false
     })
-    expect(result).toBe(startDateUnix + 24 * 60 * 60) // Thu Oct 25 2024 22:00:00 UTC
+    // 1 day + 1 hour: the slack keeps the realized duration from rounding
+    // below the selected days once the start is re-anchored at submit time.
+    expect(result).toBe(startDateUnix + 25 * 60 * 60)
+  })
+
+  it('gives a 180-day selection exactly 180 days (+1h), not 6 calendar months', () => {
+    const result = getStakeEndDate({
+      startDateUnix,
+      stakeDurationFormat: StakeDurationFormat.Day,
+      stakeDurationValue: 180,
+      isDeveloperMode: false
+    })
+    expect(result).toBe(startDateUnix + (180 * 24 + 1) * 60 * 60)
+  })
+
+  it('backs the 365-day selection off by 1h to stay under the protocol max', () => {
+    const result = getStakeEndDate({
+      startDateUnix,
+      stakeDurationFormat: StakeDurationFormat.Day,
+      stakeDurationValue: 365,
+      isDeveloperMode: false
+    })
+    expect(result).toBe(startDateUnix + (365 * 24 - 1) * 60 * 60)
+  })
+
+  it('defines every preset in whole days matching its label (web parity)', () => {
+    const presets = [...DURATION_OPTIONS_MAINNET, ...DURATION_OPTIONS_FUJI]
+    presets
+      .filter(option => option.title !== StakeDurationTitle.CUSTOM)
+      .forEach(option => {
+        expect(option.stakeDurationFormat).toBe(StakeDurationFormat.Day)
+        expect(option.stakeDurationValue).toBe(
+          'numberOfDays' in option ? option.numberOfDays : undefined
+        )
+      })
   })
 
   it('calculates end date in weeks', () => {

--- a/packages/core-mobile/app/services/earn/getStakeEndDate.ts
+++ b/packages/core-mobile/app/services/earn/getStakeEndDate.ts
@@ -37,7 +37,9 @@ export const getStakeEndDate = ({
       // days outside leap years, so +1h would overshoot it.
       const end = addDays(currentDate, stakeDurationValue)
       return getUnixTime(
-        stakeDurationValue >= DAYS_IN_YEAR ? subHours(end, 1) : addHours(end, 1)
+        stakeDurationValue === DAYS_IN_YEAR
+          ? subHours(end, 1)
+          : addHours(end, 1)
       )
     }
     case StakeDurationFormat.Week:

--- a/packages/core-mobile/app/services/earn/getStakeEndDate.ts
+++ b/packages/core-mobile/app/services/earn/getStakeEndDate.ts
@@ -1,15 +1,19 @@
 import {
   addDays,
+  addHours,
   addMonths,
   addWeeks,
   addYears,
   fromUnixTime,
-  getUnixTime
+  getUnixTime,
+  subHours
 } from 'date-fns'
 import { UnixTime, UnixTimeMs } from 'services/earn/types'
 import { utc } from '@date-fns/utc/utc'
 import { UTCDate } from '@date-fns/utc'
 import { getMinimumStakeEndTime } from './utils'
+
+const DAYS_IN_YEAR = 365
 
 export const getStakeEndDate = ({
   startDateUnix,
@@ -24,8 +28,18 @@ export const getStakeEndDate = ({
 }): UnixTime => {
   const currentDate = fromUnixTime(startDateUnix, { in: utc })
   switch (stakeDurationFormat) {
-    case StakeDurationFormat.Day:
-      return getUnixTime(addDays(currentDate, stakeDurationValue))
+    case StakeDurationFormat.Day: {
+      // Web parity (`StakingFastStake.page` / `DelegationForm`): day-based
+      // end times carry +1h of slack so the submit-time re-anchored start
+      // (now + 1 min) can't round the realized duration below the selected
+      // number of days (CP-14723). The 365-day preset instead backs off 1h:
+      // the protocol maximum end (now + 1 calendar year) equals exactly 365
+      // days outside leap years, so +1h would overshoot it.
+      const end = addDays(currentDate, stakeDurationValue)
+      return getUnixTime(
+        stakeDurationValue >= DAYS_IN_YEAR ? subHours(end, 1) : addHours(end, 1)
+      )
+    }
     case StakeDurationFormat.Week:
       return getUnixTime(addWeeks(currentDate, stakeDurationValue))
     case StakeDurationFormat.Month:
@@ -106,39 +120,44 @@ export const ONE_DAY = {
   stakeDurationValue: 1
 } as const
 
+// The preset durations are defined in WHOLE DAYS (web parity — see
+// core-web's `stakePeriods.ts` `MAINNET_PERIOD_DAYS`): the calendar titles
+// are labels only, and `stakeDurationValue` must equal `numberOfDays`.
+// They used to be calendar-based (`addMonths(6)` etc.), which made a
+// "6 Months / 180 days" selection produce a 181-184 day stake (CP-14723).
 export const TWO_WEEKS = {
   title: StakeDurationTitle.TWO_WEEKS,
   numberOfDays: 14,
-  stakeDurationFormat: StakeDurationFormat.Week,
-  stakeDurationValue: 2
+  stakeDurationFormat: StakeDurationFormat.Day,
+  stakeDurationValue: 14
 } as const
 
 export const ONE_MONTH = {
   title: StakeDurationTitle.ONE_MONTH,
   numberOfDays: 30,
-  stakeDurationFormat: StakeDurationFormat.Month,
-  stakeDurationValue: 1
+  stakeDurationFormat: StakeDurationFormat.Day,
+  stakeDurationValue: 30
 } as const
 
 export const THREE_MONTHS = {
   title: StakeDurationTitle.THREE_MONTHS,
   numberOfDays: 90,
-  stakeDurationFormat: StakeDurationFormat.Month,
-  stakeDurationValue: 3
+  stakeDurationFormat: StakeDurationFormat.Day,
+  stakeDurationValue: 90
 } as const
 
 export const SIX_MONTHS = {
   title: StakeDurationTitle.SIX_MONTHS,
   numberOfDays: 180,
-  stakeDurationFormat: StakeDurationFormat.Month,
-  stakeDurationValue: 6
+  stakeDurationFormat: StakeDurationFormat.Day,
+  stakeDurationValue: 180
 } as const
 
 export const ONE_YEAR = {
   title: StakeDurationTitle.ONE_YEAR,
   numberOfDays: 365,
-  stakeDurationFormat: StakeDurationFormat.Year,
-  stakeDurationValue: 1
+  stakeDurationFormat: StakeDurationFormat.Day,
+  stakeDurationValue: 365
 } as const
 
 export const CUSTOM = {

--- a/packages/core-mobile/app/services/earn/utils.test.ts
+++ b/packages/core-mobile/app/services/earn/utils.test.ts
@@ -311,6 +311,14 @@ describe('isEndTimeOverOneYear', () => {
     const result = isEndTimeOverOneYear(lessThanOneYearFromNow)
     expect(result).toBeFalsy()
   })
+  it('returns true for the 365-day preset end (365d minus the 1h backoff)', () => {
+    // Duration-based on purpose: the calendar comparison this replaced
+    // dropped this case across leap windows and around midnight.
+    const presetEnd = new Date(
+      Date.now() + 365 * 24 * 60 * 60 * 1000 - 60 * 60 * 1000
+    )
+    expect(isEndTimeOverOneYear(presetEnd)).toBeTruthy()
+  })
 })
 
 describe('getSortedValidatorsByEndTime', () => {

--- a/packages/core-mobile/app/services/earn/utils.ts
+++ b/packages/core-mobile/app/services/earn/utils.ts
@@ -1,11 +1,4 @@
-import {
-  add,
-  addYears,
-  fromUnixTime,
-  getUnixTime,
-  isSameDay,
-  subDays
-} from 'date-fns'
+import { add, addYears, fromUnixTime, getUnixTime, subDays } from 'date-fns'
 import { AdvancedSortFilter, NodeValidator, NodeValidators } from 'types/earn'
 import { random } from 'lodash'
 import { FujiParams, MainnetParams, StakingConfig } from 'utils/NetworkParams'
@@ -322,10 +315,26 @@ export const getAdvancedSortedValidators = (
   }
 }
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+const DAYS_IN_YEAR = 365
+
+/**
+ * Whether the requested stake end is ~a year or more out — the
+ * validator-search special case: no validator's own period can extend past
+ * such an end, so the endTime filter/sort must switch strategy instead of
+ * demanding `validatorEnd > stakeEnd` (which would empty the result set).
+ *
+ * Duration-based (rounded whole days ≥ 365) on purpose, NOT calendar-based:
+ * the previous `addYears`/`isSameDay` comparison misclassified the 365-day
+ * preset (now + 365d − 1h, see `getStakeEndDate`) whenever a Feb 29 fell
+ * inside the window (calendar year = 366 days) or the −1h slack crossed a
+ * calendar-day boundary (taps between 00:00-01:00) — breaking the 1 Year
+ * preset's node search outright.
+ */
 export const isEndTimeOverOneYear = (stakingEndTime: Date): boolean => {
   return (
-    stakingEndTime >= addYears(new Date(), 1) ||
-    isSameDay(stakingEndTime, addYears(new Date(), 1))
+    Math.round((stakingEndTime.getTime() - Date.now()) / MS_PER_DAY) >=
+    DAYS_IN_YEAR
   )
 }
 


### PR DESCRIPTION
## Description

**Ticket: [CP-14723](https://ava-labs.atlassian.net/browse/CP-14723)**

Selecting a staking duration preset produced a longer stake than the UI advertised — e.g. "6 Months / 180 days" resulted in a 181-184 day stake. The presets carried two disagreeing definitions: the UI (labels, reward estimates) used `numberOfDays` (180), while the actual end date was computed calendar-based (`addMonths(6)`), which is 181-184 days depending on the start month (3 Months: 89-92, 1 Month: 28-31, 1 Year: 365-366).

### Fix 1 — day-based presets (web parity)

core-web defines these presets purely in days (`stakePeriods.ts` `MAINNET_PERIOD_DAYS = [14, 30, 90, 180, 365]`) and builds end times as `dayjs().add(days, 'days').add(1, 'hour')` (the 365-day max instead backs off 1 hour to stay under the protocol maximum). This PR mirrors that:

- All duration presets are now defined in **whole days** (`stakeDurationFormat: Day`, `stakeDurationValue === numberOfDays`) — the calendar titles are labels only. A test enforces this invariant so future presets can't regress to calendar math.
- The Day branch of `getStakeEndDate` adds **+1h of slack** so the submit-time re-anchored start (now + 1 min) can't round the realized duration below the selected days; the **365-day preset backs off 1h** since the protocol max (now + 1 calendar year) equals exactly 365 days outside leap years.
- Reward estimates (`getStakeDuration`) stay at exact day counts, matching web's `days × MS_PER_DAY`.

Both the V2 flow and the legacy V1 duration screen share these constants, so both are fixed.

### Fix 2 — consistent day-count displays

The duration surfaces disagreed with each other by a day for custom dates: the duration screen (and the Custom cell) measured from **midnight today** while the review screen's "Time to unlock" truncated `differenceInDays` from **now** — a custom end date carries the picker's seed time-of-day, so by review time `now` had passed it and a "35 days" selection read "34 days" on review.

All three surfaces (duration summary row, Custom cell, review "Time to unlock") now share `getRoundedDurationInDays` — anchored at now, **rounded to the nearest day**. Rounding also keeps the preset slack invisible (180d + 1h → 180) and makes the 365-day preset read **365 days** on review despite its −1h backoff.

### Reviewer notes

- The `Week`/`Month`/`Year` branches of `getStakeEndDate` are now unused by presets but kept for enum/API compatibility (Custom flow untouched).
- On-chain, the 1 Year preset ends at 365d − 1h (protocol-max safety, same as web); the UI reads 365 days via rounding.

## Screenshots/Videos

https://github.com/user-attachments/assets/70e7d46b-2317-4a17-8bda-68544b563289

## Testing
iOS: 9279
Android: 9280

**Dev Testing**

- Mainnet (or Fuji) staking flow → pick "6 Months" → confirm shows "Time to unlock: 180 days"; the submitted delegation's end time is start + 180d (+1h)
- "1 Year" → end time is +365d − 1h; confirm shows 365 days
- Custom date → the day count shown on the duration screen, the Custom cell, and the review screen all match

**QA Testing**

- For each preset, compare the selected duration against the actual staking period shown in stake detail / explorer — they should match the label (±1h slack)
- Custom: pick any date and verify the same day count across duration screen → review screen
- Regression: restake prefill durations, V1 flow duration selection

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14723]: https://ava-labs.atlassian.net/browse/CP-14723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ