### PR TITLE
CP-14788: exclude staked amount from P/X-chain swap balance

### DIFF
--- a/packages/core-mobile/app/new/features/swap/hooks/useFeeValidation/utils.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFeeValidation/utils.test.ts
@@ -33,6 +33,20 @@ const makeErc20Token = (balance: bigint): LocalTokenWithBalance =>
     balance
   } as unknown as LocalTokenWithBalance)
 
+// Native P/X-chain AVAX: `balance` includes staked/locked funds, `available` is
+// the swappable portion (CP-14788).
+const makeStakedNativeToken = (
+  balance: bigint,
+  available: bigint
+): LocalTokenWithBalance =>
+  ({
+    type: TokenType.NATIVE,
+    decimals: 18,
+    symbol: 'AVAX',
+    balance,
+    available
+  } as unknown as LocalTokenWithBalance)
+
 const makeNetwork = (symbol: string, decimals: number): Network =>
   ({
     networkToken: { symbol, decimals }
@@ -86,6 +100,30 @@ describe('validateNativeToken', () => {
     it('returns undefined when balance covers fee + amount', () => {
       const error = validateNativeToken({
         fromToken: makeNativeToken(250n),
+        amount: 100n,
+        bufferedGasFee: GAS,
+        bufferedAdditiveFee: 0n
+      })
+      expect(error).toBeUndefined()
+    })
+  })
+
+  describe('P/X-chain staked balance (CP-14788)', () => {
+    it('validates against available, not total balance (amount + fee exceeds available)', () => {
+      // total balance 250 would cover amount(100) + gas(100), but only 150 is
+      // available (rest staked), so amount + fee (200) exceeds available.
+      const error = validateNativeToken({
+        fromToken: makeStakedNativeToken(250n, 150n),
+        amount: 100n,
+        bufferedGasFee: GAS,
+        bufferedAdditiveFee: 0n
+      })
+      expect(error?.message).toContain('network fee')
+    })
+
+    it('returns undefined when available covers fee + amount', () => {
+      const error = validateNativeToken({
+        fromToken: makeStakedNativeToken(10000n, 250n),
         amount: 100n,
         bufferedGasFee: GAS,
         bufferedAdditiveFee: 0n

--- a/packages/core-mobile/app/new/features/swap/hooks/useFeeValidation/utils.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFeeValidation/utils.ts
@@ -8,6 +8,7 @@ import {
 } from '@avalabs/fusion-sdk'
 import type { LocalTokenWithBalance } from 'store/balance'
 import { FusionQuoteError, fusionErrors } from '../../utils/fusionErrors'
+import { getSwappableBalance } from '../../utils/getSwappableBalance'
 
 export const getFeeEstimationError = (error: unknown): FusionQuoteError => {
   if (isEstimateNativeFeeError(error)) {
@@ -80,13 +81,17 @@ export const validateNativeToken = ({
     6
   )} ${fromToken.symbol}`
 
-  if (fromToken.balance < totalFee) {
+  // Use the swappable balance so P/X-chain staked/locked funds aren't counted
+  // as covering the amount + fee (CP-14788).
+  const swappableBalance = getSwappableBalance(fromToken)
+
+  if (swappableBalance < totalFee) {
     return !hasBridgeFee
       ? fusionErrors.networkFeeExceedsBalance(formattedFee) // Case 1: gas alone exceeds balance
       : fusionErrors.feesExceedBalance(formattedFee) // Case 2: gas + bridge fees exceed balance
   }
 
-  if (amount !== undefined && fromToken.balance < amount + totalFee) {
+  if (amount !== undefined && swappableBalance < amount + totalFee) {
     return !hasBridgeFee
       ? fusionErrors.amountExceedsBalanceAfterNetworkFee(formattedFee) // Case 3: gas + swap amount exceed balance
       : fusionErrors.amountExceedsBalanceAfterFees(formattedFee) // Case 4: gas + bridge fees + swap amount exceed balance
@@ -150,15 +155,20 @@ export const validateNonNativeToken = ({
       6
     )} ${fromToken.symbol}`
 
+    // Use the swappable balance so P/X-chain staked/locked funds aren't counted
+    // as covering the source-token bridge fee + amount (CP-14788). No-op for the
+    // ERC20/SPL tokens this path normally handles.
+    const swappableBalance = getSwappableBalance(fromToken)
+
     // Case 3: bridge fee alone exceeds token balance
-    if (fromToken.balance < bufferedAdditiveFee) {
+    if (swappableBalance < bufferedAdditiveFee) {
       return fusionErrors.bridgeFeeExceedsBalance(formattedFee)
     }
 
     // Case 4: balance covers the fee but not fee + swap amount
     if (
       amount !== undefined &&
-      fromToken.balance < amount + bufferedAdditiveFee
+      swappableBalance < amount + bufferedAdditiveFee
     ) {
       return fusionErrors.amountExceedsBalanceAfterBridgeFee(formattedFee)
     }

--- a/packages/core-mobile/app/new/features/swap/hooks/useFilteredSwapTokens.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useFilteredSwapTokens.ts
@@ -4,6 +4,7 @@ import { LocalTokenWithBalance } from 'store/balance'
 import { isTokenVisible } from 'store/balance/utils'
 import { selectEnabledChainIds } from 'store/network'
 import { selectTokenVisibility } from 'store/portfolio'
+import { getSwappableBalance } from '../utils/getSwappableBalance'
 
 export const useFilteredSwapTokens = ({
   tokens,
@@ -28,9 +29,14 @@ export const useFilteredSwapTokens = ({
       enabledChainIds.includes(token.networkChainId)
     )
 
-    // Filter by balance if hideZeroBalance is true
+    // Filter by balance if hideZeroBalance is true. Use the swappable balance so
+    // a fully-staked P/X-chain AVAX position (available === 0n) is hidden from
+    // the swap-from picker instead of appearing as a "0 AVAX", unswappable row
+    // (CP-14788). No-op for other token types (swappable balance === balance).
     if (hideZeroBalance) {
-      filteredTokens = filteredTokens.filter(token => token.balance > 0n)
+      filteredTokens = filteredTokens.filter(
+        token => getSwappableBalance(token) > 0n
+      )
     }
 
     // Sort by balance in currency (highest first)

--- a/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/utils.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/utils.test.ts
@@ -19,6 +19,18 @@ const makeToken = (
     type
   } as LocalTokenWithBalance)
 
+// P/X-chain AVAX: `balance` includes staked/locked funds, `available` is the
+// swappable (unlocked/unstaked) portion.
+const makeStakedToken = (
+  balance: bigint,
+  available: bigint
+): LocalTokenWithBalance =>
+  ({
+    balance,
+    available,
+    type: TokenType.NATIVE
+  } as unknown as LocalTokenWithBalance)
+
 describe('buildFeeOptions', () => {
   it('returns only feeUnitsMarginBps when networkFee is undefined', () => {
     const result = buildFeeOptions(2000, undefined)
@@ -115,6 +127,47 @@ describe('computeMaxAmount', () => {
 
   it('returns undefined for native when fees exceed balance', () => {
     const token = makeToken(500n)
+    const result = computeMaxAmount({
+      fromToken: token,
+      isNative: true,
+      bufferedGas: 400n,
+      additiveFee: 200n,
+      hasEstimationError: false
+    })
+    expect(result).toBeUndefined()
+  })
+
+  // -------------------------------------------------------------------------
+  // P/X-chain staked-balance tests (CP-14788)
+  // -------------------------------------------------------------------------
+
+  it('caps native max at available (not full balance) for a P-chain token with staked funds', () => {
+    // balance 10000 includes staked; only 3000 is available to swap
+    const token = makeStakedToken(10000n, 3000n)
+    const result = computeMaxAmount({
+      fromToken: token,
+      isNative: true,
+      bufferedGas: 1000n,
+      additiveFee: 0n,
+      hasEstimationError: false
+    })
+    expect(result).toBe(2000n)
+  })
+
+  it('returns available (not full balance) for a P-chain token on estimation error', () => {
+    const token = makeStakedToken(10000n, 3000n)
+    const result = computeMaxAmount({
+      fromToken: token,
+      isNative: true,
+      bufferedGas: 1000n,
+      additiveFee: 0n,
+      hasEstimationError: true
+    })
+    expect(result).toBe(3000n)
+  })
+
+  it('returns undefined for a P-chain token when fees exceed available', () => {
+    const token = makeStakedToken(10000n, 500n)
     const result = computeMaxAmount({
       fromToken: token,
       isNative: true,
@@ -236,6 +289,12 @@ describe('getPreQuoteAmount', () => {
   it('returns half balance when it exceeds minimumTransferAmount', () => {
     const token = makeToken(1000n)
     expect(getPreQuoteAmount(100n, token)).toBe(500n)
+  })
+
+  it('uses half of available (not full balance) for a P-chain staked token', () => {
+    // full balance 1000 would give 500, but only 200 is available → half is 100
+    const token = makeStakedToken(1000n, 200n)
+    expect(getPreQuoteAmount(50n, token)).toBe(100n)
   })
 })
 

--- a/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/utils.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useMaxSwapAmount/utils.ts
@@ -1,5 +1,6 @@
 import type { NetworkFees } from '@avalabs/vm-module-types'
 import type { LocalTokenWithBalance } from 'store/balance'
+import { getSwappableBalance } from '../../utils/getSwappableBalance'
 
 enum ChainFamily {
   EVM = 'evm',
@@ -79,7 +80,7 @@ export const getPreQuoteAmount = (
     return minimumTransferAmount
   }
   if (!fromToken) return minimumTransferAmount
-  const halfBalance = fromToken.balance / 2n
+  const halfBalance = getSwappableBalance(fromToken) / 2n
   return halfBalance > minimumTransferAmount
     ? halfBalance
     : minimumTransferAmount
@@ -115,14 +116,18 @@ export const computeMaxAmount = ({
 }): bigint | undefined => {
   if (!fromToken) return undefined
 
+  // Use the swappable balance (excludes P/X-chain staked/locked funds) as the
+  // ceiling so Max can't select more than the user can actually swap (CP-14788).
+  const swappableBalance = getSwappableBalance(fromToken)
+
   if (isNative) {
-    // Fall back to full balance if fee estimation failed
-    if (hasEstimationError) return fromToken.balance
+    // Fall back to full swappable balance if fee estimation failed
+    if (hasEstimationError) return swappableBalance
 
     // Wait for fee estimate before enabling Max button
     if (bufferedGas === undefined) return undefined
 
-    const max = fromToken.balance - bufferedGas - (additiveFee ?? 0n)
+    const max = swappableBalance - bufferedGas - (additiveFee ?? 0n)
     return max > 0n ? max : undefined
   }
 
@@ -131,6 +136,6 @@ export const computeMaxAmount = ({
 
   // For non-native tokens (ERC20/SPL): gas is paid in the chain's native asset, but additive fees
   // denominated in the source token must be deducted.
-  const max = fromToken.balance - additiveFee
+  const max = swappableBalance - additiveFee
   return max > 0n ? max : undefined
 }

--- a/packages/core-mobile/app/new/features/swap/screens/SelectFromSwapTokenScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SelectFromSwapTokenScreen.tsx
@@ -24,6 +24,7 @@ import { selectActiveAccount } from 'store/account'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import { useFilteredSwapTokens } from '../hooks/useFilteredSwapTokens'
 import { tokenMatchesSearch } from '../utils/tokenMatchesSearch'
+import { getSwappableBalanceDisplayValue } from '../utils/getSwappableBalance'
 
 /**
  * Token selection screen for the "from" side of a swap.
@@ -149,7 +150,7 @@ export const SelectFromSwapTokenScreen = ({
                   {item.name}
                 </Text>
                 <Text variant="subtitle2">
-                  {item.balanceDisplayValue} {item.symbol}
+                  {getSwappableBalanceDisplayValue(item)} {item.symbol}
                 </Text>
               </View>
             </View>

--- a/packages/core-mobile/app/new/features/swap/screens/SelectToSwapTokenScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SelectToSwapTokenScreen.tsx
@@ -27,6 +27,7 @@ import { useFilteredSwapTokens } from '../hooks/useFilteredSwapTokens'
 import { useSwapTokens } from '../hooks/useSwapTokens'
 import { getTokenKey } from '../utils/tokenKey'
 import { tokenMatchesSearch } from '../utils/tokenMatchesSearch'
+import { getSwappableBalanceDisplayValue } from '../utils/getSwappableBalance'
 
 type UnverifiedDivider = { type: 'unverifiedDivider' }
 type SwapTokenListItem = LocalTokenWithBalance | UnverifiedDivider
@@ -338,7 +339,7 @@ export const SelectToSwapTokenScreen = ({
                   {item.name}
                 </Text>
                 <Text variant="subtitle2">
-                  {item.balanceDisplayValue} {item.symbol}
+                  {getSwappableBalanceDisplayValue(item)} {item.symbol}
                 </Text>
               </View>
             </View>

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -1072,7 +1072,7 @@ export const SwapScreen = (): JSX.Element => {
           disabled={isSwapping}
           editable={false}
           amount={toTokenValue}
-          balance={toToken?.balance}
+          balance={toToken ? getSwappableBalance(toToken) : undefined}
           shouldShowBalance={true}
           title="You receive"
           token={

--- a/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
+++ b/packages/core-mobile/app/new/features/swap/screens/SwapScreen.tsx
@@ -120,6 +120,7 @@ import { useFeeValidation } from '../hooks/useFeeValidation'
 import { useAutoAdvanceOnFeeValidationError } from '../hooks/useAutoAdvanceOnFeeValidationError'
 import { getTokenKey } from '../utils/tokenKey'
 import { resolveReceiveAmount } from '../utils/resolveReceiveAmount'
+import { getSwappableBalance } from '../utils/getSwappableBalance'
 
 // Disable KeyboardAwareScrollView's built-in scroll-into-view. The swap card is
 // short, so KAS clamps its scroll to the maximum and yanks the card up past the
@@ -284,7 +285,7 @@ function computeValidationError({
   if (
     debouncedFromTokenValue !== undefined &&
     fromToken !== undefined &&
-    debouncedFromTokenValue > fromToken.balance
+    debouncedFromTokenValue > getSwappableBalance(fromToken)
   ) {
     return fusionErrors.exceedsBalance()
   }
@@ -1016,7 +1017,7 @@ export const SwapScreen = (): JSX.Element => {
           disabled={isSwapping}
           editable={!isSwapping}
           amount={fromTokenValue}
-          balance={fromToken?.balance}
+          balance={fromToken ? getSwappableBalance(fromToken) : undefined}
           shouldShowBalance={true}
           title="You pay"
           token={

--- a/packages/core-mobile/app/new/features/swap/utils/buildAvailableFields.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/buildAvailableFields.test.ts
@@ -1,0 +1,45 @@
+import { TokenType } from '@avalabs/vm-module-types'
+import type { LocalTokenWithBalance } from 'store/balance'
+import { buildAvailableFields } from './buildAvailableFields'
+
+describe('buildAvailableFields', () => {
+  it('returns an empty object when balanceData is undefined', () => {
+    expect(buildAvailableFields(undefined, 9, 'AVAX')).toEqual({})
+  })
+
+  it('returns an empty object for a token without an available field (EVM)', () => {
+    const balanceData = {
+      type: TokenType.NATIVE,
+      balance: 5n
+    } as unknown as LocalTokenWithBalance
+    expect(buildAvailableFields(balanceData, 18, 'AVAX')).toEqual({})
+  })
+
+  it('returns an empty object when available is present but not a bigint', () => {
+    const balanceData = {
+      type: TokenType.NATIVE,
+      balance: 5n,
+      available: undefined
+    } as unknown as LocalTokenWithBalance
+    expect(buildAvailableFields(balanceData, 9, 'AVAX')).toEqual({})
+  })
+
+  it('carries available and recomputes availableDisplayValue at the given decimals', () => {
+    const balanceData = {
+      type: TokenType.NATIVE,
+      balance: 10_000_000_000n,
+      available: 3_000_000_000n,
+      availableInCurrency: 150,
+      availableCurrencyDisplayValue: '$150.00',
+      balancePerType: { unlockedUnstaked: 3_000_000_000n }
+    } as unknown as LocalTokenWithBalance
+
+    const result = buildAvailableFields(balanceData, 9, 'AVAX')
+
+    expect(result.available).toBe(3_000_000_000n)
+    expect(result.availableDisplayValue).toBe('3') // 3e9 at 9 decimals
+    expect(result.availableInCurrency).toBe(150)
+    expect(result.availableCurrencyDisplayValue).toBe('$150.00')
+    expect(result.balancePerType).toEqual({ unlockedUnstaked: 3_000_000_000n })
+  })
+})

--- a/packages/core-mobile/app/new/features/swap/utils/buildAvailableFields.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/buildAvailableFields.ts
@@ -1,0 +1,57 @@
+import { TokenUnit } from '@avalabs/core-utils-sdk'
+import type { LocalTokenWithBalance } from 'store/balance'
+
+/**
+ * Carries the P/X-chain "available" (swappable) balance fields from a balance
+ * store token onto a rebuilt swap token.
+ *
+ * The swap token mappers (`mapApiTokenToLocal` / `mapSdkAssetToLocal`) construct
+ * a fresh `LocalTokenWithBalance` and previously copied only `balance*`. For
+ * P-chain (PVM) / X-chain (AVM) AVAX that dropped `available` / balancePerType,
+ * so a token preselected via navigation params (e.g. from the token-detail
+ * screen) lost its swappable-balance data and `getSwappableBalance` fell back to
+ * the full `balance` including staked funds. Spread the result of this into the
+ * mapped token so `available` survives the rebuild. (CP-14788)
+ *
+ * Returns an empty object for every token type without an `available` field
+ * (EVM, ERC20, BTC, SVM, SPL), so it's a no-op there.
+ *
+ * `availableDisplayValue` is recomputed from `available` at the resolved
+ * `decimals` — matching how the mappers recompute `balanceDisplayValue` — so the
+ * display precision stays consistent with the rebuilt token's decimals.
+ */
+export const buildAvailableFields = (
+  balanceData: LocalTokenWithBalance | undefined,
+  decimals: number,
+  symbol: string
+): Partial<
+  Pick<
+    Extract<LocalTokenWithBalance, { available?: bigint }>,
+    | 'available'
+    | 'availableDisplayValue'
+    | 'availableInCurrency'
+    | 'availableCurrencyDisplayValue'
+    | 'balancePerType'
+  >
+> => {
+  if (
+    !balanceData ||
+    !('available' in balanceData) ||
+    typeof balanceData.available !== 'bigint'
+  ) {
+    return {}
+  }
+
+  const available = balanceData.available
+  return {
+    available,
+    availableDisplayValue: new TokenUnit(
+      available,
+      decimals,
+      symbol
+    ).toDisplay(),
+    availableInCurrency: balanceData.availableInCurrency,
+    availableCurrencyDisplayValue: balanceData.availableCurrencyDisplayValue,
+    balancePerType: balanceData.balancePerType
+  }
+}

--- a/packages/core-mobile/app/new/features/swap/utils/getSwappableBalance.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/getSwappableBalance.test.ts
@@ -1,0 +1,89 @@
+import { TokenType } from '@avalabs/vm-module-types'
+import type { LocalTokenWithBalance } from 'store/balance'
+import {
+  getSwappableBalance,
+  getSwappableBalanceDisplayValue
+} from './getSwappableBalance'
+
+describe('getSwappableBalance', () => {
+  it('returns balance for a native EVM token (no available field)', () => {
+    const token = {
+      type: TokenType.NATIVE,
+      balance: 5000n
+    } as LocalTokenWithBalance
+    expect(getSwappableBalance(token)).toBe(5000n)
+  })
+
+  it('returns balance for an ERC20 token', () => {
+    const token = {
+      type: TokenType.ERC20,
+      balance: 1234n
+    } as LocalTokenWithBalance
+    expect(getSwappableBalance(token)).toBe(1234n)
+  })
+
+  it('returns available (not balance) for a P-chain token with staked funds', () => {
+    // balance includes staked; available is the unlocked/unstaked portion
+    const token = {
+      type: TokenType.NATIVE,
+      balance: 10000n,
+      available: 3000n
+    } as unknown as LocalTokenWithBalance
+    expect(getSwappableBalance(token)).toBe(3000n)
+  })
+
+  it('returns available for an X-chain token with locked funds', () => {
+    const token = {
+      type: TokenType.NATIVE,
+      balance: 8000n,
+      available: 5000n
+    } as unknown as LocalTokenWithBalance
+    expect(getSwappableBalance(token)).toBe(5000n)
+  })
+
+  it('returns available of 0n when everything is staked/locked', () => {
+    const token = {
+      type: TokenType.NATIVE,
+      balance: 10000n,
+      available: 0n
+    } as unknown as LocalTokenWithBalance
+    expect(getSwappableBalance(token)).toBe(0n)
+  })
+
+  it('falls back to balance when available is present but not a bigint', () => {
+    const token = {
+      type: TokenType.NATIVE,
+      balance: 7000n,
+      available: undefined
+    } as unknown as LocalTokenWithBalance
+    expect(getSwappableBalance(token)).toBe(7000n)
+  })
+})
+
+describe('getSwappableBalanceDisplayValue', () => {
+  it('returns balanceDisplayValue for a token without availableDisplayValue', () => {
+    const token = {
+      type: TokenType.ERC20,
+      balanceDisplayValue: '12.5'
+    } as unknown as LocalTokenWithBalance
+    expect(getSwappableBalanceDisplayValue(token)).toBe('12.5')
+  })
+
+  it('returns availableDisplayValue for a P/X-chain token with staked funds', () => {
+    const token = {
+      type: TokenType.NATIVE,
+      balanceDisplayValue: '100',
+      availableDisplayValue: '30'
+    } as unknown as LocalTokenWithBalance
+    expect(getSwappableBalanceDisplayValue(token)).toBe('30')
+  })
+
+  it('falls back to balanceDisplayValue when availableDisplayValue is not a string', () => {
+    const token = {
+      type: TokenType.NATIVE,
+      balanceDisplayValue: '100',
+      availableDisplayValue: undefined
+    } as unknown as LocalTokenWithBalance
+    expect(getSwappableBalanceDisplayValue(token)).toBe('100')
+  })
+})

--- a/packages/core-mobile/app/new/features/swap/utils/getSwappableBalance.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/getSwappableBalance.test.ts
@@ -50,11 +50,20 @@ describe('getSwappableBalance', () => {
     expect(getSwappableBalance(token)).toBe(0n)
   })
 
-  it('falls back to balance when available is present but not a bigint', () => {
+  it('falls back to balance when available is the key but the value is undefined', () => {
     const token = {
       type: TokenType.NATIVE,
       balance: 7000n,
       available: undefined
+    } as unknown as LocalTokenWithBalance
+    expect(getSwappableBalance(token)).toBe(7000n)
+  })
+
+  it('falls back to balance when available is a non-bigint value (e.g. a string)', () => {
+    const token = {
+      type: TokenType.NATIVE,
+      balance: 7000n,
+      available: '3000'
     } as unknown as LocalTokenWithBalance
     expect(getSwappableBalance(token)).toBe(7000n)
   })

--- a/packages/core-mobile/app/new/features/swap/utils/getSwappableBalance.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/getSwappableBalance.ts
@@ -1,0 +1,40 @@
+import type { LocalTokenWithBalance } from 'store/balance'
+
+/**
+ * Returns the portion of a token's balance that is actually available to swap.
+ *
+ * P-chain (PVM) and X-chain (AVM) AVAX report a `balance` that includes
+ * staked/locked funds, which cannot be swapped. Those token types expose an
+ * `available` field (for P-chain, the unlocked/unstaked portion) — prefer it so
+ * the swap form's displayed balance, its percentage/Max quick-amounts, and the
+ * balance validation all reflect only what the user can actually swap. This
+ * mirrors the send flow, which already validates P-chain against `available`
+ * (see app/new/common/hooks/send/utils/pvm/validate.ts).
+ *
+ * Every other token type (EVM, ERC20, BTC, SVM, SPL) has no `available` field,
+ * so `balance` is the swappable amount. (CP-14788)
+ */
+export const getSwappableBalance = (token: LocalTokenWithBalance): bigint => {
+  if ('available' in token && typeof token.available === 'bigint') {
+    return token.available
+  }
+  return token.balance
+}
+
+/**
+ * Formatted-string counterpart to {@link getSwappableBalance}, for display in
+ * lists/rows. Prefers the P/X-chain `availableDisplayValue` (excludes
+ * staked/locked funds) and falls back to `balanceDisplayValue` for every other
+ * token type. (CP-14788)
+ */
+export const getSwappableBalanceDisplayValue = (
+  token: LocalTokenWithBalance
+): string => {
+  if (
+    'availableDisplayValue' in token &&
+    typeof token.availableDisplayValue === 'string'
+  ) {
+    return token.availableDisplayValue
+  }
+  return token.balanceDisplayValue
+}

--- a/packages/core-mobile/app/new/features/swap/utils/mapApiTokenToLocal.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/mapApiTokenToLocal.test.ts
@@ -238,6 +238,68 @@ describe('mapApiTokenToLocal', () => {
       }
     })
 
+    it('carries P-chain available (swappable) fields from balance data (CP-14788)', () => {
+      const apiToken: ApiToken = {
+        symbol: 'AVAX',
+        name: 'Avalanche',
+        address: '',
+        decimals: 9, // P-chain nAVAX
+        isNative: true,
+        internalId: 'avax-native',
+        logoUri: 'https://example.com/avax.png',
+        networkCaip2Id: 'avax:11111111111111111111111111111111LpoYY',
+        top250Rank: null,
+        contractType: null
+      }
+
+      // Total balance 10 AVAX but only 3 available (7 staked).
+      const balanceData = {
+        balance: 10_000_000_000n,
+        available: 3_000_000_000n,
+        availableDisplayValue: '3',
+        availableInCurrency: 150,
+        balanceInCurrency: 500,
+        priceInCurrency: 50
+      } as unknown as LocalTokenWithBalance
+
+      const result = mapApiTokenToLocal(apiToken, 4503599627370470, balanceData)
+
+      // available must survive the rebuild so getSwappableBalance uses it
+      expect((result as any).available).toBe(3_000_000_000n)
+      expect((result as any).availableDisplayValue).toBe('3')
+      expect((result as any).availableInCurrency).toBe(150)
+      expect(result.balance).toBe(10_000_000_000n)
+    })
+
+    it('does not add available fields for a token without them (EVM)', () => {
+      const apiToken: ApiToken = {
+        symbol: 'AVAX',
+        name: 'Avalanche',
+        address: '',
+        decimals: 18,
+        isNative: true,
+        internalId: 'avax-native',
+        logoUri: 'https://example.com/avax.png',
+        networkCaip2Id: 'eip155:43114',
+        top250Rank: null,
+        contractType: null
+      }
+
+      const balanceData: Partial<LocalTokenWithBalance> = {
+        balance: 5000000000000000000n,
+        balanceInCurrency: 250,
+        priceInCurrency: 50
+      }
+
+      const result = mapApiTokenToLocal(
+        apiToken,
+        ChainId.AVALANCHE_MAINNET_ID,
+        balanceData as LocalTokenWithBalance
+      )
+
+      expect('available' in result).toBe(false)
+    })
+
     it('should format balance display correctly for USDC (6 decimals)', () => {
       const apiToken: ApiToken = {
         symbol: 'USDC',

--- a/packages/core-mobile/app/new/features/swap/utils/mapApiTokenToLocal.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/mapApiTokenToLocal.ts
@@ -4,6 +4,7 @@ import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { DEFAULT_TOKEN_DECIMALS } from '../consts'
 import { ApiToken } from '../types'
 import { getLocalTokenIdFromApi } from './getLocalTokenIdFromApi'
+import { buildAvailableFields } from './buildAvailableFields'
 
 export const mapApiTokenToLocal = (
   apiToken: ApiToken,
@@ -65,6 +66,11 @@ export const mapApiTokenToLocal = (
     balanceDisplayValue,
     balanceInCurrency: balanceData?.balanceInCurrency ?? 0,
     priceInCurrency: balanceData?.priceInCurrency ?? 0,
+
+    // Carry P/X-chain swappable-balance fields (available*, balancePerType) so a
+    // preselected P/X source keeps them through the rebuild (CP-14788). No-op for
+    // other token types.
+    ...buildAvailableFields(balanceData, decimals, apiToken.symbol),
 
     // Required fields for different token types
     reputation: null,

--- a/packages/core-mobile/app/new/features/swap/utils/mapSdkAssetToLocal.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/mapSdkAssetToLocal.ts
@@ -5,6 +5,7 @@ import type { LocalTokenWithBalance } from 'store/balance'
 import { TokenUnit } from '@avalabs/core-utils-sdk'
 import { isPChain, isXChain } from 'utils/network/isAvalancheNetwork'
 import { xpChainToken } from 'utils/units/knownTokens'
+import { buildAvailableFields } from './buildAvailableFields'
 
 const getLocalIdFromSdkAsset = (asset: Asset): string => {
   if (asset.type === FusionTokenType.NATIVE) {
@@ -74,6 +75,9 @@ export const mapSdkAssetToLocal = (
     balanceDisplayValue,
     balanceInCurrency: balanceData?.balanceInCurrency ?? 0,
     priceInCurrency: balanceData?.priceInCurrency ?? 0,
+    // Carry P/X-chain swappable-balance fields so the rebuilt token keeps them
+    // (CP-14788). No-op for other token types.
+    ...buildAvailableFields(balanceData, decimals, symbol),
     reputation: null
   } as LocalTokenWithBalance & { decimals: number; address?: string }
 }

--- a/packages/core-mobile/app/new/features/swap/utils/recurringBalanceGate.test.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/recurringBalanceGate.test.ts
@@ -47,6 +47,21 @@ const erc20Token = (balance: bigint): LocalTokenWithBalance =>
     symbol: 'USDC'
   })
 
+// Native P/X-chain AVAX: `balance` includes staked/locked funds, `available` is
+// the swappable portion (CP-14788).
+const stakedNativeToken = (
+  balance: bigint,
+  available: bigint
+): LocalTokenWithBalance =>
+  ({
+    type: TokenType.NATIVE,
+    balance,
+    available,
+    decimals: AVAX_DECIMALS,
+    symbol: 'AVAX',
+    address: ''
+  } as unknown as LocalTokenWithBalance)
+
 // Mirror the gate's own formatting so assertions verify the *amount* passed
 // (principal vs principal+fee) without hard-coding formatTokenAmount's output.
 const fmt = (amount: bigint, decimals: number, symbol: string): string =>
@@ -130,6 +145,28 @@ describe('computeRecurringBalanceError — native source', () => {
       params({ fromToken: nativeToken(AVAX(0)) })
     )
     expect(err?.isWarning).toBeUndefined()
+  })
+
+  it('checks against available, not total balance, for staked P/X-chain AVAX (CP-14788)', () => {
+    // Total balance (10) covers principal + fee (5.05), but only 3 is available
+    // (rest staked) — the schedule must not pass validation on staked funds.
+    const err = computeRecurringBalanceError(
+      params({ fromToken: stakedNativeToken(AVAX(10), AVAX(3)) })
+    )
+    expect(err?.message).toBe(
+      `Insufficient balance — 5 orders require ${fmt(
+        FIVE_AVAX_PLUS_FEE,
+        AVAX_DECIMALS,
+        'AVAX'
+      )}.`
+    )
+  })
+
+  it('is null when available covers principal + fee for staked P/X-chain AVAX', () => {
+    const err = computeRecurringBalanceError(
+      params({ fromToken: stakedNativeToken(AVAX(100), FIVE_AVAX_PLUS_FEE) })
+    )
+    expect(err).toBeNull()
   })
 })
 

--- a/packages/core-mobile/app/new/features/swap/utils/recurringBalanceGate.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/recurringBalanceGate.ts
@@ -10,6 +10,7 @@ import { TokenType } from '@avalabs/vm-module-types'
 import type { LocalTokenWithBalance } from 'store/balance'
 import type { NumberOfOrders } from 'features/recurringSwap/types'
 import { fusionErrors, type FusionQuoteError } from './fusionErrors'
+import { getSwappableBalance } from './getSwappableBalance'
 
 const formatTokenWithSymbol = (
   amount: bigint,
@@ -76,10 +77,14 @@ export function computeRecurringBalanceError({
     return null
   }
 
+  // Use the swappable balance so P/X-chain staked/locked funds aren't counted as
+  // funding a recurring schedule (CP-14788). No-op for the EVM/ERC-20 sources
+  // and C-chain native gas token this path normally handles (they have no
+  // `available` field, so it falls back to `balance`).
   if (fromToken.type === TokenType.NATIVE) {
     // Principal + native schedule fee both come out of the native balance.
     const required = totalAmountIn + additiveNativeFee
-    if (required > fromToken.balance) {
+    if (required > getSwappableBalance(fromToken)) {
       return fusionErrors.recurringTotalExceedsBalance(
         numberOfOrders,
         formatTokenWithSymbol(required, fromToken)
@@ -92,11 +97,11 @@ export function computeRecurringBalanceError({
   // schedule fee from the native balance — independent shortfalls. Surface both
   // in one message when both fail so the user isn't asked to fix one, then
   // discover the other.
-  const principalShort = totalAmountIn > fromToken.balance
+  const principalShort = totalAmountIn > getSwappableBalance(fromToken)
   const feeShort =
     additiveNativeFee > 0n &&
     nativeFromToken !== undefined &&
-    additiveNativeFee > nativeFromToken.balance
+    additiveNativeFee > getSwappableBalance(nativeFromToken)
 
   if (principalShort && feeShort && nativeFromToken !== undefined) {
     return fusionErrors.recurringInsufficientForTotalAndFee(


### PR DESCRIPTION
## Description

**Ticket: [CP-14788](https://ava-labs.atlassian.net/browse/CP-14788)**

The swap flow treated `fromToken.balance` as the swappable amount everywhere. For P-chain (PVM) and X-chain (AVM) AVAX, that total **includes staked/locked funds**, which can't be swapped — so the swap form displayed the full balance, seeded the %/Max quick-amounts from it, validated against it, and the token pickers listed it. That let users try to swap an amount that isn't actually swappable (it would fail on-chain).

The unlocked, swappable portion is already exposed as `token.available` (P-chain = `unlockedUnstaked`, X-chain = `unlocked`) — the send flow validates against it too. This PR makes swap use it consistently.

**Changes**
- Added `getSwappableBalance` (bigint) and `getSwappableBalanceDisplayValue` (formatted string) helpers — return `available` / `availableDisplayValue` for PVM/AVM, and fall back to `balance` / `balanceDisplayValue` for every other token type (EVM, ERC20, BTC, SVM, SPL). No behavior change for non-Avalanche-primary tokens.
- Applied them to:
  - The "You pay" displayed balance and its percentage/Max quick-amount buttons.
  - The `exceedsBalance` amount validation.
  - The Max computation (`useMaxSwapAmount`) and the pre-quote seed amount.
  - The fee-validation balance ceilings (`useFeeValidation`) so staked funds aren't counted as covering `amount + fee`.
  - Both "Select a token" lists (from + to).

No new dependencies. Not a breaking change.

## Screenshots/Videos

_To be added — P-AVAX swap form + token picker before/after on iOS and Android._

## Testing

**Dev Testing**

Requires a wallet holding **P-chain AVAX with an active stake** (so total balance > available balance).

- Open Swap and select **P-AVAX** as the "You pay" token. The displayed balance should show only the **available (unstaked)** amount, not the full balance.
- Open Swap **from the P-chain token-detail screen** (the token is preselected via nav params, not the picker). The "You pay" balance must still show the **available** amount — this path rebuilds the token and previously showed the full balance.
- Tap **Max** (and the 25/50/75% buttons). The filled amount should be based on the available balance, never the staked portion.
- Try to type an amount above the available balance → an "insufficient balance" error should appear and the swap should be blocked.
- Enter an amount that fits within available but whose amount + fee would exceed available → it should be blocked (not silently allowed to fail on-chain).
- Open the "Select a token" screen (both the "from" and "to" pickers) → P-AVAX (and X-AVAX) rows should show the **available** amount, not the total.
- Sanity-check a normal C-chain token (e.g. AVAX or USDC) still shows and swaps against its full balance as before.

Build on Bitrise: https://app.bitrise.io/app/7d7ca5af7066e290/pipelines/ee87e185-2e43-41f4-b151-1768d3ba303c

## Build Numbers

- iOS: 9287
- Android: 9288

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14788]: https://ava-labs.atlassian.net/browse/CP-14788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ