### PR TITLE
CP-14832: persist advanced filter toggles as set and exclude fast stakes from the Delegation filter

### DIFF
--- a/packages/core-mobile/app/new/features/stake/hooks/useStakeFilterAndSort.ts
+++ b/packages/core-mobile/app/new/features/stake/hooks/useStakeFilterAndSort.ts
@@ -17,9 +17,11 @@ export const useStakeFilterAndSort = ({
    * Adds the stake-type filters (Fast stakes / Delegation) after the status
    * ones, mirroring core-web's stake-table filter set. Opt-in so the legacy
    * (V1) stake list keeps its original All/Active/Completed choices; the V2
-   * home screen turns it on. The web-parity semantics intentionally overlap:
-   * Delegation matches on txType (which includes fast stakes), while Fast
-   * stakes matches on the convenience-fee escrow output (`isFastStakeTx`).
+   * home screen turns it on. The two type filters are mutually exclusive,
+   * matching the card badges: Fast stakes matches on the convenience-fee
+   * escrow output (`isFastStakeTx`), Delegation on txType MINUS fast stakes.
+   * Fee-less fast stakes carry no escrow output, so — like their badge —
+   * they land under Delegation.
    */
   includeTypeFilters?: boolean
 }): {
@@ -54,7 +56,7 @@ export const useStakeFilterAndSort = ({
           case StakeFilter.FastStakes:
             return isFastStakeTx(tx, isDeveloperMode)
           case StakeFilter.Delegation:
-            return isDelegationTx(tx)
+            return isDelegationTx(tx) && !isFastStakeTx(tx, isDeveloperMode)
           default:
             return true
         }

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.test.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.test.ts
@@ -159,11 +159,20 @@ describe('useRestake', () => {
     // Stale node selection cleared so the confirm can't read it.
     expect(useDelegateNodeSelection.getState().nodes).toHaveLength(0)
 
-    // Web-parity default filters seeded from the (mocked) staking config:
-    // fee ≤ 2%, remaining time ≥ 14 days.
-    expect(useDelegateFilters.getState().filters).toEqual(
-      createDefaultDelegateFilters({ minFeePercent: 2, minStakeDays: 14 })
-    )
+    // Web-parity baseline seeded from the (mocked) staking config — fee ≤ 2%,
+    // remaining time ≥ 14 days — while the user-facing filters open with every
+    // toggle off (the baseline filters underneath; the sheet shows none on).
+    const seeded = createDefaultDelegateFilters({
+      minFeePercent: 2,
+      minStakeDays: 14
+    })
+    expect(useDelegateFilters.getState().defaults).toEqual(seeded)
+    expect(useDelegateFilters.getState().filters).toEqual({
+      uptime: { ...seeded.uptime, enabled: false },
+      maxFee: { ...seeded.maxFee, enabled: false },
+      minAvailable: { ...seeded.minAvailable, enabled: false },
+      minTimeRemaining: { ...seeded.minTimeRemaining, enabled: false }
+    })
 
     expect(mockNavigate).toHaveBeenCalledWith(
       `/addStakeV2/delegate/confirm?stakeEndTime=${expectedStakeEndTime}&restakeNodeId=NodeID-A`

--- a/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.test.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/hooks/useRestake.test.ts
@@ -5,6 +5,7 @@ import { useStakeAmount } from 'hooks/earn/useStakeAmount'
 import {
   clearRestakePrefill,
   createDefaultDelegateFilters,
+  disableAllDelegateFilters,
   getRestakePrefill,
   setDelegateNodeSelection,
   takeRestakeEntry,
@@ -167,12 +168,9 @@ describe('useRestake', () => {
       minStakeDays: 14
     })
     expect(useDelegateFilters.getState().defaults).toEqual(seeded)
-    expect(useDelegateFilters.getState().filters).toEqual({
-      uptime: { ...seeded.uptime, enabled: false },
-      maxFee: { ...seeded.maxFee, enabled: false },
-      minAvailable: { ...seeded.minAvailable, enabled: false },
-      minTimeRemaining: { ...seeded.minTimeRemaining, enabled: false }
-    })
+    expect(useDelegateFilters.getState().filters).toEqual(
+      disableAllDelegateFilters(seeded)
+    )
 
     expect(mockNavigate).toHaveBeenCalledWith(
       `/addStakeV2/delegate/confirm?stakeEndTime=${expectedStakeEndTime}&restakeNodeId=NodeID-A`

--- a/packages/core-mobile/app/new/features/stake/v2/screens/AdvancedFiltersScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/AdvancedFiltersScreen.tsx
@@ -105,55 +105,41 @@ const FilterCard: FC<FilterCardProps> = ({
   )
 }
 
-// Whether an applied `{enabled, value}` filter deviates from its seeded
-// default. Drives each row's toggle: a row reads as "on" only when the user has
-// overridden the web default.
-const isOverridden = (
-  applied: { enabled: boolean; value: number },
-  base: { enabled: boolean; value: number }
-): boolean =>
-  applied.enabled !== base.enabled ||
-  (applied.enabled && applied.value !== base.value)
-
 /**
- * Builds an editable draft from the currently applied filters. Here a row's
- * `enabled` flag means "the user is overriding the web default" (it drives the
- * toggle + whether the value control shows), NOT "the filter is active" — the
- * web-parity defaults (uptime ≥ 75%, fee ≤ 2%, min time remaining) always apply
- * underneath. So a row reads as toggled on only when its applied value differs
- * from the seeded default; an untouched picker opens with every toggle off even
- * though it's pre-filtered. Numeric values are kept inside the live bounds, and
- * a row sitting at its default seeds its control at the default value so
- * flipping the toggle on starts there (then drag up to tighten or down to
- * loosen, e.g. uptime to 0% to see every node).
+ * Builds an editable draft from the user's saved filters. Toggles mirror
+ * those filters verbatim — a fresh flow opens with every toggle off (the
+ * web-parity baseline still filters underneath; see
+ * `resolveEffectiveDelegateFilters`), and whatever the user applies is
+ * exactly what they see on reopen. A user-enabled dimension replaces the
+ * baseline, so e.g. enabling uptime and dragging it below 75% genuinely
+ * loosens the list. Numeric values are kept inside the live bounds; a
+ * disabled row seeds its control at the baseline value so flipping the
+ * toggle on starts there.
  */
 const seedDraft = (
   applied: DelegateFilters,
-  defaults: DelegateFilters,
   bounds: DelegateFilterBounds
 ): DelegateFilters => ({
   uptime: {
-    enabled:
-      applied.uptime.enabled !== defaults.uptime.enabled ||
-      (applied.uptime.enabled && applied.uptime.min !== defaults.uptime.min),
+    enabled: applied.uptime.enabled,
     min: clamp(applied.uptime.min, bounds.uptime.min, bounds.uptime.max)
   },
   maxFee: {
-    enabled: isOverridden(applied.maxFee, defaults.maxFee),
+    enabled: applied.maxFee.enabled,
     // Free numeric filter: allow any fee down to 0% (a value below the network
     // floor simply yields no matches) and retain exactly what was entered on
     // reopen — only the upper bound (100%) is enforced.
     value: clamp(applied.maxFee.value, 0, MAX_FEE_INPUT)
   },
   minAvailable: {
-    enabled: isOverridden(applied.minAvailable, defaults.minAvailable),
+    enabled: applied.minAvailable.enabled,
     value:
       applied.minAvailable.value > 0
         ? Math.max(applied.minAvailable.value, bounds.minAvailable.min)
         : bounds.minAvailable.min
   },
   minTimeRemaining: {
-    enabled: isOverridden(applied.minTimeRemaining, defaults.minTimeRemaining),
+    enabled: applied.minTimeRemaining.enabled,
     value:
       applied.minTimeRemaining.value > 0
         ? clamp(
@@ -168,34 +154,20 @@ const seedDraft = (
 const AdvancedFiltersScreen = (): JSX.Element => {
   const router = useRouter()
   const filters = useDelegateFilters(state => state.filters)
-  const defaults = useDelegateFilters(state => state.defaults)
   const setFilters = useDelegateFilters(state => state.setFilters)
   const bounds = useDelegateFilterBounds()
 
   const [draft, setDraft] = useState<DelegateFilters>(() =>
-    seedDraft(filters, defaults, bounds)
+    seedDraft(filters, bounds)
   )
 
   const handleApply = useCallback((): void => {
-    // A row toggled on applies the user's value; a row toggled off reverts that
-    // dimension to the seeded web default (which still filters underneath), so
-    // the picker keeps its baseline instead of showing every node.
-    setFilters({
-      uptime: draft.uptime.enabled
-        ? { enabled: true, min: draft.uptime.min }
-        : defaults.uptime,
-      maxFee: draft.maxFee.enabled
-        ? { enabled: true, value: draft.maxFee.value }
-        : defaults.maxFee,
-      minAvailable: draft.minAvailable.enabled
-        ? { enabled: true, value: draft.minAvailable.value }
-        : defaults.minAvailable,
-      minTimeRemaining: draft.minTimeRemaining.enabled
-        ? { enabled: true, value: draft.minTimeRemaining.value }
-        : defaults.minTimeRemaining
-    })
+    // Saved verbatim, toggles included, so the sheet reopens exactly as
+    // applied. A row toggled off falls back to the web-parity baseline for
+    // that dimension (it does NOT list every node).
+    setFilters(draft)
     router.back()
-  }, [draft, defaults, router, setFilters])
+  }, [draft, router, setFilters])
 
   const handleCancel = useCallback((): void => {
     // Discard the draft — applied filters stay as they were.

--- a/packages/core-mobile/app/new/features/stake/v2/screens/AdvancedFiltersScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/AdvancedFiltersScreen.tsx
@@ -113,8 +113,9 @@ const FilterCard: FC<FilterCardProps> = ({
  * exactly what they see on reopen. A user-enabled dimension replaces the
  * baseline, so e.g. enabling uptime and dragging it below 75% genuinely
  * loosens the list. Numeric values are kept inside the live bounds; a
- * disabled row seeds its control at the baseline value so flipping the
- * toggle on starts there.
+ * disabled row keeps its last saved value (the baseline value on a fresh
+ * flow, the range minimum when it has none), so flipping the toggle back on
+ * starts where the user left off.
  */
 const seedDraft = (
   applied: DelegateFilters,

--- a/packages/core-mobile/app/new/features/stake/v2/screens/SelectNodeScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/SelectNodeScreen.tsx
@@ -22,8 +22,9 @@ import { NodeValidator } from 'types/earn'
 import { useDelegateNodeSort } from '../hooks/useDelegateNodeSort'
 import { DelegateNodeItem } from '../components/DelegateNodeItem'
 import {
-  countModifiedFilters,
+  countEnabledFilters,
   DelegateFilters,
+  resolveEffectiveDelegateFilters,
   setDelegateNodeSelection,
   useDelegateFilters
 } from '../store'
@@ -98,10 +99,16 @@ const SelectNodeScreen = (): JSX.Element => {
   const minStakeSubUnit = minStakeAmount.toSubUnit()
   const filters = useDelegateFilters(state => state.filters)
   const filterDefaults = useDelegateFilters(state => state.defaults)
-  // Badge counts only filters the user has changed from the seeded defaults, so
-  // the picker opens looking unfiltered even though the web-parity defaults are
+  // Badge counts the filters the user has toggled on (matching the sheet), so
+  // the picker opens looking unfiltered even though the web-parity baseline is
   // applied.
-  const activeFilterCount = countModifiedFilters(filters, filterDefaults)
+  const activeFilterCount = countEnabledFilters(filters)
+  // What actually narrows the list: user-enabled dimensions replace the
+  // web-parity baseline; the rest fall back to it.
+  const effectiveFilters = useMemo(
+    () => resolveEffectiveDelegateFilters(filters, filterDefaults),
+    [filters, filterDefaults]
+  )
 
   const validators = useMemo(() => {
     const all = data?.validators ?? []
@@ -143,12 +150,12 @@ const SelectNodeScreen = (): JSX.Element => {
         // sub-units (bigint) so the dep stays a primitive.
         if (available.toSubUnit() < minStakeSubUnit) continue
 
-        // Advanced filters — each only narrows the list when its toggle is on.
+        // Advanced filters (user-enabled dimensions over the web baseline).
         if (
           !passesAdvancedFilters(
             v,
             available.toDisplay({ asNumber: true }),
-            filters
+            effectiveFilters
           )
         ) {
           continue
@@ -167,7 +174,7 @@ const SelectNodeScreen = (): JSX.Element => {
     minStakeSubUnit,
     tokenDecimals,
     tokenSymbol,
-    filters
+    effectiveFilters
   ])
 
   const handlePressNode = useCallback(

--- a/packages/core-mobile/app/new/features/stake/v2/store.test.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/store.test.ts
@@ -2,6 +2,7 @@ import {
   countEnabledFilters,
   createDefaultDelegateFilters,
   DelegateFilters,
+  disableAllDelegateFilters,
   resolveEffectiveDelegateFilters,
   useDelegateFilters
 } from './store'
@@ -11,12 +12,7 @@ const BASELINE = createDefaultDelegateFilters({
   minStakeDays: 14
 })
 
-const allOff = (filters: DelegateFilters): DelegateFilters => ({
-  uptime: { ...filters.uptime, enabled: false },
-  maxFee: { ...filters.maxFee, enabled: false },
-  minAvailable: { ...filters.minAvailable, enabled: false },
-  minTimeRemaining: { ...filters.minTimeRemaining, enabled: false }
-})
+const allOff = disableAllDelegateFilters
 
 describe('resolveEffectiveDelegateFilters', () => {
   it('falls back to the baseline for dimensions the user has not enabled', () => {

--- a/packages/core-mobile/app/new/features/stake/v2/store.test.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/store.test.ts
@@ -1,0 +1,84 @@
+import {
+  countEnabledFilters,
+  createDefaultDelegateFilters,
+  DelegateFilters,
+  resolveEffectiveDelegateFilters,
+  useDelegateFilters
+} from './store'
+
+const BASELINE = createDefaultDelegateFilters({
+  minFeePercent: 2,
+  minStakeDays: 14
+})
+
+const allOff = (filters: DelegateFilters): DelegateFilters => ({
+  uptime: { ...filters.uptime, enabled: false },
+  maxFee: { ...filters.maxFee, enabled: false },
+  minAvailable: { ...filters.minAvailable, enabled: false },
+  minTimeRemaining: { ...filters.minTimeRemaining, enabled: false }
+})
+
+describe('resolveEffectiveDelegateFilters', () => {
+  it('falls back to the baseline for dimensions the user has not enabled', () => {
+    const effective = resolveEffectiveDelegateFilters(
+      allOff(BASELINE),
+      BASELINE
+    )
+    expect(effective).toEqual(BASELINE)
+  })
+
+  it('replaces the baseline with a user-enabled dimension (loosening works)', () => {
+    const userFilters: DelegateFilters = {
+      ...allOff(BASELINE),
+      uptime: { enabled: true, min: 40 } // below the 75% baseline
+    }
+    const effective = resolveEffectiveDelegateFilters(userFilters, BASELINE)
+    expect(effective.uptime).toEqual({ enabled: true, min: 40 })
+    // Untouched dimensions still filter at the baseline.
+    expect(effective.maxFee).toEqual(BASELINE.maxFee)
+    expect(effective.minTimeRemaining).toEqual(BASELINE.minTimeRemaining)
+  })
+})
+
+describe('countEnabledFilters', () => {
+  it('is 0 right after seeding, so the picker opens without a badge', () => {
+    useDelegateFilters.getState().seedDefaults(BASELINE)
+    expect(countEnabledFilters(useDelegateFilters.getState().filters)).toBe(0)
+  })
+
+  it('counts every toggled-on filter, even at its baseline value', () => {
+    const userFilters: DelegateFilters = {
+      uptime: { ...BASELINE.uptime, enabled: true },
+      maxFee: { ...BASELINE.maxFee, enabled: true },
+      minAvailable: { enabled: true, value: 100 },
+      minTimeRemaining: { ...BASELINE.minTimeRemaining, enabled: false }
+    }
+    expect(countEnabledFilters(userFilters)).toBe(3)
+  })
+})
+
+describe('useDelegateFilters.seedDefaults', () => {
+  afterEach(() => {
+    useDelegateFilters.getState().reset()
+  })
+
+  it('stores the baseline and opens the user filters all-off at baseline values', () => {
+    useDelegateFilters.getState().seedDefaults(BASELINE)
+    const { filters, defaults } = useDelegateFilters.getState()
+    expect(defaults).toEqual(BASELINE)
+    expect(filters).toEqual(allOff(BASELINE))
+  })
+
+  it('applied filters round-trip verbatim through setFilters', () => {
+    useDelegateFilters.getState().seedDefaults(BASELINE)
+    const applied: DelegateFilters = {
+      ...allOff(BASELINE),
+      maxFee: { enabled: true, value: BASELINE.maxFee.value } // on at default
+    }
+    useDelegateFilters.getState().setFilters(applied)
+    // The sheet reopens with exactly what was applied — an enabled row at its
+    // baseline value must NOT collapse back to "off" (CP-14832).
+    expect(useDelegateFilters.getState().filters).toEqual(applied)
+    expect(countEnabledFilters(useDelegateFilters.getState().filters)).toBe(1)
+  })
+})

--- a/packages/core-mobile/app/new/features/stake/v2/store.test.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/store.test.ts
@@ -14,6 +14,13 @@ const BASELINE = createDefaultDelegateFilters({
 
 const allOff = disableAllDelegateFilters
 
+// The zustand store is module-level state shared by every test in this file —
+// reset it after each test so no describe block leaks a seeded store into the
+// next.
+afterEach(() => {
+  useDelegateFilters.getState().reset()
+})
+
 describe('resolveEffectiveDelegateFilters', () => {
   it('falls back to the baseline for dimensions the user has not enabled', () => {
     const effective = resolveEffectiveDelegateFilters(
@@ -54,10 +61,6 @@ describe('countEnabledFilters', () => {
 })
 
 describe('useDelegateFilters.seedDefaults', () => {
-  afterEach(() => {
-    useDelegateFilters.getState().reset()
-  })
-
   it('stores the baseline and opens the user filters all-off at baseline values', () => {
     useDelegateFilters.getState().seedDefaults(BASELINE)
     const { filters, defaults } = useDelegateFilters.getState()

--- a/packages/core-mobile/app/new/features/stake/v2/store.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/store.ts
@@ -141,11 +141,11 @@ export const resetDelegateFilters = (): void =>
   useDelegateFilters.getState().reset()
 
 /**
- * Seeds the filters (and the baseline they're diffed against) with the
- * web-parity defaults (see `createDefaultDelegateFilters`). Call from non-React
- * contexts (e.g. when a new Delegate flow starts) so the node picker opens
- * pre-filtered like web — yet looks "unfiltered" until the user deviates — and
- * a previous session's filters don't carry over.
+ * Seeds the web-parity baseline (see `createDefaultDelegateFilters`) and
+ * resets the user filters to all-off. Call from non-React contexts (e.g. when
+ * a new Delegate flow starts) so the node picker opens pre-filtered like web —
+ * with no toggle shown as on — and a previous session's filters don't carry
+ * over.
  */
 export const applyDefaultDelegateFilters = (params: {
   minFeePercent: number

--- a/packages/core-mobile/app/new/features/stake/v2/store.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/store.ts
@@ -53,38 +53,61 @@ export const createDefaultDelegateFilters = ({
 })
 
 /**
- * Number of filters the user has changed from the seeded defaults — drives the
- * count badge. Returns 0 while the filters still match the defaults seeded on
- * flow entry, so the picker opens looking "unfiltered" even though the
- * web-parity defaults are applied; only a deviation surfaces the badge.
+ * Number of filters the user has toggled on — drives the count badge. The
+ * badge counts exactly the rows that read as "on" in the Advanced filters
+ * sheet (even at their default values), so what the user enabled is what the
+ * badge reports. Returns 0 while the user hasn't enabled anything, so the
+ * picker opens looking "unfiltered" even though the web-parity baseline
+ * filters underneath.
  */
-export const countModifiedFilters = (
+export const countEnabledFilters = (filters: DelegateFilters): number =>
+  [
+    filters.uptime.enabled,
+    filters.maxFee.enabled,
+    filters.minAvailable.enabled,
+    filters.minTimeRemaining.enabled
+  ].filter(Boolean).length
+
+/**
+ * The filters that actually narrow the node list. Per dimension, a
+ * user-enabled filter REPLACES the baseline web default (so enabling uptime
+ * and dragging it below 75% genuinely loosens the list); a dimension the
+ * user hasn't enabled falls back to the baseline seeded on flow entry.
+ */
+export const resolveEffectiveDelegateFilters = (
   filters: DelegateFilters,
   defaults: DelegateFilters
-): number => {
-  const changed = (
-    a: { enabled: boolean; value: number },
-    b: { enabled: boolean; value: number }
-  ): boolean => a.enabled !== b.enabled || (a.enabled && a.value !== b.value)
+): DelegateFilters => ({
+  uptime: filters.uptime.enabled ? filters.uptime : defaults.uptime,
+  maxFee: filters.maxFee.enabled ? filters.maxFee : defaults.maxFee,
+  minAvailable: filters.minAvailable.enabled
+    ? filters.minAvailable
+    : defaults.minAvailable,
+  minTimeRemaining: filters.minTimeRemaining.enabled
+    ? filters.minTimeRemaining
+    : defaults.minTimeRemaining
+})
 
-  let count = 0
-  // `uptime` carries its threshold in `min`; the others use `value`.
-  if (
-    filters.uptime.enabled !== defaults.uptime.enabled ||
-    (filters.uptime.enabled && filters.uptime.min !== defaults.uptime.min)
-  ) {
-    count++
-  }
-  if (changed(filters.maxFee, defaults.maxFee)) count++
-  if (changed(filters.minAvailable, defaults.minAvailable)) count++
-  if (changed(filters.minTimeRemaining, defaults.minTimeRemaining)) count++
-  return count
-}
+// Seeds the user-facing filters from the baseline: same values (so the sheet's
+// controls start at the web defaults) but every toggle off — the baseline
+// itself filters from `defaults`, not from here.
+const disableAll = (filters: DelegateFilters): DelegateFilters => ({
+  uptime: { ...filters.uptime, enabled: false },
+  maxFee: { ...filters.maxFee, enabled: false },
+  minAvailable: { ...filters.minAvailable, enabled: false },
+  minTimeRemaining: { ...filters.minTimeRemaining, enabled: false }
+})
 
 type DelegateFiltersStore = {
+  /**
+   * The user's explicit filters — `enabled` mirrors the Advanced filters
+   * sheet's toggles verbatim. NOT what filters the list by itself: the
+   * web-parity baseline (`defaults`) applies underneath, and a user-enabled
+   * dimension replaces it (see `resolveEffectiveDelegateFilters`).
+   */
   filters: DelegateFilters
-  // The defaults seeded on flow entry, retained so the count badge can tell
-  // whether the user has deviated from them (see `countModifiedFilters`).
+  // The web-parity baseline seeded on flow entry. Filters every dimension the
+  // user hasn't explicitly enabled.
   defaults: DelegateFilters
   setFilters: (filters: DelegateFilters) => void
   seedDefaults: (defaults: DelegateFilters) => void
@@ -99,9 +122,9 @@ export const useDelegateFilters = create<DelegateFiltersStore>(set => ({
   filters: DEFAULT_DELEGATE_FILTERS,
   defaults: DEFAULT_DELEGATE_FILTERS,
   setFilters: filters => set({ filters }),
-  // Seed both the applied filters and the baseline they're compared against, so
-  // the freshly-seeded state reads as "unmodified" (no badge).
-  seedDefaults: defaults => set({ filters: defaults, defaults }),
+  // Seed the baseline, and the user filters as all-off (values kept as seeds
+  // for the sheet's controls) — a fresh flow opens with no toggle on.
+  seedDefaults: defaults => set({ filters: disableAll(defaults), defaults }),
   reset: () =>
     set({
       filters: DEFAULT_DELEGATE_FILTERS,

--- a/packages/core-mobile/app/new/features/stake/v2/store.ts
+++ b/packages/core-mobile/app/new/features/stake/v2/store.ts
@@ -88,10 +88,14 @@ export const resolveEffectiveDelegateFilters = (
     : defaults.minTimeRemaining
 })
 
-// Seeds the user-facing filters from the baseline: same values (so the sheet's
-// controls start at the web defaults) but every toggle off — the baseline
-// itself filters from `defaults`, not from here.
-const disableAll = (filters: DelegateFilters): DelegateFilters => ({
+/**
+ * Seeds the user-facing filters from the baseline: same values (so the sheet's
+ * controls start at the web defaults) but every toggle off — the baseline
+ * itself filters from `defaults`, not from here.
+ */
+export const disableAllDelegateFilters = (
+  filters: DelegateFilters
+): DelegateFilters => ({
   uptime: { ...filters.uptime, enabled: false },
   maxFee: { ...filters.maxFee, enabled: false },
   minAvailable: { ...filters.minAvailable, enabled: false },
@@ -124,7 +128,8 @@ export const useDelegateFilters = create<DelegateFiltersStore>(set => ({
   setFilters: filters => set({ filters }),
   // Seed the baseline, and the user filters as all-off (values kept as seeds
   // for the sheet's controls) — a fresh flow opens with no toggle on.
-  seedDefaults: defaults => set({ filters: disableAll(defaults), defaults }),
+  seedDefaults: defaults =>
+    set({ filters: disableAllDelegateFilters(defaults), defaults }),
   reset: () =>
     set({
       filters: DEFAULT_DELEGATE_FILTERS,


### PR DESCRIPTION
## Description

**Ticket: [CP-14832](https://ava-labs.atlassian.net/browse/CP-14832)**

Two stake filter fixes:

### 1. Advanced filter toggles persist as set (CP-14832)

The Advanced filters sheet used to treat each row's toggle as "the user has deviated from the web default": enabling a filter at its default value collapsed back to "off" on reopen, and the active-filter badge ignored it. QA read this as filters silently not applying — they enabled all four filters, yet only one showed as applied.

The sheet's toggles now persist exactly as set:

- The filter store is split into two layers: `filters` (the user's explicit toggles/values, mirrored verbatim by the sheet) and `defaults` (the web-parity baseline seeded on flow entry — uptime ≥ 75%, fee ≤ the network minimum, min time remaining).
- `resolveEffectiveDelegateFilters` computes what actually narrows the node list: a user-enabled dimension replaces the baseline (so loosening, e.g. uptime below 75%, genuinely widens the list); untouched dimensions fall back to it.
- The badge counts the filters the user toggled on (`countEnabledFilters`), matching what the sheet shows, instead of diffing against defaults.
- A fresh flow still opens with every toggle off and the baseline filtering underneath — no visual change to the default picker.

### 2. Stake home: the Delegation chip no longer shows fast stakes

The Delegation filter matched on txType alone, and fast stakes ARE delegation transactions on-chain — so cards wearing the "Fast stake" badge showed up under Delegation, making the chip look broken. The filter is now mutually exclusive with Fast stakes (`isDelegationTx && !isFastStakeTx`), matching the card badges exactly. Fee-less fast stakes carry no escrow output, so — like their badge — they stay under Delegation.

No new dependencies. State is in-memory zustand only (reseeded per flow), so no migration.

## Screenshots/Videos

N/A — behavior changes are in filter logic; see the recording on the ticket for the original issue.

## Testing
iOS: 9325
Android: 9326

**Dev Testing (if applicable)**

Advanced filters:
1. Start a Delegate flow and open Advanced filters — every toggle is off; the node list is pre-filtered as before.
2. Enable all four filters without changing values, tap Apply — the badge shows 4.
3. Reopen the sheet — all four toggles are still on with their values.
4. Enable Uptime range and drag below 75% — the node list widens (user filter replaces the baseline).
5. Toggle a filter off and apply — that dimension falls back to the web-parity baseline (the list does not blow up to every node).

Stake home chips:
1. With both fast stakes and plain delegations on the account, select the Delegation chip — only cards with the "Delegating" badge appear.
2. Select Fast stakes — only "Fast stake" badge cards appear.

**QA Testing (if applicable)**

- The scenario from the ticket: enabling filters (even at their default values) must persist — the sheet reopens exactly as applied and the badge counts every enabled filter.
- The Delegation and Fast stakes chips on the stake home are mutually exclusive, matching the card badges.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

[CP-14832]: https://ava-labs.atlassian.net/browse/CP-14832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ