### PR TITLE
CP-14604: reject WalletConnect signing requests from accounts not granted to the session

### DIFF
--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/ApprovalScreen.tsx
@@ -40,6 +40,7 @@ import { SpendLimits } from '../../components/SpendLimits/SpendLimits'
 import {
   getAccountSelector,
   getAccountUnavailableMessage,
+  getDisplayAccountAddress,
   getEthSendTxValidationError,
   getHasBalanceChange,
   getInitialGasLimit,
@@ -107,6 +108,15 @@ const ApprovalScreenInner = ({
 
   const accountSelector = getAccountSelector(signingData, activeWallet.id)
   const account = useSelector(accountSelector)
+  // Address shown in the Account row. Falls back to the resolved signer for
+  // methods whose module omits `displayData.account` (avalanche_signMessage),
+  // so the sheet always names the account that will sign. CP-14604.
+  const displayAccountAddress = getDisplayAccountAddress({
+    displayAccount: displayData.account,
+    signingData,
+    caip2ChainId,
+    resolvedAccount: account
+  })
   // The request targets an account that isn't in the active wallet, so it can't
   // be signed — surface a clear reason rather than just a disabled button.
   const requestedAccountUnavailable = isRequestedAccountUnavailable(
@@ -407,14 +417,14 @@ const ApprovalScreenInner = ({
   }, [displayData.dAppInfo, renderDappInfo])
 
   const renderAccountAndNetwork = useCallback((): JSX.Element | undefined => {
-    if (displayData.account && displayData.network) {
+    if (displayAccountAddress && displayData.network) {
       return (
         <View
           sx={{
             backgroundColor: '$surfaceSecondary',
             borderRadius: 12
           }}>
-          <Account address={displayData.account} />
+          <Account address={displayAccountAddress} />
           <Separator sx={{ marginHorizontal: 16 }} />
           <Network
             logoUri={displayData.network.logoUri}
@@ -437,10 +447,10 @@ const ApprovalScreenInner = ({
       )
     }
 
-    if (displayData.account) {
-      return <Account address={displayData.account} />
+    if (displayAccountAddress) {
+      return <Account address={displayAccountAddress} />
     }
-  }, [displayData.account, displayData.network, symbol, chainId])
+  }, [displayAccountAddress, displayData.network, symbol, chainId])
 
   const renderDetails = useCallback((): JSX.Element => {
     return (

--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/utils.test.ts
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/utils.test.ts
@@ -12,6 +12,7 @@ import {
   removeWebsiteItemIfNecessary,
   overrideContractItem,
   getAccountSelector,
+  getDisplayAccountAddress,
   isRequestedAccountUnavailable,
   getAccountUnavailableMessage
 } from './utils'
@@ -297,6 +298,83 @@ describe('isRequestedAccountUnavailable', () => {
 
   it('is false when the request does not target a specific account', () => {
     expect(isRequestedAccountUnavailable(withoutAccount, undefined)).toBe(false)
+  })
+})
+
+describe('getDisplayAccountAddress', () => {
+  const P_CHAIN = 'avax:Rr9hnPVPxuUvrdCul-vjEsU1zmqKqRDo'
+  const X_CHAIN = 'avax:imji8papUf2EhV3le337w1vgFauqkJg-'
+  const SOLANA = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
+
+  const resolvedAccount = {
+    addressC: '0xC0FFEE',
+    addressBTC: 'bc1qbtc',
+    addressAVM: 'X-avax1xchain',
+    addressPVM: 'P-avax1pchain',
+    addressCoreEth: '0xC0FFEE',
+    addressSVM: 'SoLaNaAddress'
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const avalancheSignMessage = { type: RpcMethod.AVALANCHE_SIGN_MESSAGE } as any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const solanaSignMessage = { type: RpcMethod.SOLANA_SIGN_MESSAGE } as any
+
+  it('prefers the address the module supplied', () => {
+    expect(
+      getDisplayAccountAddress({
+        displayAccount: 'module-supplied',
+        signingData: avalancheSignMessage,
+        caip2ChainId: P_CHAIN,
+        resolvedAccount
+      })
+    ).toBe('module-supplied')
+  })
+
+  it('falls back to the resolved signer for avalanche_signMessage on P-Chain', () => {
+    expect(
+      getDisplayAccountAddress({
+        displayAccount: undefined,
+        signingData: avalancheSignMessage,
+        caip2ChainId: P_CHAIN,
+        resolvedAccount
+      })
+    ).toBe('P-avax1pchain')
+  })
+
+  it('uses the X-Chain address when the request targets X-Chain', () => {
+    expect(
+      getDisplayAccountAddress({
+        displayAccount: undefined,
+        signingData: avalancheSignMessage,
+        caip2ChainId: X_CHAIN,
+        resolvedAccount
+      })
+    ).toBe('X-avax1xchain')
+  })
+
+  // Guards against a duplicate Account display: the SVM module already renders
+  // an "Account" row inside details for solana_signMessage.
+  it('does not fall back for methods whose module already shows the account', () => {
+    expect(
+      getDisplayAccountAddress({
+        displayAccount: undefined,
+        signingData: solanaSignMessage,
+        caip2ChainId: SOLANA,
+        resolvedAccount
+      })
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when no account resolved', () => {
+    expect(
+      getDisplayAccountAddress({
+        displayAccount: undefined,
+        signingData: avalancheSignMessage,
+        caip2ChainId: P_CHAIN,
+        resolvedAccount: undefined
+      })
+    ).toBeUndefined()
   })
 })
 

--- a/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/utils.ts
+++ b/packages/core-mobile/app/new/features/approval/screens/ApprovalScreen/utils.ts
@@ -17,6 +17,10 @@ import {
   selectAccountByIndex,
   selectActiveAccount
 } from 'store/account/slice'
+import {
+  CoreAccountAddresses,
+  getAddressForChainId
+} from 'store/rpc/handlers/wc_sessionRequest/utils'
 
 export const removeWebsiteItemIfNecessary = (
   item: DetailItem,
@@ -79,6 +83,45 @@ export const getAccountSelector = (
     return selectAccountByIndex(walletId, signingData.accountIndex)
   }
   return selectActiveAccount
+}
+
+// Address to show in the approval screen's Account row.
+//
+// Every other signing method pins its signer as an address, and its module puts
+// that address in `displayData.account`. `avalanche_signMessage` doesn't: its
+// signer is a dApp-supplied account *index* (or the active account), so the
+// avalanche module emits `network` with no `account` and the sheet renders the
+// network alone — leaving the user unable to see which account is about to sign.
+// That is precisely the check CP-14468 ("signing uses a different address than
+// the one shown in the approval prompt") exists to make possible.
+//
+// So fall back to the account the screen ALREADY resolved via getAccountSelector
+// — the same object handed to `onApprove` — which makes displayed-address ==
+// signing-address true by construction rather than by two sources agreeing.
+// Scoped to avalanche_signMessage: methods whose module already renders an
+// account (e.g. solana_signMessage's "Account" detail row) must not gain a
+// second, duplicate display. CP-14604.
+export const getDisplayAccountAddress = ({
+  displayAccount,
+  signingData,
+  caip2ChainId,
+  resolvedAccount
+}: {
+  displayAccount: string | undefined
+  signingData: SigningData
+  caip2ChainId: string
+  resolvedAccount: CoreAccountAddresses | undefined
+}): string | undefined => {
+  if (displayAccount) return displayAccount
+
+  if (
+    signingData.type !== RpcMethod.AVALANCHE_SIGN_MESSAGE ||
+    !resolvedAccount
+  ) {
+    return undefined
+  }
+
+  return getAddressForChainId(caip2ChainId, resolvedAccount)
 }
 
 // True when the request targets a specific account that isn't part of the active

--- a/packages/core-mobile/app/store/rpc/listeners/request/handleRequestViaVMModule.ts
+++ b/packages/core-mobile/app/store/rpc/listeners/request/handleRequestViaVMModule.ts
@@ -1,4 +1,4 @@
-import { rpcErrors } from '@metamask/rpc-errors'
+import { rpcErrors, providerErrors } from '@metamask/rpc-errors'
 import {
   Module,
   RpcMethod as VmModuleRpcMethod
@@ -11,8 +11,14 @@ import { mapToVmNetwork } from 'vmModule/utils/mapToVmNetwork'
 import { getChainIdFromCaip2 } from 'utils/caip2ChainIds'
 import { Avalanche } from '@avalabs/core-wallets-sdk'
 import { getAddressByVM } from 'store/account/utils'
-import { Account, selectActiveAccount } from 'store/account'
+import {
+  Account,
+  selectActiveAccount,
+  selectAccountByIndex
+} from 'store/account'
 import { selectActiveWallet } from 'store/wallet/slice'
+import WalletConnectService from 'services/walletconnectv2/WalletConnectService'
+import { isAvalancheSignMessageAuthorized } from 'store/rpc/utils/isAvalancheSignMessageAuthorized/isAvalancheSignMessageAuthorized'
 import { WalletType } from 'services/wallet/types'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
 import {
@@ -99,6 +105,33 @@ export const handleRequestViaVMModule = async ({
 
   const params = request.data.params.request.params
   const method = request.method as unknown as VmModuleRpcMethod
+
+  // avalanche_signMessage picks its signer by a dApp-supplied account index
+  // (params [message, accountIndex]), not a signingData.account address, so it
+  // slips past the ApprovalController grant check. Enforce the WalletConnect
+  // session grant here — on the same account the approval screen will sign with
+  // (selectAccountByIndex, or the active account when no index is given). No-op
+  // for every other method and for in-app / injected-browser requests; fails
+  // closed on a missing session. CP-14604.
+  if (
+    !isAvalancheSignMessageAuthorized({
+      method,
+      isInAppRequest: request.data.topic === CORE_MOBILE_TOPIC,
+      params,
+      caip2ChainId,
+      activeAccount,
+      getAccountByIndex: index =>
+        selectAccountByIndex(activeWallet.id, index)(state),
+      getSession: () => WalletConnectService.getSession(request.data.topic)
+    })
+  ) {
+    rpcProvider.onError({
+      request,
+      error: providerErrors.unauthorized('Requested address is not authorized'),
+      listenerApi
+    })
+    return
+  }
 
   // Merge, don't fallback: a non-empty `request.context` from the caller must
   // not suppress the per-method auto-injected context (e.g. Avalanche `account`

--- a/packages/core-mobile/app/store/rpc/utils/isAccountApproved/isAccountApproved.test.ts
+++ b/packages/core-mobile/app/store/rpc/utils/isAccountApproved/isAccountApproved.test.ts
@@ -1,4 +1,94 @@
-import { isAccountApproved } from './isAccountApproved'
+import { isAccountApproved, isAddressApproved } from './isAccountApproved'
+
+describe('isAddressApproved', () => {
+  const namespaces = {
+    eip155: {
+      accounts: [
+        'eip155:43113:0xC7E5ffBd7843EdB88cCB2ebaECAa07EC55c65318',
+        'eip155:43114:0xcA0E993876152ccA6053eeDFC753092c8cE712D0'
+      ],
+      methods: ['eth_sendTransaction'],
+      events: ['chainChanged', 'accountsChanged']
+    },
+    solana: {
+      accounts: [
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:9gQmZ7fTTgv5hVScrr9QqT6SpBs7i4cKLDdj4tuae3sW'
+      ],
+      methods: ['solana_signTransaction'],
+      events: []
+    }
+  }
+
+  it('returns true when the address is granted in the namespace', () => {
+    expect(
+      isAddressApproved(
+        '0xcA0E993876152ccA6053eeDFC753092c8cE712D0',
+        'eip155:43114',
+        namespaces
+      )
+    ).toBe(true)
+  })
+
+  it('matches addresses granted under another chain of the same namespace', () => {
+    expect(
+      isAddressApproved(
+        '0xC7E5ffBd7843EdB88cCB2ebaECAa07EC55c65318',
+        'eip155:43114',
+        namespaces
+      )
+    ).toBe(true)
+  })
+
+  it('matches case-insensitively', () => {
+    expect(
+      isAddressApproved(
+        '0xca0e993876152cca6053eedfc753092c8ce712d0',
+        'eip155:43114',
+        namespaces
+      )
+    ).toBe(true)
+  })
+
+  it('returns false when the address is not granted', () => {
+    expect(
+      isAddressApproved(
+        '0x341b0073b66bfc19FCB54308861f604F5Eb8f51b',
+        'eip155:43114',
+        namespaces
+      )
+    ).toBe(false)
+  })
+
+  it('returns true for a granted Solana account', () => {
+    expect(
+      isAddressApproved(
+        '9gQmZ7fTTgv5hVScrr9QqT6SpBs7i4cKLDdj4tuae3sW',
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        namespaces
+      )
+    ).toBe(true)
+  })
+
+  it('returns false for a Solana account that was never granted', () => {
+    expect(
+      isAddressApproved(
+        '4Nd1mYQZ6X8jY6nWn6iVrDpcLzJq9z2NKV1S1nGiqNz1',
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        namespaces
+      )
+    ).toBe(false)
+  })
+
+  it('returns false when the session has no namespace for the chain', () => {
+    expect(
+      isAddressApproved(
+        'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh',
+        'bip122:000000000019d6689c085ae165831e93',
+        namespaces
+      )
+    ).toBe(false)
+  })
+})
 
 describe('isAccountApproved', () => {
   it('should return true if address is approved', () => {

--- a/packages/core-mobile/app/store/rpc/utils/isAccountApproved/isAccountApproved.test.ts
+++ b/packages/core-mobile/app/store/rpc/utils/isAccountApproved/isAccountApproved.test.ts
@@ -39,7 +39,7 @@ describe('isAddressApproved', () => {
     ).toBe(true)
   })
 
-  it('matches case-insensitively', () => {
+  it('matches EVM addresses case-insensitively (EIP-55 checksum casing)', () => {
     expect(
       isAddressApproved(
         '0xca0e993876152cca6053eedfc753092c8ce712d0',
@@ -73,6 +73,16 @@ describe('isAddressApproved', () => {
     expect(
       isAddressApproved(
         '4Nd1mYQZ6X8jY6nWn6iVrDpcLzJq9z2NKV1S1nGiqNz1',
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        namespaces
+      )
+    ).toBe(false)
+  })
+
+  it('returns false for a case variant of a granted Solana account (base58 is case-sensitive)', () => {
+    expect(
+      isAddressApproved(
+        '9gqmz7fttgv5hvscrr9qqt6spbs7i4cklddj4tuae3sw',
         'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
         namespaces
       )

--- a/packages/core-mobile/app/store/rpc/utils/isAccountApproved/isAccountApproved.ts
+++ b/packages/core-mobile/app/store/rpc/utils/isAccountApproved/isAccountApproved.ts
@@ -4,12 +4,13 @@ import {
   getAddressForChainId
 } from 'store/rpc/handlers/wc_sessionRequest/utils'
 
-export const isAccountApproved = (
-  account: CoreAccountAddresses,
+// A granted account under ANY chain of the request's namespace authorizes the
+// address — sessions grant per-namespace account access, not per-chain.
+export const isAddressApproved = (
+  address: string,
   caip2ChainId: string,
   namespaces: SessionTypes.Namespaces
 ): boolean => {
-  const address = getAddressForChainId(caip2ChainId, account)
   const namespace = caip2ChainId.split(':')[0]
 
   if (!namespace || !namespaces[namespace]) {
@@ -17,9 +18,20 @@ export const isAccountApproved = (
   }
 
   return Boolean(
-    address &&
-      namespaces[namespace]?.accounts.some(
-        acc => acc.split(':')[2]?.toLowerCase() === address.toLowerCase()
-      )
+    namespaces[namespace]?.accounts.some(
+      acc => acc.split(':')[2]?.toLowerCase() === address.toLowerCase()
+    )
+  )
+}
+
+export const isAccountApproved = (
+  account: CoreAccountAddresses,
+  caip2ChainId: string,
+  namespaces: SessionTypes.Namespaces
+): boolean => {
+  const address = getAddressForChainId(caip2ChainId, account)
+
+  return Boolean(
+    address && isAddressApproved(address, caip2ChainId, namespaces)
   )
 }

--- a/packages/core-mobile/app/store/rpc/utils/isAccountApproved/isAccountApproved.ts
+++ b/packages/core-mobile/app/store/rpc/utils/isAccountApproved/isAccountApproved.ts
@@ -17,11 +17,15 @@ export const isAddressApproved = (
     return false
   }
 
-  return Boolean(
-    namespaces[namespace]?.accounts.some(
-      acc => acc.split(':')[2]?.toLowerCase() === address.toLowerCase()
-    )
-  )
+  // Only EVM hex addresses are case-insensitive (EIP-55 checksums vary the
+  // casing); other namespaces (e.g. base58 Solana) must match exactly.
+  const matches =
+    namespace === 'eip155'
+      ? (acc: string): boolean =>
+          acc.split(':')[2]?.toLowerCase() === address.toLowerCase()
+      : (acc: string): boolean => acc.split(':')[2] === address
+
+  return Boolean(namespaces[namespace]?.accounts.some(matches))
 }
 
 export const isAccountApproved = (

--- a/packages/core-mobile/app/store/rpc/utils/isAvalancheSignMessageAuthorized/isAvalancheSignMessageAuthorized.test.ts
+++ b/packages/core-mobile/app/store/rpc/utils/isAvalancheSignMessageAuthorized/isAvalancheSignMessageAuthorized.test.ts
@@ -1,0 +1,166 @@
+import { AvalancheCaip2ChainId } from '@avalabs/core-chains-sdk'
+import { RpcMethod } from '@avalabs/vm-module-types'
+import { SessionTypes } from '@walletconnect/types'
+import { CoreAccountAddresses } from 'store/rpc/handlers/wc_sessionRequest/utils'
+import { isAvalancheSignMessageAuthorized } from './isAvalancheSignMessageAuthorized'
+
+const X = AvalancheCaip2ChainId.X
+
+const GRANTED_AVM = 'X-fuji1granted00000000000000000000000000000'
+const UNGRANTED_AVM = 'X-fuji1ungranted000000000000000000000000000'
+
+const account = (addressAVM: string): CoreAccountAddresses => ({
+  addressC: '0xc0000000000000000000000000000000000000c0',
+  addressBTC: 'bc1qbtc',
+  addressCoreEth: '0xcoreeth',
+  addressAVM,
+  addressPVM: 'P-fuji1pvm',
+  addressSVM: 'svmAddr'
+})
+
+const sessionGranting = (addresses: string[]): SessionTypes.Struct =>
+  ({
+    namespaces: {
+      avax: {
+        accounts: addresses.map(a => `${X}:${a}`),
+        methods: ['avalanche_signMessage'],
+        events: []
+      }
+    }
+  } as unknown as SessionTypes.Struct)
+
+// Explicit index 1 → an ungranted account; anything else → a granted account.
+const getAccountByIndex = (index: number): CoreAccountAddresses | undefined =>
+  index === 1 ? account(UNGRANTED_AVM) : account(GRANTED_AVM)
+
+const base = {
+  method: RpcMethod.AVALANCHE_SIGN_MESSAGE as string,
+  isInAppRequest: false,
+  params: ['hello', 1] as unknown,
+  caip2ChainId: X as string,
+  activeAccount: account(GRANTED_AVM),
+  getAccountByIndex,
+  getSession: (): SessionTypes.Struct | undefined =>
+    sessionGranting([GRANTED_AVM])
+}
+
+describe('isAvalancheSignMessageAuthorized', () => {
+  it('is a no-op (authorized) for any method other than avalanche_signMessage', () => {
+    expect(
+      isAvalancheSignMessageAuthorized({
+        ...base,
+        method: RpcMethod.ETH_SIGN,
+        // would fail closed if the guard applied, proving it is skipped
+        getSession: () => {
+          throw new Error('should not be consulted')
+        }
+      })
+    ).toBe(true)
+  })
+
+  it('is a no-op (authorized) for in-app / injected-browser requests', () => {
+    expect(
+      isAvalancheSignMessageAuthorized({
+        ...base,
+        isInAppRequest: true,
+        getSession: () => {
+          throw new Error('should not be consulted')
+        }
+      })
+    ).toBe(true)
+  })
+
+  it('rejects when the dApp-supplied account index resolves to an ungranted account', () => {
+    // params [message, 1] → getAccountByIndex(1) → UNGRANTED_AVM
+    expect(isAvalancheSignMessageAuthorized(base)).toBe(false)
+  })
+
+  it('allows when the dApp-supplied account index resolves to a granted account', () => {
+    expect(
+      isAvalancheSignMessageAuthorized({ ...base, params: ['hello', 0] })
+    ).toBe(true)
+  })
+
+  it('falls back to the active account when no index is supplied (active granted → allow)', () => {
+    expect(
+      isAvalancheSignMessageAuthorized({ ...base, params: ['hello'] })
+    ).toBe(true)
+  })
+
+  it('falls back to the active account when no index is supplied (active ungranted → reject)', () => {
+    expect(
+      isAvalancheSignMessageAuthorized({
+        ...base,
+        params: ['hello'],
+        activeAccount: account(UNGRANTED_AVM)
+      })
+    ).toBe(false)
+  })
+
+  it('fails closed when no WC session exists for the topic', () => {
+    expect(
+      isAvalancheSignMessageAuthorized({
+        ...base,
+        params: ['hello', 0],
+        getSession: () => undefined
+      })
+    ).toBe(false)
+  })
+
+  it('fails closed when getSession throws (WC client not initialized)', () => {
+    expect(
+      isAvalancheSignMessageAuthorized({
+        ...base,
+        params: ['hello', 0],
+        getSession: () => {
+          throw new Error('WalletConnect client is not initialized')
+        }
+      })
+    ).toBe(false)
+  })
+
+  it('rejects a fractional index whose accounts[0] fallback is ungranted (schema allows non-integers)', () => {
+    // 0.5 passes the module schema (nonnegative, not .int()); selectAccountByIndex
+    // finds no match and signs with accounts[0]. The guard must check that same
+    // resolved account, not the (granted) active account — else the bypass reopens.
+    expect(
+      isAvalancheSignMessageAuthorized({
+        ...base,
+        params: ['hello', 0.5],
+        getAccountByIndex: () => account(UNGRANTED_AVM)
+      })
+    ).toBe(false)
+  })
+
+  it('allows a fractional index only when its resolved account is granted', () => {
+    expect(
+      isAvalancheSignMessageAuthorized({
+        ...base,
+        params: ['hello', 0.5],
+        getAccountByIndex: () => account(GRANTED_AVM)
+      })
+    ).toBe(true)
+  })
+
+  it('fails closed when the account index resolves to no account', () => {
+    expect(
+      isAvalancheSignMessageAuthorized({
+        ...base,
+        params: ['hello', 5],
+        getAccountByIndex: () => undefined
+      })
+    ).toBe(false)
+  })
+
+  it('treats an invalid (negative) index as absent and checks the active account', () => {
+    // module schema rejects negatives; our resolution mirrors the "no index"
+    // path (active account) rather than trusting a bogus dApp value
+    expect(
+      isAvalancheSignMessageAuthorized({
+        ...base,
+        params: ['hello', -1],
+        activeAccount: account(GRANTED_AVM)
+      })
+    ).toBe(true)
+  })
+})

--- a/packages/core-mobile/app/store/rpc/utils/isAvalancheSignMessageAuthorized/isAvalancheSignMessageAuthorized.ts
+++ b/packages/core-mobile/app/store/rpc/utils/isAvalancheSignMessageAuthorized/isAvalancheSignMessageAuthorized.ts
@@ -1,0 +1,78 @@
+import { RpcMethod } from '@avalabs/vm-module-types'
+import { SessionTypes } from '@walletconnect/types'
+import { CoreAccountAddresses } from 'store/rpc/handlers/wc_sessionRequest/utils'
+import { isAccountApproved } from 'store/rpc/utils/isAccountApproved/isAccountApproved'
+
+/**
+ * Request-time WalletConnect account authorization for `avalanche_signMessage`
+ * (CP-14604 follow-up).
+ *
+ * The ApprovalController grant check runs on `signingData.account` — the
+ * module-resolved signer address. `avalanche_signMessage` is the one signing
+ * method whose signer is chosen by a dApp-supplied account *index*
+ * (`params: [message, accountIndex]`) instead of an address, so its signingData
+ * carries `accountIndex`, not `account`, and the ApprovalController check never
+ * sees it. Without this, a dApp granted account A could request a signature from
+ * account B of the same wallet.
+ *
+ * This resolves the signer the same way the approval screen does
+ * (`getAccountSelector`): an explicit non-negative index selects that account
+ * via `selectAccountByIndex`; otherwise the active account signs. It then checks
+ * the resolved account against the session's granted accounts.
+ *
+ * Returns `true` (authorized / no-op) for every other method and for in-app /
+ * injected-browser requests, so callers can invoke it unconditionally. Fails
+ * closed: a missing WC session (deleted, expired, or client uninitialized) has
+ * no grant to check against and is treated as unauthorized.
+ */
+export const isAvalancheSignMessageAuthorized = ({
+  method,
+  isInAppRequest,
+  params,
+  caip2ChainId,
+  activeAccount,
+  getAccountByIndex,
+  getSession
+}: {
+  method: string
+  isInAppRequest: boolean
+  params: unknown
+  caip2ChainId: string
+  activeAccount: CoreAccountAddresses
+  getAccountByIndex: (index: number) => CoreAccountAddresses | undefined
+  getSession: () => SessionTypes.Struct | undefined
+}): boolean => {
+  if (isInAppRequest || method !== RpcMethod.AVALANCHE_SIGN_MESSAGE) {
+    return true
+  }
+
+  // Mirror the avalanche-module param shape ([message, accountIndex]). Its
+  // schema is z.number().nonnegative() — NOT .int() — so a fractional index
+  // (e.g. 0.5) is accepted and passed through to signingData.accountIndex, and
+  // both the approval screen and the signer resolve it via selectAccountByIndex,
+  // which finds no match and falls back to accounts[0]. We must therefore treat
+  // ANY non-negative finite number as an explicit index and resolve it the SAME
+  // way (getAccountByIndex), so the account we authorize is byte-for-byte the
+  // account that will sign. Checking the active account for a fractional index
+  // instead would reopen the exact bypass this guards against. A negative / NaN
+  // / non-numeric value is rejected by the module schema before signing, so we
+  // treat it as "no index" (active account) — inert either way.
+  const index = Array.isArray(params) ? params[1] : undefined
+  const hasExplicitIndex =
+    typeof index === 'number' && Number.isFinite(index) && index >= 0
+
+  const account = hasExplicitIndex ? getAccountByIndex(index) : activeAccount
+
+  let session: SessionTypes.Struct | undefined
+  try {
+    session = getSession()
+  } catch {
+    session = undefined
+  }
+
+  if (!account || !session) {
+    return false
+  }
+
+  return isAccountApproved(account, caip2ChainId, session.namespaces)
+}

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -70,6 +70,10 @@ jest.mock('services/ledger/LedgerService', () => ({
   __esModule: true,
   default: { disconnect: jest.fn() }
 }))
+jest.mock('services/walletconnectv2/WalletConnectService', () => ({
+  __esModule: true,
+  default: { getSession: jest.fn() }
+}))
 jest.mock(
   'services/walletconnectv2/walletConnectCache/walletConnectCache',
   () => {
@@ -160,6 +164,9 @@ const mockGetPublicKeyFor = jest.requireMock('services/wallet/WalletService')
   .default.getPublicKeyFor as jest.Mock
 const mockDisconnect = jest.requireMock('services/ledger/LedgerService').default
   .disconnect as jest.Mock
+const mockGetSession = jest.requireMock(
+  'services/walletconnectv2/WalletConnectService'
+).default.getSession as jest.Mock
 
 global.confetti = { restart: jest.fn() } as unknown as typeof global.confetti
 
@@ -1085,6 +1092,199 @@ describe('ApprovalController', () => {
       approvalController.handleGoBackIfNeeded({ excludeApproval: true })
 
       expect(mockRouter.back).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ── session account authorization (CP-14604) ─────────────────────────────
+
+  describe('session account authorization', () => {
+    const displayData = {} as never
+    const SOLANA_CHAIN_ID = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
+    const GRANTED_SVM_ADDRESS = '9gQmZ7fTTgv5hVScrr9QqT6SpBs7i4cKLDdj4tuae3sW'
+    const UNGRANTED_SVM_ADDRESS = '4Nd1mYQZ6X8jY6nWn6iVrDpcLzJq9z2NKV1S1nGiqNz1'
+
+    const makeSolanaSigningData = (account: string) =>
+      ({
+        type: RpcMethod.SOLANA_SIGN_TRANSACTION,
+        account,
+        data: 'serialized-tx'
+      } as never)
+
+    const sessionWithGrantedAccounts = {
+      namespaces: {
+        solana: {
+          accounts: [`${SOLANA_CHAIN_ID}:${GRANTED_SVM_ADDRESS}`],
+          methods: ['solana_signTransaction'],
+          events: []
+        }
+      }
+    } as never
+
+    it('rejects when the signing account was never granted to the WC session', async () => {
+      mockGetSession.mockReturnValue(sessionWithGrantedAccounts)
+
+      const request = makeDappRequest(
+        RpcMethod.SOLANA_SIGN_TRANSACTION,
+        SOLANA_CHAIN_ID
+      )
+
+      const result = await approvalController.requestApproval({
+        request,
+        displayData,
+        signingData: makeSolanaSigningData(UNGRANTED_SVM_ADDRESS)
+      })
+
+      expect(mockGetSession).toHaveBeenCalledWith(DAPP_SESSION_ID)
+      expect('error' in result && result.error).toMatchObject({
+        message: 'Requested address is not authorized'
+      })
+      expect(mockRouter.navigate).not.toHaveBeenCalled()
+      expect(mockWalletConnectCacheSet).not.toHaveBeenCalled()
+    })
+
+    it('shows the approval screen when the signing account is granted to the WC session', () => {
+      mockGetSession.mockReturnValue(sessionWithGrantedAccounts)
+
+      const request = makeDappRequest(
+        RpcMethod.SOLANA_SIGN_TRANSACTION,
+        SOLANA_CHAIN_ID
+      )
+
+      approvalController.requestApproval({
+        request,
+        displayData,
+        signingData: makeSolanaSigningData(GRANTED_SVM_ADDRESS)
+      })
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(
+        expect.objectContaining({ pathname: '/approval' })
+      )
+    })
+
+    it('never queries the WC client for in-app / injected-browser requests (WC may be uninitialized)', () => {
+      const request = makeInjectedDappRequest(
+        RpcMethod.SOLANA_SIGN_TRANSACTION,
+        SOLANA_CHAIN_ID
+      )
+
+      approvalController.requestApproval({
+        request,
+        displayData,
+        signingData: makeSolanaSigningData(UNGRANTED_SVM_ADDRESS)
+      })
+
+      expect(mockGetSession).not.toHaveBeenCalled()
+      expect(mockRouter.navigate).toHaveBeenCalledWith(
+        expect.objectContaining({ pathname: '/approval' })
+      )
+    })
+
+    it('skips the check when no WC session exists for the topic', () => {
+      mockGetSession.mockReturnValue(undefined)
+
+      const request = makeDappRequest(
+        RpcMethod.SOLANA_SIGN_TRANSACTION,
+        SOLANA_CHAIN_ID
+      )
+
+      approvalController.requestApproval({
+        request,
+        displayData,
+        signingData: makeSolanaSigningData(UNGRANTED_SVM_ADDRESS)
+      })
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(
+        expect.objectContaining({ pathname: '/approval' })
+      )
+    })
+
+    it('rejects an EVM transaction whose from-address was never granted to the WC session', async () => {
+      mockGetSession.mockReturnValue({
+        namespaces: {
+          eip155: {
+            accounts: [`eip155:43114:${EVM_ADDRESS}`],
+            methods: ['eth_sendTransaction'],
+            events: []
+          }
+        }
+      } as never)
+
+      const request = makeDappRequest(
+        RpcMethod.ETH_SEND_TRANSACTION,
+        'eip155:43114'
+      )
+
+      const result = await approvalController.requestApproval({
+        request,
+        displayData,
+        signingData: {
+          type: RpcMethod.ETH_SEND_TRANSACTION,
+          account: '0x341b0073b66bfc19FCB54308861f604F5Eb8f51b',
+          data: {}
+        } as never
+      })
+
+      expect('error' in result && result.error).toMatchObject({
+        message: 'Requested address is not authorized'
+      })
+      expect(mockRouter.navigate).not.toHaveBeenCalled()
+    })
+
+    it('accepts an EVM address granted under a different chain of the eip155 namespace', () => {
+      mockGetSession.mockReturnValue({
+        namespaces: {
+          eip155: {
+            accounts: [`eip155:1:${EVM_ADDRESS}`],
+            methods: ['eth_sendTransaction'],
+            events: []
+          }
+        }
+      } as never)
+
+      const request = makeDappRequest(
+        RpcMethod.ETH_SEND_TRANSACTION,
+        'eip155:43114'
+      )
+
+      approvalController.requestApproval({
+        request,
+        displayData,
+        signingData: {
+          type: RpcMethod.ETH_SEND_TRANSACTION,
+          // lowercased vs the checksummed EVM_ADDRESS in the session grant —
+          // dApp-supplied casing must not defeat authorization
+          account: EVM_ADDRESS.toLowerCase(),
+          data: {}
+        } as never
+      })
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(
+        expect.objectContaining({ pathname: '/approval' })
+      )
+    })
+
+    it('skips the check for signing data that carries no account (avalanche transactions)', () => {
+      mockGetSession.mockReturnValue(sessionWithGrantedAccounts)
+
+      const request = makeDappRequest(
+        RpcMethod.AVALANCHE_SEND_TRANSACTION,
+        AvalancheCaip2ChainId.P
+      )
+
+      approvalController.requestApproval({
+        request,
+        displayData,
+        signingData: {
+          type: RpcMethod.AVALANCHE_SEND_TRANSACTION,
+          unsignedTxJson: '{}',
+          data: {},
+          vm: 'PVM'
+        } as never
+      })
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(
+        expect.objectContaining({ pathname: '/approval' })
+      )
     })
   })
 

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -1099,6 +1099,14 @@ describe('ApprovalController', () => {
 
   describe('session account authorization', () => {
     const displayData = {} as never
+
+    // Accept-path assertions flush pending (micro)tasks first so they keep
+    // failing loudly if navigation ever moves behind an await inside
+    // requestApproval (the returned promise itself only settles on
+    // approve/reject, so it can't be awaited here). Matches the helper in
+    // the cancel-bridge describe block.
+    const flushMicrotasks = (): Promise<void> =>
+      new Promise(resolve => setTimeout(resolve, 0))
     const SOLANA_CHAIN_ID = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
     const GRANTED_SVM_ADDRESS = '9gQmZ7fTTgv5hVScrr9QqT6SpBs7i4cKLDdj4tuae3sW'
     const UNGRANTED_SVM_ADDRESS = '4Nd1mYQZ6X8jY6nWn6iVrDpcLzJq9z2NKV1S1nGiqNz1'
@@ -1142,7 +1150,7 @@ describe('ApprovalController', () => {
       expect(mockWalletConnectCacheSet).not.toHaveBeenCalled()
     })
 
-    it('shows the approval screen when the signing account is granted to the WC session', () => {
+    it('shows the approval screen when the signing account is granted to the WC session', async () => {
       mockGetSession.mockReturnValue(sessionWithGrantedAccounts)
 
       const request = makeDappRequest(
@@ -1155,13 +1163,14 @@ describe('ApprovalController', () => {
         displayData,
         signingData: makeSolanaSigningData(GRANTED_SVM_ADDRESS)
       })
+      await flushMicrotasks()
 
       expect(mockRouter.navigate).toHaveBeenCalledWith(
         expect.objectContaining({ pathname: '/approval' })
       )
     })
 
-    it('never queries the WC client for in-app / injected-browser requests (WC may be uninitialized)', () => {
+    it('never queries the WC client for in-app / injected-browser requests (WC may be uninitialized)', async () => {
       const request = makeInjectedDappRequest(
         RpcMethod.SOLANA_SIGN_TRANSACTION,
         SOLANA_CHAIN_ID
@@ -1172,6 +1181,7 @@ describe('ApprovalController', () => {
         displayData,
         signingData: makeSolanaSigningData(UNGRANTED_SVM_ADDRESS)
       })
+      await flushMicrotasks()
 
       expect(mockGetSession).not.toHaveBeenCalled()
       expect(mockRouter.navigate).toHaveBeenCalledWith(
@@ -1179,7 +1189,7 @@ describe('ApprovalController', () => {
       )
     })
 
-    it('skips the check when no WC session exists for the topic', () => {
+    it('rejects (fails closed) when no WC session exists for the topic', async () => {
       mockGetSession.mockReturnValue(undefined)
 
       const request = makeDappRequest(
@@ -1187,15 +1197,38 @@ describe('ApprovalController', () => {
         SOLANA_CHAIN_ID
       )
 
-      approvalController.requestApproval({
+      const result = await approvalController.requestApproval({
         request,
         displayData,
-        signingData: makeSolanaSigningData(UNGRANTED_SVM_ADDRESS)
+        signingData: makeSolanaSigningData(GRANTED_SVM_ADDRESS)
       })
 
-      expect(mockRouter.navigate).toHaveBeenCalledWith(
-        expect.objectContaining({ pathname: '/approval' })
+      expect('error' in result && result.error).toMatchObject({
+        message: 'Requested address is not authorized'
+      })
+      expect(mockRouter.navigate).not.toHaveBeenCalled()
+    })
+
+    it('rejects (fails closed) when the WC client is not initialized (getSession throws)', async () => {
+      mockGetSession.mockImplementation(() => {
+        throw new Error('WalletConnect client is not initialized')
+      })
+
+      const request = makeDappRequest(
+        RpcMethod.SOLANA_SIGN_TRANSACTION,
+        SOLANA_CHAIN_ID
       )
+
+      const result = await approvalController.requestApproval({
+        request,
+        displayData,
+        signingData: makeSolanaSigningData(GRANTED_SVM_ADDRESS)
+      })
+
+      expect('error' in result && result.error).toMatchObject({
+        message: 'Requested address is not authorized'
+      })
+      expect(mockRouter.navigate).not.toHaveBeenCalled()
     })
 
     it('rejects an EVM transaction whose from-address was never granted to the WC session', async () => {
@@ -1230,7 +1263,7 @@ describe('ApprovalController', () => {
       expect(mockRouter.navigate).not.toHaveBeenCalled()
     })
 
-    it('accepts an EVM address granted under a different chain of the eip155 namespace', () => {
+    it('accepts an EVM address granted under a different chain of the eip155 namespace', async () => {
       mockGetSession.mockReturnValue({
         namespaces: {
           eip155: {
@@ -1257,13 +1290,14 @@ describe('ApprovalController', () => {
           data: {}
         } as never
       })
+      await flushMicrotasks()
 
       expect(mockRouter.navigate).toHaveBeenCalledWith(
         expect.objectContaining({ pathname: '/approval' })
       )
     })
 
-    it('skips the check for signing data that carries no account (avalanche transactions)', () => {
+    it('skips the check for signing data that carries no account (avalanche transactions)', async () => {
       mockGetSession.mockReturnValue(sessionWithGrantedAccounts)
 
       const request = makeDappRequest(
@@ -1281,6 +1315,7 @@ describe('ApprovalController', () => {
           vm: 'PVM'
         } as never
       })
+      await flushMicrotasks()
 
       expect(mockRouter.navigate).toHaveBeenCalledWith(
         expect.objectContaining({ pathname: '/approval' })

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.test.ts
@@ -1321,6 +1321,121 @@ describe('ApprovalController', () => {
         expect.objectContaining({ pathname: '/approval' })
       )
     })
+
+    // avalanche_signMessage's signer is resolved from LIVE state at approval
+    // time, so the request-time gate (in handleRequestViaVMModule) can be
+    // outrun by a mid-flight account/wallet switch. ApprovalController re-checks
+    // the account that is actually about to sign. CP-14604.
+    describe('avalanche_signMessage approval-time recheck (TOCTOU)', () => {
+      const X = AvalancheCaip2ChainId.X
+      const GRANTED_AVM = 'X-fuji1granted00000000000000000000000000000'
+      const UNGRANTED_AVM = 'X-fuji1ungranted000000000000000000000000000'
+
+      const avmAccount = (addressAVM: string): never =>
+        ({
+          addressC: '0xc0000000000000000000000000000000000000c0',
+          addressBTC: 'bc1qbtc',
+          addressCoreEth: '0xcoreeth',
+          addressAVM,
+          index: 1
+        } as never)
+
+      const avaxSessionGranting = (addressAVM: string): never =>
+        ({
+          namespaces: {
+            avax: {
+              accounts: [`${X}:${addressAVM}`],
+              methods: ['avalanche_signMessage'],
+              events: []
+            }
+          }
+        } as never)
+
+      const signMessageSigningData = {
+        type: RpcMethod.AVALANCHE_SIGN_MESSAGE,
+        data: 'deadbeef',
+        accountIndex: 1
+      } as never
+
+      const captureOnApprove = (): ((params: unknown) => Promise<void>) =>
+        mockWalletConnectCacheSet.mock.calls[
+          mockWalletConnectCacheSet.mock.calls.length - 1
+        ][0].onApprove
+
+      it('rejects at approval time when the live signer is not granted', async () => {
+        mockGetSession.mockReturnValue(avaxSessionGranting(GRANTED_AVM))
+        // getAddressForChainId is mocked in this suite — resolve the live
+        // signer to its (ungranted) X-chain address so real grant matching runs
+        mockGetAddressForChainId.mockReturnValue(UNGRANTED_AVM)
+
+        const resultPromise = approvalController.requestApproval({
+          request: makeDappRequest(RpcMethod.AVALANCHE_SIGN_MESSAGE, X),
+          displayData,
+          signingData: signMessageSigningData
+        })
+        await flushMicrotasks()
+
+        // user switched to an ungranted account before tapping Approve
+        await captureOnApprove()({
+          walletType: WalletType.MNEMONIC,
+          walletId: 'w1',
+          account: avmAccount(UNGRANTED_AVM)
+        })
+
+        const result = await resultPromise
+        expect('error' in result && result.error).toMatchObject({
+          message: 'Requested address is not authorized'
+        })
+        expect(mockOnApprove).not.toHaveBeenCalled()
+      })
+
+      it('signs when the live signer is granted', async () => {
+        mockGetSession.mockReturnValue(avaxSessionGranting(GRANTED_AVM))
+        mockGetAddressForChainId.mockReturnValue(GRANTED_AVM)
+
+        approvalController.requestApproval({
+          request: makeDappRequest(RpcMethod.AVALANCHE_SIGN_MESSAGE, X),
+          displayData,
+          signingData: signMessageSigningData
+        })
+        await flushMicrotasks()
+
+        await captureOnApprove()({
+          walletType: WalletType.MNEMONIC,
+          walletId: 'w1',
+          account: avmAccount(GRANTED_AVM)
+        })
+
+        expect(mockOnApprove).toHaveBeenCalledWith(
+          expect.objectContaining({ signingData: signMessageSigningData })
+        )
+      })
+
+      it('fails closed when the session is gone by approval time', async () => {
+        mockGetSession.mockReturnValue(avaxSessionGranting(GRANTED_AVM))
+        mockGetAddressForChainId.mockReturnValue(GRANTED_AVM)
+
+        const resultPromise = approvalController.requestApproval({
+          request: makeDappRequest(RpcMethod.AVALANCHE_SIGN_MESSAGE, X),
+          displayData,
+          signingData: signMessageSigningData
+        })
+        await flushMicrotasks()
+
+        mockGetSession.mockReturnValue(undefined) // dropped mid-flight
+        await captureOnApprove()({
+          walletType: WalletType.MNEMONIC,
+          walletId: 'w1',
+          account: avmAccount(GRANTED_AVM)
+        })
+
+        const result = await resultPromise
+        expect('error' in result && result.error).toMatchObject({
+          message: 'Requested address is not authorized'
+        })
+        expect(mockOnApprove).not.toHaveBeenCalled()
+      })
+    })
   })
 
   // ── requestApproval ───────────────────────────────────────────────────────

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -551,10 +551,19 @@ class ApprovalController implements VmModuleApprovalController {
     // Avalanche signingData variants carry no `account` and are knowingly not
     // checked: the avax namespace is only ever granted to Core-domain dApps,
     // and those methods always sign with the active account the user sees.
+    // Fails closed: a request with no live session (deleted/expired mid-flight,
+    // or WC uninitialized) has no grants to check against, so it's rejected —
+    // its response is undeliverable anyway.
     if ('account' in signingData && !isInAppRequest(request)) {
-      const session = WalletConnectService.getSession(request.sessionId)
+      const session = (() => {
+        try {
+          return WalletConnectService.getSession(request.sessionId)
+        } catch {
+          return undefined
+        }
+      })()
       if (
-        session &&
+        !session ||
         !isAddressApproved(
           signingData.account,
           request.chainId,

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -33,6 +33,9 @@ import WalletService from 'services/wallet/WalletService'
 import { Curve } from 'utils/publicKeys'
 import { ledgerParamsStore } from 'features/ledger/store'
 import { OnApproveParams } from 'services/walletconnectv2/walletConnectCache/types'
+import WalletConnectService from 'services/walletconnectv2/WalletConnectService'
+import { providerErrors } from '@metamask/rpc-errors'
+import { isAddressApproved } from 'store/rpc/utils/isAccountApproved/isAccountApproved'
 import { WalletType } from 'services/wallet/types'
 import { promptForAppReviewAfterSuccessfulTransaction } from 'features/appReview/utils/promptForAppReviewAfterSuccessfulTransaction'
 import { CONFETTI_DURATION_MS } from 'common/consts'
@@ -537,6 +540,34 @@ class ApprovalController implements VmModuleApprovalController {
     const { request, displayData, signingData } = params
     const requestId = request.requestId
     this.userCancelledMap.delete(requestId)
+
+    // A dApp may only sign with accounts the user granted to its WalletConnect
+    // session (session.namespaces) — enforced pre-vm-module via
+    // isAddressApproved and lost in the migration (CP-14604). signingData
+    // .account is the module-resolved signer, so this checks exactly the
+    // address that would sign. In-app and injected-browser requests
+    // (CORE_MOBILE_TOPIC) are excluded: they keep their own account gating,
+    // and getSession would throw while the WC client is still initializing.
+    // Avalanche signingData variants carry no `account` and are knowingly not
+    // checked: the avax namespace is only ever granted to Core-domain dApps,
+    // and those methods always sign with the active account the user sees.
+    if ('account' in signingData && !isInAppRequest(request)) {
+      const session = WalletConnectService.getSession(request.sessionId)
+      if (
+        session &&
+        !isAddressApproved(
+          signingData.account,
+          request.chainId,
+          session.namespaces
+        )
+      ) {
+        return {
+          error: providerErrors.unauthorized(
+            'Requested address is not authorized'
+          )
+        }
+      }
+    }
 
     // Quick Swaps bypass — sync find then async run keeps the common
     // (no-validator) path microtask-free so the modal navigation

--- a/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
+++ b/packages/core-mobile/app/vmModule/ApprovalController/ApprovalController.ts
@@ -7,7 +7,8 @@ import {
   BatchApprovalParams,
   BatchApprovalResponse,
   RpcRequest,
-  RequestPublicKeyParams
+  RequestPublicKeyParams,
+  RpcMethod
 } from '@avalabs/vm-module-types'
 import { walletConnectCache } from 'services/walletconnectv2/walletConnectCache/walletConnectCache'
 import { transactionSnackbar } from 'new/common/utils/toast'
@@ -35,7 +36,10 @@ import { ledgerParamsStore } from 'features/ledger/store'
 import { OnApproveParams } from 'services/walletconnectv2/walletConnectCache/types'
 import WalletConnectService from 'services/walletconnectv2/WalletConnectService'
 import { providerErrors } from '@metamask/rpc-errors'
-import { isAddressApproved } from 'store/rpc/utils/isAccountApproved/isAccountApproved'
+import {
+  isAddressApproved,
+  isAccountApproved
+} from 'store/rpc/utils/isAccountApproved/isAccountApproved'
 import { WalletType } from 'services/wallet/types'
 import { promptForAppReviewAfterSuccessfulTransaction } from 'features/appReview/utils/promptForAppReviewAfterSuccessfulTransaction'
 import { CONFETTI_DURATION_MS } from 'common/consts'
@@ -355,6 +359,19 @@ class ApprovalController implements VmModuleApprovalController {
     this.activeApprovals.delete(requestId)
   }
 
+  // WalletConnect session for a request's topic, or undefined. getSession throws
+  // while the WC client is still initializing (and returns undefined for an
+  // unknown/expired topic); both collapse to undefined so callers fail closed.
+  private getSessionOrUndefined(
+    sessionId: string
+  ): ReturnType<typeof WalletConnectService.getSession> {
+    try {
+      return WalletConnectService.getSession(sessionId)
+    } catch {
+      return undefined
+    }
+  }
+
   // Cancel a parked approval whose request was aborted. Runs the REAL reject so
   // the orphaned promise settles and Ledger BLE + store are torn down; once
   // on-device Ledger signing has begun (`ledgerSigning`) the cancel is a no-op.
@@ -507,6 +524,33 @@ class ApprovalController implements VmModuleApprovalController {
     // up; a late Approve tap must not sign/broadcast. (CP-14422)
     if (this.userCancelledMap.get(requestId)) return
 
+    // avalanche_signMessage picks its signer from LIVE state at approval time
+    // (getAccountSelector → active account or dApp-supplied index), so re-verify
+    // the account that is actually about to sign against the WC session grant.
+    // The request-time gate in handleRequestViaVMModule checks dispatch-time
+    // state and can be outrun by a mid-flight account/wallet switch; every other
+    // method pins its signer as signingData.account (already grant-checked in
+    // requestApproval). In-app requests keep their own gating; fails closed on a
+    // missing session. CP-14604.
+    if (
+      signingData.type === RpcMethod.AVALANCHE_SIGN_MESSAGE &&
+      !isInAppRequest(request)
+    ) {
+      const session = this.getSessionOrUndefined(request.sessionId)
+      if (
+        !session ||
+        !isAccountApproved(params.account, request.chainId, session.namespaces)
+      ) {
+        this.clearCancelBridge(requestId)
+        resolve({
+          error: providerErrors.unauthorized(
+            'Requested address is not authorized'
+          )
+        })
+        return
+      }
+    }
+
     // Cache the actual selected signer so onTransactionConfirmed /
     // onTransactionReverted emit the real address for dApp txs — including
     // the injected browser (which the !isInAppRequest gate excluded,
@@ -548,20 +592,16 @@ class ApprovalController implements VmModuleApprovalController {
     // address that would sign. In-app and injected-browser requests
     // (CORE_MOBILE_TOPIC) are excluded: they keep their own account gating,
     // and getSession would throw while the WC client is still initializing.
-    // Avalanche signingData variants carry no `account` and are knowingly not
-    // checked: the avax namespace is only ever granted to Core-domain dApps,
-    // and those methods always sign with the active account the user sees.
+    // Avalanche signingData variants carry no `account`, so they aren't checked
+    // here: AVALANCHE_SEND/SIGN_TRANSACTION sign with the server-injected active
+    // account (getContext in handleRequestViaVMModule), and avalanche_signMessage
+    // — the one method whose signer is a dApp-supplied account index — is grant-
+    // checked upstream in handleRequestViaVMModule (isAvalancheSignMessageAuthorized).
     // Fails closed: a request with no live session (deleted/expired mid-flight,
     // or WC uninitialized) has no grants to check against, so it's rejected —
     // its response is undeliverable anyway.
     if ('account' in signingData && !isInAppRequest(request)) {
-      const session = (() => {
-        try {
-          return WalletConnectService.getSession(request.sessionId)
-        } catch {
-          return undefined
-        }
-      })()
+      const session = this.getSessionOrUndefined(request.sessionId)
       if (
         !session ||
         !isAddressApproved(


### PR DESCRIPTION
## Description

**Ticket: [CP-14604](https://ava-labs.atlassian.net/browse/CP-14604)**

Restores WalletConnect request-time session-account authorization that was lost in the vm-module migration (CP-8450 left a TODO, CP-8365/CP-8916 removed the legacy `isAddressApproved` check). Since then, a connected dApp could request signing with **any** account in the active wallet, including accounts the user never granted to that dApp's session.

This is the follow-up Bogdan split out of CP-14468. PR #3906 closed the cross-wallet case (different wallet, same index) with the `account.walletId !== walletId` guard. Two accounts in the *same* wallet share a `walletId`, so that guard waves them through, and this PR closes that remaining hole.

Worth flagging for reviewers: CP-14604's ticket description is Eunji's jup.ag regression checklist copied from CP-14468. Steps 1 to 5 are a non-regression check, not a reproduction of the bug. The happy path was never broken on main.

**Changes:**

- `isAccountApproved.ts`: adds `isAddressApproved(address, caip2ChainId, namespaces)`, an address-based sibling of the existing (previously unused) helper. Checks the address against the session's granted accounts for the request's CAIP-2 namespace, any chain within the namespace. Case-insensitive for EVM, exact match for non-EVM addresses, since Solana base58 and Avalanche bech32 are case-sensitive. `isAccountApproved` now delegates to it.
- `ApprovalController.requestApproval`: when `signingData` carries an `account` (the module-resolved signer, covering EVM tx, all EVM message signing, all 3 Solana methods, both Bitcoin methods) and the request is not in-app, the WC session for the request's topic is looked up and the request is rejected with `providerErrors.unauthorized('Requested address is not authorized')`, the same error as pre-migration, before the approval screen opens.
- `isAvalancheSignMessageAuthorized.ts` plus a call site in `handleRequestViaVMModule`: `avalanche_signMessage` is the one signing method whose signer is chosen by a dApp-supplied account *index* rather than an address, so its `signingData` carries `accountIndex` and never reaches the check above. This resolves the signer the same way the approval screen does and checks it against the session grant at dispatch time.
- `ApprovalController.onApprove`: re-checks `avalanche_signMessage` at approval time, because that method picks its signer from live state and could otherwise be outrun by a programmatic account switch between dispatch and approval.
- `ApprovalScreen/utils.ts` and `ApprovalScreen.tsx`: new `getDisplayAccountAddress()`. The `avalanche_signMessage` approval sheet previously showed no account at all, only Network and the message, because the avalanche module emits only `network` where the SVM module emits an `addressItem`. On a ticket whose entire subject is "the signed address must match the displayed address", the user could not actually perform that check. This falls back to the account the screen already resolved via `getAccountSelector`, so the address shown is the same object handed to `onApprove` and displayed equals signer by construction rather than by two sources agreeing. Scoped to `avalanche_signMessage` so `solana_signMessage` does not gain a duplicate row.

**Design notes:**

- Enforced at the ApprovalController (a single chokepoint on the exact address that will sign) instead of `validateRequest`, which avoids per-method param parsing that could drift from the VM modules.
- The `!isInAppRequest(request)` guard is load-bearing. `WalletConnectService.getSession` throws while the WC client is initializing, so in-app Send/Swap during app startup must not touch it. In-app and injected-browser requests ride `CORE_MOBILE_TOPIC` (a per-launch uuid, not spoofable by a dApp) and keep their own account gating.
- Fails closed. A request with no live session (deleted or expired mid-flight, or WC uninitialized) has no grants to check against, so it is rejected. Its response is undeliverable anyway.
- `AVALANCHE_SEND/SIGN_TRANSACTION` are still not checked, and that is deliberate rather than an oversight: their `signingData` carries no `account` and they sign with the server-injected active account (`getContext` in `handleRequestViaVMModule`), which is the account the user can see.
- Legit flows cannot be falsely rejected. The SVM module schemas require the signer account in request params and never fall back to the active account, and dApps only ever learn granted accounts (`accountsChanged` grants before it announces).

**Correction to an earlier version of this description:** it claimed the `avax` namespace is only granted to Core-domain dApps. That is not true. A test dApp self-identifying as `https://jup.ag` was offered and granted the `avax` namespace with both P-Chain and X-Chain, reproduced twice during dev testing. `isCoreDomain()` trusts a dApp-supplied metadata string. That makes the `avalanche_signMessage` half of this PR load-bearing rather than defense in depth.

**Dependencies:** rebased onto main. The branch had been sitting on stale `@avalabs/*-module` 3.9.0 pins while main moved to 4.0.1 in #4014, and 4.0.1's avalanche module requires the `getAuthHeaders` wiring main added in #4012. No conflicts, and no changes to `package.json` or `yarn.lock` from this branch.

## Screenshots/Videos

Android, Pixel 8 Pro, internal build, on the merged 4.0.1 tree. Setup in every shot: one wallet with 7 accounts, a WalletConnect session granting **only Account 1**, and Core's active account left on **Account 2**.

The authorization change itself has deliberately nothing to show, because rejected requests never open a sheet. A recording of those paths is a still portfolio, so the evidence for them is the dApp-side error codes and timings in the Testing section. The one visible change is the display fix:

<table>
<tr>
<td width="50%"><b>Before</b><br>Network and message only. No account shown, so the user cannot check the signed address against the displayed one.</td>
<td width="50%"><b>After</b><br><code>Account: P-avax1jsp…f2mrt</code>, matching the granted <code>P-avax1jsphj9g0unpdjs354gxsdmkylducq36v3f2mrt</code>, while Core sat on Account 2.</td>
</tr>
<tr>
<td><img width="320" alt="01-BEFORE-avalanche_signMessage-no-account-row" src="https://github.com/user-attachments/assets/36aaec4b-abb7-4e37-ba95-7bc827c84610" /></td>
<td><img width="320" alt="02-AFTER-avalanche_signMessage-shows-account-P-avax1jsp" src="https://github.com/user-attachments/assets/09a33712-c8da-41fe-bd99-ba82bdc5ddd7" /></td>
</tr>
</table>

Same request (`avalanche_signMessage`, `accountIndex: 0`) on the same tree, before and after the fix.

<details>
<summary><b>Supporting captures</b> (7): display-fix regression, approval paths, the control, a reject path, and case R</summary>

<br>

**Display-fix regression: `solana_signMessage` still shows exactly one Account row**, so the change did not add a duplicate.

<img width="320" alt="03-solana_signMessage-still-single-account-row" src="https://github.com/user-attachments/assets/c2e7c686-000d-4c0e-b049-56d47ff21463" />

**Case A. `solana_signMessage` from granted Account 1.** Sheet shows `8rxgp3YA…M14U`. The returned signature verifies against Account 1 and fails against Account 2.

<img width="320" alt="04-caseA-solana_signMessage-shows-granted-account-1" src="https://github.com/user-attachments/assets/349558ee-cbdd-4b39-ab2a-0769f4f0cddc" />

**Case D. `solana_signTransaction`, real Jupiter swap, granted Account 1.** `From 8rxgp3YA…M14U`. The "may fail" warning is expected: Account 1 holds almost no SOL, so Blockaid's simulation errors.

<img width="320" alt="05-caseD-solana_signTransaction-jupiter-from-account-1" src="https://github.com/user-attachments/assets/faa3b851-9098-4ea0-99b7-3b704ce93ba7" />

**Case I, the control. `accountIndex: 1` where Account 2 *is* granted.** Correctly reaches the approval screen rather than being gated. Rejecting in the UI returned `4001`, not `4100`, which shows the gate did not short-circuit it.

<img width="320" alt="06-caseI-control-index1-granted-reaches-approval" src="https://github.com/user-attachments/assets/27e3a40f-6391-444e-ac61-040842d35eac" />

**Case B. What a reject actually looks like.** The screen immediately after a rejected request: portfolio sitting still, no sheet ever opened. Pair with the dApp-side `4100` at 929ms.

<img width="320" alt="07-caseB-reject-no-sheet-portfolio-unchanged" src="https://github.com/user-attachments/assets/50d94fbf-ae2f-4ad2-b399-aad1136ee24c" />

**Case R, the strongest regression check.** In-app Send with `From A8PsKy2J…ZTYT`, which is Account 2, an account the live WC session does **not** grant. Correctly not gated, then broadcast and finalized on mainnet as `gbvYRX6N…Tuz9TU`.

<img width="320" alt="08-caseR-inapp-send-FROM-non-granted-account-2" src="https://github.com/user-attachments/assets/1b3f2c9b-966e-493f-8248-d0673daf6068" />

**The session grant used throughout:** 1 of 7 accounts, Account 1 only.

<img width="320" alt="09-wc-session-granting-only-account-1" src="https://github.com/user-attachments/assets/51e9bc73-1cb0-4c1e-803f-c84acb509719" />

</details>

iOS not covered in this round.

## Testing

Bitrise: iOS 9439, Android 9440.

Unit: 200 tests across 9 suites (`ApprovalController` and its validators, `quickSwapsBypass`, `isAccountApproved`, `isAvalancheSignMessageAuthorized`, `ApprovalScreen/utils`). Full `tsc -p .` clean.

**Dev Testing (if applicable)**

Verified on device (Android, Pixel 8 Pro, internal build) against a real WalletConnect v2 dApp harness that lets the requesting account be chosen per request. Setup throughout: mainnet, one wallet with 7 accounts, a WC session granting **only Account 1**, and Core's active account left on **Account 2**, which is exactly this ticket's scope.

| # | Scenario | Expected | Result |
|---|---|---|---|
| A | `solana_signMessage`, granted Acct 1 | Sheet shows Acct 1, signs | PASS. Sheet showed `8rxgp3YA…M14U`; signature verifies against Acct 1 and fails against Acct 2 |
| B | `solana_signMessage`, non-granted Acct 2 | Reject, no sheet | PASS. 929ms, `4100` |
| C | `solana_signTransaction`, real Jupiter swap, Acct 2 | Reject | PASS. 868ms, `4100` |
| D | `solana_signTransaction`, real Jupiter swap, Acct 1 | Sheet shows Acct 1, signs | PASS. Sheet showed `From 8rxgp3YA…M14U`; signature verifies against Acct 1 and fails against Acct 2 |
| E | `avalanche_signMessage`, `accountIndex: 1` (Acct 2) | Reject | PASS. 376ms, `4100` |
| F | `avalanche_signMessage`, `accountIndex: 0` (Acct 1) | Sheet shows Acct 1, signs | PASS |
| H | `avalanche_signMessage`, `accountIndex: 0.5` | Reject | PASS. 318ms, `4100` |
| I | Control: `accountIndex: 1` where Acct 2 **is** granted | Reach approval | PASS. Reached the sheet; rejecting in the UI returned `4001`, not `4100` |
| R | In-app Send 0.001 SOL **from** non-granted Acct 2 | Not gated | PASS. Broadcast and finalized on mainnet |
| G | Session deleted mid-flight, then Approve | Fail closed | Inconclusive, see below |

Notes on the ones that carry the most weight:

- **A and D are cryptographic, not cosmetic.** The returned ed25519 signatures verify against Account 1's public key and fail against Account 2's, so the account shown really is the account that signed.
- **H is the sharpest test.** `0.5` passes the avalanche module's `z.number().nonnegative()` schema, which is not `.int()`, so `selectAccountByIndex` matches nothing and the signer falls back to `accounts[0]`, meaning Account 1. It was set up adversarially, with a session granting Account 2 and Core's active account also on Account 2, so an implementation that treated a fractional index as "no index" and checked the active account would have passed the gate and then signed with a different account. It rejected in 318ms.
- **R is the strongest regression check.** It signs with Account 2, an account the live session does not grant, and is correctly not gated, which proves the `!isInAppRequest(request)` guard is doing real work. Logs confirm the path: topic `1bfab1bf-…` (a uuid, so `CORE_MOBILE_TOPIC`) and `getSolanaSigner called { accountIndex: 1 }`. On-chain receipt `gbvYRX6NZMBwVTwNiZUCMMurGMTjeeD9HhMwLt7DSkWzpNEwzbFP1zUfFh8wZpHsgQHJ3bQnAjkKB1FF7Tuz9TU`: 1,000,000 lamports from `A8PsKy2J…ZTYT` to `8rxgp3YA…M14U`, `err: null`, finalized.
- **Timing is itself evidence.** Rejects land in 318ms to 929ms while approvals take 30s or more, since they wait on a human tap. That gap shows rejects short-circuit before any sheet is constructed.
- **G is inconclusive by nature.** With the session deleted the response is undeliverable, so a fail-closed rejection cannot be distinguished from having nothing to deliver. Covered by unit test `ApprovalController.test.ts:1414` instead.

Display fix regression checks, run with the fix applied: the gate still rejects `accountIndex: 1` (491ms, `4100`), and `solana_signMessage` still shows exactly one Account row.

Two limitations worth stating plainly:

- A mid-flight active-account switch is unreachable from Android's UI. The approval form sheet covers the account switcher and a scrim tap does nothing, so the approval-time re-check can only be exercised against a programmatic switch. Not a defect, it just bounds what a device test can reach.
- iOS was not tested in this round, and neither were the EVM or Bitcoin reject paths on device. Both are covered by unit tests and share the same `signingData.account` chokepoint as the Solana methods that were verified.

**QA Testing (if applicable)**

Acceptance: a dApp can only trigger signing with accounts that are part of its WalletConnect session grant. Requests for any other account are rejected with an explicit error and no approval prompt, including accounts belonging to the same wallet as the granted one.

1. Onboard a wallet with at least 2 accounts, connect to a WC dApp granting **only** Account 1.
2. Switch Core's active account to Account 2.
3. Sign from the dApp. The approval sheet must show Account 1, and signing must succeed as before.
4. Confirm the address on the sheet matches the address the dApp reports back as the signer.

Regression surface to sweep: in-app Send, Swap and Stake, injected-browser dApp signing, Core web over WC including BTC and AVAX flows, and Ledger approvals. All are unaffected paths.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios (Android only; iOS not covered this round)
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CP-14604]: https://ava-labs.atlassian.net/browse/CP-14604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

