### PR TITLE
fix: Swap screen crash — restore getRecoveredAtomicAmount by bumping fusion-sdk

### DIFF
--- a/packages/core-mobile/package.json
+++ b/packages/core-mobile/package.json
@@ -39,7 +39,7 @@
     "@avalabs/crypto-nitro": "0.3.2",
     "@avalabs/crypto-sdk": "1.0.2",
     "@avalabs/evm-module": "3.9.0",
-    "@avalabs/fusion-sdk": "0.0.0-fix-fusion-hyperliquid-withdra-20260716134252",
+    "@avalabs/fusion-sdk": "0.0.0-feat-enable-hvm-big-blocks-20260720201517",
     "@avalabs/glacier-sdk": "3.1.0-canary.672f5c3.0",
     "@avalabs/k2-alpine": "workspace:*",
     "@avalabs/perps-sdk": "0.0.0-fix-perps-unified-portfolio-ba-20260716132651",

--- a/yarn.lock
+++ b/yarn.lock
@@ -478,7 +478,7 @@ __metadata:
     "@avalabs/crypto-nitro": 0.3.2
     "@avalabs/crypto-sdk": 1.0.2
     "@avalabs/evm-module": 3.9.0
-    "@avalabs/fusion-sdk": 0.0.0-fix-fusion-hyperliquid-withdra-20260716134252
+    "@avalabs/fusion-sdk": 0.0.0-feat-enable-hvm-big-blocks-20260720201517
     "@avalabs/glacier-sdk": 3.1.0-canary.672f5c3.0
     "@avalabs/k2-alpine": "workspace:*"
     "@avalabs/perps-sdk": 0.0.0-fix-perps-unified-portfolio-ba-20260716132651
@@ -940,13 +940,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/fusion-sdk@npm:0.0.0-fix-fusion-hyperliquid-withdra-20260716134252":
-  version: 0.0.0-fix-fusion-hyperliquid-withdra-20260716134252
-  resolution: "@avalabs/fusion-sdk@npm:0.0.0-fix-fusion-hyperliquid-withdra-20260716134252"
+"@avalabs/fusion-sdk@npm:0.0.0-feat-enable-hvm-big-blocks-20260720201517":
+  version: 0.0.0-feat-enable-hvm-big-blocks-20260720201517
+  resolution: "@avalabs/fusion-sdk@npm:0.0.0-feat-enable-hvm-big-blocks-20260720201517"
   dependencies:
     "@bitcoinerlab/secp256k1": ^1.2.0
     "@layerzerolabs/lz-v2-utilities": ^3.0.17
     "@lombard.finance/sdk": ^4.3.0
+    "@msgpack/msgpack": ^3.1.3
     "@scure/base": ^1.0.1
     axios: ^1.12.0
     bignumber.js: ^9.3.1
@@ -958,7 +959,7 @@ __metadata:
     "@solana/kit": ^5.0.0 || ^6.0.0
     viem: ^2.38.0
     zod: ^4.1.0
-  checksum: 290da193d7c4542f6bb2bbb6b655c0d73d1f6cce1c0c55f634db576a6a166f1566a9116bd45ff6911566d059c671e5cc00692f33dd1a0e4b9b757fcaa16b5b99
+  checksum: 2cc10259f17e891b131fd2c8a32f8d17ca1c9fef5ea68c7bfd15a9dc52d88722376fff7bffaf6c0c6c3f48fbd7db2579ab2cc67aedae95e484f12350a6b8fd7f
   languageName: node
   linkType: hard
 
@@ -11224,7 +11225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@msgpack/msgpack@npm:^3.0.0":
+"@msgpack/msgpack@npm:^3.0.0, @msgpack/msgpack@npm:^3.1.3":
   version: 3.1.3
   resolution: "@msgpack/msgpack@npm:3.1.3"
   checksum: b76416a5c52ec1364a78902a43b33d18d2813f469165fe5d4ad22d2b67f1269f7f2ee660a5fee764de117aa47116db61a84aa57cccb9007d7fc7abd01a78ef33
@@ -37048,7 +37049,7 @@ react-native-webview@ava-labs/react-native-webview:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: c05a6ae9fc4f1f1111d47e61df17db4805be799c9f03de1ed52fa302e8dd7a9ece0e49a85e553817a7e53f4a79098045c90eebb768f42d555b257e0488a3c6f1
+  checksum: 3e4689674406deb2ad9efa9f529597341b4ab33e379b7c7cd72aff8d5e37862fda1a37aba984951a67cc3938969be138bc3c4469e4963dd170b172148339e056
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

**Ticket: N/A** — hotfix for a Swap crash on `main`

Opening the Swap screen on latest `main` crashes with a render error: `undefined is not a function` in `shouldShowRecoveredFundsNotice.ts`. Two PRs crossed on the fusion-sdk version:

- CP-14678 (#3977) bumped `@avalabs/fusion-sdk` to **0.27.0** and added code calling `getRecoveredAtomicAmount` (introduced in 0.27.0)
- CP-13659 (#3984) then downgraded the pin to the `fix-fusion-hyperliquid-withdra-20260716134252` snapshot to pick up the Hyperliquid withdraw fix — but that snapshot was cut from a 0.25-based branch and has no `getRecoveredAtomicAmount` export at all

So the import resolves to `undefined` and SwapScreen throws on render. The same mismatch produced 12 `tsc` errors (`shouldShowRecoveredFundsNotice.ts` + test, `useSwapActivityDisplay.ts`, `createCctCallbacks.test.ts`, `usePerpsClearinghouse.ts`).

This PR bumps the pin to the `feat-enable-hvm-big-blocks-20260720201517` snapshot, which contains **both** changes: `getRecoveredAtomicAmount` is exported, and the Hyperliquid withdraw handler is byte-equivalent to the current pin's (protocol-v2 relay verification, withdrawable-dropped guard). Neither published option works alone — 0.27.0 lacks the withdraw fix, the current snapshot lacks the export.

Dependency note / follow-up: this is still a feature-branch snapshot (it additionally carries unreleased hyperevm big-blocks code). It should be replaced with a proper fusion-sdk release (0.28.0?) once the SDK team cuts one from their main.

## Screenshots/Videos

N/A — dependency bump; the observable change is the Swap screen no longer crashing on open.

## Testing

**Dev Testing**

- `yarn tsc` — clean (was 12 errors)
- `yarn test app/new/features/swap app/new/features/notifications` — 50 suites, 820 tests passing
- Manual: open the Swap screen on a dev build — it crashed on open before this bump; needs a reload check to confirm

**QA Testing**

- Open Swap and get a quote (including a cross-chain AVAX quote to exercise the recovered-funds notice path)
- Regression on the withdraw fix this pin originally carried: Hyperliquid/perps withdraw flow still completes

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)