### PR TITLE
CP-14775: replace the 1 Year duration preset with Node Max in the delegate flow

### DIFF
--- a/packages/core-mobile/app/new/features/stake/components/DurationOptions.tsx
+++ b/packages/core-mobile/app/new/features/stake/components/DurationOptions.tsx
@@ -32,9 +32,9 @@ export const DurationOptions = ({
   customEndDate?: Date
   /**
    * Overrides the default preset list — the delegate flow passes its
-   * node-aware list (1 Year swapped for Node max, see `withNodeMaxOption`).
-   * Must keep the default lists' length/positions so the index-based helpers
-   * below stay valid.
+   * node-aware list (1 Year swapped for Node max, see `withNodeMaxOption`,
+   * re-sorted by days). Must keep the default lists' LENGTH with Custom last,
+   * so `getCustomDurationIndex` stays valid; day-option positions may differ.
    */
   durations?: DurationOption[]
   /**

--- a/packages/core-mobile/app/new/features/stake/components/DurationOptions.tsx
+++ b/packages/core-mobile/app/new/features/stake/components/DurationOptions.tsx
@@ -85,9 +85,13 @@ export const DurationOptions = ({
             const globalIndex = rowIndex * 3 + index
             const isSelected = globalIndex === selectedIndex
             const selectedTheme = isSelected ? inversedTheme : theme
+            // Node Max is exempt: it ends at the node's exact end time so it
+            // always fits, even when its rounded day label exceeds the
+            // conservative `maxNumberOfDays` cap.
             const isDisabled =
               maxNumberOfDays !== undefined &&
               'numberOfDays' in item &&
+              item.title !== StakeDurationTitle.NODE_MAX &&
               item.numberOfDays > maxNumberOfDays
 
             return (

--- a/packages/core-mobile/app/new/features/stake/components/DurationOptions.tsx
+++ b/packages/core-mobile/app/new/features/stake/components/DurationOptions.tsx
@@ -14,6 +14,7 @@ import { useSelector } from 'react-redux'
 import {
   DURATION_OPTIONS_FUJI,
   DURATION_OPTIONS_MAINNET,
+  DurationOption,
   StakeDurationFormat,
   StakeDurationTitle
 } from 'services/earn/getStakeEndDate'
@@ -22,18 +23,36 @@ import { selectIsDeveloperMode } from 'store/settings/advanced'
 export const DurationOptions = ({
   selectedIndex,
   onSelectDuration,
-  customEndDate
+  customEndDate,
+  durations: durationsProp,
+  maxNumberOfDays
 }: {
   selectedIndex?: number
   onSelectDuration: (selectedIndex: number) => void
   customEndDate?: Date
+  /**
+   * Overrides the default preset list — the delegate flow passes its
+   * node-aware list (1 Year swapped for Node max, see `withNodeMaxOption`).
+   * Must keep the default lists' length/positions so the index-based helpers
+   * below stay valid.
+   */
+  durations?: DurationOption[]
+  /**
+   * Disables day-based presets longer than this (the delegate flow passes
+   * the days until the selected node's end time, so presets the node can't
+   * cover read as unavailable instead of failing on Next). Custom stays
+   * enabled — its picker is capped separately.
+   */
+  maxNumberOfDays?: number
 }): JSX.Element => {
   const { theme } = useTheme()
   const { theme: inversedTheme } = useInversedTheme({ isDark: theme.isDark })
   const isDeveloperMode = useSelector(selectIsDeveloperMode)
   const durations = useMemo(
-    () => (isDeveloperMode ? DURATION_OPTIONS_FUJI : DURATION_OPTIONS_MAINNET),
-    [isDeveloperMode]
+    () =>
+      durationsProp ??
+      (isDeveloperMode ? DURATION_OPTIONS_FUJI : DURATION_OPTIONS_MAINNET),
+    [durationsProp, isDeveloperMode]
   )
   const rows = useMemo(() => {
     const chunks = []
@@ -66,11 +85,16 @@ export const DurationOptions = ({
             const globalIndex = rowIndex * 3 + index
             const isSelected = globalIndex === selectedIndex
             const selectedTheme = isSelected ? inversedTheme : theme
+            const isDisabled =
+              maxNumberOfDays !== undefined &&
+              'numberOfDays' in item &&
+              item.numberOfDays > maxNumberOfDays
 
             return (
               <TouchableOpacity
                 key={item.title}
-                style={{ flex: 1 }}
+                style={{ flex: 1, opacity: isDisabled ? 0.4 : 1 }}
+                disabled={isDisabled}
                 onPress={() => onSelectDuration(globalIndex)}>
                 <View
                   sx={{

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
@@ -13,9 +13,11 @@ import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import {
   addDays,
   addHours,
+  differenceInDays,
   format,
   getUnixTime,
-  millisecondsToSeconds
+  millisecondsToSeconds,
+  subHours
 } from 'date-fns'
 import { Href, useRouter } from 'expo-router'
 import { useAvaxPrice } from 'features/portfolio/hooks/useAvaxPrice'
@@ -108,12 +110,25 @@ const StakeDurationScreen = ({
   const { formatCurrency } = useFormatCurrency()
   const now = useNow()
   const rewardChartRef = useRef<StakeRewardChartHandle>(null)
-  // Days until the selected node's end time (delegate flow only). A plain
-  // number so the memo below only re-runs when the day count actually
-  // changes, not on every `now` tick.
-  const nodeEndDays = maxEndDate
-    ? getRoundedDurationInDays(now, maxEndDate)
-    : undefined
+  // Days until the selected node's end time (delegate flow only). Captured
+  // ONCE at mount: this number drives the option list's contents and
+  // ordering, and `now` ticking across a rounding boundary mid-session would
+  // otherwise re-sort the list under the index-tracked selection. The
+  // exact-time `exceedsNodeEndTime` guard below (on the reactive `now`)
+  // stays authoritative for correctness.
+  const [nodeEndDays] = useState<number | undefined>(() =>
+    maxEndDate ? getRoundedDurationInDays(Date.now(), maxEndDate) : undefined
+  )
+  // Conservative cap for DISABLING presets: a day preset actually ends at
+  // now + N days + 1h of submit-drift slack, so it only fits the node when
+  // N ≤ floor(remaining − 1h). The rounded `nodeEndDays` can round UP
+  // (179.6d → 180), which would leave an overshooting preset enabled only
+  // to fail on Next.
+  const [coverableNodeDays] = useState<number | undefined>(() =>
+    maxEndDate
+      ? Math.max(0, differenceInDays(subHours(maxEndDate, 1), new Date()))
+      : undefined
+  )
   const durationsWithDays: DurationOptionWithDays[] = useMemo(() => {
     const base = isDeveloperMode
       ? DURATION_OPTIONS_WITH_DAYS_FUJI
@@ -150,7 +165,11 @@ const StakeDurationScreen = ({
       option => option.title === defaultTitle
     )
     const defaultOption = durationsWithDays[defaultIndex]
-    if (defaultOption && defaultOption.numberOfDays <= nodeEndDays) {
+    if (
+      defaultOption &&
+      coverableNodeDays !== undefined &&
+      defaultOption.numberOfDays <= coverableNodeDays
+    ) {
       return defaultIndex
     }
     // The usual default (3 Months) outlasts the selected node, so its card
@@ -161,7 +180,7 @@ const StakeDurationScreen = ({
       option => option.title === StakeDurationTitle.NODE_MAX
     )
     return nodeMaxIndex >= 0 ? nodeMaxIndex : staticDefault
-  }, [isDeveloperMode, nodeEndDays, durationsWithDays])
+  }, [isDeveloperMode, nodeEndDays, coverableNodeDays, durationsWithDays])
   const customDurationIndex = useMemo(
     () => getCustomDurationIndex(isDeveloperMode),
     [isDeveloperMode]
@@ -178,8 +197,12 @@ const StakeDurationScreen = ({
         // A preset the node can't cover renders disabled — starting on it
         // would select a disabled card. Fall through to the custom-date
         // branch instead, where the existing node-end guard explains why the
-        // original duration no longer fits.
-        (nodeEndDays === undefined || duration.numberOfDays <= nodeEndDays)
+        // original duration no longer fits. Node Max always fits (it ends at
+        // the node's exact end time), even when its rounded day label
+        // exceeds the conservative cap.
+        (coverableNodeDays === undefined ||
+          duration.title === StakeDurationTitle.NODE_MAX ||
+          duration.numberOfDays <= coverableNodeDays)
     )
     return index >= 0 ? index : undefined
   })
@@ -401,7 +424,7 @@ const StakeDurationScreen = ({
             onSelectDuration={handleSelectDuration}
             customEndDate={customEndDate}
             durations={[...durationsWithDays, CUSTOM]}
-            maxNumberOfDays={nodeEndDays}
+            maxNumberOfDays={coverableNodeDays}
           />
         )
       },
@@ -418,7 +441,7 @@ const StakeDurationScreen = ({
     getDurationInDays,
     estimatedReward,
     durationsWithDays,
-    nodeEndDays
+    coverableNodeDays
   ])
 
   useEffect(() => {

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
@@ -124,10 +124,22 @@ const StakeDurationScreen = ({
       ? base
       : withNodeMaxOption(base, nodeEndDays)
   }, [isDeveloperMode, nodeEndDays])
-  const defaultDurationIndex = useMemo(
-    () => getDefaultDurationIndex(isDeveloperMode),
-    [isDeveloperMode]
-  )
+  const defaultDurationIndex = useMemo(() => {
+    const staticDefault = getDefaultDurationIndex(isDeveloperMode)
+    if (nodeEndDays === undefined) return staticDefault
+    const defaultOption = durationsWithDays[staticDefault]
+    if (defaultOption && defaultOption.numberOfDays <= nodeEndDays) {
+      return staticDefault
+    }
+    // The usual default (3 Months) outlasts the selected node, so its card
+    // renders disabled — defaulting to it would open the screen with a
+    // disabled card selected. Fall back to Node Max, the longest option this
+    // node can cover.
+    const nodeMaxIndex = durationsWithDays.findIndex(
+      option => option.title === StakeDurationTitle.NODE_MAX
+    )
+    return nodeMaxIndex >= 0 ? nodeMaxIndex : staticDefault
+  }, [isDeveloperMode, nodeEndDays, durationsWithDays])
   const customDurationIndex = useMemo(
     () => getCustomDurationIndex(isDeveloperMode),
     [isDeveloperMode]
@@ -139,7 +151,13 @@ const StakeDurationScreen = ({
   const [initialPresetIndex] = useState<number | undefined>(() => {
     if (initialDurationDays === undefined) return undefined
     const index = durationsWithDays.findIndex(
-      duration => duration.numberOfDays === initialDurationDays
+      duration =>
+        duration.numberOfDays === initialDurationDays &&
+        // A preset the node can't cover renders disabled — starting on it
+        // would select a disabled card. Fall through to the custom-date
+        // branch instead, where the existing node-end guard explains why the
+        // original duration no longer fits.
+        (nodeEndDays === undefined || duration.numberOfDays <= nodeEndDays)
     )
     return index >= 0 ? index : undefined
   })

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
@@ -125,16 +125,33 @@ const StakeDurationScreen = ({
     // meaningless "Node Max / 0 days" card, so keep the base list instead;
     // every day preset then renders disabled via `maxNumberOfDays` and the
     // node-end guard on Next explains why.
-    return nodeEndDays === undefined || nodeEndDays < 1
-      ? base
-      : withNodeMaxOption(base, nodeEndDays)
+    if (nodeEndDays === undefined || nodeEndDays < 1) {
+      return base
+    }
+    // Sorted by days so the reward chart stays monotonic when Node Max lands
+    // between fixed presets (a node ending in 100 days would otherwise plot
+    // ..., 90, 180, 100). Index-dependent lookups below resolve by title, not
+    // position; the Custom option is appended after this list, so its index
+    // (the list length) is unaffected.
+    return withNodeMaxOption(base, nodeEndDays).sort(
+      (a, b) => a.numberOfDays - b.numberOfDays
+    )
   }, [isDeveloperMode, nodeEndDays])
   const defaultDurationIndex = useMemo(() => {
     const staticDefault = getDefaultDurationIndex(isDeveloperMode)
     if (nodeEndDays === undefined) return staticDefault
-    const defaultOption = durationsWithDays[staticDefault]
+    // The dynamic list is re-sorted around Node Max, so resolve the default
+    // by TITLE rather than by the static list's position.
+    const staticList = isDeveloperMode
+      ? DURATION_OPTIONS_WITH_DAYS_FUJI
+      : DURATION_OPTIONS_WITH_DAYS_MAINNET
+    const defaultTitle = staticList[staticDefault]?.title
+    const defaultIndex = durationsWithDays.findIndex(
+      option => option.title === defaultTitle
+    )
+    const defaultOption = durationsWithDays[defaultIndex]
     if (defaultOption && defaultOption.numberOfDays <= nodeEndDays) {
-      return staticDefault
+      return defaultIndex
     }
     // The usual default (3 Months) outlasts the selected node, so its card
     // renders disabled — defaulting to it would open the screen with a

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
@@ -41,11 +41,14 @@ import { useAnimatedReaction, useSharedValue } from 'react-native-reanimated'
 import { scheduleOnRN } from 'react-native-worklets'
 import { useSelector } from 'react-redux'
 import {
+  CUSTOM,
   DURATION_OPTIONS_WITH_DAYS_FUJI,
   DURATION_OPTIONS_WITH_DAYS_MAINNET,
   DurationOptionWithDays,
   getStakeEndDate,
-  THREE_MONTHS
+  StakeDurationTitle,
+  THREE_MONTHS,
+  withNodeMaxOption
 } from 'services/earn/getStakeEndDate'
 import { UnixTime } from 'services/earn/types'
 import { selectIsDeveloperMode } from 'store/settings/advanced'
@@ -105,13 +108,22 @@ const StakeDurationScreen = ({
   const { formatCurrency } = useFormatCurrency()
   const now = useNow()
   const rewardChartRef = useRef<StakeRewardChartHandle>(null)
-  const durationsWithDays: DurationOptionWithDays[] = useMemo(
-    () =>
-      isDeveloperMode
-        ? DURATION_OPTIONS_WITH_DAYS_FUJI
-        : DURATION_OPTIONS_WITH_DAYS_MAINNET,
-    [isDeveloperMode]
-  )
+  // Days until the selected node's end time (delegate flow only). A plain
+  // number so the memo below only re-runs when the day count actually
+  // changes, not on every `now` tick.
+  const nodeEndDays = maxEndDate
+    ? getRoundedDurationInDays(now, maxEndDate)
+    : undefined
+  const durationsWithDays: DurationOptionWithDays[] = useMemo(() => {
+    const base = isDeveloperMode
+      ? DURATION_OPTIONS_WITH_DAYS_FUJI
+      : DURATION_OPTIONS_WITH_DAYS_MAINNET
+    // Delegate flow: swap the 1 Year preset for "Node max" — stake until the
+    // selected validator's end time (see `withNodeMaxOption`).
+    return nodeEndDays === undefined
+      ? base
+      : withNodeMaxOption(base, nodeEndDays)
+  }, [isDeveloperMode, nodeEndDays])
   const defaultDurationIndex = useMemo(
     () => getDefaultDurationIndex(isDeveloperMode),
     [isDeveloperMode]
@@ -348,6 +360,8 @@ const StakeDurationScreen = ({
             selectedIndex={selectedDurationIndex}
             onSelectDuration={handleSelectDuration}
             customEndDate={customEndDate}
+            durations={[...durationsWithDays, CUSTOM]}
+            maxNumberOfDays={nodeEndDays}
           />
         )
       },
@@ -362,13 +376,25 @@ const StakeDurationScreen = ({
     handleSelectDuration,
     customEndDate,
     getDurationInDays,
-    estimatedReward
+    estimatedReward,
+    durationsWithDays,
+    nodeEndDays
   ])
 
   useEffect(() => {
     if (selectedChartIndex !== undefined) {
-      if (durationsWithDays[selectedChartIndex]) {
-        const selectedDuration = durationsWithDays[selectedChartIndex]
+      const selectedDuration = durationsWithDays[selectedChartIndex]
+      if (selectedDuration) {
+        // "Node max" stakes until the validator's exact end time — computing
+        // it as now + N rounded days (like the other presets) could overshoot
+        // the node by up to half a day and trip the exceedsNodeEndTime guard.
+        if (
+          selectedDuration.title === StakeDurationTitle.NODE_MAX &&
+          nodeEndTimeUnix !== undefined
+        ) {
+          setStakeEndTime(nodeEndTimeUnix)
+          return
+        }
         const calculatedStakeEndTime = getStakeEndDate({
           startDateUnix: millisecondsToSeconds(now),
           stakeDurationFormat: selectedDuration.stakeDurationFormat,
@@ -385,7 +411,8 @@ const StakeDurationScreen = ({
     now,
     durationsWithDays,
     isDeveloperMode,
-    customEndDate
+    customEndDate,
+    nodeEndTimeUnix
   ])
 
   const renderFooter = useCallback(() => {

--- a/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/StakeDurationScreen.tsx
@@ -119,8 +119,13 @@ const StakeDurationScreen = ({
       ? DURATION_OPTIONS_WITH_DAYS_FUJI
       : DURATION_OPTIONS_WITH_DAYS_MAINNET
     // Delegate flow: swap the 1 Year preset for "Node max" — stake until the
-    // selected validator's end time (see `withNodeMaxOption`).
-    return nodeEndDays === undefined
+    // selected validator's end time (see `withNodeMaxOption`). A node ending
+    // within the day (normally unreachable — the picker's minimum-time filter
+    // and the restake guard screen such nodes out) would make that a
+    // meaningless "Node Max / 0 days" card, so keep the base list instead;
+    // every day preset then renders disabled via `maxNumberOfDays` and the
+    // node-end guard on Next explains why.
+    return nodeEndDays === undefined || nodeEndDays < 1
       ? base
       : withNodeMaxOption(base, nodeEndDays)
   }, [isDeveloperMode, nodeEndDays])

--- a/packages/core-mobile/app/services/earn/getStakeEndDate.test.ts
+++ b/packages/core-mobile/app/services/earn/getStakeEndDate.test.ts
@@ -2,10 +2,12 @@ import { fromUnixTime, addDays, getUnixTime } from 'date-fns'
 import {
   DURATION_OPTIONS_MAINNET,
   DURATION_OPTIONS_FUJI,
+  DURATION_OPTIONS_WITH_DAYS_MAINNET,
   DurationOptionWithDays,
   getStakeEndDate,
   StakeDurationFormat,
-  StakeDurationTitle
+  StakeDurationTitle,
+  withNodeMaxOption
 } from 'services/earn/getStakeEndDate'
 import { getMinimumStakeEndTime } from 'services/earn/utils'
 
@@ -109,5 +111,42 @@ describe('getStakeEndDate', () => {
 
     expect(result).toBe(mockCustomEndDate)
     expect(getMinimumStakeEndTime).toHaveBeenCalledWith(true, currentDate)
+  })
+})
+
+describe('withNodeMaxOption', () => {
+  const base: DurationOptionWithDays[] = DURATION_OPTIONS_WITH_DAYS_MAINNET
+
+  it('swaps the 1 Year preset for a Node max option with the given days', () => {
+    const result = withNodeMaxOption(base, 134)
+    const nodeMax = result.find(o => o.title === StakeDurationTitle.NODE_MAX)
+    expect(nodeMax).toEqual({
+      title: StakeDurationTitle.NODE_MAX,
+      numberOfDays: 134,
+      stakeDurationFormat: StakeDurationFormat.Day,
+      stakeDurationValue: 134
+    })
+    expect(result.some(o => o.title === StakeDurationTitle.ONE_YEAR)).toBe(
+      false
+    )
+  })
+
+  it('keeps every other preset and the list positions intact', () => {
+    // Index-based helpers (default/custom index) rely on positions not
+    // shifting when the delegate flow swaps the option in.
+    const result = withNodeMaxOption(base, 200)
+    expect(result).toHaveLength(base.length)
+    base.forEach((option, index) => {
+      if (option.title !== StakeDurationTitle.ONE_YEAR) {
+        expect(result[index]).toBe(option)
+      } else {
+        expect(result[index]?.title).toBe(StakeDurationTitle.NODE_MAX)
+      }
+    })
+  })
+
+  it('does not mutate the source list', () => {
+    withNodeMaxOption(base, 10)
+    expect(base.some(o => o.title === StakeDurationTitle.ONE_YEAR)).toBe(true)
   })
 })

--- a/packages/core-mobile/app/services/earn/getStakeEndDate.ts
+++ b/packages/core-mobile/app/services/earn/getStakeEndDate.ts
@@ -99,6 +99,7 @@ export enum StakeDurationTitle {
   THREE_MONTHS = '3 Months',
   SIX_MONTHS = '6 Months',
   ONE_YEAR = '1 Year',
+  NODE_MAX = 'Node Max',
   CUSTOM = 'Custom'
 }
 
@@ -191,6 +192,34 @@ export const DURATION_OPTIONS_FUJI: DurationOption[] = [
   ...DURATION_OPTIONS_WITH_DAYS_FUJI,
   CUSTOM
 ]
+
+/**
+ * Replaces the 1 Year preset with a "Node max" option running until the
+ * selected validator's end time (CP-14775, matching web). Delegation
+ * flow only — it is the one flow where a node is picked before the duration.
+ * Two motivations: a full 365 days is never actually stakeable (validators
+ * have at most 365 days minus the minutes since they were accepted), and
+ * when the node ends sooner than the longer presets this is the only
+ * one-tap way to stake the maximum without entering a custom date.
+ *
+ * `numberOfDays` drives the card label and the reward estimate; the duration
+ * screen resolves the actual end timestamp from the node itself so the stake
+ * ends exactly at the validator's end time, not at a rounded day count.
+ */
+export const withNodeMaxOption = (
+  options: DurationOptionWithDays[],
+  nodeEndDays: number
+): DurationOptionWithDays[] =>
+  options.map(option =>
+    option.title === StakeDurationTitle.ONE_YEAR
+      ? {
+          title: StakeDurationTitle.NODE_MAX,
+          numberOfDays: nodeEndDays,
+          stakeDurationFormat: StakeDurationFormat.Day,
+          stakeDurationValue: nodeEndDays
+        }
+      : option
+  )
 
 export type DurationOptionWithDays = Extract<
   DurationOption,


### PR DESCRIPTION
## Description

**Ticket: [CP-14775](https://ava-labs.atlassian.net/browse/CP-14775)** (mobile follow-up to web's [CP-14772](https://ava-labs.atlassian.net/browse/CP-14772))

Replaces the "1 Year" duration preset with **"Node Max"** in the delegate flow — a one-tap option that stakes until the selected validator's end time, restoring web's old "node max" card.

**Why**

- A full 365 days is never actually stakeable: by the time a validator is accepted and picked, its remaining time is 364 days + change, so the 1 Year card was effectively a dead option.
- When the node ends sooner than the longer presets, Node Max is the only one-tap way to stake the maximum without manually entering a custom date.

**How**

- `withNodeMaxOption` swaps the 1 Year preset for a Node Max option carrying the days until the selected node's end time. Selecting it sets the stake end to the validator's **exact** end timestamp (not a rounded day count, which could overshoot by up to half a day and trip the node-end guard).
- Presets the node can't cover render **disabled** (grayed out, untappable) instead of failing on Next; the existing node-end guard remains as a safety net for chart-driven selections.
- The dynamic list is **sorted by days** so the reward chart stays monotonic when Node Max lands between fixed presets (e.g. a node ending in 100 days plots ..., 90, 100, 180-disabled).
- The default selection (3 Months) falls back to Node Max when the node can't cover it, and a restake prefill never lands on a disabled preset (it falls through to the custom-date branch where the guard message explains).
- Defensive edge: a node ending within the day (normally unreachable — the picker's minimum-time filter and the restake guard screen such nodes out) keeps the base list instead of showing a "Node Max / 0 days" card.

**Scope**: delegate flow only. Fast stake doesn't pass `maxEndDate`, so it keeps its current duration options untouched (confirmed with the reporter); the V1 duration screen is also unaffected (all new props are optional). Restake gains no new steps — its error handling was verified against the new presets.

No new dependencies.

## Screenshots/Videos

<img width="330" alt="IMG_1803" src="https://github.com/user-attachments/assets/9bd2bfe6-4427-4ad3-bc19-a12c66ad09b2" />
<img width="330" alt="IMG_1802" src="https://github.com/user-attachments/assets/5c42c70f-a17a-49fb-a350-ee77210dcbeb" />
<img width="330" alt="IMG_1801" src="https://github.com/user-attachments/assets/a7399088-efff-41ff-88b9-5addf2872f13" />

## Testing
iOS: 9358
Android: 9359

**Dev Testing (if applicable)**

1. Delegate flow → pick a node with ~1 year remaining → the duration screen shows "Node Max" (with the day count) where "1 Year" used to be; selecting it and confirming produces a stake ending exactly at the node's end time.
2. Pick a node ending in under 6 months → the 6 Months card is grayed out and untappable, cards appear in ascending day order with Node Max slotted in, and the reward chart increases left to right.
3. Pick a node ending in under 3 months → the screen opens with Node Max selected (not a disabled 3 Months).
4. Fast stake flow → duration options unchanged (1 Year still present).

**QA Testing (if applicable)**

- Delegate flow: "Node Max" replaces "1 Year"; presets longer than the selected node's remaining time are disabled; the chart is monotonic.
- Fast stake and restake flows have no new steps or changed options.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14775]: https://ava-labs.atlassian.net/browse/CP-14775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-14772]: https://ava-labs.atlassian.net/browse/CP-14772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ