### PR TITLE
CP-14877: switch between Long and Short on the Place Order screen via native select

### DIFF
--- a/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionPill.test.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionPill.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react'
+import renderer, { act } from 'react-test-renderer'
+
+jest.mock('@avalabs/k2-alpine', () => {
+  const rn = require('react-native') as typeof import('react-native')
+  const r = require('react') as typeof import('react')
+  const pass =
+    (C: React.ElementType) =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ({ children, sx: _sx, variant: _v, ...rest }: any) =>
+      r.createElement(C, rest, children)
+  return {
+    View: pass(rn.View),
+    Text: pass(rn.Text),
+    Icons: {
+      Custom: {
+        TrendingArrowUp: () => null,
+        TrendingArrowDown: () => null
+      },
+      Navigation: {
+        ExpandMore: () => null
+      }
+    },
+    useTheme: () => ({
+      theme: {
+        colors: {
+          $textSuccess: '#0f0',
+          $textDanger: '#f00',
+          $textSecondary: '#888'
+        }
+      }
+    })
+  }
+})
+
+jest.mock('common/hooks/useFormatCurrency', () => ({
+  useFormatCurrency: () => ({ formatCurrency: () => '$0' })
+}))
+
+jest.mock('./PerpsCoinLogo', () => ({ PerpsCoinLogo: () => null }))
+jest.mock('./DexBadge', () => ({ DexBadge: () => null }))
+
+// Render the native select as a plain View so tests can find it by testID and
+// drive onPressAction directly (zeego itself can't render under jest).
+jest.mock('common/components/DropdownMenu', () => {
+  const rn = require('react-native') as typeof import('react-native')
+  const r = require('react') as typeof import('react')
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    DropdownMenu: ({ children, ...rest }: any) =>
+      r.createElement(rn.View, rest, children)
+  }
+})
+
+import { PositionPill } from './PositionPill'
+
+const SIDE_SELECT = 'perpetuals_place_order_side_select'
+
+describe('PositionPill side select', () => {
+  it('renders no dropdown trigger without onChangeSide', async () => {
+    let instance
+    await act(async () => {
+      instance = renderer.create(
+        <PositionPill coin="BTC" price={100} side="long" />
+      )
+    })
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(instance!.root.findAllByProps({ testID: SIDE_SELECT })).toHaveLength(
+      0
+    )
+  })
+
+  it('offers Long and Short with the current side selected', async () => {
+    let instance
+    await act(async () => {
+      instance = renderer.create(
+        <PositionPill coin="BTC" price={100} side="long" onChangeSide={jest.fn()} />
+      )
+    })
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const menu = instance!.root.findAllByProps({ testID: SIDE_SELECT })[0]
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(menu!.props.groups).toEqual([
+      {
+        key: 'perp-order-side',
+        items: [
+          { id: 'long', title: 'Long', selected: true },
+          { id: 'short', title: 'Short', selected: false }
+        ]
+      }
+    ])
+  })
+
+  it('reports the picked side through onChangeSide', async () => {
+    const onChangeSide = jest.fn()
+    let instance
+    await act(async () => {
+      instance = renderer.create(
+        <PositionPill
+          coin="BTC"
+          price={100}
+          side="long"
+          onChangeSide={onChangeSide}
+        />
+      )
+    })
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const menu = instance!.root.findAllByProps({ testID: SIDE_SELECT })[0]
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    await act(async () => {
+      menu!.props.onPressAction({ nativeEvent: { event: 'short' } })
+    })
+    expect(onChangeSide).toHaveBeenCalledWith('short')
+  })
+
+  it('ignores unknown menu events', async () => {
+    const onChangeSide = jest.fn()
+    let instance
+    await act(async () => {
+      instance = renderer.create(
+        <PositionPill
+          coin="BTC"
+          price={100}
+          side="long"
+          onChangeSide={onChangeSide}
+        />
+      )
+    })
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const menu = instance!.root.findAllByProps({ testID: SIDE_SELECT })[0]
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    await act(async () => {
+      menu!.props.onPressAction({ nativeEvent: { event: 'bogus' } })
+    })
+    expect(onChangeSide).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionPill.test.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionPill.test.tsx
@@ -56,31 +56,40 @@ import { PositionPill } from './PositionPill'
 
 const SIDE_SELECT = 'perpetuals_place_order_side_select'
 
+const render = async (
+  element: React.ReactElement
+): Promise<renderer.ReactTestRenderer> => {
+  let instance!: renderer.ReactTestRenderer
+  await act(async () => {
+    instance = renderer.create(element)
+  })
+  return instance
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sideMenu = (instance: renderer.ReactTestRenderer): any =>
+  instance.root.findAllByProps({ testID: SIDE_SELECT })[0]
+
 describe('PositionPill side select', () => {
   it('renders no dropdown trigger without onChangeSide', async () => {
-    let instance
-    await act(async () => {
-      instance = renderer.create(
-        <PositionPill coin="BTC" price={100} side="long" />
-      )
-    })
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(instance!.root.findAllByProps({ testID: SIDE_SELECT })).toHaveLength(
+    const instance = await render(
+      <PositionPill coin="BTC" price={100} side="long" />
+    )
+    expect(instance.root.findAllByProps({ testID: SIDE_SELECT })).toHaveLength(
       0
     )
   })
 
   it('offers Long and Short with the current side selected', async () => {
-    let instance
-    await act(async () => {
-      instance = renderer.create(
-        <PositionPill coin="BTC" price={100} side="long" onChangeSide={jest.fn()} />
-      )
-    })
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const menu = instance!.root.findAllByProps({ testID: SIDE_SELECT })[0]
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(menu!.props.groups).toEqual([
+    const instance = await render(
+      <PositionPill
+        coin="BTC"
+        price={100}
+        side="long"
+        onChangeSide={jest.fn()}
+      />
+    )
+    expect(sideMenu(instance).props.groups).toEqual([
       {
         key: 'perp-order-side',
         items: [
@@ -93,44 +102,36 @@ describe('PositionPill side select', () => {
 
   it('reports the picked side through onChangeSide', async () => {
     const onChangeSide = jest.fn()
-    let instance
+    const instance = await render(
+      <PositionPill
+        coin="BTC"
+        price={100}
+        side="long"
+        onChangeSide={onChangeSide}
+      />
+    )
+    const menu = sideMenu(instance)
+
     await act(async () => {
-      instance = renderer.create(
-        <PositionPill
-          coin="BTC"
-          price={100}
-          side="long"
-          onChangeSide={onChangeSide}
-        />
-      )
-    })
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const menu = instance!.root.findAllByProps({ testID: SIDE_SELECT })[0]
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await act(async () => {
-      menu!.props.onPressAction({ nativeEvent: { event: 'short' } })
+      menu.props.onPressAction({ nativeEvent: { event: 'short' } })
     })
     expect(onChangeSide).toHaveBeenCalledWith('short')
   })
 
   it('ignores unknown menu events', async () => {
     const onChangeSide = jest.fn()
-    let instance
+    const instance = await render(
+      <PositionPill
+        coin="BTC"
+        price={100}
+        side="long"
+        onChangeSide={onChangeSide}
+      />
+    )
+    const menu = sideMenu(instance)
+
     await act(async () => {
-      instance = renderer.create(
-        <PositionPill
-          coin="BTC"
-          price={100}
-          side="long"
-          onChangeSide={onChangeSide}
-        />
-      )
-    })
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const menu = instance!.root.findAllByProps({ testID: SIDE_SELECT })[0]
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await act(async () => {
-      menu!.props.onPressAction({ nativeEvent: { event: 'bogus' } })
+      menu.props.onPressAction({ nativeEvent: { event: 'bogus' } })
     })
     expect(onChangeSide).not.toHaveBeenCalled()
   })

--- a/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionPill.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionPill.tsx
@@ -86,14 +86,19 @@ export const PositionPill = ({
       sx={{
         backgroundColor: '$surfaceSecondary',
         borderRadius: 12,
-        padding: 16,
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'space-between',
         borderBottomLeftRadius: 4,
         borderBottomRightRadius: 4
       }}>
-      <View sx={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+      <View
+        sx={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: 8,
+          padding: 16
+        }}>
         <PerpsCoinLogo size={27} symbol={coin} />
         <Text variant="body1" sx={{ color: '$textPrimary' }}>
           {tickerOfCoin(coin)}
@@ -106,6 +111,9 @@ export const PositionPill = ({
       {onChangeSide !== undefined && side !== undefined ? (
         <DropdownMenu
           groups={sideGroups}
+          style={{
+            padding: 16
+          }}
           onPressAction={handleSideAction}
           testID="perpetuals_place_order_side_select">
           {sideLabel}

--- a/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionPill.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionPill.tsx
@@ -1,6 +1,10 @@
 import { Icons, Text, useTheme, View } from '@avalabs/k2-alpine'
+import {
+  DropdownGroup,
+  DropdownMenu
+} from 'common/components/DropdownMenu'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
-import React from 'react'
+import React, { useCallback, useMemo } from 'react'
 import type { OrderSide } from '../contexts/PlaceOrderContext'
 import { dexOfCoin, tickerOfCoin } from '../utils/coinDex'
 import { DexBadge } from './DexBadge'
@@ -10,17 +14,72 @@ interface PositionPillProps {
   coin: string
   price: number
   side?: OrderSide
+  /**
+   * When set, the side label becomes a native select (dropdown) offering
+   * Long/Short. Only the open-order flow passes this — Trigger/Close render
+   * the pill read-only.
+   */
+  onChangeSide?: (side: OrderSide) => void
 }
 
 export const PositionPill = ({
   coin,
   price,
-  side
+  side,
+  onChangeSide
 }: PositionPillProps): JSX.Element => {
   const { theme } = useTheme()
   const { formatCurrency } = useFormatCurrency()
 
   const isLong = side === 'long'
+
+  const sideGroups = useMemo<DropdownGroup[]>(
+    () => [
+      {
+        key: 'perp-order-side',
+        items: [
+          { id: 'long', title: 'Long', selected: isLong },
+          { id: 'short', title: 'Short', selected: !isLong }
+        ]
+      }
+    ],
+    [isLong]
+  )
+
+  const handleSideAction = useCallback(
+    ({ nativeEvent: { event } }: { nativeEvent: { event: string } }) => {
+      if (event === 'long' || event === 'short') {
+        onChangeSide?.(event)
+      }
+    },
+    [onChangeSide]
+  )
+
+  const sideLabel = side !== undefined && (
+    <View sx={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+      <Text variant="heading3">{isLong ? 'Long' : 'Short'}</Text>
+      {isLong ? (
+        <Icons.Custom.TrendingArrowUp
+          width={18}
+          height={16}
+          color={theme.colors.$textSuccess}
+        />
+      ) : (
+        <Icons.Custom.TrendingArrowDown
+          width={18}
+          height={16}
+          color={theme.colors.$textDanger}
+        />
+      )}
+      {onChangeSide !== undefined && (
+        <Icons.Navigation.ExpandMore
+          width={20}
+          height={20}
+          color={theme.colors.$textSecondary}
+        />
+      )}
+    </View>
+  )
 
   return (
     <View
@@ -44,23 +103,15 @@ export const PositionPill = ({
           {formatCurrency({ amount: price })}
         </Text>
       </View>
-      {side !== undefined && (
-        <View sx={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-          <Text variant="heading3">{isLong ? 'Long' : 'Short'}</Text>
-          {isLong ? (
-            <Icons.Custom.TrendingArrowUp
-              width={18}
-              height={16}
-              color={theme.colors.$textSuccess}
-            />
-          ) : (
-            <Icons.Custom.TrendingArrowDown
-              width={18}
-              height={16}
-              color={theme.colors.$textDanger}
-            />
-          )}
-        </View>
+      {onChangeSide !== undefined && side !== undefined ? (
+        <DropdownMenu
+          groups={sideGroups}
+          onPressAction={handleSideAction}
+          testID="perpetuals_place_order_side_select">
+          {sideLabel}
+        </DropdownMenu>
+      ) : (
+        sideLabel
       )}
     </View>
   )

--- a/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionPill.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionPill.tsx
@@ -1,8 +1,5 @@
 import { Icons, Text, useTheme, View } from '@avalabs/k2-alpine'
-import {
-  DropdownGroup,
-  DropdownMenu
-} from 'common/components/DropdownMenu'
+import { DropdownGroup, DropdownMenu } from 'common/components/DropdownMenu'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import React, { useCallback, useMemo } from 'react'
 import type { OrderSide } from '../contexts/PlaceOrderContext'

--- a/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionPill.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionPill.tsx
@@ -119,7 +119,7 @@ export const PositionPill = ({
           {sideLabel}
         </DropdownMenu>
       ) : (
-        sideLabel
+        <View sx={{ padding: 16 }}>{sideLabel}</View>
       )}
     </View>
   )

--- a/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionPill.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionPill.tsx
@@ -1,5 +1,8 @@
 import { Icons, Text, useTheme, View } from '@avalabs/k2-alpine'
-import { DropdownGroup, DropdownMenu } from 'common/components/DropdownMenu'
+import {
+  type DropdownGroup,
+  DropdownMenu
+} from 'common/components/DropdownMenu'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import React, { useCallback, useMemo } from 'react'
 import type { OrderSide } from '../contexts/PlaceOrderContext'

--- a/packages/core-mobile/app/new/features/trade/perpetuals/contexts/PlaceOrderContext.test.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/contexts/PlaceOrderContext.test.tsx
@@ -15,7 +15,7 @@ const Probe = (): null => {
 }
 
 const renderProvider = (props?: {
-  side?: OrderSide
+  initialSide?: OrderSide
   initialTakeProfitPrice?: number
   initialStopLossPrice?: number
 }): renderer.ReactTestRenderer => {
@@ -24,7 +24,7 @@ const renderProvider = (props?: {
     instance = renderer.create(
       <PlaceOrderProvider
         coin="BTC"
-        side={props?.side ?? 'long'}
+        initialSide={props?.initialSide ?? 'long'}
         entryPrice={100}
         maxLeverage={40}
         initialLeverage={5}
@@ -40,7 +40,7 @@ const renderProvider = (props?: {
 describe('PlaceOrderContext switchSide', () => {
   it('flips the side and clears TP/SL prices and toggles', () => {
     renderProvider({
-      side: 'long',
+      initialSide: 'long',
       initialTakeProfitPrice: 120,
       initialStopLossPrice: 90
     })
@@ -61,7 +61,7 @@ describe('PlaceOrderContext switchSide', () => {
 
   it('is a no-op (keeps TP/SL) when switching to the current side', () => {
     renderProvider({
-      side: 'long',
+      initialSide: 'long',
       initialTakeProfitPrice: 120,
       initialStopLossPrice: 90
     })
@@ -78,7 +78,7 @@ describe('PlaceOrderContext switchSide', () => {
   })
 
   it('recomputes the liquidation price for the new side', () => {
-    renderProvider({ side: 'long' })
+    renderProvider({ initialSide: 'long' })
     const longLiquidation = ctx.liquidationPrice
 
     act(() => {

--- a/packages/core-mobile/app/new/features/trade/perpetuals/contexts/PlaceOrderContext.test.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/contexts/PlaceOrderContext.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react'
+import renderer, { act } from 'react-test-renderer'
+import {
+  PlaceOrderProvider,
+  usePlaceOrder,
+  type OrderSide
+} from './PlaceOrderContext'
+
+// Captures the live context value on every render so assertions read the
+// latest state without a UI layer.
+let ctx!: ReturnType<typeof usePlaceOrder>
+const Probe = (): null => {
+  ctx = usePlaceOrder()
+  return null
+}
+
+const renderProvider = (props?: {
+  side?: OrderSide
+  initialTakeProfitPrice?: number
+  initialStopLossPrice?: number
+}): renderer.ReactTestRenderer => {
+  let instance!: renderer.ReactTestRenderer
+  act(() => {
+    instance = renderer.create(
+      <PlaceOrderProvider
+        coin="BTC"
+        side={props?.side ?? 'long'}
+        entryPrice={100}
+        maxLeverage={40}
+        initialLeverage={5}
+        initialTakeProfitPrice={props?.initialTakeProfitPrice}
+        initialStopLossPrice={props?.initialStopLossPrice}>
+        <Probe />
+      </PlaceOrderProvider>
+    )
+  })
+  return instance
+}
+
+describe('PlaceOrderContext switchSide', () => {
+  it('flips the side and clears TP/SL prices and toggles', () => {
+    renderProvider({
+      side: 'long',
+      initialTakeProfitPrice: 120,
+      initialStopLossPrice: 90
+    })
+    expect(ctx.side).toBe('long')
+    expect(ctx.takeProfitEnabled).toBe(true)
+    expect(ctx.stopLossEnabled).toBe(true)
+
+    act(() => {
+      ctx.switchSide('short')
+    })
+
+    expect(ctx.side).toBe('short')
+    expect(ctx.takeProfitEnabled).toBe(false)
+    expect(ctx.takeProfitPrice).toBeUndefined()
+    expect(ctx.stopLossEnabled).toBe(false)
+    expect(ctx.stopLossPrice).toBeUndefined()
+  })
+
+  it('is a no-op (keeps TP/SL) when switching to the current side', () => {
+    renderProvider({
+      side: 'long',
+      initialTakeProfitPrice: 120,
+      initialStopLossPrice: 90
+    })
+
+    act(() => {
+      ctx.switchSide('long')
+    })
+
+    expect(ctx.side).toBe('long')
+    expect(ctx.takeProfitEnabled).toBe(true)
+    expect(ctx.takeProfitPrice).toBe(120)
+    expect(ctx.stopLossEnabled).toBe(true)
+    expect(ctx.stopLossPrice).toBe(90)
+  })
+
+  it('recomputes the liquidation price for the new side', () => {
+    renderProvider({ side: 'long' })
+    const longLiquidation = ctx.liquidationPrice
+
+    act(() => {
+      ctx.switchSide('short')
+    })
+
+    // Long liquidation sits below entry, short above — they must differ.
+    expect(ctx.liquidationPrice).not.toBe(longLiquidation)
+  })
+})

--- a/packages/core-mobile/app/new/features/trade/perpetuals/contexts/PlaceOrderContext.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/contexts/PlaceOrderContext.tsx
@@ -55,7 +55,12 @@ const PlaceOrderContext = createContext<PlaceOrderState | undefined>(undefined)
 
 export interface PlaceOrderProviderProps {
   coin: string
-  side: OrderSide
+  /**
+   * Seed only — sets the initial `PlaceOrderState.side` via `useState`. The
+   * place-order screen flips the live side afterwards via `switchSide`, so
+   * this prop is not kept in sync with it.
+   */
+  initialSide: OrderSide
   entryPrice: number
   maxLeverage: number
   /**
@@ -73,7 +78,7 @@ export interface PlaceOrderProviderProps {
 
 export const PlaceOrderProvider = ({
   coin,
-  side: initialSide,
+  initialSide,
   entryPrice,
   maxLeverage,
   initialAmount = 0,

--- a/packages/core-mobile/app/new/features/trade/perpetuals/contexts/PlaceOrderContext.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/contexts/PlaceOrderContext.tsx
@@ -1,5 +1,6 @@
 import React, {
   createContext,
+  useCallback,
   useContext,
   useMemo,
   useState,
@@ -12,6 +13,12 @@ export type OrderSide = 'long' | 'short'
 interface PlaceOrderState {
   coin: string
   side: OrderSide
+  /**
+   * Flip the order direction in place (open flow only). Clears TP/SL prices
+   * and toggles because trigger prices are direction-specific — a long's TP
+   * sits on the wrong side of the price for a short. No-op if unchanged.
+   */
+  switchSide: (side: OrderSide) => void
   entryPrice: number
   maxLeverage: number
 
@@ -66,7 +73,7 @@ export interface PlaceOrderProviderProps {
 
 export const PlaceOrderProvider = ({
   coin,
-  side,
+  side: initialSide,
   entryPrice,
   maxLeverage,
   initialAmount = 0,
@@ -75,6 +82,7 @@ export const PlaceOrderProvider = ({
   initialStopLossPrice,
   children
 }: PlaceOrderProviderProps): JSX.Element => {
+  const [side, setSide] = useState(initialSide)
   const [amount, setAmount] = useState(initialAmount)
   // Seed leverage directly from the always-present `initialLeverage`.
   // `maxLeverage` is sourced from live market data and can lag a beat, so the
@@ -95,10 +103,25 @@ export const PlaceOrderProvider = ({
     initialStopLossPrice
   )
 
+  const switchSide = useCallback(
+    (newSide: OrderSide) => {
+      if (newSide === side) {
+        return
+      }
+      setSide(newSide)
+      setTakeProfitEnabled(false)
+      setTakeProfitPrice(undefined)
+      setStopLossEnabled(false)
+      setStopLossPrice(undefined)
+    },
+    [side]
+  )
+
   const value = useMemo<PlaceOrderState>(
     () => ({
       coin,
       side,
+      switchSide,
       entryPrice,
       maxLeverage,
       amount,
@@ -126,6 +149,7 @@ export const PlaceOrderProvider = ({
     [
       coin,
       side,
+      switchSide,
       entryPrice,
       maxLeverage,
       amount,

--- a/packages/core-mobile/app/new/features/trade/perpetuals/hooks/useSeededPlaceOrderProps.test.ts
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/hooks/useSeededPlaceOrderProps.test.ts
@@ -16,7 +16,7 @@ describe('resolveSeededPlaceOrderProps', () => {
       maxLeverage: '25'
     })
     expect(props.coin).toBe('ETH')
-    expect(props.side).toBe('short')
+    expect(props.initialSide).toBe('short')
     expect(props.entryPrice).toBe(1973.1)
     expect(props.maxLeverage).toBe(25)
     // No leverage param → 0 until the live HL leverage is applied by the hook.
@@ -111,7 +111,7 @@ describe('resolveSeededPlaceOrderProps', () => {
   it('defaults when params are absent', () => {
     const props = resolveSeededPlaceOrderProps({})
     expect(props.coin).toBe('AVAX')
-    expect(props.side).toBe('long')
+    expect(props.initialSide).toBe('long')
     // No fabricated price/leverage: the hook fills these from live market data.
     expect(props.entryPrice).toBe(0)
     expect(props.maxLeverage).toBe(0)

--- a/packages/core-mobile/app/new/features/trade/perpetuals/hooks/useSeededPlaceOrderProps.ts
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/hooks/useSeededPlaceOrderProps.ts
@@ -64,7 +64,7 @@ export const resolveSeededPlaceOrderProps = (
 
   return {
     coin: normalizePerpCoinParam(params.coin ?? FALLBACK_COIN),
-    side: (params.side === 'short' ? 'short' : 'long') as OrderSide,
+    initialSide: (params.side === 'short' ? 'short' : 'long') as OrderSide,
     entryPrice,
     maxLeverage,
     initialLeverage,

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsPlaceOrderScreen.test.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsPlaceOrderScreen.test.tsx
@@ -294,6 +294,44 @@ describe('PerpetualsPlaceOrderScreen geo-restriction', () => {
     expect(dial.props.step).toBe(0.0005)
   })
 
+  it('warns when the amount exceeds the flipped side capacity and disables confirm', async () => {
+    // amount is mocked at 10; capacity here is 0.05 BTC × $100 mark = $5, so
+    // the dialed amount exceeds the new side's capacity.
+    mockActiveAsset.maxBuySizeCoin = 0.05
+    const instance = await render()
+
+    expect(
+      instance.root.findAll(node =>
+        node.children.some(
+          child =>
+            typeof child === 'string' && child.includes('Reduce your position')
+        )
+      ).length
+    ).toBeGreaterThan(0)
+    expect(confirmButton(instance).props.disabled).toBe(true)
+  })
+
+  it('shows the normal maximum-position caption when capacity is ample', async () => {
+    const instance = await render()
+
+    expect(
+      instance.root.findAll(node =>
+        node.children.some(
+          child =>
+            typeof child === 'string' && child.includes('Maximum position:')
+        )
+      ).length
+    ).toBeGreaterThan(0)
+    expect(
+      instance.root.findAll(node =>
+        node.children.some(
+          child =>
+            typeof child === 'string' && child.includes('Reduce your position')
+        )
+      )
+    ).toHaveLength(0)
+  })
+
   it('stays on screen (order not submitted) when the order fails', async () => {
     mockRecheck.mockResolvedValueOnce(false)
     mockSubmitOrder.mockResolvedValueOnce(false)

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsPlaceOrderScreen.test.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsPlaceOrderScreen.test.tsx
@@ -22,10 +22,13 @@ jest.mock('common/utils/toast', () => ({
   showSnackbar: (...args: any[]) => mockShowSnackbar(...args)
 }))
 
+const mockSwitchSide = jest.fn()
+const mockOrder = { side: 'long' as 'long' | 'short' }
 jest.mock('../contexts/PlaceOrderContext', () => ({
   usePlaceOrder: () => ({
     coin: 'BTC',
-    side: 'long',
+    side: mockOrder.side,
+    switchSide: mockSwitchSide,
     entryPrice: 1,
     amount: 10,
     setAmount: jest.fn(),
@@ -100,24 +103,34 @@ jest.mock('../components/PerpsEnableTradingModal', () => ({
   PerpsEnableTradingModal: () => null
 }))
 
-jest.mock('../components/PositionPill', () => ({ PositionPill: () => null }))
+const mockPillProps = jest.fn()
+jest.mock('../components/PositionPill', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  PositionPill: (props: any) => {
+    mockPillProps(props)
+    return null
+  }
+}))
 jest.mock('../components/TriggerToggleCard', () => ({
   TriggerToggleCard: () => null
 }))
 jest.mock('../../../../assets/icons/hyperliquid-logo.svg', () => () => null)
 
+const mockScrollScreenProps = jest.fn()
 jest.mock('common/components/ScrollScreen', () => {
   const rn = require('react-native') as typeof import('react-native')
   const r = require('react') as typeof import('react')
   return {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ScrollScreen: ({ children, renderFooter }: any) =>
-      r.createElement(
+    ScrollScreen: ({ children, renderFooter, ...rest }: any) => {
+      mockScrollScreenProps(rest)
+      return r.createElement(
         rn.View,
         null,
         children,
         renderFooter ? renderFooter() : null
       )
+    }
   }
 })
 
@@ -166,6 +179,10 @@ describe('PerpetualsPlaceOrderScreen geo-restriction', () => {
     mockRecheck.mockReset()
     mockShowSnackbar.mockReset()
     mockSubmitOrder.mockReset()
+    mockOrder.side = 'long'
+    mockSwitchSide.mockReset()
+    mockPillProps.mockReset()
+    mockScrollScreenProps.mockReset()
     mockState.isGeoBlocked = false
     mockTrading.isTradingEnabled = true
     mockActiveAsset.maxBuySizeCoin = 1.5
@@ -315,5 +332,39 @@ describe('PerpetualsPlaceOrderScreen terms of use', () => {
       link.props.onPress()
     })
     expect(mockOpenUrl).toHaveBeenCalledWith(TERMS_OF_USE_URL)
+  })
+})
+
+describe('PerpetualsPlaceOrderScreen side select', () => {
+  beforeEach(() => {
+    mockOrder.side = 'long'
+    mockSwitchSide.mockReset()
+    mockPillProps.mockReset()
+    mockScrollScreenProps.mockReset()
+  })
+
+  it('hands the context switchSide to the position pill', async () => {
+    await render()
+    expect(mockPillProps).toHaveBeenCalledWith(
+      expect.objectContaining({ side: 'long', onChangeSide: mockSwitchSide })
+    )
+  })
+
+  it('derives labels and capacity from the short side', async () => {
+    mockOrder.side = 'short'
+    const instance = await render()
+
+    expect(confirmButton(instance).props.label).toBe('Slide to buy Short')
+    expect(mockScrollScreenProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subtitle: expect.stringContaining('go down')
+      })
+    )
+
+    // Short capacity comes from maxSellSizeCoin (1 BTC × $100), not buy (1.5).
+    const dial = instance.root.findByProps({
+      testID: 'perpetuals_place_order_amount'
+    })
+    expect(dial.props.max).toBe(100)
   })
 })

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsPlaceOrderScreen.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsPlaceOrderScreen.tsx
@@ -268,7 +268,12 @@ export const PerpetualsPlaceOrderScreen = (): JSX.Element => {
         contentContainerStyle={{ padding: 16 }}>
         <View sx={{ paddingTop: 8, gap: 20 }}>
           <View sx={{ gap: 8 }}>
-            <PositionPill coin={coin} price={entryPrice} side={side} onChangeSide={switchSide} />
+            <PositionPill
+              coin={coin}
+              price={entryPrice}
+              side={side}
+              onChangeSide={switchSide}
+            />
 
             <View sx={{ gap: 4 }}>
               <View

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsPlaceOrderScreen.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsPlaceOrderScreen.tsx
@@ -70,6 +70,7 @@ export const PerpetualsPlaceOrderScreen = (): JSX.Element => {
   const {
     coin,
     side,
+    switchSide,
     entryPrice,
     amount,
     setAmount,
@@ -267,7 +268,7 @@ export const PerpetualsPlaceOrderScreen = (): JSX.Element => {
         contentContainerStyle={{ padding: 16 }}>
         <View sx={{ paddingTop: 8, gap: 20 }}>
           <View sx={{ gap: 8 }}>
-            <PositionPill coin={coin} price={entryPrice} side={side} />
+            <PositionPill coin={coin} price={entryPrice} side={side} onChangeSide={switchSide} />
 
             <View sx={{ gap: 4 }}>
               <View

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsPlaceOrderScreen.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsPlaceOrderScreen.tsx
@@ -62,6 +62,32 @@ const positionCapacityMessage = (
 const positionDialStep = (maxPositionNotionalUsd: number): number =>
   maxPositionNotionalUsd / 1000
 
+/**
+ * Caption under the amount dial. Flipping Long/Short swaps the capacity
+ * source (`maxBuySizeCoin` vs `maxSellSizeCoin`), so a previously valid
+ * dialed amount can end up above the new side's max — the dial visually
+ * clamps its readout, but `amount` itself is left untouched (no
+ * auto-clamping), so this surfaces that mismatch instead of silently
+ * disabling the confirm button.
+ */
+const positionCaptionText = (
+  maxPositionNotionalUsd: number | undefined,
+  amountExceedsCapacity: boolean,
+  formatCurrency: (props: { amount: number }) => string
+): string => {
+  if (maxPositionNotionalUsd === undefined) {
+    return 'Maximum position: —'
+  }
+  if (amountExceedsCapacity) {
+    return `Reduce your position to ${formatCurrency({
+      amount: maxPositionNotionalUsd
+    })} or less`
+  }
+  return `Maximum position: ${formatCurrency({
+    amount: maxPositionNotionalUsd
+  })}`
+}
+
 export const PerpetualsPlaceOrderScreen = (): JSX.Element => {
   const router = useRouter()
   const { formatCurrency } = useFormatCurrency()
@@ -308,12 +334,17 @@ export const PerpetualsPlaceOrderScreen = (): JSX.Element => {
               </View>
               <Text
                 variant="caption"
-                sx={{ color: '$textSecondary', textAlign: 'center' }}>
-                {maxPositionNotionalUsd === undefined
-                  ? 'Maximum position: —'
-                  : `Maximum position: ${formatCurrency({
-                      amount: maxPositionNotionalUsd
-                    })}`}
+                sx={{
+                  color: amountExceedsCapacity
+                    ? '$textDanger'
+                    : '$textSecondary',
+                  textAlign: 'center'
+                }}>
+                {positionCaptionText(
+                  maxPositionNotionalUsd,
+                  amountExceedsCapacity,
+                  formatCurrency
+                )}
               </Text>
             </View>
           </View>


### PR DESCRIPTION
## Description

**Ticket: [CP-14877](https://ava-labs.atlassian.net/browse/CP-14877)**

Lets the user switch between Long and Short directly on the perps Place Order screen using our native select (zeego `DropdownMenu`), instead of backing out of the modal and re-entering from the market details screen.

- `PlaceOrderContext`: `side` is now state (seeded from the renamed `initialSide` prop) with an atomic `switchSide` action. Flipping direction clears take-profit/stop-loss prices and toggles, since trigger prices are direction-specific — a long's TP sits on the wrong side of the price for a short. Switching to the current side is a no-op.
- `PositionPill`: new optional `onChangeSide` prop. When set (Place Order screen only), the Long/Short label becomes a native dropdown trigger with a chevron affordance and the current side check-marked. Trigger/Close/Manage screens pass nothing and render exactly as before.
- `PerpetualsPlaceOrderScreen`: wires `switchSide` into the pill. Subtitle, slide-button label, liquidation price, and buy-vs-sell position capacity all recompute from existing `side` derivations. When the flipped side's capacity is below the dialed amount, the caption under the dial now shows a danger-colored "Reduce your position to $X or less" warning (submit was already correctly disabled by the existing capacity guard; this makes the reason visible).

No new dependencies. No breaking changes.

## Screenshots/Videos

https://github.com/user-attachments/assets/bea98fa7-3b15-4d20-9f30-b8fcd9d138c8


## Testing

iOS - 9393
Android - 9394

**Dev Testing**

Happy path:
1. Open a perps market → tap Long → Place Order screen
2. Tap the "Long ▲" label in the position pill → native menu opens with Long check-marked
3. Pick Short → pill shows "Short ▼", subtitle flips to "will go down", slide button reads "Slide to buy Short", "Maximum position" updates to the sell-side cap
4. Slide to confirm → order submits as a short

Edge cases:
- Set a take profit and/or stop loss, then flip side → both toggles turn off and prices clear (re-enable requires entering a new price)
- Pick the same side from the menu → nothing changes, TP/SL preserved
- Dial to max on the higher-capacity side, flip to the lower-capacity side → slide button disabled and the caption shows "Reduce your position to $X or less" in red; lowering the dial re-enables
- Manage flow (existing position) and Trigger/Close screens → side label unchanged, no chevron/menu

Bitrise build:

iOS - 9384
Android - 9385

**QA Testing**

- Verify direction switching on the Place Order screen on both platforms (iOS native menu / Android dropdown)
- Verify orders submit with the direction shown at submit time
- Verify TP/SL are cleared on every direction change and preserved when re-selecting the same direction
- Verify an existing position's direction cannot be changed from the Manage flow

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CP-14877]: https://ava-labs.atlassian.net/browse/CP-14877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ