### PR TITLE
CP-14881: add adjust margin (add/remove) to isolated perps positions

### DIFF
--- a/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionCard.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/components/PositionCard.tsx
@@ -6,6 +6,7 @@ import {
   Icons,
   Pressable,
   PriceChangeStatus,
+  SplitButton,
   StatusArrow,
   Text,
   useTheme,
@@ -222,6 +223,14 @@ export const PositionCard = ({
     </>
   )
 
+  const handleMarketClose = useCallback(() => {
+    onMarketClose?.()
+  }, [onMarketClose])
+
+  const handleLimitClose = useCallback(() => {
+    onLimitClose?.()
+  }, [onLimitClose])
+
   return (
     <Animated.View
       layout={LinearTransition.easing(Easing.inOut(Easing.ease))}
@@ -248,21 +257,17 @@ export const PositionCard = ({
             onLayout={handleExpandedLayout}>
             <View>
               <View
-                sx={{ flexDirection: 'row', gap: 4, paddingHorizontal: 14 }}>
-                <Button
-                  type="secondary"
-                  size="small"
-                  onPress={onMarketClose}
-                  style={{ flex: 1 }}>
-                  Market close
-                </Button>
-                <Button
-                  type="secondary"
-                  size="small"
-                  onPress={onLimitClose}
-                  style={{ flex: 1 }}>
-                  Limit close
-                </Button>
+                sx={{ flexDirection: 'row', gap: 16, paddingHorizontal: 14 }}>
+                <SplitButton
+                  left={{
+                    children: 'Market close',
+                    onPress: handleMarketClose
+                  }}
+                  right={{
+                    children: 'Limit close',
+                    onPress: handleLimitClose
+                  }}
+                />
                 <Button
                   type="secondary"
                   size="small"

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsAdjustMarginScreen.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsAdjustMarginScreen.tsx
@@ -1,0 +1,440 @@
+import { TokenUnit } from '@avalabs/core-utils-sdk'
+import {
+  ActivityIndicator,
+  alpha,
+  Button,
+  GroupList,
+  PriceChangeStatus,
+  SegmentedControl,
+  StatusArrow,
+  Text,
+  TokenUnitInputWidget,
+  useTheme,
+  View
+} from '@avalabs/k2-alpine'
+import type { AssetPosition } from '@avalabs/perps-sdk'
+import { ScrollScreen } from 'common/components/ScrollScreen'
+import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
+import { useRouter } from 'expo-router'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
+import { useSharedValue } from 'react-native-reanimated'
+import { formatNumber } from 'utils/formatNumber/formatNumber'
+import { DexBadge } from '../components/DexBadge'
+import { PerpsCoinLogo } from '../components/PerpsCoinLogo'
+import { usePlaceOrder } from '../contexts/PlaceOrderContext'
+import { usePerpsEnableTradingGate } from '../hooks/usePerpsEnableTradingGate'
+import { usePerpsPositionActions } from '../hooks/usePerpsPositionActions'
+import { usePerpsPositions } from '../hooks/usePerpsPositions'
+import { dexOfCoin, tickerOfCoin } from '../utils/coinDex'
+import {
+  estimateLiquidationPriceFromMargin,
+  floorToDecimals,
+  maxRemovableMarginUsd
+} from '../utils/economics'
+import { toNumber } from '../utils/format'
+
+type AdjustMode = 'add' | 'remove'
+
+const MODES: AdjustMode[] = ['add', 'remove']
+const MODE_ITEMS = [{ title: 'Add' }, { title: 'Remove' }]
+
+/** USDC margin amounts are entered/submitted with 2 decimals (cents). */
+const AMOUNT_DECIMALS = 2
+// Empty symbol: the design captions the amount ("Amount to add in USDC")
+// below the input instead of suffixing every keystroke.
+const AMOUNT_TOKEN = { maxDecimals: AMOUNT_DECIMALS, symbol: '' }
+
+// Fractions of the active mode's max, resolved against the live `balance`
+// prop at press time so they stay correct as the max updates.
+const AMOUNT_PRESETS = [
+  { label: '25%', percent: 0.25 },
+  { label: '50%', percent: 0.5 },
+  { label: '100%', percent: 1 }
+] as const
+
+const toAmountUnit = (amount: number): TokenUnit =>
+  new TokenUnit(
+    Math.round(amount * 10 ** AMOUNT_DECIMALS),
+    AMOUNT_DECIMALS,
+    AMOUNT_TOKEN.symbol
+  )
+
+/**
+ * The caption under the amount card. Explains *why* nothing can be entered
+ * instead of a bare "Balance: 0.00": adding needs free account collateral,
+ * and a position at its set leverage sits exactly at Hyperliquid's required
+ * margin, so nothing is removable until margin is added on top or the
+ * position gains unrealized profit. `isDanger` renders the blocking cases
+ * (over max, nothing to add/remove) in the danger color.
+ */
+const buildHelperText = ({
+  mode,
+  exceedsMax,
+  maxForMode,
+  withdrawableUsd,
+  isWithdrawableLoading
+}: {
+  mode: AdjustMode
+  exceedsMax: boolean
+  maxForMode: number
+  withdrawableUsd: number | undefined
+  isWithdrawableLoading: boolean
+}): { text: string; isDanger: boolean } => {
+  if (exceedsMax) {
+    return {
+      text:
+        mode === 'add'
+          ? 'Amount exceeds your available balance'
+          : 'Amount exceeds the margin available to remove',
+      isDanger: true
+    }
+  }
+  if (maxForMode > 0) {
+    return {
+      text: `Balance: ${formatNumber(Math.max(0, withdrawableUsd ?? 0))} USDC`,
+      isDanger: false
+    }
+  }
+  if (mode === 'remove') {
+    return {
+      text: 'No margin available to remove',
+      isDanger: true
+    }
+  }
+  return isWithdrawableLoading
+    ? { text: 'Balance: -', isDanger: false }
+    : {
+        text: 'No balance available to add',
+        isDanger: true
+      }
+}
+
+/**
+ * Add or remove isolated USDC margin for an open position to change its
+ * liquidation risk. Only reachable for isolated positions (the Manage screen
+ * gates its Margin row); submits a signed USD delta through
+ * `updateIsolatedMargin` — positive adds, negative removes.
+ */
+export const PerpetualsAdjustMarginScreen = (): JSX.Element => {
+  const { theme } = useTheme()
+  const router = useRouter()
+  const { formatCurrency } = useFormatCurrency()
+  // `coin` / `maxLeverage` come from the manage layout's shared context —
+  // maxLeverage is the market cap that drives the liquidation estimate.
+  const { coin, maxLeverage } = usePlaceOrder()
+  const { positions, withdrawableUsd, isWithdrawableLoading } =
+    usePerpsPositions()
+  const { updateIsolatedMargin, busy } = usePerpsPositionActions()
+  const { requireTradingEnabled, enableTradingModal } =
+    usePerpsEnableTradingGate()
+
+  const [mode, setMode] = useState<AdjustMode>('add')
+  const selectedSegmentIndex = useSharedValue(0)
+  /** Amount in USDC; `0` is treated as empty. */
+  const [amount, setAmount] = useState(0)
+
+  // Live clearinghouse position (kept current over WS) so margin / PnL /
+  // liquidation stay fresh while the sheet is open. Falls back to the last
+  // seen snapshot during transient refetches so the sheet never blanks.
+  const livePosition = useMemo(
+    () =>
+      positions.find(p => p.position.coin.toUpperCase() === coin.toUpperCase())
+        ?.position,
+    [positions, coin]
+  )
+  const snapshotRef = useRef<AssetPosition['position'] | undefined>(undefined)
+  if (livePosition !== undefined) {
+    snapshotRef.current = livePosition
+  }
+  const position = livePosition ?? snapshotRef.current
+
+  const szi = toNumber(position?.szi)
+  const isLong = szi >= 0
+  const entryPrice = toNumber(position?.entryPx)
+  const marginUsed = toNumber(position?.marginUsed)
+  const setLeverage = position?.leverage.value ?? 0
+
+  // Position notional backing the maintenance-margin / liquidation math.
+  // Prefer the exchange-reported value; fall back to size × entry.
+  const notionalUsd = useMemo(() => {
+    const reported = Math.abs(toNumber(position?.positionValue))
+    return reported > 0 ? reported : Math.abs(szi) * entryPrice
+  }, [position?.positionValue, szi, entryPrice])
+
+  const maxForMode = useMemo(() => {
+    const max =
+      mode === 'add'
+        ? Math.max(0, withdrawableUsd ?? 0)
+        : maxRemovableMarginUsd({
+            marginUsed,
+            unrealizedPnl: toNumber(position?.unrealizedPnl),
+            notionalUsd,
+            leverage: setLeverage
+          })
+    // Floored to the input precision so the 100% preset can't round up past
+    // the true cap and trip validation / HL's margin-reduction check.
+    return floorToDecimals(max, AMOUNT_DECIMALS)
+  }, [
+    mode,
+    withdrawableUsd,
+    marginUsed,
+    position?.unrealizedPnl,
+    notionalUsd,
+    setLeverage
+  ])
+
+  const currentLiqPx = toNumber(position?.liquidationPx)
+  const projectedLiqPx = useMemo(() => {
+    if (amount <= 0 || maxLeverage <= 0) {
+      return Number.NaN
+    }
+    const newMargin = mode === 'add' ? marginUsed + amount : marginUsed - amount
+    return estimateLiquidationPriceFromMargin({
+      entryPrice,
+      isLong,
+      maxLeverage,
+      notionalUsd,
+      marginUsd: newMargin
+    })
+  }, [amount, mode, marginUsed, entryPrice, isLong, maxLeverage, notionalUsd])
+
+  const exceedsMax = amount > maxForMode + 1e-9
+  const canSubmit = position !== undefined && amount > 0 && !exceedsMax && !busy
+
+  const helperText = buildHelperText({
+    mode,
+    exceedsMax,
+    maxForMode,
+    withdrawableUsd,
+    isWithdrawableLoading
+  })
+
+  const handleSelectMode = useCallback(
+    (index: number) => {
+      selectedSegmentIndex.value = index
+      setMode(MODES[index] ?? 'add')
+      // The widget is remounted via `key={mode}`, clearing the typed value.
+      setAmount(0)
+    },
+    [selectedSegmentIndex]
+  )
+
+  const handleAmountChange = useCallback((value: TokenUnit): void => {
+    setAmount(value.toDisplay({ asNumber: true }))
+  }, [])
+
+  const amountCaption = useCallback(
+    (): string => `Amount to ${mode} in USDC`,
+    [mode]
+  )
+
+  const handleConfirm = useCallback(async () => {
+    if (!canSubmit) {
+      return
+    }
+    // Adjusting margin signs an L1 action, so ensure trading is set up first.
+    if (!requireTradingEnabled()) {
+      return
+    }
+    const ok = await updateIsolatedMargin(
+      coin,
+      mode === 'add' ? amount : -amount
+    )
+    if (ok) {
+      router.back()
+    }
+  }, [
+    canSubmit,
+    requireTradingEnabled,
+    updateIsolatedMargin,
+    coin,
+    mode,
+    amount,
+    router
+  ])
+
+  const renderFooter = useCallback(
+    () => (
+      <Button
+        type="primary"
+        size="large"
+        disabled={!canSubmit}
+        testID="perpetuals_adjust_margin_confirm"
+        onPress={handleConfirm}>
+        {busy ? <ActivityIndicator size="small" /> : 'Confirm'}
+      </Button>
+    ),
+    [canSubmit, busy, handleConfirm]
+  )
+
+  const liquidationValue = (
+    <View sx={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+      <Text variant="body1">
+        {currentLiqPx > 0 ? formatCurrency({ amount: currentLiqPx }) : '—'}
+      </Text>
+      {Number.isFinite(projectedLiqPx) && (
+        <>
+          <Text variant="body1" sx={{ color: '$textSecondary' }}>
+            →
+          </Text>
+          <Text
+            variant="body1"
+            sx={{ color: mode === 'add' ? '$textSuccess' : '$textDanger' }}>
+            {formatCurrency({ amount: projectedLiqPx })}
+          </Text>
+        </>
+      )}
+    </View>
+  )
+
+  return (
+    <>
+      <ScrollScreen
+        isModal
+        title="Adjust margin"
+        navigationTitle="Adjust margin"
+        subtitle="Add or remove USDC to change the liquidation risk of this position"
+        shouldAvoidKeyboard
+        renderFooter={renderFooter}
+        contentContainerStyle={{ padding: 16 }}>
+        <View sx={{ paddingTop: 8, gap: 10 }}>
+          <View sx={{ gap: 4 }}>
+            <View
+              sx={{
+                backgroundColor: '$surfaceSecondary',
+                borderRadius: 12,
+                borderBottomLeftRadius: 4,
+                borderBottomRightRadius: 4,
+                padding: 16,
+                flexDirection: 'row',
+                alignItems: 'center'
+              }}>
+              <PerpsCoinLogo size={32} symbol={coin} />
+              <View sx={{ marginLeft: 10, flex: 1, gap: 2 }}>
+                <View
+                  sx={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+                  <Text variant="body2" sx={{ fontFamily: 'Inter-Medium' }}>
+                    {`${tickerOfCoin(coin)}-USDC`}
+                  </Text>
+                  <DexBadge dex={dexOfCoin(coin)} />
+                </View>
+                <View
+                  sx={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    alignSelf: 'flex-start',
+                    gap: 8
+                  }}>
+                  <View
+                    sx={{
+                      backgroundColor: alpha(theme.colors.$textPrimary, 0.1),
+                      borderRadius: 6,
+                      paddingHorizontal: 6,
+                      paddingVertical: 2
+                    }}>
+                    <Text variant="caption" sx={{ fontFamily: 'Inter-Medium' }}>
+                      {`${setLeverage}×`}
+                    </Text>
+                  </View>
+                  <Text
+                    variant="caption"
+                    sx={{
+                      color: '$textSecondary',
+                      fontFamily: 'Inter-Medium'
+                    }}>
+                    Isolated
+                  </Text>
+                </View>
+              </View>
+              <View sx={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+                <Text variant="heading3">{isLong ? 'Long' : 'Short'}</Text>
+                <StatusArrow
+                  status={
+                    isLong ? PriceChangeStatus.Up : PriceChangeStatus.Down
+                  }
+                  size={16}
+                />
+              </View>
+            </View>
+
+            <View
+              sx={{
+                backgroundColor: '$surfaceSecondary',
+                borderRadius: 12,
+                borderTopLeftRadius: 4,
+                borderTopRightRadius: 4,
+                paddingTop: 20
+              }}>
+              <SegmentedControl
+                items={MODE_ITEMS}
+                selectedSegmentIndex={selectedSegmentIndex}
+                onSelectSegment={handleSelectMode}
+                dynamicItemWidth={false}
+                type="thin"
+                backgroundColor={alpha(theme.colors.$textPrimary, 0.1)}
+                style={{ alignSelf: 'center', width: 150 }}
+                height={27}
+              />
+              <TokenUnitInputWidget
+                key={mode}
+                autoFocus
+                token={AMOUNT_TOKEN}
+                balance={toAmountUnit(maxForMode)}
+                onChange={handleAmountChange}
+                formatInCurrency={amountCaption}
+                presets={AMOUNT_PRESETS}
+                valid={!exceedsMax}
+                cardSx={{ backgroundColor: 'transparent', paddingTop: 12 }}
+              />
+            </View>
+          </View>
+
+          <Text
+            variant="caption"
+            sx={{
+              textAlign: 'center',
+              color: helperText.isDanger ? '$textDanger' : '$textPrimary'
+            }}>
+            {helperText.text}
+          </Text>
+
+          <GroupList
+            titleSx={{ fontFamily: 'Inter-Regular' }}
+            data={[
+              {
+                title: `Current margin for ${tickerOfCoin(coin)}`,
+                value: (
+                  <Text variant="body1">
+                    {`${formatNumber(marginUsed)} USDC`}
+                  </Text>
+                )
+              },
+              {
+                title:
+                  mode === 'add'
+                    ? 'Margin available to add'
+                    : 'Margin available to remove',
+                value: (
+                  <Text variant="body1">
+                    {`${formatNumber(maxForMode)} USDC`}
+                  </Text>
+                )
+              },
+              {
+                title: 'Liquidation price',
+                value: liquidationValue
+              }
+            ]}
+          />
+
+          <Text variant="caption" sx={{ color: '$textSecondary' }}>
+            Adjusting margin only changes this position's collateral and
+            liquidation price - your entry price, size, and unrealized PnL are
+            unchanged.
+          </Text>
+        </View>
+      </ScrollScreen>
+      {enableTradingModal}
+    </>
+  )
+}

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsAdjustMarginScreen.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsAdjustMarginScreen.tsx
@@ -90,8 +90,13 @@ const buildHelperText = ({
     }
   }
   if (maxForMode > 0) {
+    // Remove mode's cap is the position's removable margin, not the account
+    // balance — labelling it "Balance" would show an unrelated number.
     return {
-      text: `Balance: ${formatNumber(Math.max(0, withdrawableUsd ?? 0))} USDC`,
+      text:
+        mode === 'add'
+          ? `Balance: ${formatNumber(Math.max(0, withdrawableUsd ?? 0))} USDC`
+          : `Available to remove: ${formatNumber(maxForMode)} USDC`,
       isDanger: false
     }
   }
@@ -384,7 +389,7 @@ export const PerpetualsAdjustMarginScreen = (): JSX.Element => {
                 formatInCurrency={amountCaption}
                 presets={AMOUNT_PRESETS}
                 valid={!exceedsMax}
-                cardSx={{ backgroundColor: 'transparent', paddingTop: 12 }}
+                cardSx={{ paddingTop: 12 }}
               />
             </View>
           </View>

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsBalanceScreen.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsBalanceScreen.tsx
@@ -198,7 +198,7 @@ export const PerpetualsBalanceScreen = (): JSX.Element => {
         isModal
         title="Available balance"
         navigationTitle="Available balance"
-        contentContainerStyle={{ flexGrow: 1 }}>
+        contentContainerStyle={{ flexGrow: 1, padding: 16 }}>
         <View
           testID="perps-balance-loading"
           sx={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
@@ -214,7 +214,7 @@ export const PerpetualsBalanceScreen = (): JSX.Element => {
         isModal
         title="Available balance"
         navigationTitle="Available balance"
-        contentContainerStyle={{ flexGrow: 1 }}>
+        contentContainerStyle={{ flexGrow: 1, padding: 16 }}>
         <PerpsApiDownState onRetry={refetchBalance} />
       </ScrollScreen>
     )

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsManageScreen.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsManageScreen.tsx
@@ -11,16 +11,19 @@ import { ScrollScreen } from 'common/components/ScrollScreen'
 import { useFormatCurrency } from 'common/hooks/useFormatCurrency'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import React, { useCallback, useMemo, useState } from 'react'
+import { formatNumber } from 'utils/formatNumber/formatNumber'
 import { TriggerToggleCard } from '../components/TriggerToggleCard'
 import { usePlaceOrder } from '../contexts/PlaceOrderContext'
 import { usePerpsAllOpenOrders } from '../hooks/usePerpsAllOpenOrders'
 import { usePerpsEnableTradingGate } from '../hooks/usePerpsEnableTradingGate'
 import { usePerpsPositionActions } from '../hooks/usePerpsPositionActions'
+import { usePerpsPositions } from '../hooks/usePerpsPositions'
 import { useTriggerToggles } from '../hooks/useTriggerToggles'
 import { dexOfCoin, tickerOfCoin } from '../utils/coinDex'
 import { DexBadge } from '../components/DexBadge'
 import { PerpsCoinLogo } from '../components/PerpsCoinLogo'
 import { formatSigned, pnlColor } from '../utils/economics'
+import { toNumber } from '../utils/format'
 import { extractPositionTriggerOrders } from '../utils/toPosition'
 
 export const PerpetualsManageScreen = (): JSX.Element => {
@@ -62,6 +65,19 @@ export const PerpetualsManageScreen = (): JSX.Element => {
   const effectiveStopLossPrice = stopLossEnabled ? stopLossPrice : undefined
   const tpChanged = effectiveTakeProfitPrice !== initialTakeProfitPrice
   const slChanged = effectiveStopLossPrice !== initialStopLossPrice
+
+  // The live clearinghouse position for this coin: the Margin row must show
+  // the current margin (a route-param snapshot would go stale after an
+  // adjustment) and only isolated positions can have their margin adjusted.
+  const { positions } = usePerpsPositions()
+  const livePosition = useMemo(
+    () =>
+      positions.find(p => p.position.coin.toUpperCase() === coin.toUpperCase())
+        ?.position,
+    [positions, coin]
+  )
+  const isIsolated = livePosition?.leverage.type === 'isolated'
+  const marginUsed = toNumber(livePosition?.marginUsed)
 
   // The position's existing on-book TP/SL triggers (with order ids). A changed
   // or turned-off side must cancel its existing trigger — HL has no modify, so
@@ -264,7 +280,23 @@ export const PerpetualsManageScreen = (): JSX.Element => {
                     }${pnlPct.toFixed(1)}%)`}
                   </Text>
                 )
-              }
+              },
+              // Margin can only be added/removed on isolated positions —
+              // cross positions share the account-wide collateral.
+              ...(isIsolated
+                ? [
+                    {
+                      title: 'Margin',
+                      value: (
+                        <Text variant="body1">
+                          {`${formatNumber(marginUsed)} USDC`}
+                        </Text>
+                      ),
+                      onPress: () =>
+                        router.navigate('/perpetualsManage/adjustMargin')
+                    }
+                  ]
+                : [])
             ]}
           />
 

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsWithdrawScreen.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsWithdrawScreen.tsx
@@ -190,7 +190,7 @@ export const PerpetualsWithdrawScreen = (): JSX.Element => {
         isModal
         title="How much do you want to withdraw?"
         navigationTitle="Enter withdraw amount"
-        contentContainerStyle={{ flexGrow: 1 }}>
+        contentContainerStyle={{ flexGrow: 1, padding: 16 }}>
         <View
           testID="perps-withdrawable-loading"
           sx={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
@@ -206,7 +206,7 @@ export const PerpetualsWithdrawScreen = (): JSX.Element => {
         isModal
         title="How much do you want to withdraw?"
         navigationTitle="Enter withdraw amount"
-        contentContainerStyle={{ flexGrow: 1 }}>
+        contentContainerStyle={{ flexGrow: 1, padding: 16 }}>
         <PerpsApiDownState onRetry={refetchWithdrawable} />
       </ScrollScreen>
     )

--- a/packages/core-mobile/app/new/features/trade/perpetuals/utils/economics.test.ts
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/utils/economics.test.ts
@@ -1,6 +1,9 @@
 import {
   estimateLiquidationPrice,
+  estimateLiquidationPriceFromMargin,
+  floorToDecimals,
   formatSigned,
+  maxRemovableMarginUsd,
   isTriggerValid,
   pctFromEntry,
   pnlColor,
@@ -48,6 +51,200 @@ describe('estimateLiquidationPrice', () => {
     const withoutMm = estimateLiquidationPrice(100, 10, true)
     // Real liquidation is closer to entry (higher for a long) → smaller buffer.
     expect(withMm).toBeGreaterThan(withoutMm)
+  })
+})
+
+describe('estimateLiquidationPriceFromMargin', () => {
+  // 10× long at $100 entry, $1000 notional, $100 margin on a 10×-max coin:
+  // mmf = 0.05, buffer = 0.1 − 0.05 = 0.05 → liq = 100 · (1 − 0.05/0.95).
+  it('matches the leverage-based estimate when margin = notional/leverage', () => {
+    const fromMargin = estimateLiquidationPriceFromMargin({
+      entryPrice: 100,
+      isLong: true,
+      maxLeverage: 10,
+      notionalUsd: 1000,
+      marginUsd: 100
+    })
+    expect(fromMargin).toBeCloseTo(estimateLiquidationPrice(100, 10, true, 10))
+  })
+
+  it('moves a long liquidation down when margin is added', () => {
+    const base = {
+      entryPrice: 100,
+      isLong: true,
+      maxLeverage: 10,
+      notionalUsd: 1000
+    }
+    const before = estimateLiquidationPriceFromMargin({
+      ...base,
+      marginUsd: 100
+    })
+    const after = estimateLiquidationPriceFromMargin({
+      ...base,
+      marginUsd: 200
+    })
+    expect(after).toBeLessThan(before)
+  })
+
+  it('moves a short liquidation up when margin is added', () => {
+    const base = {
+      entryPrice: 100,
+      isLong: false,
+      maxLeverage: 10,
+      notionalUsd: 1000
+    }
+    const before = estimateLiquidationPriceFromMargin({
+      ...base,
+      marginUsd: 100
+    })
+    const after = estimateLiquidationPriceFromMargin({
+      ...base,
+      marginUsd: 200
+    })
+    expect(after).toBeGreaterThan(before)
+  })
+
+  it('returns NaN when a long is over-collateralized past zero', () => {
+    expect(
+      estimateLiquidationPriceFromMargin({
+        entryPrice: 100,
+        isLong: true,
+        maxLeverage: 10,
+        notionalUsd: 1000,
+        marginUsd: 5000
+      })
+    ).toBeNaN()
+  })
+
+  it('returns NaN for invalid inputs', () => {
+    expect(
+      estimateLiquidationPriceFromMargin({
+        entryPrice: 100,
+        isLong: true,
+        maxLeverage: 0,
+        notionalUsd: 1000,
+        marginUsd: 100
+      })
+    ).toBeNaN()
+    expect(
+      estimateLiquidationPriceFromMargin({
+        entryPrice: 100,
+        isLong: true,
+        maxLeverage: 10,
+        notionalUsd: 0,
+        marginUsd: 100
+      })
+    ).toBeNaN()
+    expect(
+      estimateLiquidationPriceFromMargin({
+        entryPrice: 100,
+        isLong: true,
+        maxLeverage: 10,
+        notionalUsd: 1000,
+        marginUsd: 0
+      })
+    ).toBeNaN()
+  })
+})
+
+describe('maxRemovableMarginUsd', () => {
+  it('is ~0 for a flat position at its set leverage', () => {
+    // $1000 notional at 10×: margin = $100 = transfer floor → nothing removable.
+    expect(
+      maxRemovableMarginUsd({
+        marginUsed: 100,
+        unrealizedPnl: 0,
+        notionalUsd: 1000,
+        leverage: 10
+      })
+    ).toBe(0)
+  })
+
+  it('releases the margin above the transfer floor, with a 2% cushion', () => {
+    // $200 margin against a $100 floor → (200 − 100) · 0.98 = 98.
+    expect(
+      maxRemovableMarginUsd({
+        marginUsed: 200,
+        unrealizedPnl: 0,
+        notionalUsd: 1000,
+        leverage: 10
+      })
+    ).toBeCloseTo(98)
+  })
+
+  it('counts unrealized PnL toward the removable equity', () => {
+    // Equity = 100 + 50 = 150 vs a $100 floor → (150 − 100) · 0.98 = 49.
+    expect(
+      maxRemovableMarginUsd({
+        marginUsed: 100,
+        unrealizedPnl: 50,
+        notionalUsd: 1000,
+        leverage: 10
+      })
+    ).toBeCloseTo(49)
+  })
+
+  it('applies the 10% notional floor at high set leverage', () => {
+    // 40×: notional/leverage = $25 but the floor is 0.1 · 1000 = $100.
+    expect(
+      maxRemovableMarginUsd({
+        marginUsed: 200,
+        unrealizedPnl: 0,
+        notionalUsd: 1000,
+        leverage: 40
+      })
+    ).toBeCloseTo(98)
+  })
+
+  it('never exceeds the deposited margin', () => {
+    // Huge positive PnL can't unlock more than what was put in.
+    expect(
+      maxRemovableMarginUsd({
+        marginUsed: 100,
+        unrealizedPnl: 10_000,
+        notionalUsd: 1000,
+        leverage: 10
+      })
+    ).toBe(100)
+  })
+
+  it('clamps to 0 when underwater and for unknown leverage/notional', () => {
+    expect(
+      maxRemovableMarginUsd({
+        marginUsed: 100,
+        unrealizedPnl: -80,
+        notionalUsd: 1000,
+        leverage: 10
+      })
+    ).toBe(0)
+    expect(
+      maxRemovableMarginUsd({
+        marginUsed: 100,
+        unrealizedPnl: 0,
+        notionalUsd: 0,
+        leverage: 10
+      })
+    ).toBe(0)
+    expect(
+      maxRemovableMarginUsd({
+        marginUsed: 100,
+        unrealizedPnl: 0,
+        notionalUsd: 1000,
+        leverage: 0
+      })
+    ).toBe(0)
+  })
+})
+
+describe('floorToDecimals', () => {
+  it('floors instead of rounding so presets cannot exceed the cap', () => {
+    expect(floorToDecimals(7.069, 2)).toBe(7.06)
+    expect(floorToDecimals(7.061, 2)).toBe(7.06)
+  })
+
+  it('clamps negatives and non-finite values to 0', () => {
+    expect(floorToDecimals(-1.23, 2)).toBe(0)
+    expect(floorToDecimals(Number.NaN, 2)).toBe(0)
   })
 })
 

--- a/packages/core-mobile/app/new/features/trade/perpetuals/utils/economics.ts
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/utils/economics.ts
@@ -143,7 +143,12 @@ export const maxRemovableMarginUsd = ({
  */
 export const floorToDecimals = (value: number, decimals: number): number => {
   if (!Number.isFinite(value)) return 0
-  const factor = 10 ** decimals
+  // Clamp to a safe non-negative integer so a bad `decimals` can't produce a
+  // NaN/zero factor and leak NaN to callers.
+  const safeDecimals = Number.isFinite(decimals)
+    ? Math.max(0, Math.trunc(decimals))
+    : 0
+  const factor = 10 ** safeDecimals
   return Math.max(0, Math.floor(value * factor) / factor)
 }
 

--- a/packages/core-mobile/app/new/features/trade/perpetuals/utils/economics.ts
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/utils/economics.ts
@@ -43,6 +43,110 @@ export const estimateLiquidationPrice = (
   return (entryPrice * (1 - side / leverage)) / denominator
 }
 
+/**
+ * Isolated-margin liquidation estimate from the margin backing the position,
+ * for flows that change the collateral rather than the leverage (adjust
+ * margin). Mirrors Hyperliquid's formula
+ *   liq = entry − side · marginAvailable / size / (1 − mmf · side)
+ * with `mmf = 1 / (2 · maxLeverage)`; written per-unit-of-notional it reduces
+ * to the closed forms below. Returns `NaN` for invalid inputs or when a long
+ * is collateralized enough that its liquidation would fall at/below 0
+ * (callers should then omit the estimate).
+ */
+export const estimateLiquidationPriceFromMargin = ({
+  entryPrice,
+  isLong,
+  maxLeverage,
+  notionalUsd,
+  marginUsd
+}: {
+  entryPrice: number
+  isLong: boolean
+  maxLeverage: number
+  /** Position notional in USD (size × entry). */
+  notionalUsd: number
+  /** Margin (equity) backing the position after the adjustment. */
+  marginUsd: number
+}): number => {
+  if (
+    !Number.isFinite(entryPrice) ||
+    entryPrice <= 0 ||
+    !Number.isFinite(maxLeverage) ||
+    maxLeverage <= 0 ||
+    !Number.isFinite(notionalUsd) ||
+    notionalUsd <= 0 ||
+    !Number.isFinite(marginUsd) ||
+    marginUsd <= 0
+  ) {
+    return Number.NaN
+  }
+  const maintenanceMarginFraction = 1 / (2 * maxLeverage)
+  // Per-notional buffer: equity backing the position, less the maintenance it
+  // must keep.
+  const buffer = marginUsd / notionalUsd - maintenanceMarginFraction
+  if (isLong) {
+    const liq = entryPrice * (1 - buffer / (1 - maintenanceMarginFraction))
+    return liq > 0 ? liq : Number.NaN
+  }
+  return entryPrice * (1 + buffer / (1 + maintenanceMarginFraction))
+}
+
+/**
+ * Max isolated margin the user can withdraw without Hyperliquid rejecting the
+ * reduction ("position does not have sufficient margin for reduction").
+ *
+ * Per HL's margining rules, after any margin removal the remaining position
+ * equity must satisfy
+ *   transfer_margin_required = max(initial_margin_required, 0.1 · notional)
+ * where `initial_margin_required = notional / leverage` (the position's own
+ * set leverage, NOT the market max). Unrealized PnL counts toward the
+ * remaining equity, so
+ *   removable = (marginUsed + unrealizedPnl) − max(notional/leverage, 0.1·notional)
+ * A roughly flat position at its set leverage therefore has ~0 removable
+ * (matches HL). Capped at the deposited margin and to `0` when leverage /
+ * notional are unknown, with a 2% cushion for price drift before submit.
+ *
+ * @see https://hyperliquid.gitbook.io/hyperliquid-docs/trading/margining
+ */
+export const maxRemovableMarginUsd = ({
+  marginUsed,
+  unrealizedPnl,
+  notionalUsd,
+  leverage
+}: {
+  marginUsed: number
+  unrealizedPnl: number
+  /** Position notional in USD (size × entry). */
+  notionalUsd: number
+  /** The position's set leverage. */
+  leverage: number
+}): number => {
+  if (
+    !Number.isFinite(leverage) ||
+    leverage <= 0 ||
+    !Number.isFinite(notionalUsd) ||
+    notionalUsd <= 0 ||
+    !Number.isFinite(marginUsed)
+  ) {
+    return 0
+  }
+  const equity =
+    marginUsed + (Number.isFinite(unrealizedPnl) ? unrealizedPnl : 0)
+  const transferFloor = Math.max(notionalUsd / leverage, 0.1 * notionalUsd)
+  const removable = (equity - transferFloor) * 0.98
+  return Math.max(0, Math.min(marginUsed, removable))
+}
+
+/**
+ * Floor to `decimals` places so a quick-amount preset can't round *up* past
+ * the true cap and trip validation / HL's margin-reduction check.
+ */
+export const floorToDecimals = (value: number, decimals: number): number => {
+  if (!Number.isFinite(value)) return 0
+  const factor = 10 ** decimals
+  return Math.max(0, Math.floor(value * factor) / factor)
+}
+
 /** Position size in tokens implied by USD position notional at entry. */
 export const positionSizeTokens = (
   positionNotionalUsd: number,

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/perpetualsManage/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/perpetualsManage/_layout.tsx
@@ -16,6 +16,7 @@ export default function PerpetualsManageLayout(): JSX.Element {
       <Stack screenOptions={modalStackNavigatorScreenOptions}>
         <Stack.Screen name="index" options={modalFirstScreenOptions} />
         <Stack.Screen name="trigger" options={stackScreensOptions} />
+        <Stack.Screen name="adjustMargin" options={stackScreensOptions} />
       </Stack>
     </PlaceOrderProvider>
   )

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/perpetualsManage/adjustMargin.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/perpetualsManage/adjustMargin.tsx
@@ -1,0 +1,3 @@
+import { PerpetualsAdjustMarginScreen } from 'features/trade/perpetuals/screens/PerpetualsAdjustMarginScreen'
+
+export { PerpetualsAdjustMarginScreen as default }

--- a/packages/k2-alpine/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/k2-alpine/src/components/SegmentedControl/SegmentedControl.tsx
@@ -30,6 +30,7 @@ export const SegmentedControl = ({
   dynamicItemWidth,
   style,
   type = 'default',
+  height,
   backgroundColor
 }: {
   items: { title: string; badge?: JSX.Element }[]
@@ -38,6 +39,7 @@ export const SegmentedControl = ({
   dynamicItemWidth: boolean
   style?: ViewStyle
   type?: 'default' | 'thin'
+  height?: number
   backgroundColor?: string
 }): JSX.Element | null => {
   const { theme } = useTheme()
@@ -170,7 +172,7 @@ export const SegmentedControl = ({
           {items.map((item, index) => {
             return (
               <Segment
-                sx={{ height: type === 'thin' ? 36 : 42 }}
+                sx={{ height: height ?? (type === 'thin' ? 36 : 42) }}
                 key={index}
                 ratio={dynamicItemWidth ? textRatios : 1 / itemsCount}
                 text={item.title}

--- a/packages/k2-alpine/src/components/TokenUnitInput/TokenUnitInputWidget.tsx
+++ b/packages/k2-alpine/src/components/TokenUnitInput/TokenUnitInputWidget.tsx
@@ -9,9 +9,14 @@ export interface TokenUnitInputPreset {
   label: string
   /**
    * Display amount applied to the input when this preset is tapped
-   * (e.g. `100` for 100 tokens).
+   * (e.g. `100` for 100 tokens). Ignored when `percent` is set.
    */
-  value: number
+  value?: number
+  /**
+   * Fraction of the live `balance` applied when tapped (e.g. `0.25` for 25%).
+   * Unlike `value`, this tracks `balance` prop updates after mount.
+   */
+  percent?: number
 }
 
 // Internal button model. A button either applies a fixed display `value`
@@ -60,15 +65,21 @@ export const TokenUnitInputWidget = ({
   /** When false, the amount renders in the danger color. */
   valid?: boolean
   /**
-   * Custom quick-amount buttons rendered as fixed display amounts (e.g.
-   * `$100 / $250 / $500`). When provided, overrides the default
+   * Custom quick-amount buttons, either fixed display amounts (e.g.
+   * `$100 / $250 / $500` via `value`) or balance fractions (e.g.
+   * `25% / 50% / 100%` via `percent`). When provided, overrides the default
    * `25% / 50% / Max` percentage buttons.
    */
   presets?: readonly TokenUnitInputPreset[]
 }): JSX.Element => {
   const [buttons, setButtons] = useState<AmountButton[]>(() =>
     presets && presets.length > 0
-      ? presets.map(p => ({ text: p.label, value: p.value, isSelected: false }))
+      ? presets.map(p => ({
+          text: p.label,
+          value: p.value,
+          percent: p.percent,
+          isSelected: false
+        }))
       : [
           { text: '25%', percent: 0.25, isSelected: false },
           { text: '50%', percent: 0.5, isSelected: false },
@@ -90,6 +101,11 @@ export const TokenUnitInputWidget = ({
             token.symbol
           )
         : balance.mul(button.percent ?? 0)
+    // A zero result (e.g. a percentage of an empty balance) would replace the
+    // placeholder with a literal "0" and highlight the button — keep it a no-op.
+    if (valueUnit.isZero()) {
+      return
+    }
     textInputRef.current?.setValue(
       valueUnit.toDisplay({ asNumber: true }).toString()
     )

--- a/packages/k2-alpine/src/components/TokenUnitInput/TokenUnitInputWidget.tsx
+++ b/packages/k2-alpine/src/components/TokenUnitInput/TokenUnitInputWidget.tsx
@@ -93,17 +93,19 @@ export const TokenUnitInputWidget = ({
     // straight from `balance.mul` (bigint math), fixed presets round to the
     // nearest subunit. Going through `displayValue * 10 ** decimals` could
     // diverge by a subunit from the bigint parsing `TokenUnitInput` uses.
+    // `percent` wins over `value` (matching the `TokenUnitInputPreset` docs).
     const valueUnit =
-      button.value !== undefined
-        ? new TokenUnit(
-            Math.round(button.value * 10 ** token.maxDecimals),
+      button.percent !== undefined
+        ? balance.mul(button.percent)
+        : new TokenUnit(
+            Math.round((button.value ?? 0) * 10 ** token.maxDecimals),
             token.maxDecimals,
             token.symbol
           )
-        : balance.mul(button.percent ?? 0)
-    // A zero result (e.g. a percentage of an empty balance) would replace the
-    // placeholder with a literal "0" and highlight the button — keep it a no-op.
-    if (valueUnit.isZero()) {
+    // A zero percentage result (e.g. a fraction of an empty balance) would
+    // replace the placeholder with a literal "0" and highlight the button —
+    // keep it a no-op. Fixed-value presets apply as-is.
+    if (button.percent !== undefined && valueUnit.isZero()) {
       return
     }
     textInputRef.current?.setValue(
@@ -125,9 +127,9 @@ export const TokenUnitInputWidget = ({
         prevButtons.map(b => ({
           ...b,
           isSelected:
-            b.value !== undefined
-              ? value.toDisplay({ asNumber: true }) === b.value
-              : value.toDisplay() === balance.mul(b.percent ?? 0).toDisplay()
+            b.percent !== undefined
+              ? value.toDisplay() === balance.mul(b.percent).toDisplay()
+              : value.toDisplay({ asNumber: true }) === b.value
         }))
       )
 


### PR DESCRIPTION
## Description

**Ticket: [CP-14881](https://ava-labs.atlassian.net/browse/CP-14881)**

Adds the **Adjust margin** flow for isolated perps positions ([Figma](https://www.figma.com/design/aj9mmgDMaaxZXkuIRKLhIn/Core-Mobile-2026?node-id=23374-28065)), mirroring core-web's `AdjustMarginModal`.

- **Entry point**: a new "Margin" row on the Manage position screen showing the live `marginUsed`, rendered only for isolated positions (cross positions share account-wide collateral). Drills into `/perpetualsManage/adjustMargin`.
- **New `PerpetualsAdjustMarginScreen`**: Add/Remove segmented toggle, amount input with 25%/50%/100% presets of the active mode's max, details rows (current margin, margin available to add/remove, liquidation price with a live current → projected preview), and a Confirm gated by the enable-trading flow. Submits a signed USD delta via the previously unused `updateIsolatedMargin` (positive adds, negative removes). The position re-resolves live over WS while the sheet is open.
- **Domain math** (ported from core-web into `utils/economics.ts`, unit-tested):
  - `maxRemovableMarginUsd` — Hyperliquid's transfer floor `max(notional/setLeverage, 0.1·notional)`, unrealized PnL counted toward equity, 2% price-drift cushion, capped at deposited margin (prevents HL's "insufficient margin for reduction" reject).
  - `estimateLiquidationPriceFromMargin` — margin-based liquidation estimate for the projection.
  - `floorToDecimals` — the 100% preset can never round up past the true cap.
- **k2-alpine**:
  - `TokenUnitInputWidget` presets support `percent` (fraction of the live `balance`, resolved at press time so they track balance updates); percentage presets no-op at zero max instead of writing a literal "0".
  - `SegmentedControl` gains an optional `height` prop.
- Zero-max states are explained in the caption (danger color): "No balance available to add" / "No margin available to remove" (a fresh isolated position sits exactly at HL's required margin — only added-on-top margin or unrealized profit is removable).
- Misc: Market/Limit close on the expanded position card use `SplitButton`; padding fixes on the Balance/Withdraw loading and error states.

No new dependencies.

## Screenshots/Videos

_TODO: add iOS/Android screenshots and recording._

## Testing

**Dev Testing**

Happy path:
1. Open an isolated position (place order with margin mode Isolated), go to Positions → expand → Manage.
2. A "Margin" row shows the position's current margin → tap it.
3. **Add**: with free account collateral available, enter an amount (or tap 25/50/100%) — the liquidation price shows current → projected (green), Confirm submits, snackbar "Margin updated", Manage margin row and liq price update.
4. **Remove**: after adding margin on top, switch to Remove — ~98% of the added margin is offered; projected liq price shows in red; Confirm returns the margin.

Edge cases:
- Cross position → no Margin row on Manage.
- Zero free collateral → Add shows "No balance available to add" (red), presets no-op, Confirm disabled.
- Fresh isolated position at set leverage → Remove shows "No margin available to remove" (red) — expected per HL margining rules (matches core-web / HL app).
- Amount above max → red error caption + Confirm disabled.
- Trading not enabled → Confirm opens the enable-trading sheet first.

Bitrise: iOS - [9405](https://app.bitrise.io/build/c65d84a5-a3c1-4658-85c0-ac3625494b7a) / Android - [9405](https://app.bitrise.io/build/8d08d512-9ab0-4423-8e41-18bb77f3160c)

**QA Testing**

- Verify add/remove margin on an isolated position updates the position's margin and liquidation price on Hyperliquid (cross-check with app.hyperliquid.xyz).
- Verify the projected liquidation price approximates HL's posted value after confirm (small drift from funding/fees is expected).
- Verify removal is capped: attempting to remove more than the offered max is blocked client-side; the 100% preset never triggers an HL "insufficient margin for reduction" reject.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CP-14881]: https://ava-labs.atlassian.net/browse/CP-14881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ