### PR TITLE
CP-14508: perps chart TV resolution picker + surface-colored toolbar fades

### DIFF
--- a/packages/core-mobile/app/new/features/trade/perpetuals/components/tradingview.html
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/components/tradingview.html
@@ -377,6 +377,7 @@
                 "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
               disabled_features: [
                 'use_localstorage_for_settings',
+                'left_toolbar',
                 'header_widget',
                 'timeframes_toolbar',
                 'legend_widget',

--- a/packages/core-mobile/app/new/features/trade/perpetuals/components/tradingview.html
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/components/tradingview.html
@@ -126,6 +126,31 @@
           }
         }
 
+        // TV hardcodes its toolbar scroll-fade gradients to theme colors
+        // (#0f0f0f dark / #fff light) that don't match our surfacePrimary BG.
+        // Repaint them via custom_css_url; attribute selectors keep working
+        // across library rebuilds (the class-name hashes change per build).
+        function customCssUrl() {
+          var to = /^#[0-9a-fA-F]{6}$/.test(BG) ? BG + '00' : 'transparent'
+          var fades = [
+            ['fadeTop', '180deg'],
+            ['fadeBot', '0deg'],
+            ['fadeBottom', '0deg'],
+            ['fadeLeft', '90deg'],
+            ['fadeRight', '270deg']
+          ]
+          var css = fades
+            .map(function (f) {
+              return (
+                '[class^="' + f[0] + '-"],[class*=" ' + f[0] + '-"]' +
+                '{background-image:linear-gradient(' + f[1] + ',' +
+                BG + ',' + to + ') !important;}'
+              )
+            })
+            .join('')
+          return 'data:text/css;base64,' + btoa(css)
+        }
+
         var TV_STUDIES_OVERRIDES = {
           'volume.volume.plottype': 'columns',
           'volume.volume.transparency': 70,
@@ -341,12 +366,12 @@
               locale: 'en',
               theme: IS_LIGHT ? 'light' : 'dark',
               toolbar_bg: BG,
+              custom_css_url: customCssUrl(),
               custom_font_family:
                 "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
               disabled_features: [
                 'use_localstorage_for_settings',
                 'header_widget',
-                'left_toolbar',
                 'timeframes_toolbar',
                 'legend_widget',
                 'border_around_the_chart',

--- a/packages/core-mobile/app/new/features/trade/perpetuals/components/tradingview.html
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/components/tradingview.html
@@ -68,20 +68,26 @@
         // SDK constants are injected by the RN host via
         // `injectedJavaScriptBeforeContentLoaded`. Fall back to a minimal set if
         // injection didn't land (e.g. older RN-WebView builds).
-        var SUPPORTED_RES = window.__PERPS_TV_RESOLUTIONS || [
-          '60',
-          '240',
-          '1D',
-          '1W',
-          '1M'
-        ]
+        // Fallbacks mirror the full perps-sdk RESOLUTION_TO_INTERVAL map so
+        // every resolution the RN picker can request still resolves here.
         var RES_TO_HL = window.__PERPS_RES_TO_INTERVAL || {
+          1: '1m',
+          3: '3m',
+          5: '5m',
+          15: '15m',
+          30: '30m',
           60: '1h',
+          120: '2h',
           240: '4h',
+          480: '8h',
+          720: '12h',
           '1D': '1d',
+          '3D': '3d',
           '1W': '1w',
           '1M': '1M'
         }
+        var SUPPORTED_RES =
+          window.__PERPS_TV_RESOLUTIONS || Object.keys(RES_TO_HL)
 
         // Palette mirrors core-web's perps page (apps/core/app/perps/utils/palette.ts).
         var PERPS_GREEN = '#1FA95E'

--- a/packages/core-mobile/app/new/features/trade/perpetuals/components/tradingview.html
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/components/tradingview.html
@@ -66,10 +66,10 @@
         document.body.style.backgroundColor = BG
 
         // SDK constants are injected by the RN host via
-        // `injectedJavaScriptBeforeContentLoaded`. Fall back to a minimal set if
-        // injection didn't land (e.g. older RN-WebView builds).
-        // Fallbacks mirror the full perps-sdk RESOLUTION_TO_INTERVAL map so
-        // every resolution the RN picker can request still resolves here.
+        // `injectedJavaScriptBeforeContentLoaded`. If injection didn't land
+        // (e.g. older RN-WebView builds), fall back to a copy of the full
+        // perps-sdk RESOLUTION_TO_INTERVAL map so every resolution the RN
+        // picker can request still resolves here.
         var RES_TO_HL = window.__PERPS_RES_TO_INTERVAL || {
           1: '1m',
           3: '3m',

--- a/packages/core-mobile/app/new/features/trade/perpetuals/components/tradingview.html
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/components/tradingview.html
@@ -375,9 +375,10 @@
               custom_css_url: customCssUrl(),
               custom_font_family:
                 "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+              // Drawing toolbar stays available but starts collapsed.
+              enabled_features: ['hide_left_toolbar_by_default'],
               disabled_features: [
                 'use_localstorage_for_settings',
-                'left_toolbar',
                 'header_widget',
                 'timeframes_toolbar',
                 'legend_widget',

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsDetailsScreen.test.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsDetailsScreen.test.tsx
@@ -86,8 +86,9 @@ jest.mock('@avalabs/k2-alpine', () => {
       r.createElement(rn.View, rest, children),
     SegmentedControl: () => null,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ScrollView: ({ children, ...rest }: any) =>
-      r.createElement(rn.ScrollView, rest, children),
+    ScrollView: r.forwardRef(({ children, ...rest }: any, ref: any) =>
+      r.createElement(rn.ScrollView, { ...rest, ref }, children)
+    ),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     SlidingButton: (_props: any) =>
       r.createElement(rn.View, { testID: 'sliding-button' }),

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsDetailsScreen.test.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsDetailsScreen.test.tsx
@@ -86,6 +86,9 @@ jest.mock('@avalabs/k2-alpine', () => {
       r.createElement(rn.View, rest, children),
     SegmentedControl: () => null,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ScrollView: ({ children, ...rest }: any) =>
+      r.createElement(rn.ScrollView, rest, children),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     SlidingButton: (_props: any) =>
       r.createElement(rn.View, { testID: 'sliding-button' }),
     Icons: {

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsDetailsScreen.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsDetailsScreen.tsx
@@ -1,16 +1,26 @@
 import {
   Button,
   Icons,
+  ScrollView,
   SegmentedControl,
   SlidingButton,
   Text,
   useTheme,
   View
 } from '@avalabs/k2-alpine'
-import type { TvResolution } from '@avalabs/perps-sdk'
+import {
+  RESOLUTION_TO_INTERVAL,
+  type TvResolution
+} from '@avalabs/perps-sdk'
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
+import type {
+  LayoutChangeEvent,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  ScrollView as RNScrollView
+} from 'react-native'
 import { useSharedValue } from 'react-native-reanimated'
 import { MarketChart } from '../components/MarketChart'
 import { MarketDetailsHeader } from '../components/MarketDetailsHeader'
@@ -22,21 +32,46 @@ import { usePerpsClearinghouse } from '../hooks/usePerpsClearinghouse'
 import { FALLBACK_COIN } from '../utils/economics'
 import { normalizePerpCoinParam, tickerOfCoin } from '../utils/coinDex'
 
-const RANGES: readonly { label: string; resolution: TvResolution }[] = [
-  { label: '24H', resolution: '60' },
-  { label: '1W', resolution: '240' },
-  { label: '1M', resolution: '1D' },
-  { label: '3M', resolution: '1D' },
-  { label: '1Y', resolution: '1W' }
-] as const
+// Curated subset of the TradingView resolutions the chart's datafeed supports
+// (1M 5M 15M 1H 4H 12H 1D 1W). Labels are the Hyperliquid interval names,
+// upper-cased. Note: adding the month resolution back would collide with `1M`
+// (minute) — labels would need rethinking then.
+const RANGE_RESOLUTIONS: readonly TvResolution[] = [
+  '1',
+  '5',
+  '15',
+  '60',
+  '240',
+  '720',
+  '1D',
+  '1W'
+]
+
+const RANGES = RANGE_RESOLUTIONS.map(resolution => ({
+  label: RESOLUTION_TO_INTERVAL[resolution].toUpperCase(),
+  resolution
+}))
 
 const RANGE_ITEMS = RANGES.map(r => ({ title: r.label }))
+
+// Fixed per-segment width: the control must be wider than the screen (it lives
+// in a horizontal ScrollView), so it can't size itself from its container.
+const RANGE_SEGMENT_WIDTH = 52
+
+// Horizontal padding of the range list; also the breathing room kept around a
+// segment when scrolling it into view.
+const RANGE_LIST_PADDING = 16
+
+const DEFAULT_RANGE_INDEX = Math.max(
+  RANGES.findIndex(r => r.resolution === '60'), // 1h, the previous default
+  0
+)
 
 export const PerpetualsDetailsScreen = (): JSX.Element => {
   const { theme } = useTheme()
   const router = useRouter()
-  const [selectedIndex, setSelectedIndex] = useState(0)
-  const selectedSegmentIndex = useSharedValue(0)
+  const [selectedIndex, setSelectedIndex] = useState(DEFAULT_RANGE_INDEX)
+  const selectedSegmentIndex = useSharedValue(DEFAULT_RANGE_INDEX)
 
   const { coin: coinParam } = useLocalSearchParams<{ coin?: string }>()
   // Preserve HIP-3 dex case (`xyz:CL`); only the ticker is upper-cased.
@@ -60,10 +95,44 @@ export const PerpetualsDetailsScreen = (): JSX.Element => {
   const pricescale =
     pxDecimals !== undefined ? Math.pow(10, pxDecimals) : undefined
 
+  const rangeScrollRef = useRef<RNScrollView>(null)
+  const rangeScrollOffset = useRef(0)
+  const rangeViewportWidth = useRef(0)
+
+  const handleRangeScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      rangeScrollOffset.current = event.nativeEvent.contentOffset.x
+    },
+    []
+  )
+
+  const handleRangeLayout = useCallback((event: LayoutChangeEvent) => {
+    rangeViewportWidth.current = event.nativeEvent.layout.width
+  }, [])
+
   const handleSelectRange = useCallback(
     (index: number) => {
       selectedSegmentIndex.value = index
       setSelectedIndex(index)
+
+      // A segment at the edge can be tapped while partially clipped — scroll
+      // it fully into view, keeping the list padding as breathing room.
+      const viewport = rangeViewportWidth.current
+      if (viewport === 0) return
+      const itemStart = RANGE_LIST_PADDING + index * RANGE_SEGMENT_WIDTH
+      const itemEnd = itemStart + RANGE_SEGMENT_WIDTH
+      const offset = rangeScrollOffset.current
+      if (itemStart - RANGE_LIST_PADDING < offset) {
+        rangeScrollRef.current?.scrollTo({
+          x: itemStart - RANGE_LIST_PADDING,
+          animated: true
+        })
+      } else if (itemEnd + RANGE_LIST_PADDING > offset + viewport) {
+        rangeScrollRef.current?.scrollTo({
+          x: itemEnd + RANGE_LIST_PADDING - viewport,
+          animated: true
+        })
+      }
     },
     [selectedSegmentIndex]
   )
@@ -195,15 +264,25 @@ export const PerpetualsDetailsScreen = (): JSX.Element => {
         />
       </View>
 
-      <SegmentedControl
-        items={RANGE_ITEMS}
-        selectedSegmentIndex={selectedSegmentIndex}
-        onSelectSegment={handleSelectRange}
-        dynamicItemWidth={false}
-        backgroundColor={theme.colors.$surfaceSecondary}
-        type="thin"
-        style={{ marginHorizontal: 16, marginTop: 12 }}
-      />
+      <ScrollView
+        ref={rangeScrollRef}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        onScroll={handleRangeScroll}
+        scrollEventThrottle={16}
+        onLayout={handleRangeLayout}
+        style={{ flexGrow: 0, marginTop: 12 }}
+        contentContainerStyle={{ paddingHorizontal: RANGE_LIST_PADDING }}>
+        <SegmentedControl
+          items={RANGE_ITEMS}
+          selectedSegmentIndex={selectedSegmentIndex}
+          onSelectSegment={handleSelectRange}
+          dynamicItemWidth={false}
+          backgroundColor={theme.colors.$surfaceSecondary}
+          type="thin"
+          style={{ width: RANGES.length * RANGE_SEGMENT_WIDTH }}
+        />
+      </ScrollView>
 
       <View sx={{ marginTop: 16, marginHorizontal: 16 }}>
         <MarketStatistics assetCtx={assetCtx} />

--- a/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsDetailsScreen.tsx
+++ b/packages/core-mobile/app/new/features/trade/perpetuals/screens/PerpetualsDetailsScreen.tsx
@@ -8,10 +8,7 @@ import {
   useTheme,
   View
 } from '@avalabs/k2-alpine'
-import {
-  RESOLUTION_TO_INTERVAL,
-  type TvResolution
-} from '@avalabs/perps-sdk'
+import { RESOLUTION_TO_INTERVAL, type TvResolution } from '@avalabs/perps-sdk'
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import React, { useCallback, useRef, useState } from 'react'


### PR DESCRIPTION
## Description

**Ticket: [CP-14508](https://ava-labs.atlassian.net/browse/CP-14508)**

- Replaces the perps market details range picker (`24H / 1W / 1M / 3M / 1Y`, several of which mapped to the same candle resolution) with the actual TradingView resolutions supported by the Hyperliquid datafeed: `1M 5M 15M 1H 4H 12H 1D 1W` (default `1H`, same underlying resolution as before)
- The picker is now horizontally scrollable (fixed-width segments inside a horizontal `ScrollView`); tapping a partially clipped segment scrolls it fully into view
- Repaints TradingView's drawing-toolbar scroll fades: the charting library hardcodes them to `#0f0f0f` (dark) / `#fff` (light), which shows as a black band over our `$surfacePrimary` background. A small stylesheet generated at runtime and injected via `custom_css_url` (a `data:` URL) redraws the fades with the surface color passed in by the RN host. Selectors are attribute-based (`[class^="fadeTop-"]`) so they survive charting-library rebuilds where the hashed class names change

No new dependencies.

## Screenshots/Videos

https://github.com/user-attachments/assets/34da0451-235e-4129-aac9-b06fad7f91e1


## Testing

**Dev Testing**

- Open any perps market details screen
- The timeframe row shows `1M 5M 15M 1H 4H 12H 1D 1W` with `1H` selected; the row scrolls horizontally and tapping an edge-clipped segment scrolls it fully into view
- Tap each resolution and confirm the chart reloads candles at that interval
- On the chart, scroll the left drawing toolbar vertically: the fade above/below the tools should match the screen background (no black band), in both light and dark mode

Bitrise:
- iOS - 9409
- Android - 9410

**QA Testing**

- Perps market details: timeframe selector shows the 8 TV resolutions, scrolls horizontally, selection drives the chart's candle interval
- Chart drawing toolbar (left edge) scroll fade matches the screen surface color in light and dark themes

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CP-14508]: https://ava-labs.atlassian.net/browse/CP-14508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ