### PR TITLE
chore: migrate CODEOWNERS to @ava-labs/core-engineering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @atn4z7 @ruijialin-avalabs @onghwan @bogdandobritoiu @B0Y3R-AVA @alexnicolae-ava
-/packages/core-mobile/e2e/ @Any2suited66 @eunjisong
+# Core Engineering owns the entire repository.
+* @ava-labs/core-engineering


### PR DESCRIPTION
Replaces the individual codeowners with the consolidated `@ava-labs/core-engineering` team, which now owns the entire repository. The redundant `/e2e/` rule is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)