### PR TITLE
CP-14651: subscribe a new recurring swap for push notifications without needing a screen visit

### DIFF
--- a/packages/core-mobile/app/new/features/recurringSwap/hooks/_makeOrderActionHook.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/hooks/_makeOrderActionHook.ts
@@ -316,11 +316,13 @@ export function makeOrderActionHook(
         // the bare prefix a post-switch firing would refetch the *new*
         // account's query, whereas the scoped key only ever touches the
         // (now-inactive) query it was meant for. Note the helper refetches with
-        // `refetchType: 'all'` (see CP-14651), so a post-switch firing does
-        // issue a real `listOrders` call for the acting account rather than just
-        // marking it stale — which is the intent here: the catch-up must settle
-        // the status of the order the user acted on, whichever account is active
-        // by the time it fires. The builder lowercases the owner so this
+        // `refetchType: 'all'` (see CP-14651), so a post-switch firing issues a
+        // real `listOrders` call rather than just marking the query stale. That
+        // call always targets the acting account — the owner of the order that
+        // was cancelled/paused/resumed — and never the account that happens to
+        // be active when the timer fires. That is the intent: the catch-up has
+        // to settle the status of the order the user acted on, wherever the user
+        // has navigated to since. The builder lowercases the owner so this
         // matches the query key even though `args.address` (Markr's per-order
         // owner) may differ in checksum casing from the wallet's `addressC`.
         scheduleStaggeredInvalidate(

--- a/packages/core-mobile/app/new/features/recurringSwap/hooks/_makeOrderActionHook.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/hooks/_makeOrderActionHook.ts
@@ -315,8 +315,12 @@ export function makeOrderActionHook(
         // are module-scoped and aren't cleared on unmount/account-switch; with
         // the bare prefix a post-switch firing would refetch the *new*
         // account's query, whereas the scoped key only ever touches the
-        // (now-inactive) query it was meant for — a harmless stale-mark, never
-        // a cross-account refetch. The builder lowercases the owner so this
+        // (now-inactive) query it was meant for. Note the helper refetches with
+        // `refetchType: 'all'` (see CP-14651), so a post-switch firing does
+        // issue a real `listOrders` call for the acting account rather than just
+        // marking it stale — which is the intent here: the catch-up must settle
+        // the status of the order the user acted on, whichever account is active
+        // by the time it fires. The builder lowercases the owner so this
         // matches the query key even though `args.address` (Markr's per-order
         // owner) may differ in checksum casing from the wallet's `addressC`.
         scheduleStaggeredInvalidate(

--- a/packages/core-mobile/app/new/features/recurringSwap/store/subscribeAfterCreate.test.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/store/subscribeAfterCreate.test.ts
@@ -1,0 +1,227 @@
+/**
+ * CP-14651 regression guard.
+ *
+ * Creating a recurring swap must end with this device subscribed for that
+ * order's push notifications. The client has no orderId at broadcast time
+ * (`executeFirstFill` returns only `{ txHash }`), so the only route to a
+ * subscription is `ensureOrderSubscriptions` seeing the order in a landed
+ * `listOrders` snapshot — which means a refetch has to happen AFTER Markr's
+ * indexer catches up, several seconds later.
+ *
+ * The create flow works against that:
+ *   1. `submitRecurringSwap` invalidates at broadcast, while SwapScreen (and
+ *      therefore its `RecurringSchedulesBanner` observer) is still mounted —
+ *      but Markr hasn't indexed the order yet, so the snapshot is empty.
+ *   2. `scheduleStaggeredInvalidate` queues catch-up invalidates at t=5/15/30s
+ *      to cover exactly that lag.
+ *   3. `SwapScreen` then calls `dismissAll()`, dropping the only observer.
+ *
+ * `queryClient.invalidateQueries` defaults to `refetchType: 'active'`, so once
+ * the modal is gone those catch-up invalidates mark the query stale and refetch
+ * nothing. The order never lands, the cache subscriber never fires, and the
+ * device is never subscribed — no push and no notification-center row.
+ *
+ * This test drives a REAL QueryClient (not the hand-rolled cache-event fake the
+ * sibling `listeners.test.ts` uses) because the bug lives in React Query's
+ * active-vs-inactive refetch semantics; a fake that just invokes subscribers
+ * cannot express it.
+ */
+
+// ─── MMKV mock (must be before imports) ───────────────────────────────────────
+
+const mockMmkvStore: Record<string, string | boolean> = {}
+jest.mock('utils/mmkv/storages', () => ({
+  commonStorage: {
+    getString: (k: string) => {
+      const v = mockMmkvStore[k]
+      return typeof v === 'string' ? v : undefined
+    },
+    getBoolean: (k: string) => {
+      const v = mockMmkvStore[k]
+      return typeof v === 'boolean' ? v : undefined
+    },
+    set: (k: string, v: string | boolean) => {
+      mockMmkvStore[k] = v
+    }
+  }
+}))
+
+// ─── Ambient mocks ────────────────────────────────────────────────────────────
+
+jest.mock('common/utils/toast', () => ({ showSnackbar: jest.fn() }))
+
+jest.mock('utils/Logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}))
+
+jest.mock('./pendingActionStore', () => ({
+  pendingActionStore: {
+    getState: () => ({
+      pending: {},
+      markPending: jest.fn(),
+      clearPending: jest.fn(),
+      isExpired: () => false
+    })
+  }
+}))
+
+jest.mock('store/posthog', () => ({
+  selectIsRecurringSwapsBlocked: () => false
+}))
+
+// ─── Network boundaries ───────────────────────────────────────────────────────
+
+const mockSubscribeForRecurringSwap = jest.fn<Promise<void>, [unknown]>(() =>
+  Promise.resolve()
+)
+jest.mock(
+  'services/notifications/recurringSwap/subscribeForRecurringSwap',
+  () => ({
+    subscribeForRecurringSwap: (arg: unknown) =>
+      mockSubscribeForRecurringSwap(arg)
+  })
+)
+
+jest.mock('services/notifications/registerDeviceToNotificationSender', () => ({
+  registerAndGetDeviceArn: () => Promise.resolve('arn:registered-fallback')
+}))
+
+// ─── Real QueryClient, injected where the app reads its singleton ─────────────
+// A getter (not a plain property) so the instance is resolved at each use site
+// rather than at module-require time — `jest.mock` factories are hoisted above
+// the `let` below, so an eager read would hit the uninitialised binding.
+
+let mockQueryClient: QueryClient
+jest.mock('contexts/ReactQueryProvider', () => ({
+  get queryClient() {
+    return mockQueryClient
+  }
+}))
+
+// ─── Subject under test ───────────────────────────────────────────────────────
+
+import { QueryClient, QueryObserver } from '@tanstack/react-query'
+import { CommonStorageKeys } from 'utils/mmkv'
+import { recurringSchedulesQueryKey } from '../hooks/useRecurringSchedules'
+import { RecurringOrderStatus, type RecurringOrder } from '../types'
+import { scheduleStaggeredInvalidate } from '../utils/staggeredInvalidate'
+import { startRecurringFailureWatcher } from './listeners'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const OWNER = '0xOwner1'
+const CHAIN_ID = 43114
+const DEVICE_ARN = 'arn:test-device'
+const SCHEDULES_KEY = recurringSchedulesQueryKey(OWNER, CHAIN_ID)
+
+/** The order Markr surfaces a few seconds after the first fill is broadcast. */
+const NEW_ORDER = {
+  orderId: '0xorder-just-created',
+  owner: OWNER,
+  chainId: CHAIN_ID,
+  status: RecurringOrderStatus.Active,
+  numberOfOrders: 3,
+  executedOrders: 1,
+  remainingOrders: 2,
+  failures: []
+} as unknown as RecurringOrder
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('CP-14651 — subscribing the order created in a dismissed swap modal', () => {
+  let stopWatcher: () => void
+  // Flipped to true to model Markr's indexer catching up post-broadcast.
+  let isIndexed: boolean
+
+  const listOrders = jest.fn(async () => (isIndexed ? [NEW_ORDER] : []))
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+
+    Object.keys(mockMmkvStore).forEach(k => delete mockMmkvStore[k])
+    mockMmkvStore[CommonStorageKeys.NOTIFICATIONS_OPTIMIZATION] = DEVICE_ARN
+
+    mockQueryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } }
+    })
+
+    isIndexed = false
+    listOrders.mockClear()
+    mockSubscribeForRecurringSwap.mockClear()
+
+    stopWatcher = startRecurringFailureWatcher(() => false)
+  })
+
+  afterEach(() => {
+    stopWatcher()
+    mockQueryClient.clear()
+    jest.useRealTimers()
+  })
+
+  /**
+   * Stands in for the `RecurringSchedulesBanner` observer that SwapScreen
+   * mounts. Returns the teardown that models `dismissAll()`.
+   */
+  const mountSchedulesObserver = (): (() => void) => {
+    const observer = new QueryObserver(mockQueryClient, {
+      queryKey: SCHEDULES_KEY,
+      queryFn: listOrders,
+      staleTime: 5 * 60_000
+    })
+    return observer.subscribe(() => undefined)
+  }
+
+  it('subscribes the new order even though the modal unmounts before Markr indexes it', async () => {
+    // SwapScreen is open: the banner observes this account's schedules.
+    const dismissModal = mountSchedulesObserver()
+    await jest.advanceTimersByTimeAsync(0)
+    expect(mockSubscribeForRecurringSwap).not.toHaveBeenCalled()
+
+    // First fill broadcast → invalidate at broadcast. Markr hasn't indexed the
+    // order yet, so this refetch returns an empty list and there is nothing to
+    // subscribe.
+    mockQueryClient.invalidateQueries({ queryKey: SCHEDULES_KEY })
+    await jest.advanceTimersByTimeAsync(0)
+    expect(mockSubscribeForRecurringSwap).not.toHaveBeenCalled()
+
+    // The catch-up batch is queued for t=5/15/30s...
+    scheduleStaggeredInvalidate(SCHEDULES_KEY)
+
+    // ...Markr indexes the order...
+    isIndexed = true
+
+    // ...and SwapScreen dismisses itself, dropping the only observer.
+    dismissModal()
+
+    // Let the entire catch-up window elapse.
+    await jest.advanceTimersByTimeAsync(31_000)
+
+    expect(mockSubscribeForRecurringSwap).toHaveBeenCalledWith({
+      orderId: NEW_ORDER.orderId,
+      deviceArn: DEVICE_ARN
+    })
+  })
+
+  it('still subscribes when the user leaves a schedules-observing screen mounted', async () => {
+    // Control case: same flow, but the observer survives (e.g. Swap was opened
+    // from the Activity tab, so ActivityScreen's banner stays mounted under the
+    // modal). This path already worked before the fix — it is here so a
+    // regression in the fix cannot pass by breaking the happy path.
+    mountSchedulesObserver()
+    await jest.advanceTimersByTimeAsync(0)
+
+    mockQueryClient.invalidateQueries({ queryKey: SCHEDULES_KEY })
+    await jest.advanceTimersByTimeAsync(0)
+
+    scheduleStaggeredInvalidate(SCHEDULES_KEY)
+    isIndexed = true
+    await jest.advanceTimersByTimeAsync(31_000)
+
+    expect(mockSubscribeForRecurringSwap).toHaveBeenCalledWith({
+      orderId: NEW_ORDER.orderId,
+      deviceArn: DEVICE_ARN
+    })
+  })
+})

--- a/packages/core-mobile/app/new/features/recurringSwap/utils/staggeredInvalidate.ts
+++ b/packages/core-mobile/app/new/features/recurringSwap/utils/staggeredInvalidate.ts
@@ -48,7 +48,20 @@ export function scheduleStaggeredInvalidate(queryKey: QueryKey): void {
       if (set.size === 0 && pending.get(k) === set) {
         pending.delete(k)
       }
-      queryClient.invalidateQueries({ queryKey })
+      // `refetchType: 'all'` rather than the default `'active'`: the whole point
+      // of this batch is to catch up with Markr's indexer AFTER the flow that
+      // scheduled it has finished, and those flows tear down their own
+      // observers on the way out (`SwapScreen` calls `dismissAll()` the moment
+      // `submitRecurringSwap` resolves). With the default, every timer here fired
+      // against zero observers, marked the query stale and refetched nothing — so
+      // a newly created order never landed in the cache, the schedules cache
+      // subscriber never fired, and `ensureOrderSubscriptions` never subscribed
+      // the device for that order's push notifications. Net effect (CP-14651):
+      // every leg executing between order creation and the user's next visit to
+      // Activity / Swap / the schedules screen was silently dropped — no push and
+      // no notification-center row — because the notification-history row is
+      // written per subscribed device.
+      queryClient.invalidateQueries({ queryKey, refetchType: 'all' })
     }, delayMs)
     set.add(id)
   }


### PR DESCRIPTION
## Description

**Ticket: [CP-14651](https://ava-labs.atlassian.net/browse/CP-14651)**

Reported as "recurring swap notifications don't come through on Android". It is not an Android bug. The deciding factor is whether a `RECURRING_SCHEDULES` React Query observer is mounted when a `listOrders` refetch could land.

The client has no orderId at broadcast time (`executeFirstFill` returns only `{ txHash }`), so the only route to a push subscription is `ensureOrderSubscriptions` seeing the order in a landed `listOrders` snapshot. `submitRecurringSwap` invalidates at broadcast, but Markr's indexer lags by a few seconds, so that snapshot comes back empty. `scheduleStaggeredInvalidate` queues catch-up invalidates at t=5/15/30s to cover the lag — and then `SwapScreen` calls `dismissAll()` the moment `submitRecurringSwap` resolves.

`invalidateQueries` defaults to `refetchType: 'active'`. With the modal gone there is no observer, so all three catch-up timers marked the query stale and refetched **nothing**. The order never landed in the cache, the schedules cache subscriber never fired, and the device was never subscribed. Because the notification-history row is written per subscribed device (`webhook/recurring-swaps` → `createNotificationHistoryAfterSend(subscription.clientId, …)`), every leg executing before the user's next visit to Activity / Swap / the schedules screen was silently dropped: no push and no notification-center row.

Fix is one line — the catch-up batch now uses `refetchType: 'all'` so it refetches the cached-but-inactive query. Also updates a now-stale comment in `_makeOrderActionHook.ts` that described the scoped invalidate as "a harmless stale-mark", which is no longer accurate.

Measured on a Pixel 8 Pro (mainnet C-Chain, user stayed on Portfolio throughout):

| | Before | After |
| --- | --- | --- |
| Subscribe latency | 4m22s, and only after navigating to Activity | **5.3s, no navigation** |
| Legs lost | every leg until the user opens a schedules screen | leg 1 only (see follow-up) |

No dependencies introduced. Not breaking.

## Screenshots/Videos

Device logs are the meaningful artifact here rather than UI. Before the fix, order `0x579c0ad8…`:

```
14:45:15   order created → cache event count=0      (Markr not yet indexed)
14:45:20   catch-up  5s → observers=0, no refetch
14:45:30   catch-up 15s → observers=0, no refetch
14:45:45   catch-up 30s → observers=0, no refetch
           ── 3m51s, device NOT subscribed ──
14:49:36   user opens a schedules-observing screen
14:49:37   count=1 statuses=["active"] → POST /v1/push/recurring-swaps/subscribe
14:49:38   status=200                                (4m22s after creation)
```

After the fix, order `0x7a7045de…`:

```
15:05:29   count=1                                  (new order not yet indexed)
15:05:33   catch-up 5s → observers=0 → refetch HAPPENS
15:05:33   count=2 statuses=["active","active"] → POST subscribe
15:05:49   status=200                                (5.3s after creation)
15:11      "Recurring swap executed — Swap 2 of USDC to AVAX complete" row arrives
```

Notification center before the fix showed no row for the leg that executed at creation, and rows for every leg after the subscribe timestamp (Swap 2 at 2:50, Swap 3 at 2:56, Swap 4 at 3:02, Swap 5 at 3:08 Completed).

## Testing

**Dev Testing**
iOS: 9421
Android: 9422

Happy path (this is the reported repro):

1. Create a recurring swap, then stay on Portfolio. Do not open Activity, Swap, or the schedules screen.
2. Within ~30s the device should POST `/v1/push/recurring-swaps/subscribe` and get a 200.
3. The next leg should produce a push and a notification-center row without any navigation.

Before this change, step 2 never happened and step 3 produced nothing until you visited a schedules-observing screen.

Edge cases covered by unit tests in `subscribeAfterCreate.test.ts`, which drives a real `QueryClient`:

- observer torn down before Markr indexes the order (the bug) — now subscribes
- observer left mounted (e.g. Swap opened from the Activity tab) — still subscribes, guards against a fix that only moves the problem

Also exercised: cancel / pause / resume still settle correctly via `_makeOrderActionHook` (`scheduleStaggeredInvalidate` is shared).

`yarn test` for `recurringSwap`, `notifications`, `services/notifications`: 275 passing / 26 suites. tsc and eslint clean for the changed files.

**QA Testing**

Acceptance criteria: after creating a recurring swap, you receive notifications for subsequent legs **without** opening the recurring schedules screen or the Activity tab.

Note for QA: the very first swap executes at order-creation time, before any subscription can exist, so its notification-center row is still expected to be missing. That is a known backend follow-up, not a regression in this PR.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

## Follow-up (needs backend)

Leg 1 executes inside `executeFirstFill` at order creation, before the subscription exists, so `getActiveSubscriptionsByOrderId` returns empty and no history row is written. Confirmed on device. A client cannot subscribe to an order before that order exists, so this race is structural to per-`(orderId, deviceArn)` subscriptions. Two options for the notification-sender service:

1. Backfill notification history for already-executed legs when a subscribe arrives late (push suppressed, matching the existing first-leg behaviour).
2. Subscribe recurring-swap notifications by owner address, like balance changes, and fan out to every registered device. Removes this race and also fixes the separate case where a second device on the same wallet never subscribes.

Option 2 preferred.


[CP-14651]: https://ava-labs.atlassian.net/browse/CP-14651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ