### PR TITLE
CP-14715: dismiss the lingering Android keyboard on modal close

### DIFF
--- a/packages/core-mobile/app/new/common/utils/dismissKeyboardOnRemove.test.ts
+++ b/packages/core-mobile/app/new/common/utils/dismissKeyboardOnRemove.test.ts
@@ -1,0 +1,48 @@
+import { KeyboardController } from 'react-native-keyboard-controller'
+import { dismissKeyboardOnRemove } from './dismissKeyboardOnRemove'
+
+jest.mock('react-native-keyboard-controller', () => ({
+  KeyboardController: { dismiss: jest.fn() }
+}))
+
+// The dismiss is deferred one microtask; awaiting a resolved promise flushes it.
+const flushMicrotasks = (): Promise<void> => Promise.resolve()
+
+describe('dismissKeyboardOnRemove', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('dismisses the keyboard when removal was not prevented', async () => {
+    dismissKeyboardOnRemove({ defaultPrevented: false })
+
+    // Deferred until sibling beforeRemove listeners have run, so nothing yet.
+    expect(KeyboardController.dismiss).not.toHaveBeenCalled()
+
+    await flushMicrotasks()
+
+    expect(KeyboardController.dismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not dismiss when removal was prevented (e.g. usePreventScreenRemoval)', async () => {
+    dismissKeyboardOnRemove({ defaultPrevented: true })
+    await flushMicrotasks()
+
+    expect(KeyboardController.dismiss).not.toHaveBeenCalled()
+  })
+
+  it('re-reads defaultPrevented at microtask time, not call time', async () => {
+    // Guards the direct-root-level-modal case: a beforeRemove listener sharing
+    // this navigator's emitter can preventDefault() synchronously AFTER this
+    // handler runs but BEFORE the deferred microtask fires. Reading
+    // defaultPrevented at call time (instead of at microtask time) would
+    // regress that, so this locks in the deferred read.
+    const e = { defaultPrevented: false }
+    dismissKeyboardOnRemove(e)
+    e.defaultPrevented = true
+
+    await flushMicrotasks()
+
+    expect(KeyboardController.dismiss).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core-mobile/app/new/common/utils/dismissKeyboardOnRemove.ts
+++ b/packages/core-mobile/app/new/common/utils/dismissKeyboardOnRemove.ts
@@ -1,0 +1,47 @@
+import { KeyboardController } from 'react-native-keyboard-controller'
+
+/**
+ * Dismisses the software keyboard when a route is removed from the navigation
+ * stack — header/hardware back, swipe/pan dismiss, and programmatic navigation
+ * all dispatch a POP that fires `beforeRemove`.
+ *
+ * On Android the soft keyboard is not reliably hidden when a modal route
+ * unmounts, so it lingers over the screen underneath (CP-14715). This is wired
+ * (Android-only) as a navigator-level `screenListeners.beforeRemove` on the
+ * root signed-in Stack, which hosts every modal group as a screen, so a single
+ * listener covers every modal dismissal (Swap, Send, Staking, Settings
+ * sub-screens, …). Verified on-device: the listener fires for native
+ * swipe-dismiss and the IME goes down.
+ *
+ * A navigator-level listener is used deliberately: the native-stack
+ * `transitionStart`/`transitionEnd`/`blur` events don't reach a listener
+ * registered on the leaving *screen*, because React tears that screen (and its
+ * listeners) down first. `screenListeners` live on the navigator, which is not
+ * torn down, so `beforeRemove` is delivered reliably.
+ *
+ * In-flight-tx safety (Swap/Claim/Delegation) is NOT provided by the
+ * `defaultPrevented` check below: those screens call `usePreventScreenRemoval`
+ * on a *nested* leaf screen, so react-navigation's `shouldPreventRemove`
+ * short-circuits in the child navigator and returns before the root Stack ever
+ * emits `beforeRemove` — this handler simply never runs when a nested screen
+ * blocks removal.
+ *
+ * The `queueMicrotask` defer + `e.defaultPrevented` check guards the remaining
+ * case: a `beforeRemove` listener registered *directly* on a root-level
+ * single-screen modal shares this navigator's emitter and runs synchronously
+ * alongside this handler. Deferring one microtask lets that listener's
+ * `preventDefault()` land first, so we read the final decision and never yank
+ * the keyboard away when the removal was actually cancelled.
+ *
+ * `KeyboardController.dismiss()` hides the IME through the native keyboard
+ * controller regardless of which input currently holds focus.
+ */
+export const dismissKeyboardOnRemove = (e: {
+  defaultPrevented: boolean
+}): void => {
+  queueMicrotask(() => {
+    if (!e.defaultPrevented) {
+      KeyboardController.dismiss()
+    }
+  })
+}

--- a/packages/core-mobile/app/new/routes/(signedIn)/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/_layout.tsx
@@ -10,6 +10,7 @@ import {
   onClosingTransitionEnd,
   onClosingTransitionStart
 } from 'common/utils/navigationGuard'
+import { dismissKeyboardOnRemove } from 'common/utils/dismissKeyboardOnRemove'
 import { useTriggerAfterLoginFlows } from 'common/hooks/useTriggerAfterLoginFlows'
 import { LedgerSetupProvider } from 'features/ledger'
 import { useLedgerAppStateListener } from 'features/ledger/hooks/useLedgerAppStateListener'
@@ -17,6 +18,7 @@ import { CollectiblesProvider } from 'features/portfolio/collectibles/Collectibl
 import { PerpsProvider } from 'features/trade/perpetuals/contexts/PerpsProvider'
 import { NavigationPresentationMode } from 'new/common/types'
 import React from 'react'
+import { Platform } from 'react-native'
 import { useSelector } from 'react-redux'
 import { selectWalletState } from 'store/app'
 import { WalletState } from 'store/app/types'
@@ -57,6 +59,13 @@ export default function WalletLayout(): JSX.Element {
           <Stack
             screenOptions={{ headerShown: false }}
             screenListeners={{
+              // Android keeps the soft keyboard up when a modal route unmounts,
+              // so it lingers over the screen underneath (CP-14715). This root
+              // Stack hosts every modal group, so one listener covers them all.
+              // iOS already tears the IME down on unmount, so scope to Android.
+              ...(Platform.OS === 'android' && {
+                beforeRemove: dismissKeyboardOnRemove
+              }),
               transitionStart: e => {
                 if (e.data.closing) onClosingTransitionStart()
               },


### PR DESCRIPTION
## Description

**Ticket: [CP-14715](https://ava-labs.atlassian.net/browse/CP-14715)**

On Android the soft keyboard was not reliably hidden when a modal route unmounts, so it lingered over the screen underneath after dismissing Swap, Send, Staking, Settings sub-screens (contacts/networks/currency/connected sites), Send NFT, and more. This is a regression that showed up after the RN upgrade.

The fix wires a single navigator-level `screenListeners.beforeRemove` handler onto the root `(signedIn)` Stack, which hosts every modal group as a screen, so one listener covers every modal dismissal instead of touching ~50 individual screens. On dismiss, native-stack dispatches a POP that fires `beforeRemove` for the modal route, and the handler calls `KeyboardController.dismiss()`.

- Scoped to Android via `Platform.OS`, since iOS already tears the IME down on unmount (matches the existing Android keyboard isolation from CP-14676).
- A navigator-level listener is used on purpose: `screenListeners` live on the navigator, which is not torn down, so `beforeRemove` is delivered reliably even though React tears the leaving screen (and any screen-registered listeners) down first.
- In-flight-tx safety (Swap/Claim/Delegation) is preserved by react-navigation itself: those screens call `usePreventScreenRemoval` on a nested leaf, so `shouldPreventRemove` short-circuits in the child navigator before the root Stack ever emits `beforeRemove`, and this handler never runs when removal is blocked.

No new dependencies.
## Testing

**Dev Testing (if applicable)**

- Open any modal with a text field (e.g. Settings -> Networks, or Send), focus the input so the keyboard shows, then dismiss the modal via swipe-down, hardware/header back, and programmatic close. Keyboard should hide over the screen underneath in every case.
- Send NFT: complete a send and confirm the keyboard does not linger after the flow closes.
- In-flight tx: start a swap, hit Confirm so `usePreventScreenRemoval` is active, then try to swipe-dismiss. The modal should refuse to close and the keyboard should not be yanked. (In practice the swap flow already dismisses the keyboard at the "Next" step, so there is usually no keyboard up by then.)
- Verified on-device (Android, via logcat): `beforeRemove` fires at the root listener on native swipe-dismiss and the IME goes down.
- _TODO: trigger a Bitrise build and reference it here; move ticket to Testing._

**QA Testing (if applicable)**

- Across Android, open modals that raise the keyboard (Swap, Send, Staking, Network, Contracts, Currency, Connected Sites) and dismiss them with the keyboard up. Expected: keyboard is gone once the modal closes, in every area.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14715]: https://ava-labs.atlassian.net/browse/CP-14715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ