### PR TITLE
fix: authorize core-proxy-api Glacier calls with AppCheck token only (drop dead x-core-api-key)

### DIFF
--- a/packages/core-mobile/app/utils/api/common/getCoreAuthHeaders.test.ts
+++ b/packages/core-mobile/app/utils/api/common/getCoreAuthHeaders.test.ts
@@ -5,12 +5,6 @@ jest.mock('services/fcm/AppCheckService', () => ({
   getToken: jest.fn()
 }))
 
-jest.mock('react-native-config', () => ({
-  CORE_API_KEY: undefined
-}))
-
-const Config = require('react-native-config')
-
 const mockGetToken = AppCheckService.getToken as jest.MockedFunction<
   typeof AppCheckService.getToken
 >
@@ -18,28 +12,15 @@ const mockGetToken = AppCheckService.getToken as jest.MockedFunction<
 describe('getCoreAuthHeaders', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    Config.CORE_API_KEY = undefined
   })
 
-  it('returns the AppCheck token header', async () => {
+  it('returns only the AppCheck token header (no x-core-api-key)', async () => {
     mockGetToken.mockResolvedValue({ token: 'appcheck-token' } as Awaited<
       ReturnType<typeof AppCheckService.getToken>
     >)
 
     await expect(getCoreAuthHeaders()).resolves.toEqual({
       'X-Firebase-AppCheck': 'appcheck-token'
-    })
-  })
-
-  it('includes the Core API key header when configured', async () => {
-    Config.CORE_API_KEY = 'core-api-key'
-    mockGetToken.mockResolvedValue({ token: 'appcheck-token' } as Awaited<
-      ReturnType<typeof AppCheckService.getToken>
-    >)
-
-    await expect(getCoreAuthHeaders()).resolves.toEqual({
-      'X-Firebase-AppCheck': 'appcheck-token',
-      'x-core-api-key': 'core-api-key'
     })
   })
 

--- a/packages/core-mobile/app/utils/api/common/getCoreAuthHeaders.ts
+++ b/packages/core-mobile/app/utils/api/common/getCoreAuthHeaders.ts
@@ -1,13 +1,14 @@
-import Config from 'react-native-config'
 import AppCheckService from 'services/fcm/AppCheckService'
 import { APPCHECK_HEADER } from 'utils/api/common/appCheckFetch'
 
-const CORE_API_KEY_HEADER = 'x-core-api-key'
-
 /**
  * Resolves the auth headers required by core-proxy-api (e.g. the Glacier
- * proxy): a Firebase AppCheck token, plus the Core API key when one is
- * configured (dev/E2E builds — it both authorizes and bypasses rate limits).
+ * proxy): a Firebase AppCheck token.
+ *
+ * The proxy authorizes on the AppCheck token alone. We intentionally do NOT
+ * send an `x-core-api-key` — the proxy rejects a request that carries an
+ * invalid/legacy key with a 401 even when a valid AppCheck token is present,
+ * so attaching the (now-defunct) Glacier key breaks every Glacier call.
  *
  * Meant to be invoked per request (e.g. as a glacier-sdk HEADERS resolver or
  * the vm-modules `runtime.getAuthHeaders`) so the short-lived AppCheck token
@@ -17,9 +18,6 @@ const CORE_API_KEY_HEADER = 'x-core-api-key'
 export const getCoreAuthHeaders = async (): Promise<Record<string, string>> => {
   const { token } = await AppCheckService.getToken()
   return {
-    [APPCHECK_HEADER]: token,
-    ...(Config.CORE_API_KEY
-      ? { [CORE_API_KEY_HEADER]: Config.CORE_API_KEY }
-      : {})
+    [APPCHECK_HEADER]: token
   }
 }

--- a/packages/core-mobile/app/vmModule/ModuleManager.ts
+++ b/packages/core-mobile/app/vmModule/ModuleManager.ts
@@ -103,8 +103,8 @@ class ModuleManager {
         fetch: global.fetch,
         httpAgent: new http.Agent(),
         // Required by EvmModule/AvalancheModule: their internal Glacier calls
-        // go through core-proxy-api, which needs AppCheck (or a Core API key)
-        // on every request.
+        // go through core-proxy-api, which authorizes on the Firebase AppCheck
+        // token supplied here on every request.
         getAuthHeaders: getCoreAuthHeaders
       }
     }


### PR DESCRIPTION
## Description

**Ticket: [CP- ]**

After the Glacier proxy migration (CP-14673 / #4012), X/P chain transaction activity stopped showing on dev/local builds.

Root cause: `getCoreAuthHeaders` still attaches an `x-core-api-key` header whenever `CORE_API_KEY` is set in the env, but the value shipped in the dev env files is the legacy Glacier key, which is dead against `core-proxy-api`. The proxy rejects a request carrying an invalid key with a 401 even when a valid Firebase AppCheck token is also present. Since X/P transaction history has no fallback path (it relies solely on the avalanche-module's proxy call), every fetch fails and the activity list renders the empty "No recent transactions" state. C-Chain masks the same failure because it has an independent direct-host GlacierService fallback.

This change makes `getCoreAuthHeaders` send only the Firebase AppCheck token, which is how the proxy is meant to authorize. `getCoreAuthHeaders` was the only consumer of `Config.CORE_API_KEY`, so this removes the key from every Glacier request (the vm-modules `runtime.getAuthHeaders` and the in-app GlacierService resolver).

Verified on device: with the key dropped, the exact P-Chain history request flips from 401 to 200 and the activity list populates fully.

Note: this does not fix the internal build, which fails for a separate reason (the AppCheck debug provider has no registered `APPCHECK_DEBUG_TOKEN`). That is being tracked in its own ticket.

- Dependencies: none
- Breaking: no

## Screenshots/Videos

P-Chain activity before this change: blank "No recent transactions". After: full history renders (received / sent / imported). Verified on Android on device; iOS to follow from the Bitrise build.

## Testing

**Dev Testing**

- On a build off this branch, unlock, switch the active network to P-Chain (then X-Chain), and open the Activity tab.
- Expected: transaction history loads where it was previously blank.
- Confirm C-Chain activity still works as before.
- Error state: with no network connection the Activity tab should show its normal error/empty state, not crash.
- Bitrise build: _link to be added_

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
