### PR TITLE
CP-14765: restore Android form-sheet swipe-to-dismiss on ScrollScreen's non-keyboard branch

### DIFF
--- a/packages/core-mobile/app/new/common/components/ScrollScreen.test.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.test.tsx
@@ -76,9 +76,11 @@ jest.mock('./LinearGradientBottomWrapper', () => ({
   LinearGradientBottomWrapper: ({ children }: any) => children
 }))
 
-import { View } from 'react-native'
+import { Platform, View } from 'react-native'
 import { ScrollScreen } from './ScrollScreen'
 
+// Mirrors the `useEffectiveHeaderHeight` mock above.
+const HEADER_HEIGHT = 100
 const MEASURED_VIEWPORT_HEIGHT = 640
 const MEASURED_TITLE_REGION_HEIGHT = 80
 const MEASURED_TITLE_HEIGHT = 40
@@ -323,5 +325,88 @@ describe('ScrollScreen content minHeight', () => {
     await fireScrollViewLayout(instance, MEASURED_VIEWPORT_HEIGHT)
 
     expect(onLayout).toHaveBeenCalledTimes(1)
+  })
+})
+
+// CP-14765: on an Android form sheet the non-keyboard branch used to render a
+// full-height gesture-handler ScrollView, which claimed every vertical drag and
+// locked the sheet's BottomSheetBehavior out of swipe-to-dismiss entirely. It
+// now takes the same treatment the keyboard branch got in CP-14679: a plain RN
+// ScrollView (so the sheet can negotiate nested scrolling) offset *below* the
+// header with `marginTop`, leaving the grabber/header strip permanently
+// draggable.
+describe('ScrollScreen Android form-sheet swipe-to-dismiss (non-keyboard branch)', () => {
+  const fireContentSizeChange = async (
+    instance: ReactTestRenderer,
+    height: number
+  ): Promise<void> => {
+    const scrollView = instance.root.findByType(ScrollView)
+    await act(async () => {
+      scrollView.props.onContentSizeChange(390, height)
+    })
+  }
+
+  const getScrollViewStyle = (
+    instance: ReactTestRenderer
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): any =>
+    StyleSheet.flatten(instance.root.findByType(ScrollView).props.style) ?? {}
+
+  const getContentContainerPaddingTop = (
+    instance: ReactTestRenderer
+  ): number | undefined =>
+    StyleSheet.flatten(
+      instance.root.findByType(ScrollView).props.contentContainerStyle
+    )?.paddingTop
+
+  describe('on Android', () => {
+    beforeEach(() => {
+      jest.replaceProperty(Platform, 'OS', 'android')
+    })
+
+    it('offsets a modal below the header with a margin so the sheet keeps a draggable strip', async () => {
+      const instance = await render({ isModal: true })
+
+      expect(getScrollViewStyle(instance).marginTop).toBe(HEADER_HEIGHT)
+      expect(getContentContainerPaddingTop(instance)).toBe(0)
+    })
+
+    it('leaves nested scrolling off while the content fits, so a body swipe dismisses', async () => {
+      const instance = await render({ isModal: true })
+
+      await fireScrollViewLayout(instance, MEASURED_VIEWPORT_HEIGHT)
+      await fireContentSizeChange(instance, MEASURED_VIEWPORT_HEIGHT)
+
+      expect(
+        instance.root.findByType(ScrollView).props.nestedScrollEnabled
+      ).toBe(false)
+    })
+
+    it('turns nested scrolling on once the content overflows, so a body swipe scrolls', async () => {
+      const instance = await render({ isModal: true })
+
+      await fireScrollViewLayout(instance, MEASURED_VIEWPORT_HEIGHT)
+      await fireContentSizeChange(instance, MEASURED_VIEWPORT_HEIGHT * 2)
+
+      expect(
+        instance.root.findByType(ScrollView).props.nestedScrollEnabled
+      ).toBe(true)
+    })
+
+    it('leaves non-modal screens under the transparent header', async () => {
+      const instance = await render({ isModal: false })
+
+      expect(getScrollViewStyle(instance).marginTop).toBeUndefined()
+      expect(getContentContainerPaddingTop(instance)).toBe(HEADER_HEIGHT)
+    })
+  })
+
+  it('leaves iOS modals under the transparent header', async () => {
+    jest.replaceProperty(Platform, 'OS', 'ios')
+
+    const instance = await render({ isModal: true })
+
+    expect(getScrollViewStyle(instance).marginTop).toBeUndefined()
+    expect(getContentContainerPaddingTop(instance)).toBe(HEADER_HEIGHT)
   })
 })

--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -20,6 +20,7 @@ import {
   NativeScrollEvent,
   NativeSyntheticEvent,
   Platform,
+  ScrollView as RNScrollView,
   StyleProp,
   View,
   ViewStyle
@@ -206,17 +207,15 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
     const [isScrollable, setIsScrollable] = useState(false)
 
     const updateIsScrollable = useCallback(() => {
-      // Only the keyboard-aware branch's Android form-sheet nested-scroll path
-      // reads this (see `nestedScrollEnabled` below): it negotiates with a
-      // parent `BottomSheetBehavior`, which only exists when the screen is a
-      // modal. Everywhere else the value is never consumed — the non-keyboard
-      // branch renders a gesture-handler ScrollView with no `isScrollable` prop,
-      // and iOS / non-modal screens have no sheet to negotiate with. Skip the
-      // state update in all those cases to avoid renders for a value nothing
-      // reads (e.g. an Android modal ActionSheet using `onScrolledToEnd` on the
-      // non-keyboard branch). Keep this gate in sync with `scrollBelowHeader`
+      // Only the Android form-sheet nested-scroll path reads this (see
+      // `nestedScrollEnabled` below): it negotiates with a parent
+      // `BottomSheetBehavior`, which only exists when the screen is a modal.
+      // BOTH branches consume it now — the non-keyboard branch takes the same
+      // treatment as of CP-14765. iOS / non-modal screens have no sheet to
+      // negotiate with, so skip the state update there to avoid renders for a
+      // value nothing reads. Keep this gate in sync with `scrollBelowHeader`
       // and `nestedScrollEnabled` below.
-      if (Platform.OS !== 'android' || !isModal || !shouldAvoidKeyboard) return
+      if (Platform.OS !== 'android' || !isModal) return
       // Wait until BOTH the viewport and the content have been measured before
       // computing scrollability. `onLayout` and `onContentSizeChange` fire in
       // either order; acting on a half-measured state (e.g. content known but
@@ -228,7 +227,7 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
       const maxScroll = scrollContentHeight.current - scrollViewHeight.current
       const scrollable = maxScroll > 0
       setIsScrollable(prev => (prev === scrollable ? prev : scrollable))
-    }, [isModal, shouldAvoidKeyboard])
+    }, [isModal])
 
     const checkScrolledToEnd = useCallback(
       (contentOffsetY: number) => {
@@ -773,16 +772,51 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
 
     // All of our screens have to be scrollable
     // If we don't have an input on the screen then we should not enable keyboard avoiding
+    //
+    // On an Android form sheet this branch used to kill the sheet's
+    // swipe-to-dismiss outright (CP-14765). Two reasons, both fixed below:
+    //
+    //  1. The gesture-handler `ScrollView` wraps the native scroll view in a
+    //     `NativeViewGestureHandler`, which requests disallow-intercept from its
+    //     ancestors as soon as it takes the touch. That locks the parent
+    //     `BottomSheetBehavior` out of the vertical drag, so dragging down does
+    //     nothing at all — it neither scrolls nor dismisses. A plain RN
+    //     ScrollView instead lets the sheet negotiate through Android's nested
+    //     scrolling (opted into via `nestedScrollEnabled` only while the content
+    //     actually overflows, exactly like the keyboard branch).
+    //  2. It spanned the full sheet height and only inset its content
+    //     (`paddingTop`), so it covered the grabber/header strip too and there
+    //     was nowhere left to grab the sheet. Offsetting with `marginTop` keeps
+    //     that strip over a non-scrolling view, so header/grabber drags always
+    //     reach the sheet.
+    //
+    // This mirrors the treatment the keyboard branch already got in CP-14679;
+    // iOS and non-modal screens keep the gesture-handler ScrollView and the
+    // under-header layout so content still scrolls beneath the transparent
+    // header.
+    const scrollBelowHeader = Platform.OS === 'android' && Boolean(isModal)
+    const ScrollComponent = scrollBelowHeader ? RNScrollView : ScrollView
     return (
       <View style={[{ flex: 1 }, props.style]} collapsable={false}>
-        <ScrollView
+        <ScrollComponent
           ref={setScrollViewRef}
           testID={testID}
-          style={{ flex: 1 }}
           showsVerticalScrollIndicator={false}
           keyboardDismissMode="interactive"
           keyboardShouldPersistTaps="handled"
           {...props}
+          // See (1) above — only meaningful on the Android modal path, where a
+          // parent sheet exists to negotiate with.
+          nestedScrollEnabled={scrollBelowHeader && isScrollable}
+          // Defaults first so `flex: 1` still applies unless the caller
+          // overrides it (previous behaviour: `props.style` replaced it
+          // outright), and the Android modal offset last so the fix can't be
+          // dropped by a caller-supplied style.
+          style={[
+            { flex: 1 },
+            props?.style,
+            scrollBelowHeader ? { marginTop: headerHeight } : null
+          ]}
           contentContainerStyle={[
             props?.contentContainerStyle,
             {
@@ -791,21 +825,26 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
               // the inset when there's no measured footer.
               paddingBottom:
                 (footerLayout?.height ?? insets.bottom) + EXTRA_PADDING_BOTTOM,
-              paddingTop: headerHeight,
+              // Offset lives on the scroll view's margin when below the
+              // header; otherwise inset the content so it sits under the
+              // transparent header.
+              paddingTop: scrollBelowHeader ? 0 : headerHeight,
               minHeight
             }
           ]}
           onScroll={onScroll}
           onScrollEndDrag={handleScrollEndDrag}
+          // `scrollBelowHeader` needs the composed handler too: it's what keeps
+          // `isScrollable` (and therefore `nestedScrollEnabled`) up to date.
           onContentSizeChange={
-            onScrolledToEnd
+            onScrolledToEnd || scrollBelowHeader
               ? handleContentSizeChangeComposed
               : onContentSizeChangeProp
           }
           onLayout={handleScrollViewLayoutComposed}>
           {renderHeaderContent()}
           {children}
-        </ScrollView>
+        </ScrollComponent>
 
         {renderFooterContent()}
         {renderHeaderBackground()}


### PR DESCRIPTION
## Description

**Ticket: [CP-14765](https://ava-labs.atlassian.net/browse/CP-14765)**

Restores swipe-to-dismiss on Android form-sheet modals that render `ScrollScreen` **without** `shouldAvoidKeyboard`. QA could not dismiss "How long do you want to stake?" or "Almost done, review your stake…" at all — only a ~10px strip at the very top of the sheet responded, which reads as "the modal is stuck".

This is not a staking bug and it is not the keyboard bug fixed in #4017. `ScrollScreen` has two branches:

- **Keyboard branch** (`shouldAvoidKeyboard`) renders `KeyboardAwareScrollView`, a plain RN ScrollView. It was fixed in CP-14679 (#3966): the scroll view is offset *below* the header with `marginTop`, and `nestedScrollEnabled` is on only while the content overflows.
- **Non-keyboard branch** renders `ScrollView` from **react-native-gesture-handler** at full sheet height with only `paddingTop`. It never got that treatment.

On an Android form sheet the RNGH ScrollView wraps the native scroller in a `NativeViewGestureHandler`, which requests disallow-intercept from its ancestors as soon as it takes the touch. That locks the sheet's `BottomSheetBehavior` out of the vertical drag, so dragging down does nothing at all — it neither scrolls nor dismisses. Because the scroll view also covered the grabber/header strip, there was nowhere left to grab the sheet.

That explains why only 4 of the 6 screens on the ticket were fixed by the keyboard PR: `AddContactScreen` and `AddEditNetworkScreen` both pass `shouldAvoidKeyboard`, so they were already on the fixed branch. The two stake screens have no text inputs, so they weren't. `ListScreen` is unaffected — it overrides its scroller with `KeyboardAwareScrollView` via `renderScrollComponent`, which is why the list screens on the ticket also passed.

The fix gives the non-keyboard branch the same treatment, scoped to Android modals only:

- Use a plain RN `ScrollView` so the sheet can negotiate through Android's nested scrolling.
- Offset with `marginTop` instead of `paddingTop`, so the grabber/header strip sits over a non-scrolling view and always drags the sheet.
- `nestedScrollEnabled` only while the content actually overflows — so short content dismisses from the body and overflowing content scrolls.

iOS and non-modal screens keep the gesture-handler ScrollView and the under-header layout, so nothing changes there.

**Scope note:** 57 modal `ScrollScreen` usages take the non-keyboard branch (Perps, Receive, Ledger, Keystone, account settings, V1 add-stake, notifications, …). All of them had unreliable Android swipe-to-dismiss and all are fixed by this change, so this is worth a broad Android modal-dismissal sweep rather than a stake-only retest.

No dependencies introduced. Not breaking.

## Screenshots/Videos

All recorded on a physical Pixel 8 Pro (Android 16, gesture nav) against this branch, in Testnet mode — hence the 1 AVAX minimum and testnet networks in the lists. The floating green "Admin" pill is the internal dev-build overlay, not part of this change.

**The two screens from the ticket**

1. "How long do you want to stake?" — swipe down on the body dismisses:

https://github.com/user-attachments/assets/bf3e6924-515b-46f9-8ff1-f81059841685


2. "Almost done, review your stake…" — swipe down on the body dismisses:

https://github.com/user-attachments/assets/96161580-57b2-49d6-91ba-a0f57da2b949


**Same fix on other non-keyboard modals** (this was never stake-specific)

3. Receive:

https://github.com/user-attachments/assets/c141e47e-e43e-46f4-91fd-e643a39e5d73


4. "Choose a way to start staking":

https://github.com/user-attachments/assets/df0cd14a-db9f-4d5d-913d-645071aac905


**Regression checks**

5. Long modal (Settings): a body swipe **scrolls** the content both ways and the header stays pinned; the grabber strip dismisses. This is the intended CP-14679 behavior for overflowing content, not a regression:

https://github.com/user-attachments/assets/a11480da-fcc3-4ffa-91c0-e1dfb5281ab0


6. Add contact — the `shouldAvoidKeyboard` branch, which was already working, still does:

https://github.com/user-attachments/assets/9ab94163-4f67-4cd0-9d76-e4b7ef5607d3


7. Reward chart drag still tracks (1 day / +0.0002 AVAX → 30 days / +0.007 AVAX), confirming the plain-RN-ScrollView swap didn't break child gesture handling:

https://github.com/user-attachments/assets/c8b0ebe7-e81c-4f6c-8efc-f2fa7c027de5


iOS: no behavioral change — the fix is gated on `Platform.OS === 'android' && isModal`.

## Testing

**Dev Testing (if applicable)**

iOS: 9432
Android: 9433

Verified on a physical Pixel 8 Pro (Android 16, gesture nav), which is where QA reproduced it. Isolated with a controlled comparison inside the same modal stack — adjacent screens differing only by `shouldAvoidKeyboard`:

| Screen | Branch | Body swipe before | After |
| --- | --- | --- | --- |
| How long do you want to stake? | non-keyboard | ❌ nothing | ✅ dismisses |
| Almost done, review your stake… | non-keyboard | ❌ nothing | ✅ dismisses |
| Choose a way to start staking | non-keyboard | ❌ nothing | ✅ dismisses |
| How much do you want to stake? | keyboard | ✅ dismisses | ✅ unchanged |

Regression checks on device:

- Long modal (Settings) still scrolls, header stays fixed, and it dismisses from the header/grabber strip — CP-14679's contract is preserved.
- Reward chart drag on the duration screen still works (moved to 180 days; reward and Duration row updated) — confirms the ScrollView swap didn't break child gesture handling.

Unit tests: 5 new cases in `ScrollScreen.test.tsx` covering the Android modal `marginTop`/`paddingTop` offset, `nestedScrollEnabled` off when content fits and on when it overflows, plus iOS and non-modal controls. 3 of them fail against the old component (verified by reverting), so they are real guards — this behavior has now regressed twice (#3961 removed the prop, #3966 restored it to one branch only).

`yarn tsc` and `yarn lint` clean; 19/19 `ScrollScreen` tests pass.

Bitrise build: to be triggered and referenced here.

**QA Testing (if applicable)**

Android only. On a physical device (this did not reproduce on an emulator).

1. Stake → **+** → Fast stake → Next to reach **"How long do you want to stake?"**.
2. Swipe down anywhere in the body of the sheet. Expected: the modal dismisses.
3. Next again to reach **"Almost done, review your stake…"**. Swipe down in the body. Expected: the modal dismisses.
4. Repeat from the grabber strip at the very top of the sheet. Expected: dismisses.
5. Open a **long** modal (Account settings, or Perps place order). Expected: swiping the body **scrolls** the content rather than dismissing; swiping the header/grabber strip dismisses.
6. Confirm text-input modals are unchanged: Settings → Contacts → Add contact, and Settings → Networks → a custom network. Expected: dismiss as they already did.
7. Spot-check other non-keyboard modals for dismissal: Receive, Notifications, Perps details/leverage, Ledger/Keystone connection screens.
8. iOS smoke check: modal dismissal and scrolling unchanged.

Acceptance criteria: on Android, every form-sheet modal can be dismissed by swiping down — from the body when the content fits, and from the header/grabber strip when the content overflows — and content that overflows still scrolls.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14765]: https://ava-labs.atlassian.net/browse/CP-14765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ