### PR TITLE
Point vm modules at staging for internal and e2e builds by tracking the AppCheck provider instead of __DEV__

### DIFF
--- a/packages/core-mobile/app/services/fcm/AppCheckService.ts
+++ b/packages/core-mobile/app/services/fcm/AppCheckService.ts
@@ -4,11 +4,11 @@ import {
 } from '@react-native-firebase/app-check'
 import Logger from 'utils/Logger'
 import Config from 'react-native-config'
-import { isDebugOrInternalBuild, isE2EBuild } from 'utils/Utils'
+import { usesDebugAppCheckProvider } from 'utils/Utils'
 
 class AppCheckService {
   init = (): void => {
-    const shouldUseDebugProvider = isDebugOrInternalBuild() || isE2EBuild
+    const shouldUseDebugProvider = usesDebugAppCheckProvider()
 
     const rnfbProvider = firebase
       .appCheck()

--- a/packages/core-mobile/app/utils/Utils.test.ts
+++ b/packages/core-mobile/app/utils/Utils.test.ts
@@ -1,6 +1,65 @@
-import { truncateNodeId } from './Utils'
+import DeviceInfo from 'react-native-device-info'
+import { truncateNodeId, usesDebugAppCheckProvider } from './Utils'
+
+const setDev = (value: boolean): void => {
+  ;(globalThis as unknown as { __DEV__: boolean }).__DEV__ = value
+}
 
 describe('/app/utils/Utils', () => {
+  /**
+   * These pin the real build matrix. The AppCheck provider and the vm-module
+   * `Environment` both hang off this predicate, so a regression here silently
+   * points a debug-attested build at the production proxy (401 on every X/P
+   * Glacier call) — which is exactly what a bare `__DEV__` check did.
+   */
+  describe('usesDebugAppCheckProvider', () => {
+    const originalDev = (globalThis as unknown as { __DEV__: boolean }).__DEV__
+    const bundleIdSpy = jest.spyOn(DeviceInfo, 'getBundleId')
+
+    afterEach(() => {
+      setDev(originalDev)
+      bundleIdSpy.mockReset()
+    })
+
+    it('is false for an external release build (real attestation, prod services)', () => {
+      setDev(false)
+      bundleIdSpy.mockReturnValue('org.avalabs.avaxwallet')
+
+      expect(usesDebugAppCheckProvider()).toBe(false)
+    })
+
+    it('is true for an internal release build, despite __DEV__ being false', () => {
+      setDev(false)
+      bundleIdSpy.mockReturnValue('org.avalabs.avaxwallet.internal')
+
+      expect(usesDebugAppCheckProvider()).toBe(true)
+    })
+
+    it('is true for a local dev build', () => {
+      setDev(true)
+      bundleIdSpy.mockReturnValue('org.avalabs.avaxwallet')
+
+      expect(usesDebugAppCheckProvider()).toBe(true)
+    })
+
+    it('is true for an e2e build on an external bundle id', () => {
+      setDev(false)
+      bundleIdSpy.mockReturnValue('org.avalabs.avaxwallet')
+
+      let usesDebugProvider: boolean | undefined
+      jest.isolateModules(() => {
+        jest.doMock('react-native-config', () => ({
+          __esModule: true,
+          default: { E2E_MNEMONIC: 'mock e2e mnemonic' }
+        }))
+
+        usesDebugProvider = require('./Utils').usesDebugAppCheckProvider()
+      })
+
+      expect(usesDebugProvider).toBe(true)
+    })
+  })
+
   describe('truncateNodeId', () => {
     const nodeID = 'NodeID-9zPtXnScuWRvoiTDe498ZtjgoTXwTwxr9'
     it('returns the whole NodeId if size is bigger than length', () => {

--- a/packages/core-mobile/app/utils/Utils.ts
+++ b/packages/core-mobile/app/utils/Utils.ts
@@ -145,5 +145,24 @@ export const isDebugOrInternalBuild = (): boolean => {
  */
 export const isE2EBuild = !!Config.E2E_MNEMONIC
 
+/**
+ * True when this build authenticates to backend services with an AppCheck
+ * *debug* token instead of real device attestation (playIntegrity / appAttest):
+ * local dev, internal builds, and e2e builds.
+ *
+ * Debug tokens are registered against the internal Firebase project, which the
+ * production core-proxy-api does not trust. Any build that returns true here
+ * must therefore also talk to the dev/staging services, so both the AppCheck
+ * provider and the vm-module `Environment` are derived from this one predicate.
+ *
+ * Do NOT reintroduce a bare `__DEV__` check for this: `__DEV__` only says
+ * whether the JS is a dev-mode bundle, and internal/e2e builds are release-mode
+ * bundles (`__DEV__ === false`) that still use the debug provider. Reading
+ * `__DEV__` is what pointed internal builds at the prod proxy while sending an
+ * internal-project AppCheck token, 401ing every X/P Glacier call (CP-14673).
+ */
+export const usesDebugAppCheckProvider = (): boolean =>
+  isDebugOrInternalBuild() || isE2EBuild
+
 export const isIOS = Platform.OS === 'ios'
 export const isAndroid = Platform.OS === 'android'

--- a/packages/core-mobile/app/vmModule/ModuleManager.test.ts
+++ b/packages/core-mobile/app/vmModule/ModuleManager.test.ts
@@ -3,6 +3,7 @@ import { BitcoinModule } from '@avalabs/bitcoin-module'
 import { AvalancheModule } from '@avalabs/avalanche-module'
 import { SvmModule } from '@avalabs/svm-module'
 import { NetworkVMType, Network } from '@avalabs/core-chains-sdk'
+import { Environment } from '@avalabs/vm-module-types'
 import ModuleManager from 'vmModule/ModuleManager'
 import { WalletType } from 'services/wallet/types'
 import {
@@ -359,6 +360,73 @@ describe('ModuleManager', () => {
 
         expect(result).toEqual([undefined])
       })
+    })
+  })
+
+  /**
+   * The modules resolve their Glacier host from `environment` alone — `getEnv()`
+   * in each module is a closed switch on the enum, with no URL override, and it
+   * never reads PROXY_URL/GLACIER_URL. So it must agree with the AppCheck
+   * provider: internal and e2e builds send debug AppCheck tokens that the
+   * production core-proxy-api rejects. `__DEV__` is false in those builds, so
+   * gating on it 401'd every X/P balance and activity call.
+   */
+  describe('environment passed to the vm modules', () => {
+    const originalDev = (globalThis as unknown as { __DEV__: boolean }).__DEV__
+
+    afterEach(() => {
+      ;(globalThis as unknown as { __DEV__: boolean }).__DEV__ = originalDev
+    })
+
+    const initAndCaptureEnvironment = async (
+      bundleId: string
+    ): Promise<unknown> => {
+      // internal and external release builds both ship a non-dev bundle
+      ;(globalThis as unknown as { __DEV__: boolean }).__DEV__ = false
+
+      const captured: Record<string, unknown>[] = []
+      const stubModule = (): jest.Mock =>
+        jest.fn(params => {
+          captured.push(params)
+        })
+
+      await jest.isolateModulesAsync(async () => {
+        // keep the rest of the surface (getVersion etc. is read at import time)
+        jest.doMock('react-native-device-info', () => ({
+          ...jest.requireActual(
+            'react-native-device-info/jest/react-native-device-info-mock'
+          ),
+          getBundleId: () => bundleId
+        }))
+        jest.doMock('@avalabs/evm-module', () => ({ EvmModule: stubModule() }))
+        jest.doMock('@avalabs/bitcoin-module', () => ({
+          BitcoinModule: stubModule()
+        }))
+        jest.doMock('@avalabs/avalanche-module', () => ({
+          AvalancheModule: stubModule()
+        }))
+        jest.doMock('@avalabs/svm-module', () => ({ SvmModule: stubModule() }))
+
+        await require('vmModule/ModuleManager').default.init()
+      })
+
+      expect(captured).toHaveLength(4)
+      // all four must agree, or chains disagree on which host to call
+      expect(new Set(captured.map(params => params.environment)).size).toBe(1)
+
+      return captured[0]?.environment
+    }
+
+    it('uses DEV for an internal release build', async () => {
+      await expect(
+        initAndCaptureEnvironment('org.avalabs.avaxwallet.internal')
+      ).resolves.toBe(Environment.DEV)
+    })
+
+    it('uses PRODUCTION for an external release build', async () => {
+      await expect(
+        initAndCaptureEnvironment('org.avalabs.avaxwallet')
+      ).resolves.toBe(Environment.PRODUCTION)
     })
   })
 })

--- a/packages/core-mobile/app/vmModule/ModuleManager.ts
+++ b/packages/core-mobile/app/vmModule/ModuleManager.ts
@@ -26,6 +26,7 @@ import {
 import { APPLICATION_NAME, APPLICATION_VERSION } from 'utils/api/constants'
 import { DerivationPath } from '@avalabs/core-wallets-sdk'
 import { emptyAddresses } from 'utils/publicKeys'
+import { usesDebugAppCheckProvider } from 'utils/Utils'
 import { WalletType } from 'services/wallet/types'
 import { isUnsupportedXpDerivationError } from 'services/wallet/KeystoneWallet/errors'
 import { ModuleErrors, VmModuleErrors } from './errors'
@@ -34,8 +35,6 @@ import { approvalController } from './ApprovalController/ApprovalController'
 // https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md
 // Syntax for namespace is defined in CAIP-2
 const NAMESPACE_REGEX = new RegExp('[-a-z0-9]{3,8}')
-
-const isDev = typeof __DEV__ === 'boolean' && __DEV__
 
 class ModuleManager {
   #modules: Module[] | undefined
@@ -88,7 +87,13 @@ class ModuleManager {
   init = async (): Promise<void> => {
     if (this.#modules !== undefined) return
 
-    const environment = isDev ? Environment.DEV : Environment.PRODUCTION
+    // Must track the AppCheck provider, not `__DEV__`: the modules' internal
+    // Glacier calls go to core-proxy-api, and its prod deployment rejects the
+    // debug AppCheck tokens that internal/e2e builds send. See
+    // usesDebugAppCheckProvider.
+    const environment = usesDebugAppCheckProvider()
+      ? Environment.DEV
+      : Environment.PRODUCTION
 
     const moduleInitParams: ConstructorParams & {
       runtime: Required<Pick<RuntimeParams, 'getAuthHeaders'>>


### PR DESCRIPTION
## Description

**Ticket: [CP-14916](https://ava-labs.atlassian.net/browse/CP-14916)**

Internal builds returned 401 on every X/P balance and activity call. The cause was two gates answering different questions:

- `AppCheckService` picks the AppCheck provider from the **bundle id** (`isDebugOrInternalBuild()` = `__DEV__ || bundleId.includes('.internal')`), so internal builds always use the *debug* provider.
- `ModuleManager` picked the vm-module `Environment` from **`__DEV__`**, which is false in a release bundle, so internal builds got `Environment.PRODUCTION`.

So an internal build sent a debug AppCheck token, minted against the internal Firebase project, to the production `core-proxy-api`, which does not trust that project. 401 on everything the modules fetch from Glacier.

`__DEV__` being false for internal builds is correct and not something we can change. It means "this is a dev-mode bundle", not "which backend should I use". Android hardcodes `devEnabled.set(false)` for any variant outside `debuggableVariants` (`["externalDebug", "internalDebug"]`), and iOS derives it from a `*Debug*` match on the Xcode configuration. An embedded, distributable bundle always has `__DEV__ === false`.

The fix extracts the predicate `AppCheckService` was already computing inline and has both call sites read from it:

```ts
export const usesDebugAppCheckProvider = (): boolean =>
  isDebugOrInternalBuild() || isE2EBuild
```

Now a build that uses the debug AppCheck provider points at the staging services by construction, and the two cannot drift apart again.

This also fixes e2e builds, which had the same mismatch and had not been noticed. `internalE2e` and `externalE2e` are both outside `debuggableVariants`, so `__DEV__` is false while `isE2EBuild` forces the debug provider. Gating only on `isDebugOrInternalBuild()` would have missed `externalE2e`.

External production builds are unaffected. They use real device attestation (playIntegrity / appAttest) and keep `Environment.PRODUCTION`.

Worth knowing for reviewers: the modules give no way to override this from env. `getEnv()` in each vm-module is a closed switch on the `Environment` enum, there is no URL field in `ConstructorParams`, and it never reads `PROXY_URL` or `GLACIER_URL`. So `Environment` is the only lever, and it has to be right.

No dependencies introduced. Not a breaking change.

There is a related change outside this repo, which is not required for this fix but should land alongside it: the `.env.internal` AWS secret should point `GLACIER_URL` at `https://core-glacier-api.avax-test.network` (new proxy staging) while `PROXY_URL` stays on `https://proxy-api-dev.avax.network`. The two hosts serve disjoint route sets, and `/networks`, `/tokenlist` and `/perps/available` all 404 on `core-proxy-api`.

## Screenshots/Videos

No UI change, so there is nothing meaningful to capture. The observable result is X/P balances and activity populating on an internal build instead of rendering an empty state.

## Testing

**Dev Testing (if applicable)**

Note that this cannot be reproduced locally. `yarn android` builds `internalDebug`, which *is* in `debuggableVariants`, so `__DEV__` is true, both gates agree, and X/P works either way. A release-mode build is required.

1. Trigger the `android-internal` or `ios-internal` Bitrise workflow off this branch.
2. Install and open the app on a real device, then view a wallet with X/P activity.
3. X/P balances and activity should populate. Before this change they rendered as an empty "No recent transactions" state.
4. If watching network traffic, Glacier requests from the modules should land on `core-proxy-api.avax-test.network` rather than `core-proxy-api.avax.network`.

Verified on a Bitrise internal build off this branch: X/P balances and activity populate.

Unit tests added:

- `Utils.test.ts` pins the build matrix for the predicate: external release false, internal release true despite `__DEV__` being false, local dev true, e2e on an external bundle id true.
- `ModuleManager.test.ts` asserts the `environment` actually handed to all four module constructors, and that all four agree. Confirmed these fail when the gate is reverted to `__DEV__`, so they catch the regression rather than just describing current behavior.

**QA Testing (if applicable)**

Acceptance criteria: on an internal build, X/P balances and activity load for a wallet that has them. An auth failure previously surfaced as a plausible-looking empty state, so please confirm real data appears rather than just the absence of an error.

Worth flagging that this empty-state behavior is a separate problem this PR does not address: `avalanche-module` swallows the 401 behind a 5 minute `isGlacierHealthy=false` guard, so a failed call is indistinguishable from an empty wallet in the UI. That is the reason this took two weeks to find and is worth its own ticket.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)



[CP-14916]: https://ava-labs.atlassian.net/browse/CP-14916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ