### PR TITLE
CP-14765: migrate the delegate node picker to ListScreenV2 so its Android form sheet dismisses

### DIFF
--- a/packages/core-mobile/app/new/features/stake/v2/screens/SelectNodeScreen.tsx
+++ b/packages/core-mobile/app/new/features/stake/v2/screens/SelectNodeScreen.tsx
@@ -9,7 +9,7 @@ import {
 } from '@avalabs/k2-alpine'
 import { DropdownMenu } from 'common/components/DropdownMenu'
 import { ErrorState } from 'common/components/ErrorState'
-import { ListScreen } from 'common/components/ListScreen'
+import { ListScreenV2 } from 'common/components/ListScreenV2'
 import { useRouter } from 'expo-router'
 import useStakingParams from 'hooks/earn/useStakingParams'
 import { useNodes } from 'hooks/earn/useNodes'
@@ -284,11 +284,19 @@ const SelectNodeScreen = (): JSX.Element => {
   }, [isFetching, error, validators.length, searchText])
 
   return (
-    <ListScreen
+    <ListScreenV2
       title={`Find and select your\npreferred node`}
       data={validators}
       renderItem={renderItem}
       isModal
+      // Deliberately NOT `headerOutsideList`: that variant puts the title and
+      // search bar in a fixed region above the list, and on an Android form
+      // sheet a partial drag on that region (one that doesn't travel far enough
+      // to dismiss) leaves the sheet's nested-scroll interaction half-finished
+      // and the list permanently unscrollable — taps still work, and it only
+      // clears by closing and reopening the sheet. Device-verified on a Pixel 8
+      // Pro: with the header inside the list (this default path) the same
+      // partial drag snaps back and scrolling keeps working.
       keyExtractor={item => item.validator.nodeID}
       renderHeader={renderHeader}
       renderEmpty={renderEmpty}


### PR DESCRIPTION
## Description

**Ticket: [CP-14765](https://ava-labs.atlassian.net/browse/CP-14765)**

Follow-up to #4019. After that landed, Eunji retested on her Pixel 7 and reported the Fast stake flow was good but the **Delegate** flow still would not dismiss.

The screen is `SelectNodeScreen`, the "Find and select your preferred node" picker. It is the only screen on the delegate path that is not `ScrollScreen` based, which is exactly why Fast stake passed and Delegate did not:

| Flow | Screens | Component |
| --- | --- | --- |
| Fast stake | index, amount, duration, confirm | all `ScrollScreen`, fixed by #4019 |
| Delegate | index, **selectNode**, nodeDetails, amount, duration, confirm | **`ListScreen`** (v1), never fixed |

**Correction to #4019.** That PR claimed `ListScreen` was unaffected because it overrides its scroller with `KeyboardAwareScrollView` via `renderScrollComponent`. That is wrong, and it is why this screen was missed. react-native-gesture-handler's `FlatList` sets its **own** `renderScrollComponent` after spreading caller props (`GestureComponents.js:82-89`), so the caller's value is silently discarded. `ListScreen`'s `KeyboardAwareScrollView` never mounts. v1 `ListScreen` therefore has both defects #4019 fixed in `ScrollScreen`:

1. It renders RNGH's `ScrollView` (`createNativeWrapper(RNScrollView, { disallowInterruption: true })`), whose `NativeViewGestureHandler` requests disallow-intercept from its ancestors, locking the sheet's `BottomSheetBehavior` out of the vertical drag.
2. It spans the full sheet height with the header offset applied as `ListHeaderComponent` `paddingTop` rather than the list's `marginTop`, so it covers the grabber strip too.

Net effect for the user: dragging the list body did nothing at all. Only a drag on the roughly 8px grabber strip dismissed the sheet, which reads as "the modal is stuck".

`ListScreenV2` (FlashList) already carries the Android form-sheet fix from CP-14376 / #3929, so the fix is to move this screen onto it. That is the whole change, one line plus a comment.

**Why not `headerOutsideList`.** My first attempt passed that flag, since `useNodes` is a cold network fetch and CP-14376 documents that a list which is empty at mount may never get wired for sheet dismissal. On device that flag introduced a worse bug: it renders the title and search bar in a fixed region above the list, and a partial drag on that region (one that does not travel far enough to dismiss) leaves the sheet's nested-scroll interaction half finished and the list **permanently unscrollable**. Taps still work, it survives navigating away and back, and it only clears by closing and reopening the sheet. I confirmed the flag was the cause by disabling it and repeating the identical gesture: the drag snaps back and scrolling keeps working. Videos of both below.

**Known follow-ups, not addressed here**

- `PerpetualsSearchScreen` and `PerpetualsPositionsSearchScreen` both pass `headerOutsideList`, so that stuck-scroll is very likely live for them today. Same root cause, separate ticket.
- On both `ListScreenV2` paths, a downward drag dismisses the sheet rather than scrolling the list back toward the top. That is pre-existing and also affects the swap token pickers, so it is not introduced here.
- 19 other callers still use v1 `ListScreen` and retain the original swipe-to-dismiss defect on Android form sheets. `cp-listscreen-v2-migration` (CP-14713) would clear them wholesale.

No dependencies introduced. Not breaking.

## Screenshots/Videos

Recorded on a physical Pixel 8 Pro (Android 16, gesture nav) in Testnet mode, which is why the lists show testnet validators and a 1 AVAX minimum. The floating green "Admin" pill is the internal dev-build overlay.

1. Before, on v1 `ListScreen`: the list scrolls back to the top, then two further body drags do nothing and the sheet stays open.
https://github.com/user-attachments/assets/6494b02b-9de5-4be0-8090-4bd45567f309


2. After, on `ListScreenV2`: the same body drag at scroll top dismisses the sheet.
https://github.com/user-attachments/assets/f18cd5a6-df8c-47a4-ba71-7a227cfdd0d8


3. The rejected `headerOutsideList` variant: scrolling works, then a 140px drag on the fixed header region kills scrolling entirely (three scroll attempts produce no movement).

https://github.com/user-attachments/assets/99f7cb69-cbbd-4d03-81a4-f018bcafa131



4. The shipped fix under the identical gesture sequence: the sheet stays open and keeps scrolling through all three attempts.


https://github.com/user-attachments/assets/7b60a6a0-a21a-4fba-8a54-6fdf067e3b3d


iOS: this screen now renders FlashList instead of FlatList. `headerOutsideList` is Android only and is not used, so there is no layout change on iOS.

## Testing

**Dev Testing (if applicable)**

iOS: 9436
Android: 9437

Verified on a physical Pixel 8 Pro against this branch, driving the real UI path (Stake, +, Delegate) rather than a deep link, so the picker is pushed with the back button visible.

| Gesture | Before (v1 `ListScreen`) | After (`ListScreenV2`) |
| --- | --- | --- |
| Body drag down at scroll top | Nothing, 3 consecutive attempts | Dismisses |
| Body drag up | Scrolls | Scrolls |
| Grabber strip drag | Dismisses | Dismisses |
| Partial drag on header region, then scroll | n/a | Scrolling still works |

Also confirmed on device: the two line title clears the floating back button, the search bar and Sort / Advanced filters chips work, and tapping a row still opens Node details with the correct node (FlashList recycles views where FlatList did not, so `onPress` binding was worth checking).

Manually checked by James on the same device: search plus keyboard focus while typing, the loading and "No Matching Nodes" empty states, and node tap through to details. All good.

`tsc -p .` clean with the build cache cleared, `eslint` clean, and the full unit suite passes (345 suites, 4276 tests), including the `ScrollScreen` regression tests added in #4019.

No new unit tests: the change is a component swap, and the behavior it fixes is native Android sheet gesture handling that jest cannot exercise.

**QA Testing (if applicable)**

Android, on a physical device.

1. Stake, then **+**, then **Delegate** to reach "Find and select your preferred node".
2. Swipe down anywhere in the list body while the list is at the top. Expected: the sheet dismisses.
3. Reopen, scroll the list down, then drag up. Expected: the list scrolls normally.
4. Reopen and drag the grabber strip at the very top. Expected: the sheet dismisses.
5. Type a NodeID prefix in the search bar. Expected: results filter, focus is not dropped mid typing, and the keyboard does not flicker.
6. Search for something with no matches. Expected: "No Matching Nodes" centred and clear of the keyboard. Clear it and the list returns.
7. Tap a node. Expected: Node details opens for that node, and the header chevrons page through the list in the same order.
8. Open Sort and Advanced filters, apply something, and come back. Expected: the list reflects it and still scrolls and dismisses.
9. Restake fallback: from a completed stake where the original node cannot be reused, Restake replaces to this picker as the stack's only route, so the back button is hidden. Expected: the title still sits correctly and the sheet dismisses.
10. iOS smoke check: the picker scrolls, searches, and dismisses as before.

Acceptance criteria: on Android, the delegate node picker can be dismissed by swiping down on the list body when the list is at the top, the list scrolls normally, and scrolling never becomes stuck after a partial drag.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14765]: https://ava-labs.atlassian.net/browse/CP-14765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ