### PR TITLE
CP-14765: keep Android form-sheet swipe-to-dismiss on overflowing content

### DIFF
--- a/packages/core-mobile/app/new/common/components/ScrollScreen.test.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.test.tsx
@@ -346,6 +346,18 @@ describe('ScrollScreen Android form-sheet swipe-to-dismiss (non-keyboard branch)
     })
   }
 
+  const fireScroll = async (
+    instance: ReactTestRenderer,
+    offsetY: number
+  ): Promise<void> => {
+    const scrollView = instance.root.findByType(ScrollView)
+    await act(async () => {
+      scrollView.props.onScroll({
+        nativeEvent: { contentOffset: { y: offsetY } }
+      })
+    })
+  }
+
   const getScrollViewStyle = (
     instance: ReactTestRenderer
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -382,7 +394,12 @@ describe('ScrollScreen Android form-sheet swipe-to-dismiss (non-keyboard branch)
       ).toBe(false)
     })
 
-    it('turns nested scrolling on once the content overflows, so a body swipe scrolls', async () => {
+    // CP-14765 follow-up: overflow alone must NOT disable dismissal. Gating
+    // only on overflow made dismissal depend on content height — the delegate
+    // "How long do you want to stake?" step renders one extra caption that Fast
+    // Stake doesn't, which was enough to kill swipe-to-dismiss on that screen
+    // while the identical Fast Stake screen kept it.
+    it('keeps nested scrolling off while overflowing content sits at the top, so a body swipe still dismisses', async () => {
       const instance = await render({ isModal: true })
 
       await fireScrollViewLayout(instance, MEASURED_VIEWPORT_HEIGHT)
@@ -390,7 +407,46 @@ describe('ScrollScreen Android form-sheet swipe-to-dismiss (non-keyboard branch)
 
       expect(
         instance.root.findByType(ScrollView).props.nestedScrollEnabled
+      ).toBe(false)
+    })
+
+    it('turns nested scrolling on once overflowing content is scrolled away from the top, so a body swipe scrolls', async () => {
+      const instance = await render({ isModal: true })
+
+      await fireScrollViewLayout(instance, MEASURED_VIEWPORT_HEIGHT)
+      await fireContentSizeChange(instance, MEASURED_VIEWPORT_HEIGHT * 2)
+      await fireScroll(instance, 120)
+
+      expect(
+        instance.root.findByType(ScrollView).props.nestedScrollEnabled
       ).toBe(true)
+    })
+
+    it('hands dismissal back once the user scrolls to the top again', async () => {
+      const instance = await render({ isModal: true })
+
+      await fireScrollViewLayout(instance, MEASURED_VIEWPORT_HEIGHT)
+      await fireContentSizeChange(instance, MEASURED_VIEWPORT_HEIGHT * 2)
+      await fireScroll(instance, 120)
+      await fireScroll(instance, 0)
+
+      expect(
+        instance.root.findByType(ScrollView).props.nestedScrollEnabled
+      ).toBe(false)
+    })
+
+    // Android reports sub-pixel offsets while settling; those must still read
+    // as "at the top" or the sheet silently loses dismissal at rest.
+    it('treats a sub-pixel resting offset as the top', async () => {
+      const instance = await render({ isModal: true })
+
+      await fireScrollViewLayout(instance, MEASURED_VIEWPORT_HEIGHT)
+      await fireContentSizeChange(instance, MEASURED_VIEWPORT_HEIGHT * 2)
+      await fireScroll(instance, 0.5)
+
+      expect(
+        instance.root.findByType(ScrollView).props.nestedScrollEnabled
+      ).toBe(false)
     })
 
     it('leaves non-modal screens under the transparent header', async () => {

--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -197,6 +197,9 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
     const subtitleHeight = useSharedValue<number>(0)
 
     const SCROLL_END_THRESHOLD = 20
+    // Offsets at or below this count as "parked at the top" (see
+    // `isAtScrollTop`). Small enough that a real scroll never reads as top.
+    const SCROLL_TOP_EPSILON = 1
 
     // Whether the content actually overflows the viewport. Drives Android
     // `nestedScrollEnabled` on the keyboard-aware branch: when the content
@@ -205,6 +208,29 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
     // of being captured by the sheet's drag-to-dismiss. When the content fits,
     // we leave it off so a short modal stays swipe-to-dismiss. (CP-14679)
     const [isScrollable, setIsScrollable] = useState(false)
+
+    // Whether the scroll offset is parked at the very top. Combined with
+    // `isScrollable` to decide who owns a downward drag on an Android form
+    // sheet (see `nestedScrollEnabled` below).
+    //
+    // `isScrollable` alone was too coarse: it handed EVERY downward drag on
+    // overflowing content to the ScrollView, so a form sheet lost
+    // swipe-to-dismiss entirely the moment its content grew past the viewport.
+    // That made dismissal depend on content height — the delegate
+    // "How long do you want to stake?" step renders one extra node-end caption
+    // that Fast Stake doesn't, which was enough to cross the threshold and kill
+    // dismissal on that screen alone (CP-14765).
+    //
+    // Android reads `nestedScrollEnabled` at touch-down, so gating on the
+    // offset assigns the whole gesture up front, which is what we want:
+    //   • at the top   → nested scrolling off, the sheet takes the downward
+    //                    drag and dismisses. Dragging UP still scrolls, since
+    //                    this flag only governs nested-scroll participation
+    //                    with the parent, not the ScrollView's own scrolling.
+    //   • scrolled     → nested scrolling on, so a downward drag scrolls back
+    //                    toward the top instead of being captured by the
+    //                    sheet's drag-to-dismiss (the CP-14679 behaviour).
+    const [isAtScrollTop, setIsAtScrollTop] = useState(true)
 
     const updateIsScrollable = useCallback(() => {
       // Only the Android form-sheet nested-scroll path reads this (see
@@ -351,6 +377,11 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
       showNavigationHeaderTitle
     })
 
+    // Only the Android form-sheet path reads `isAtScrollTop`; matches the
+    // `updateIsScrollable` gate so iOS / non-modal screens never re-render for
+    // a value nothing consumes.
+    const tracksScrollTop = Platform.OS === 'android' && Boolean(isModal)
+
     const onScroll = useCallback(
       (
         event:
@@ -360,7 +391,7 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
       ) => {
         onFadingScroll(event)
 
-        if (onScrolledToEnd) {
+        if (onScrolledToEnd || tracksScrollTop) {
           let offsetY = 0
           if (typeof event === 'number') {
             offsetY = event
@@ -369,10 +400,20 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
           } else {
             offsetY = event.contentOffset.y
           }
-          checkScrolledToEnd(offsetY)
+          if (onScrolledToEnd) {
+            checkScrolledToEnd(offsetY)
+          }
+          if (tracksScrollTop) {
+            // Epsilon rather than `=== 0`: Android reports sub-pixel offsets
+            // when settling, which would otherwise read as "scrolled" and keep
+            // dismissal disabled at rest. Only commit on a change so this
+            // doesn't re-render on every scroll frame.
+            const atTop = offsetY <= SCROLL_TOP_EPSILON
+            setIsAtScrollTop(prev => (prev === atTop ? prev : atTop))
+          }
         }
       },
-      [onFadingScroll, onScrolledToEnd, checkScrolledToEnd]
+      [onFadingScroll, onScrolledToEnd, checkScrolledToEnd, tracksScrollTop]
     )
 
     // Snap the header on release, mirroring ListScreenV2's `onScrollEndDrag`:
@@ -722,7 +763,9 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
             // actually overflows — a short modal keeps swipe-to-dismiss. (The
             // gesture-handler ScrollView branch below arbitrates this on its own
             // and doesn't need the prop.) (CP-14679)
-            nestedScrollEnabled={scrollBelowHeader && isScrollable}
+            nestedScrollEnabled={
+              scrollBelowHeader && isScrollable && !isAtScrollTop
+            }
             // `props.style` is merged last so a caller's style is preserved
             // (it would otherwise be dropped: `{...props}` spreads `style` but
             // this explicit `style` prop replaces it). Defaults come first so
@@ -807,7 +850,9 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
           {...props}
           // See (1) above — only meaningful on the Android modal path, where a
           // parent sheet exists to negotiate with.
-          nestedScrollEnabled={scrollBelowHeader && isScrollable}
+          nestedScrollEnabled={
+            scrollBelowHeader && isScrollable && !isAtScrollTop
+          }
           // Defaults first so `flex: 1` still applies unless the caller
           // overrides it (previous behaviour: `props.style` replaced it
           // outright), and the Android modal offset last so the fix can't be


### PR DESCRIPTION
## Description

**Ticket: [CP-14765](https://ava-labs.atlassian.net/browse/CP-14765)**

Follow-up to #4019. The delegate flow's "How long do you want to stake?" step still could not be swipe-dismissed on Android, while the identical Fast Stake screen dismissed fine.

Both flows render the same `StakeDurationScreen` through the same layout, so the difference is not the flow. It is content height. `ScrollScreen` gated `nestedScrollEnabled` purely on whether the content overflowed:

```ts
nestedScrollEnabled={scrollBelowHeader && isScrollable}
```

Once content overflows, that hands every downward drag to the ScrollView, so the sheet's `BottomSheetBehavior` never sees it and the screen stops being dismissible. That made dismissal a function of how tall the content happened to be. The delegate variant renders one extra node-end caption that Fast Stake does not (`StakeDurationScreen`, guarded on `maxEndDate !== undefined`, which only `delegate/duration.tsx` passes), and that was enough to cross the threshold.

The fix adds the scroll offset to the gate:

```ts
nestedScrollEnabled={scrollBelowHeader && isScrollable && !isAtScrollTop}
```

Android reads this prop at touch-down, so each gesture gets assigned up front:

- **At the top:** nested scrolling is off, the sheet takes the downward drag and dismisses. Dragging up still scrolls, because this flag only governs nested-scroll participation with the parent, not the ScrollView's own scrolling.
- **Scrolled:** nested scrolling is on, so a downward drag scrolls back toward the top instead of being captured by drag-to-dismiss. This is the CP-14679 behavior, preserved.

Dismissal no longer depends on content height, so this covers every overflowing `ScrollScreen` form sheet rather than just this one screen.

**One thing to weigh in on:** I applied the gate to both the keyboard-aware and non-keyboard branches rather than only the branch with the reported bug. Having two branches compute the same decision differently is what let CP-14679 and CP-14765 drift apart in the first place. The tradeoff is that the keyboard branch has a text input in play, so if you would rather that case get its own QA pass, I can scope this to the non-keyboard branch.

No dependencies introduced. Not a breaking change.

## Screenshots/Videos

No visual change, the change is behavioral. The observable result is that dragging the body of the delegate "How long do you want to stake?" sheet downward now dismisses it.

## Testing

**Dev Testing (if applicable)**

iOS: 9437
Android: 9438

Verified on a physical Pixel with Metro against this branch: dragging the body of the delegate duration sheet downward dismisses it.

1. Stake, then Delegate (not Fast Stake), pick an amount, select a node, continue to "How long do you want to stake?".
2. Drag downward on the body of the sheet. It should dismiss. Before this change it did nothing.
3. Regression check, Fast Stake: same screen via the Fast Stake flow should still dismiss.
4. Regression check, scrolling is preserved: on a form sheet whose content overflows, scroll down a little, then drag downward. It should scroll back toward the top rather than dismissing. Only a drag that starts at the top dismisses.
5. Regression check, keyboard branch: open a form sheet with a text input and confirm both dismissal at the top and scrolling once scrolled.

Unit tests, 22 passing in `ScrollScreen.test.tsx`:

- Overflowing content sitting at the top keeps nested scrolling off, so a body swipe still dismisses.
- Overflowing content scrolled away from the top turns it on, so a body swipe scrolls.
- Scrolling back to the top hands dismissal back.
- A sub-pixel resting offset still counts as the top, since Android reports those while settling and they would otherwise silently disable dismissal at rest.

One existing test changed rather than being added to: `turns nested scrolling on once the content overflows` asserted the old contract, where overflow alone enabled nested scrolling. It now asserts the top versus scrolled split.

**QA Testing (if applicable)**

Acceptance criteria: on Android, every form sheet can be dismissed by dragging its body downward when it is scrolled to the top, regardless of how tall its content is, and sheets with scrollable content still scroll normally once scrolled.

The highest value check is a sweep of tall form sheets across the app, not just the stake flow. The old behavior silently removed dismissal from any sheet whose content grew past the viewport, so other screens may have been affected without a ticket.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CP-14765]: https://ava-labs.atlassian.net/browse/CP-14765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ