### PR TITLE
CP-13250: report internal builds under their own Sentry environment instead of production

### DIFF
--- a/packages/core-mobile/app/services/sentry/SentryService.test.ts
+++ b/packages/core-mobile/app/services/sentry/SentryService.test.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/react-native'
+import DeviceInfo from 'react-native-device-info'
 
 // ---------------------------------------------------------------------------
 // Shared scope mock – reused across all withScope callback invocations
@@ -124,6 +125,95 @@ describe('SentryService', () => {
             ])
           })
         )
+      })
+
+      // CP-13250: internal builds used to inherit `ENVIRONMENT=production` from
+      // `.env.internal` and file their errors against the production
+      // environment. The environment must track build identity instead.
+      describe('environment', () => {
+        // `service` above was loaded through jest.isolateModules, so the copy
+        // of react-native-device-info that `utils/Utils` closed over lives in
+        // that isolated registry — spying on this file's import would not
+        // affect it. Load a service instance alongside the device-info module
+        // from one shared registry so the bundle id can be controlled.
+        let envService: typeof import('./SentryService').default
+        let bundleIdSpy: jest.SpyInstance<string, []>
+
+        beforeAll(() => {
+          const g = global as unknown as Record<string, unknown>
+          const prevDev = g.__DEV__
+          g.__DEV__ = false
+          jest.isolateModules(() => {
+            const deviceInfoModule = require('react-native-device-info')
+            const deviceInfo: typeof DeviceInfo =
+              deviceInfoModule.default ?? deviceInfoModule
+            bundleIdSpy = jest.spyOn(deviceInfo, 'getBundleId')
+            envService = loadService()
+          })
+          g.__DEV__ = prevDev
+        })
+
+        // mockReset (not mockRestore) so the spy stays installed for the
+        // remaining cases in this block.
+        afterEach(() => {
+          bundleIdSpy.mockReset()
+        })
+
+        const environmentPassedToSentry = (): unknown =>
+          (Sentry.init as jest.Mock).mock.calls[0]?.[0]?.environment
+
+        /**
+         * The environment is resolved when `init()` runs, not when the module
+         * loads, so `__DEV__` has to be false at call time to exercise the
+         * release-build branches. (`isAvailable` is the one captured at load
+         * time, which the `beforeAll` above already handles.)
+         */
+        const initAsReleaseBuild = (): void => {
+          const g = global as unknown as Record<string, unknown>
+          const prevDev = g.__DEV__
+          g.__DEV__ = false
+          try {
+            envService.init()
+          } finally {
+            g.__DEV__ = prevDev
+          }
+        }
+
+        it('reports internal iOS builds as internal, not production', () => {
+          bundleIdSpy.mockReturnValue('org.avalabs.avaxwallet.internal')
+
+          initAsReleaseBuild()
+
+          expect(environmentPassedToSentry()).toBe('internal')
+        })
+
+        it('reports internal Android builds as internal, not production', () => {
+          bundleIdSpy.mockReturnValue('com.avaxwallet.internal')
+
+          initAsReleaseBuild()
+
+          expect(environmentPassedToSentry()).toBe('internal')
+        })
+
+        // The react-native-config mock in this file deliberately omits
+        // ENVIRONMENT, so the pre-fix implementation would report `undefined`
+        // here rather than a real environment name.
+        it('reports store builds as production', () => {
+          bundleIdSpy.mockReturnValue('org.avalabs.corewallet')
+
+          initAsReleaseBuild()
+
+          expect(environmentPassedToSentry()).toBe('production')
+        })
+
+        it('reports local dev bundles as development', () => {
+          bundleIdSpy.mockReturnValue('org.avalabs.corewallet')
+
+          // __DEV__ is true here, matching a Metro-served debug build.
+          envService.init()
+
+          expect(environmentPassedToSentry()).toBe('development')
+        })
       })
     })
 

--- a/packages/core-mobile/app/services/sentry/SentryService.test.ts
+++ b/packages/core-mobile/app/services/sentry/SentryService.test.ts
@@ -206,6 +206,18 @@ describe('SentryService', () => {
           expect(environmentPassedToSentry()).toBe('production')
         })
 
+        it('still initialises Sentry when the native bundle-id read throws', () => {
+          bundleIdSpy.mockImplementation(() => {
+            throw new TypeError('native module not ready')
+          })
+
+          expect(() => initAsReleaseBuild()).not.toThrow()
+          expect(Sentry.init).toHaveBeenCalled()
+          // Not 'production' — a failed lookup must not pollute the production
+          // environment.
+          expect(environmentPassedToSentry()).toBe('unknown')
+        })
+
         it('reports local dev bundles as development', () => {
           bundleIdSpy.mockReturnValue('org.avalabs.corewallet')
 

--- a/packages/core-mobile/app/services/sentry/SentryService.ts
+++ b/packages/core-mobile/app/services/sentry/SentryService.ts
@@ -1,5 +1,5 @@
 import Config from 'react-native-config'
-import { isE2EBuild } from 'utils/Utils'
+import { isDebugOrInternalBuild, isE2EBuild } from 'utils/Utils'
 import * as Sentry from '@sentry/react-native'
 import { DefaultSampleRate } from 'services/sentry/SentryWrapper'
 import { scrub } from 'utils/data/scrubber'
@@ -33,6 +33,36 @@ const navigationIntegration = Sentry.reactNavigationIntegration({
   enableTimeToInitialDisplay: true
 })
 
+type SentryEnvironment = 'development' | 'internal' | 'production'
+
+/**
+ * The Sentry environment this build reports under, derived from the build's own
+ * identity rather than from the `ENVIRONMENT` value baked into the env file.
+ *
+ * `ENVIRONMENT` does double duty in CI: `bitrise.yml` sets it to `production`
+ * on the internal workflows so that `scripts/bitrise/setEnv.sh` selects
+ * `.env.internal`. That is deliberate for backend selection, but the same value
+ * used to be handed straight to `Sentry.init({ environment })`, so every
+ * internal build filed its errors under `production` — ~8k events across ~750
+ * users in a 30-day window, including AppCheck debug-token failures that are
+ * impossible on a real production build (CP-13250).
+ *
+ * Build identity is the trustworthy signal, so reuse the predicate that already
+ * decides the AppCheck provider and the vm-module host (CP-14673). Do NOT go
+ * back to reading `Config.ENVIRONMENT` here.
+ *
+ * e2e builds need no branch of their own: `isAvailable` is false whenever
+ * `isE2EBuild` is true, so they never initialise Sentry at all.
+ *
+ * Evaluated lazily inside `init()` because `isDebugOrInternalBuild()` reads the
+ * bundle id from a native module.
+ */
+const resolveEnvironment = (): SentryEnvironment => {
+  if (__DEV__) return 'development'
+  if (isDebugOrInternalBuild()) return 'internal'
+  return 'production'
+}
+
 function scrubSentryData<T extends ErrorEvent | TransactionEvent>(event: T): T {
   /**
    * eliminating breadcrumbs. This should eliminate
@@ -62,7 +92,7 @@ const init = (): void => {
       // TODO: re-enable patchGlobalPromise here https://ava-labs.atlassian.net/browse/CP-8616
       patchGlobalPromise: false,
       dsn: Config.SENTRY_DSN,
-      environment: Config.ENVIRONMENT,
+      environment: resolveEnvironment(),
       debug: false,
       spotlight: DevDebuggingConfig.SENTRY_SPOTLIGHT,
       // Expected field conditions that carry no actionable signal. Entries

--- a/packages/core-mobile/app/services/sentry/SentryService.ts
+++ b/packages/core-mobile/app/services/sentry/SentryService.ts
@@ -33,7 +33,7 @@ const navigationIntegration = Sentry.reactNavigationIntegration({
   enableTimeToInitialDisplay: true
 })
 
-type SentryEnvironment = 'development' | 'internal' | 'production'
+type SentryEnvironment = 'development' | 'internal' | 'production' | 'unknown'
 
 /**
  * The Sentry environment this build reports under, derived from the build's own
@@ -52,15 +52,25 @@ type SentryEnvironment = 'development' | 'internal' | 'production'
  * back to reading `Config.ENVIRONMENT` here.
  *
  * e2e builds need no branch of their own: `isAvailable` is false whenever
- * `isE2EBuild` is true, so they never initialise Sentry at all.
+ * `isE2EBuild` is true, so no release-mode e2e build ever initialises Sentry.
  *
  * Evaluated lazily inside `init()` because `isDebugOrInternalBuild()` reads the
  * bundle id from a native module.
  */
 const resolveEnvironment = (): SentryEnvironment => {
   if (__DEV__) return 'development'
-  if (isDebugOrInternalBuild()) return 'internal'
-  return 'production'
+
+  try {
+    return isDebugOrInternalBuild() ? 'internal' : 'production'
+  } catch {
+    // `init()` runs from index.js before any error boundary exists, so an
+    // unguarded throw out of the native bundle-id read would abort Sentry.init
+    // and leave the whole session with no error reporting. Losing the build
+    // label is the cheaper failure. Deliberately not 'production': a failure
+    // here must never put unattributable events back into the production
+    // environment this ticket cleaned up (CP-13250).
+    return 'unknown'
+  }
 }
 
 function scrubSentryData<T extends ErrorEvent | TransactionEvent>(event: T): T {


### PR DESCRIPTION
## Description

**Ticket: [CP-13250](https://ava-labs.atlassian.net/browse/CP-13250)**

Internal builds were filing their Sentry errors against the **production** environment, so real production signal was mixed with internal-build noise. The ticket's original symptom — AppCheck debug-token failures showing up in prod, which can only happen on a dev/internal build — is still reproducing. Sentry over the last 30 days:

- **8,129 events from 747 users** tagged `environment:production` but coming from `org.avalabs.avaxwallet.internal` / `com.avaxwallet.internal`
- that's roughly **4%** of all 204k "production" events
- the `development` environment had **21** events in the same window, i.e. effectively unused

### Root cause

`ENVIRONMENT` does double duty, and the two jobs disagree:

1. `bitrise.yml` sets `ENVIRONMENT: production` on the internal workflows (`android-internal`, `ios-internal`, and the e2e/for-testing variants).
2. `scripts/bitrise/setEnv.sh` keys off exactly that (`ENVIRONMENT=production` **+** `APP_TITLE="Core Mobile Internal"`) to copy `.env.internal` → `.env`. This part is correct and intentional — it is how internal builds select their backends.
3. `SentryService` then passed `Config.ENVIRONMENT` — the `ENVIRONMENT=` line inside whichever env file was loaded — straight into `Sentry.init({ environment })`. `.env.internal` carries `ENVIRONMENT=production`, so internal builds announced themselves as production.

So the build correctly picked the internal env file, and that file then told Sentry it was production.

### The change

Derive the Sentry environment from **build identity** instead of from the env file, reusing the predicate that already decides the AppCheck provider and the vm-module host (CP-14673):

```ts
const resolveEnvironment = (): SentryEnvironment => {
  if (__DEV__) return 'development'
  try {
    return isDebugOrInternalBuild() ? 'internal' : 'production'
  } catch {
    return 'unknown'
  }
}
```

Notes on the shape of this:

- **`Config.ENVIRONMENT` had exactly one consumer in the app** — this Sentry line. (DataDog used to read it; that's gone.) Nothing else changes behaviour.
- **No new `e2e` environment.** `isAvailable` is `((__DEV__ && SPOTLIGHT) || (!__DEV__ && !isE2EBuild)) && !!DSN`, so no release-mode e2e build initialises Sentry at all. An `e2e` branch would have been unreachable. The `_build-*-external-for-testing` regression workflows all set `E2E: "true"`, so they're covered by the same gate.
- **Resolved lazily inside `init()`**, because `isDebugOrInternalBuild()` reads the bundle id from a native module. `init()` runs from `index.js` before any error boundary exists, so the read is wrapped — an unguarded throw there would abort `Sentry.init` and leave the session with no error reporting at all. The fallback is deliberately **not** `production`, so a failed lookup can never re-pollute the environment this ticket is cleaning up.
- Fixed in the app rather than by editing the `ENVIRONMENT=` line in the `.env.internal` AWS secret, so the behaviour is unit-tested, reviewable in the repo, and survives re-provisioning of the secrets.

No dependencies introduced. Not a breaking change.

### Follow-up needed outside this PR

- Add `internal` as a monitored environment in Sentry so that traffic doesn't just go dark once it stops landing in `production`.
- Any alert rule / saved search / dashboard scoped to `environment:production` will see a ~4% baseline drop. That's the intended outcome, but it's worth knowing before someone reads it as a regression.
- **Separate defect, not fixed here:** internal releases report version `0.0.0` (`MARKETING_VERSION = 0.0.0` placeholder in `project.pbxproj`, never overwritten for internal on either platform), which makes internal regressions untriageable by version. Worth its own ticket.

## Screenshots/Videos

Not applicable — no UI surface. The observable change is the `environment` tag on outbound Sentry events.

## Testing

**Dev Testing**

Verified locally:

- `yarn jest app/services/sentry app/utils` → **285 passed / 30 suites**
- Wider sweep `app/services/sentry app/utils app/vmModule` → **503 passed / 41 suites**
- `tsc -p . --noEmit` (with `.tsbuildinfo` cleared, so it's a real build not an incremental no-op) → exit 0
- `eslint` on both changed files → clean
- **Confirmed the new tests are not vacuous:** reverting the one line back to `environment: Config.ENVIRONMENT` makes all 4 new environment tests fail; restoring the fix makes them pass.

5 unit tests added, covering internal iOS, internal Android, store, local-dev, and the native-read-throws fallback.

To verify on a real build:

1. Trigger an `ios-internal` / `android-internal` Bitrise build from this branch.
2. Install it, then force an error that reports to Sentry (airplane mode + pull to refresh the portfolio is enough).
3. In Sentry (`ava-labs/core-react-native`), confirm the event lands under `environment:internal` and **not** `production`. Query to confirm the old behaviour is gone: `release:*internal* environment:production` should stop gaining new events at the new build number.
4. Sanity-check the other direction: a store/external build must still report `environment:production`.

Edge case worth a look during QA: a local `yarn ios` / `yarn android` debug run should report `development` (it won't actually send unless Spotlight is on, which is the pre-existing behaviour).

**QA Testing**

No user-facing behaviour changes — this only affects where our own telemetry lands, so there is nothing for QA to exercise functionally. Acceptance criteria is the Sentry-side check in step 3 above.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-13250]: https://ava-labs.atlassian.net/browse/CP-13250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ