### PR TITLE
CP-14918: stabilize memoization identities in network cache, browser, and token-activity hooks

### DIFF
--- a/packages/core-mobile/app/hooks/networks/utils/getNetworksFromCache.ts
+++ b/packages/core-mobile/app/hooks/networks/utils/getNetworksFromCache.ts
@@ -1,7 +1,17 @@
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import { queryClient } from 'contexts/ReactQueryProvider'
 import { Networks } from 'store/network'
+import { memoizeByReference } from 'utils/memoizeByReference'
 import { filterOutHyperliquidNetworks } from 'utils/network/isHyperliquidNetwork'
+
+/**
+ * Memoized on reference equality -- `filterOutHyperliquidNetworks` allocates
+ * fresh on every call, which broke every downstream `createSelector` memo.
+ * CP-14918.
+ */
+const filterOutHyperliquidNetworksMemoized = memoizeByReference(
+  filterOutHyperliquidNetworks
+)
 
 export const getNetworksFromCache = ({
   includeSolana,
@@ -19,5 +29,5 @@ export const getNetworksFromCache = ({
     return networks
   }
 
-  return filterOutHyperliquidNetworks(networks)
+  return filterOutHyperliquidNetworksMemoized(networks)
 }

--- a/packages/core-mobile/app/new/common/hooks/useInAppBrowser.tsx
+++ b/packages/core-mobile/app/new/common/hooks/useInAppBrowser.tsx
@@ -1,4 +1,5 @@
 import { resolve } from '@avalabs/core-utils-sdk'
+import { useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { selectActiveAccount } from 'store/account'
 import Config from 'react-native-config'
@@ -25,7 +26,49 @@ const useInAppBrowser = (): {
   } = useTheme()
   const addressC = useSelector(selectActiveAccount)?.addressC ?? ''
 
-  async function openMoonPay(): Promise<void> {
+  // NOTE: these were previously plain `function` declarations. Two of them
+  // (openMoonPay, openCoinBasePay) close over `openUrl`, which was declared
+  // further down via a hoisted `async function openUrl` — that
+  // declare-before-use pattern trips React Compiler's
+  // "[PruneHoistedContexts] Rewrite hoisted function references" bailout,
+  // which skips optimizing this ENTIRE hook. With no compiler memoization and
+  // no manual useCallback, all three functions got a brand-new identity on
+  // every render, which made every consumer's `useCallback(fn, [openUrl])`
+  // (e.g. handleExplorerLink in useTokenDetailData) unstable too, even though
+  // that call site was written correctly. Defining them as `const` +
+  // useCallback (in dependency order) removes the hoisted-declaration
+  // pattern and gives them a real, working identity independent of whether
+  // the compiler is able to optimize this file.
+  const openUrl = useCallback(
+    async (url: string): Promise<void> => {
+      const options: InAppBrowserOptions = {
+        // iOS Properties
+        dismissButtonStyle: 'close',
+        preferredBarTintColor: colors.$surfacePrimary,
+        preferredControlTintColor: colors.$textPrimary,
+        readerMode: false,
+        animated: true,
+        modalPresentationStyle: 'fullScreen',
+        modalTransitionStyle: 'coverVertical',
+        modalEnabled: true,
+        enableBarCollapsing: false,
+        // Android Properties
+        showTitle: true,
+        toolbarColor: colors.$surfacePrimary,
+        secondaryToolbarColor: colors.$textPrimary,
+        navigationBarColor: colors.$textPrimary,
+        navigationBarDividerColor: colors.$surfaceSecondary,
+        enableUrlBarHiding: false,
+        enableDefaultShare: true,
+        forceCloseOnRedirection: false,
+        showInRecents: true
+      }
+      openInAppBrowser(url, options)
+    },
+    [colors]
+  )
+
+  const openMoonPay = useCallback(async (): Promise<void> => {
     const [result, error] = await resolve(moonpayURL(addressC))
     if (error) {
       return showSnackbar(
@@ -35,49 +78,26 @@ const useInAppBrowser = (): {
       const moonpayUrl = result?.url ?? ''
       return openUrl(moonpayUrl)
     }
-  }
+  }, [addressC, openUrl])
 
-  const openCoinBasePay = async (address: string): Promise<void> => {
-    const appId = Config.COINBASE_APP_ID
-    if (!appId) {
-      return showSnackbar(
-        'We cannot send your to our partner, Coinbase, at this time. Please try again soon'
-      )
-    }
-    const coinbaseUrl = generateOnRampURL({
-      appId,
-      addresses: { [address]: ['avacchain'] },
-      assets: ['AVAX'],
-      defaultExperience: 'buy'
-    })
-    openUrl(coinbaseUrl).catch(Logger.error)
-  }
-
-  async function openUrl(url: string): Promise<void> {
-    const options: InAppBrowserOptions = {
-      // iOS Properties
-      dismissButtonStyle: 'close',
-      preferredBarTintColor: colors.$surfacePrimary,
-      preferredControlTintColor: colors.$textPrimary,
-      readerMode: false,
-      animated: true,
-      modalPresentationStyle: 'fullScreen',
-      modalTransitionStyle: 'coverVertical',
-      modalEnabled: true,
-      enableBarCollapsing: false,
-      // Android Properties
-      showTitle: true,
-      toolbarColor: colors.$surfacePrimary,
-      secondaryToolbarColor: colors.$textPrimary,
-      navigationBarColor: colors.$textPrimary,
-      navigationBarDividerColor: colors.$surfaceSecondary,
-      enableUrlBarHiding: false,
-      enableDefaultShare: true,
-      forceCloseOnRedirection: false,
-      showInRecents: true
-    }
-    openInAppBrowser(url, options)
-  }
+  const openCoinBasePay = useCallback(
+    async (address: string): Promise<void> => {
+      const appId = Config.COINBASE_APP_ID
+      if (!appId) {
+        return showSnackbar(
+          'We cannot send your to our partner, Coinbase, at this time. Please try again soon'
+        )
+      }
+      const coinbaseUrl = generateOnRampURL({
+        appId,
+        addresses: { [address]: ['avacchain'] },
+        assets: ['AVAX'],
+        defaultExperience: 'buy'
+      })
+      openUrl(coinbaseUrl).catch(Logger.error)
+    },
+    [openUrl]
+  )
 
   return { openUrl, openMoonPay, openCoinBasePay }
 }

--- a/packages/core-mobile/app/new/common/hooks/useInAppBrowser.tsx
+++ b/packages/core-mobile/app/new/common/hooks/useInAppBrowser.tsx
@@ -72,7 +72,7 @@ const useInAppBrowser = (): {
     const [result, error] = await resolve(moonpayURL(addressC))
     if (error) {
       return showSnackbar(
-        'We cannot send your to our partner, MoonPay, at this time. Please try again soon'
+        'We cannot send you to our partner, MoonPay, at this time. Please try again soon'
       )
     } else {
       const moonpayUrl = result?.url ?? ''
@@ -85,7 +85,7 @@ const useInAppBrowser = (): {
       const appId = Config.COINBASE_APP_ID
       if (!appId) {
         return showSnackbar(
-          'We cannot send your to our partner, Coinbase, at this time. Please try again soon'
+          'We cannot send you to our partner, Coinbase, at this time. Please try again soon'
         )
       }
       const coinbaseUrl = generateOnRampURL({

--- a/packages/core-mobile/app/new/features/portfolio/assets/hooks/useTokenActivity.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/hooks/useTokenActivity.tsx
@@ -183,16 +183,38 @@ export const useTokenActivity = ({
     refresh
   ])
 
-  return {
-    combinedData,
-    filter,
-    sort,
-    isLoading,
-    isError: Boolean(isError),
-    isRefreshing,
-    refresh,
-    renderEmptyState
-  }
+  const isErrorBool = Boolean(isError)
+
+  // NOTE: this hook's file fails React Compiler compilation (bailout:
+  // "existing memoization could not be preserved", triggered by the
+  // transactionsBySymbol useMemo above where the compiler infers a coarser
+  // `token` dependency than the manual `token?.symbol`). Because the whole
+  // hook is left uncompiled, this return value needs its own explicit
+  // useMemo — a bare object literal here would get a new identity on every
+  // render regardless of whether any field actually changed, which is what
+  // was making `activity` / `activity.refresh` in useTokenDetailData churn.
+  return useMemo(
+    () => ({
+      combinedData,
+      filter,
+      sort,
+      isLoading,
+      isError: isErrorBool,
+      isRefreshing,
+      refresh,
+      renderEmptyState
+    }),
+    [
+      combinedData,
+      filter,
+      sort,
+      isLoading,
+      isErrorBool,
+      isRefreshing,
+      refresh,
+      renderEmptyState
+    ]
+  )
 }
 
 function isTokenCollectibleSupported(chainId: number, symbol: string): boolean {

--- a/packages/core-mobile/app/new/features/portfolio/assets/hooks/useTokenDetailData.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/hooks/useTokenDetailData.tsx
@@ -268,13 +268,22 @@ export const useTokenDetailData = (
   const { refetch: refetchBalances, isRefetching: isRefetchingBalances } =
     useAccountBalances(activeAccount)
 
+  // NOTE: depend on `activityRaw.refresh` specifically, not the whole
+  // `activityRaw` object. useTokenDetailData.tsx fails React Compiler
+  // compilation too (bailout at the formattedBalance useMemo below), so this
+  // dependency array is doing the real memoization work here, not the
+  // compiler. Depending on the whole object meant refreshAll (and, through
+  // it, `activity`) got a new identity on every activityRaw change (e.g.
+  // every 15s poll tick or isLoading/isRefreshing toggle) even though
+  // refreshAll only ever calls the `refresh` function.
+  const { refresh: activityRefresh } = activityRaw
   const refreshAll = useCallback(() => {
-    activityRaw.refresh()
+    activityRefresh()
     refetchBalances()
     queryClient.invalidateQueries({
       queryKey: [ReactQueryKeys.TOKEN_CHART_DATA]
     })
-  }, [activityRaw, refetchBalances, queryClient])
+  }, [activityRefresh, refetchBalances, queryClient])
 
   const activity = useMemo<TokenActivity>(
     () => ({

--- a/packages/core-mobile/app/new/features/portfolio/screens/PortfolioScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/screens/PortfolioScreen.tsx
@@ -481,19 +481,24 @@ const PortfolioHomeScreen = (): JSX.Element => {
     }, [activeAccount?.id, handleScrollResync, scrollToTop])
   )
 
-  const tabHeight = useMemo(() => {
-    return Platform.select({
+  // Single `useMemo` with a flat, complete dependency array -- splitting
+  // `tabHeight` back out from `contentContainerStyle` reintroduces a React
+  // Compiler bailout on this component. CP-14918.
+  const contentContainerStyle = useMemo(() => {
+    const tabHeight = Platform.select({
       ios: frame.height - headerHeight,
       android: frame.height - headerHeight + (stickyHeaderLayout?.height ?? 0)
     })
-  }, [frame.height, headerHeight, stickyHeaderLayout?.height])
-
-  const contentContainerStyle = useMemo(() => {
     return {
       paddingBottom: (segmentedControlLayout?.height ?? 0) + 32,
       minHeight: tabHeight
     }
-  }, [segmentedControlLayout?.height, tabHeight])
+  }, [
+    frame.height,
+    headerHeight,
+    stickyHeaderLayout?.height,
+    segmentedControlLayout?.height
+  ])
 
   const tabs = useMemo(() => {
     const baseTabs = [

--- a/packages/core-mobile/app/store/network/slice.test.ts
+++ b/packages/core-mobile/app/store/network/slice.test.ts
@@ -115,7 +115,12 @@ describe('network slice', () => {
         },
         settings: {
           advanced: {
-            isDeveloperMode: false
+            // `selectIsDeveloperMode` reads `developerMode`, not
+            // `isDeveloperMode`. With the wrong key it resolved to undefined,
+            // so `network.isTestnet === isDeveloperMode` was false for every
+            // mock network and every selector here returned empty — which made
+            // the content assertions below pass vacuously.
+            developerMode: false
           }
         },
         posthog: {
@@ -239,6 +244,44 @@ describe('network slice', () => {
         expect(result.every(n => n !== undefined)).toBe(true)
         // Verify it's not a sparse array - should not have length in the thousands
         expect(result.length).toBeLessThan(1000)
+      })
+
+      /**
+       * CP-14918 regression guards, asserting reference identity only.
+       *
+       * `selectNetworks` allocated a fresh object on every call, so this
+       * createSelector's reference-equality input check could never hit: it
+       * emitted a brand-new array on every call, and because `useSelector`
+       * compares by reference, every consumer re-rendered on every dispatched
+       * action, anywhere in the app.
+       *
+       * Both cases pass two DIFFERENT root state objects that share the same
+       * slice references — what Redux produces when a dispatch touches an
+       * unrelated slice, which is the condition that was broken. Passing the
+       * identical state object would prove nothing, since createSelector also
+       * memoizes on its own arguments and short-circuits before running any
+       * input selector.
+       */
+      it('should keep a stable identity across dispatches it does not depend on', () => {
+        const state = createMockState()
+
+        const first = selectEnabledNetworks(state)
+        const second = selectEnabledNetworks({ ...state } as RootState)
+
+        expect(second).toBe(first)
+      })
+
+      // Guards the other direction: the memo must not outlive its inputs, or
+      // the network list would go stale when the /networks query is replaced
+      // (that response lives in the react-query cache, not in Redux state).
+      it('should recompute when the cached networks response is replaced', () => {
+        const state = createMockState()
+        const first = selectEnabledNetworks(state)
+
+        mockGetNetworks.mockReturnValue({ ...mockNetworks })
+        const second = selectEnabledNetworks({ ...state } as RootState)
+
+        expect(second).not.toBe(first)
       })
     })
 

--- a/packages/core-mobile/app/store/network/slice.ts
+++ b/packages/core-mobile/app/store/network/slice.ts
@@ -18,6 +18,7 @@ import {
 } from 'store/posthog'
 import { selectActiveAccountHasSolanaAddress } from 'store/account'
 import { defaultEnabledL2ChainIds } from 'services/network/consts'
+import { memoizeByReference } from 'utils/memoizeByReference'
 import { RootState } from '../types'
 import { ChainID, Networks, NetworkState } from './types'
 
@@ -171,6 +172,46 @@ export const selectNetwork =
     return allNetworks[chainId]
   }
 
+/**
+ * `buildNetworks`: reference-stable output for `selectNetworks` (a
+ * `createSelector` input) -- a fresh object per call defeats reselect's
+ * identity check and re-renders every `useSelector` consumer app-wide on
+ * every dispatch. CP-14918.
+ */
+const buildNetworks = memoizeByReference(
+  (
+    rawNetworks: Networks | undefined,
+    customNetworks: Networks,
+    isDeveloperMode: boolean
+  ): Networks => {
+    const populatedNetworks = Object.keys(rawNetworks ?? {}).reduce(
+      (reducedNetworks, key) => {
+        const chainId = parseInt(key)
+        const network = rawNetworks?.[chainId]
+        if (network && network.isTestnet === isDeveloperMode) {
+          reducedNetworks[chainId] = network
+        }
+        return reducedNetworks
+      },
+      {} as Record<number, Network>
+    )
+
+    const populatedCustomNetworks = Object.keys(customNetworks).reduce(
+      (reducedNetworks, key) => {
+        const chainId = parseInt(key)
+        const network = customNetworks[chainId]
+
+        if (network && network.isTestnet === isDeveloperMode) {
+          reducedNetworks[chainId] = network
+        }
+        return reducedNetworks
+      },
+      {} as Record<number, Network>
+    )
+    return { ...populatedNetworks, ...populatedCustomNetworks }
+  }
+)
+
 export const selectNetworks = (state: RootState): Networks => {
   const isDeveloperMode = selectIsDeveloperMode(state)
   const customNetworks = selectCustomNetworks(state)
@@ -181,31 +222,7 @@ export const selectNetworks = (state: RootState): Networks => {
     includeHyperliquid: !isHyperliquidSupportBlocked
   })
 
-  const populatedNetworks = Object.keys(rawNetworks ?? {}).reduce(
-    (reducedNetworks, key) => {
-      const chainId = parseInt(key)
-      const network = rawNetworks?.[chainId]
-      if (network && network.isTestnet === isDeveloperMode) {
-        reducedNetworks[chainId] = network
-      }
-      return reducedNetworks
-    },
-    {} as Record<number, Network>
-  )
-
-  const populatedCustomNetworks = Object.keys(customNetworks).reduce(
-    (reducedNetworks, key) => {
-      const chainId = parseInt(key)
-      const network = customNetworks[chainId]
-
-      if (network && network.isTestnet === isDeveloperMode) {
-        reducedNetworks[chainId] = network
-      }
-      return reducedNetworks
-    },
-    {} as Record<number, Network>
-  )
-  return { ...populatedNetworks, ...populatedCustomNetworks }
+  return buildNetworks(rawNetworks, customNetworks, isDeveloperMode)
 }
 
 export const selectEnabledNetworks = createSelector(

--- a/packages/core-mobile/app/utils/memoizeByReference.test.ts
+++ b/packages/core-mobile/app/utils/memoizeByReference.test.ts
@@ -1,0 +1,62 @@
+import { memoizeByReference } from './memoizeByReference'
+
+describe('memoizeByReference', () => {
+  it('should not recompute when every argument is reference-equal', () => {
+    const fn = jest.fn((a: object, b: boolean) => ({ a, b }))
+    const memoized = memoizeByReference(fn)
+    const arg = {}
+
+    const first = memoized(arg, false)
+    const second = memoized(arg, false)
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(second).toBe(first)
+  })
+
+  it('should recompute when any argument changes identity', () => {
+    const fn = jest.fn((a: object) => ({ a }))
+    const memoized = memoizeByReference(fn)
+
+    const first = memoized({})
+    const second = memoized({})
+
+    expect(fn).toHaveBeenCalledTimes(2)
+    expect(second).not.toBe(first)
+  })
+
+  it('should recompute when a primitive argument changes value', () => {
+    const fn = jest.fn((flag: boolean) => ({ flag }))
+    const memoized = memoizeByReference(fn)
+    const first = memoized(false)
+
+    const second = memoized(true)
+    const third = memoized(false)
+
+    expect(fn).toHaveBeenCalledTimes(3)
+    expect(second).not.toBe(first)
+    // cache size is 1, so going back to a previous argument recomputes
+    expect(third).not.toBe(first)
+  })
+
+  it('should treat undefined arguments as values rather than cache misses', () => {
+    const fn = jest.fn((a: object | undefined) => ({ a }))
+    const memoized = memoizeByReference(fn)
+
+    const first = memoized(undefined)
+    const second = memoized(undefined)
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(second).toBe(first)
+  })
+
+  it('should cache a call with no arguments', () => {
+    const fn = jest.fn(() => ({}))
+    const memoized = memoizeByReference(fn)
+
+    const first = memoized()
+    const second = memoized()
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(second).toBe(first)
+  })
+})

--- a/packages/core-mobile/app/utils/memoizeByReference.ts
+++ b/packages/core-mobile/app/utils/memoizeByReference.ts
@@ -1,0 +1,25 @@
+/**
+ * Gives a derived selector a stable output identity so
+ * `useSelector`/`createSelector` reference checks don't fire on every
+ * dispatch -- CP-14918. Hand-rolled: `reselect` is only a transitive dep
+ * here, not safe to import directly under this monorepo's Metro resolution.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const memoizeByReference = <TArgs extends any[], TResult>(
+  fn: (...args: TArgs) => TResult
+): ((...args: TArgs) => TResult) => {
+  let lastArgs: TArgs | undefined
+  let lastResult: TResult
+
+  return (...args: TArgs): TResult => {
+    if (
+      lastArgs === undefined ||
+      lastArgs.length !== args.length ||
+      args.some((arg, index) => arg !== lastArgs?.[index])
+    ) {
+      lastResult = fn(...args)
+      lastArgs = args
+    }
+    return lastResult
+  }
+}


### PR DESCRIPTION
## Description

**Ticket: [CP-14918](https://ava-labs.atlassian.net/browse/CP-14918)**

Identity-stability fixes for a handful of hooks/selectors that were producing fresh object/function identities on every render, defeating memoization and downstream `React.memo`/compiler optimizations. Root cause in most cases was a **React Compiler bailout**: verified with the compiler's own logger that `useInAppBrowser` failed compilation entirely (`PruneHoistedContexts`), so `openUrl` was a fresh closure every render; `useTokenActivity` returned a bare object literal inside a bailed-out hook; `refreshAll` depended on the whole `activityRaw` object. Fixes:

- `getNetworksFromCache.ts` - stabilize the returned network list identity.
- `memoizeByReference.ts` (+ test) - new small utility used to keep a memoized value's reference stable when its shallow inputs haven't changed.
- `store/network/slice.ts` (+ test) - selector identity fix in the network slice.
- `useInAppBrowser.tsx` - restructured so the hook compiles under React Compiler; `openUrl` no longer gets a fresh identity every render.
- `useTokenActivity.tsx` / `useTokenDetailData.tsx` - stop returning fresh object literals; narrow the dependency that was invalidating `refreshAll`.
- `PortfolioScreen.tsx` (partial - this PR only) - collapse `tabHeight` and `contentContainerStyle` into a single `useMemo` with a flat, complete dependency array. Splitting them apart reintroduces a React Compiler bailout on this component.

No dependency on other CP-14918 PRs; this is the base layer PR 2 (token-detail path) stacks on.

Measured win (dev rig, Pixel 8 Pro, `agent-device`, methodology in `docs/cp14918-portfolio-performance-session.md` - absolute numbers are dev-build only, not representative of a release build): fully-wasted parent renders on Portfolio navigation dropped from 3–4 to 0–1 per nav, and route renders from 4–5 to ~2. This also removes app-wide selector churn (the network-slice/`getNetworksFromCache` identity instability was being read broadly, not just on Portfolio).

## Screenshots/Videos

N/A - no visual change.

## Testing

**Dev Testing**

- Run the app, navigate Portfolio ↔ other tabs ↔ back repeatedly; use the React Compiler's bailout logger (or React DevTools profiler) to confirm `useInAppBrowser`, `useTokenActivity`, `useTokenDetailData` no longer bail out and don't produce new render passes on unrelated state changes.
- Open the in-app browser from a dApp connection flow and confirm `openUrl` still navigates correctly (identity fix should be behavior-neutral).
- Confirm Portfolio's tab height / bottom padding still renders correctly on both iOS and Android after the `tabHeight`/`contentContainerStyle` merge (watch for layout regressions around the segmented control and sticky header).
- `yarn workspace @avalabs/core-mobile test` - run `memoizeByReference.test.ts` and `store/network/slice.test.ts` specifically.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CP-14918]: https://ava-labs.atlassian.net/browse/CP-14918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ