### PR TITLE
CP-14918: gate the prefetched token-detail route and speed up token lookup

### DIFF
--- a/packages/core-mobile/app/new/common/hooks/useSearchableTokenList.ts
+++ b/packages/core-mobile/app/new/common/hooks/useSearchableTokenList.ts
@@ -59,6 +59,11 @@ export function useSearchableTokenList({
   const allNetworkTokens = useMemo(() => {
     if (tokens === undefined) return []
 
+    // Zero-balance contract tokens get thrown away by `isGreaterThanZero`
+    // anyway when `hideZeroBalance` is set -- skipping the merge/filter/sort
+    // here is output-identical and removes a ~56k-token map. CP-14918.
+    if (hideZeroBalance) return []
+
     return (
       tokens.map(token => {
         return {
@@ -76,7 +81,7 @@ export function useSearchableTokenList({
         } as LocalTokenWithBalance
       }) ?? []
     )
-  }, [tokens])
+  }, [tokens, hideZeroBalance])
 
   const [searchText, setSearchText] = useState('')
   const tokenVisibility = useSelector(selectTokenVisibility)

--- a/packages/core-mobile/app/new/features/portfolio/assets/screens/NonXpTokenDetailScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/screens/NonXpTokenDetailScreen.tsx
@@ -6,8 +6,8 @@ import { useEffectiveHeaderHeight } from 'common/hooks/useEffectiveHeaderHeight'
 import { ActionButtons } from 'features/portfolio/assets/components/ActionButtons'
 import TransactionHistory from 'features/portfolio/assets/components/TransactionHistory'
 import { useTokenDetailData } from 'features/portfolio/assets/hooks/useTokenDetailData'
-import React, { useCallback, useMemo } from 'react'
-import { useWindowDimensions } from 'react-native'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { InteractionManager, useWindowDimensions } from 'react-native'
 import { RefreshControl } from 'react-native-gesture-handler'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { LocalTokenWithBalance } from 'store/balance'
@@ -16,7 +16,40 @@ type Props = {
   token: LocalTokenWithBalance | undefined
 }
 
+// Height `TokenPriceChart` (common/components/chart/TokenPriceChart.tsx)
+// occupies once mounted, so the placeholder below can reserve the exact
+// same space and the deferred mount (CP-14918, "Fix 3") causes zero layout
+// shift. Derived from its source, not measured at runtime. Fixed part common
+// to every chart state: wrapper `paddingBottom` (18) + 2x inter-child `gap`
+// (12) + `PriceChart` default `height` prop (235) + range-selector/type-
+// toggle row (max(SegmentedControl "thin" 36, ChartTypeToggle 36) = 36)
+// = 18 + 24 + 235 + 36 = 313. Only `ChartHeader`'s height varies by state:
+//   - loading: ChartHeaderSkeleton, SKELETON_HEIGHT = 62 (ChartHeader.tsx:169-195)
+//       -> 313 + 62 = 375
+//   - loaded: heading3 (27) + subtitle2 (16) + PriceChangeIndicator's
+//     lineHeight-18 override (ChartHeader.tsx:302-311) = 61 -> 313 + 61 = 374
+//   - empty/error (no indicator, falls back to a plain buttonSmall "-"):
+//     heading3 (27) + subtitle2 (16) + buttonSmall (14) = 57 -> 313 + 57 = 370
+// The chart always mounts into `loading` first (the candles query only
+// starts once this deferred mount happens), so 375 is the height actually
+// present at swap-in — the shift the deferral causes. The later
+// 375 -> 374 settle as data arrives is the chart's own intrinsic layout
+// change, not something this placeholder is responsible for.
+const TOKEN_PRICE_CHART_HEIGHT = 375
+
 export const NonXpTokenDetailScreen = ({ token }: Props): JSX.Element => {
+  // Defer the Skia price chart past the push animation. Mounting a Canvas plus
+  // its Simultaneous(LongPress, Pan) gesture in the first commit put native
+  // binding and gesture-recogniser construction inside the tap-to-paint window
+  // (CP-14918). Header and action buttons paint first; the chart follows.
+  const [isChartReady, setIsChartReady] = useState(false)
+  useEffect(() => {
+    const handle = InteractionManager.runAfterInteractions(() =>
+      setIsChartReady(true)
+    )
+    return () => handle.cancel()
+  }, [])
+
   const frame = useWindowDimensions()
   const headerHeight = useEffectiveHeaderHeight()
   const insets = useSafeAreaInsets()
@@ -85,7 +118,7 @@ export const NonXpTokenDetailScreen = ({ token }: Props): JSX.Element => {
           paddingVertical: 24
         }}
       />
-      {isPriceChartBlocked || !token ? null : (
+      {isPriceChartBlocked || !token ? null : isChartReady ? (
         <TokenPriceChart
           token={token}
           width={frame.width}
@@ -93,6 +126,10 @@ export const NonXpTokenDetailScreen = ({ token }: Props): JSX.Element => {
             trackTokenId ? handleOpenTrackTokenDetail : undefined
           }
         />
+      ) : (
+        // Reserves the space `TokenPriceChart` will occupy so its deferred
+        // mount above doesn't reflow `TransactionHistory` below it.
+        <View style={{ height: TOKEN_PRICE_CHART_HEIGHT }} />
       )}
       <TransactionHistory
         mode="plain"

--- a/packages/core-mobile/app/new/features/portfolio/assets/screens/TokenDetailScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/assets/screens/TokenDetailScreen.tsx
@@ -2,10 +2,11 @@ import {
   isTokenWithBalanceAVM,
   isTokenWithBalancePVM
 } from '@avalabs/avalanche-module'
-import { useErc20ContractTokens } from 'common/hooks/useErc20ContractTokens'
-import { useSearchableTokenList } from 'common/hooks/useSearchableTokenList'
+import { useTokensWithBalanceForAccount } from 'features/portfolio/hooks/useTokensWithBalanceForAccount'
 import { useLocalSearchParams } from 'expo-router'
 import React, { useMemo } from 'react'
+import { useSelector } from 'react-redux'
+import { selectActiveAccount } from 'store/account'
 import { NonXpTokenDetailScreen } from './NonXpTokenDetailScreen'
 import { XpTokenDetailScreen } from './XpTokenDetailScreen'
 
@@ -14,20 +15,55 @@ export const TokenDetailScreen = (): React.JSX.Element => {
     localId: string
     chainId: string
   }>()
-  const erc20ContractTokens = useErc20ContractTokens()
-  // Keep zero-balance tokens visible so the page doesn't crash after sending max balance.
-  const { filteredTokenList } = useSearchableTokenList({
-    tokens: erc20ContractTokens,
-    hideZeroBalance: false
+  const activeAccount = useSelector(selectActiveAccount)
+
+  // Resolve the token straight from this network's balance data.
+  //
+  // This used to go through `useSearchableTokenList`, which merges every
+  // C-Chain and Ethereum contract token (~56k on mainnet) with the account's
+  // balances and then filters and sorts the whole set — all to find one token
+  // whose localId and chainId we already have from the route params. On a
+  // Pixel 8 Pro that cost ~700ms of synchronous JS inside the push-to-paint
+  // window, which is the stall reported in CP-14918.
+  //
+  // Zero-balance tokens still resolve here: the balance response keeps a token
+  // entry (with a 0 balance) after its balance is spent, so the screen does not
+  // break after sending a max balance.
+  //
+  // CP-14918: this screen can mount with no route params — PortfolioScreen's
+  // router.prefetch('/tokenDetail') call warms this route before any token is
+  // chosen. `chainId` is then `NaN`, which is falsy, so
+  // useTokensWithBalanceForAccount's `if (chainId)` branch is skipped and it
+  // falls through to the *other* branch: flatMap every token across every
+  // enabled network for `activeAccount` — real synchronous work during
+  // Portfolio's idle window, not the empty array a first read suggests.
+  // Passing `activeAccount` also makes the hook's internal useAccountBalances
+  // call mount a live QueryObserver on the same balanceKey every other
+  // Portfolio consumer subscribes to (the observer-fan-out class Task O
+  // fixed). Gate `account` on both params being present so the hook's
+  // `!account` guard returns `[]` immediately instead — the query key it
+  // builds from `account?.id` (undefined) is also disjoint from every real
+  // consumer's key, so no observer joins the shared fan-out either.
+  const hasRouteParams = Boolean(localId) && Boolean(chainId)
+
+  const tokensForChain = useTokensWithBalanceForAccount({
+    account: hasRouteParams ? activeAccount : undefined,
+    chainId: Number(chainId)
   })
 
   const token = useMemo(
-    () =>
-      filteredTokenList.find(
-        tk => tk.localId === localId && tk.networkChainId === Number(chainId)
-      ),
-    [chainId, filteredTokenList, localId]
+    () => tokensForChain.find(tk => tk.localId === localId),
+    [tokensForChain, localId]
   )
+
+  // Render-null gate: the preloaded, param-less instance must stay fully
+  // inert -- do not remove `hasRouteParams` / the empty-fragment return, or
+  // the preload mounts a real `useTokenDetailData(undefined)` child tree
+  // (background balance observers, RTK-Query poll) forever. CP-14918
+  // (closes C1/C2, §15.5).
+  if (!hasRouteParams) {
+    return <></>
+  }
 
   if (token && (isTokenWithBalanceAVM(token) || isTokenWithBalancePVM(token))) {
     return <XpTokenDetailScreen token={token} />

--- a/packages/core-mobile/app/new/features/portfolio/screens/PortfolioScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/screens/PortfolioScreen.tsx
@@ -40,7 +40,7 @@ import { useBalanceTotalPriceChangeForAccount } from 'features/portfolio/hooks/u
 import { useSendSelectedToken } from 'features/send/store'
 import { useNavigateToSwap } from 'features/swap/hooks/useNavigateToSwap'
 import { useFormatCurrency } from 'new/common/hooks/useFormatCurrency'
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   InteractionManager,
   LayoutChangeEvent,
@@ -103,8 +103,20 @@ const PortfolioHomeScreen = (): JSX.Element => {
   const isPrivacyModeEnabled = useFocusedSelector(selectIsPrivacyModeEnabled)
   const [_, setSelectedToken] = useSendSelectedToken()
   const { theme } = useTheme()
-  const { navigate, push } = useRouter()
+  const { navigate, push, prefetch } = useRouter()
   const { navigateToSwap } = useNavigateToSwap()
+
+  // Prefetches `/tokenDetail` once per Portfolio-tab lifetime. NOT inert --
+  // a preloaded route is never frozen (native-stack excludes preloaded
+  // routes from `shouldFreeze`); inertness comes from `TokenDetailScreen`'s
+  // `hasRouteParams` gate instead. No `getId` on this route, so the later
+  // real push reuses this same instance. CP-14918.
+  useEffect(() => {
+    const handle = InteractionManager.runAfterInteractions(() => {
+      prefetch('/tokenDetail')
+    })
+    return () => handle.cancel()
+  }, [prefetch])
 
   const [stickyHeaderLayout, setStickyHeaderLayout] = useState<
     LayoutRectangle | undefined
@@ -597,7 +609,7 @@ const PortfolioHomeScreen = (): JSX.Element => {
         <BottomTabWrapper>{renderSegmentedControl()}</BottomTabWrapper>
       </View>
 
-      {/* 
+      {/*
         This is a workaround to display the header background + separator on Android.
         Android returns a header height of 0, so we need to display the background + separator manually.
       */}


### PR DESCRIPTION
## Description

**Ticket: [CP-14918](https://ava-labs.atlassian.net/browse/CP-14918)**

Token-detail navigation path performance fixes. **Stacks on PR 1** (`cp-14918-identity-fixes`) - this branch should be created off that branch, not off `main`, since it relies on PR 1's identity-stability fixes to avoid re-introducing the same compiler bailouts.

Summary of changes:

- `TokenDetailScreen.tsx` - replaces the old `useSearchableTokenList` + `.find()` token resolution (a full map/filter/sort over ~56k contract tokens on every mount, purely to find one token whose ids were already in the route params) with a direct `useTokensWithBalanceForAccount` lookup. Also adds a `hasRouteParams` render-null gate: the route is now prefetched (see below) so an instance can exist with no params, and without this gate that preloaded instance mounted a real `useTokenDetailData(undefined)` child tree forever (background balance observers, an RTK-Query poll that never stops). All hooks still run above the early return so hook order never changes.
- `NonXpTokenDetailScreen.tsx` - defers the Skia price-chart mount past first paint (the chart mount is the single largest cost in the tap-to-paint window) behind a fixed-height 375px placeholder, so the swap-in causes no reflow and the header/action buttons become interactive first.
- `useSearchableTokenList.ts` - skips the all-network-token merge/filter/sort entirely when `hideZeroBalance` is set: every token built in that memo has a zero balance and the first filter dropped them all anyway, so the work was provably dead. Benefits every `hideZeroBalance: true` caller (Portfolio header, Assets list, Activity, Send).
- `PortfolioScreen.tsx` (remaining hunks) - `router.prefetch('/tokenDetail')` once per Portfolio-tab lifetime. This is **not** the same as inertness: a preloaded route is never frozen by native-stack (`shouldFreeze` excludes preloaded routes); inertness comes entirely from `TokenDetailScreen`'s `hasRouteParams` gate above. Also a trivial whitespace fix in a comment.

`TokenPriceChart.tsx` was in scope per the original split plan but no longer differs from `main` after the probe-strip commit - nothing to include here.

Measured win (dev rig, Pixel 8 Pro, n=5 trials, navs #2–6 only - nav #1 of a fresh launch is excluded because the prefetch makes it structurally incomparable; absolute numbers are dev-build only): tap→painted (median) went from a **1199ms session-1 baseline to ~400ms** with the direct token lookup + merge skip + deferred chart + render-null-gated prefetch combined. See `docs/cp14918-portfolio-performance-session.md` for full methodology and the intermediate 519.8ms checkpoint.

## Screenshots/Videos

To be added (placeholder-then-chart ordering on nav #1 and nav #2+ should be verified visually before merge).

## Testing

**Dev Testing**

- Fresh app launch → open Portfolio → tap a token → confirm placeholder renders, then chart loads in (no flash of stale/empty content).
- Repeat the tap on nav #2+ (after the prefetch has had a chance to run) and confirm the perceived latency drop.
- Force a scenario where the preloaded/prefetched `tokenDetail` instance never receives real params (e.g. background the app immediately after Portfolio mounts) and confirm nothing renders for it (no visible flash, no lingering network/balance observers via a heap/network inspector).
- Navigate to a token detail screen, back out, and re-enter for a different token - confirm the merge-skip doesn't stale-cache the wrong token's data.
- `yarn workspace @avalabs/core-mobile test` for the touched files.

**QA Testing**

- Confirm token-detail chart, price, and activity data are all correct for a variety of tokens (including newly-added/low-liquidity tokens) after the direct-lookup change - this bypasses the old broader search/merge path.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CP-14918]: https://ava-labs.atlassian.net/browse/CP-14918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ