### PR TITLE
CP-14918: latch the balance gate and surface total-failure as an error state

### DIFF
--- a/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalanceSummary.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalanceSummary.ts
@@ -46,14 +46,33 @@ export function useAccountBalanceSummary(
       }
     }
 
-    const isBalanceLoaded = data.length > 0 || isError || isOffline
+    // `useAccountBalances`' own `isLoading` already resolves to `false` once
+    // that hook's fetch attempt has settled (including the "some network
+    // never reported back" edge case — see its comment), so folding `!isLoading`
+    // in here keeps this looser "got at least one balance" formula from being
+    // the one thing still holding the loading gate open in that same edge case.
+    const isBalanceLoaded =
+      data.length > 0 || isError || isOffline || !isLoading
 
     const isAllBalancesInaccurate =
       data.length > 0 && data.every(balance => balance.dataAccurate === false)
     const isAllBalancesError =
       isError ||
       isOffline ||
-      (data.length > 0 && data.every(balance => balance.error != null))
+      (data.length > 0 && data.every(balance => balance.error != null)) ||
+      // Every enabled network can — in the same silent-drop edge case that
+      // makes `useAccountBalances` latch `isLoading` false without full data
+      // (see its comment) — end up with ZERO entries in `data`: no success,
+      // no per-network error object, nothing. `isBalanceLoaded` above still
+      // needs to flip true here so we don't spin forever, but without this
+      // clause that reads as "loaded and confirmed empty", which renders a
+      // confident "you have no assets" empty state for what may be a funded
+      // wallet that simply failed to load. Route it to the error state
+      // instead. Legitimate zero-balance wallets don't hit this: every
+      // successfully-resolved network still contributes one entry (even with
+      // an empty token list), so `data.length` only reads 0 when nothing
+      // resolved at all.
+      (!isLoading && data.length === 0)
 
     // Calculate total balance
     const balancesForAccount = data.filter(

--- a/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalances.test.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalances.test.ts
@@ -1,0 +1,225 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { useAccountBalances } from './useAccountBalances'
+
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQuery: jest.fn(),
+  useQueryClient: () => ({ setQueryData: jest.fn() })
+}))
+
+jest.mock('react-redux', () => ({
+  useSelector: (fn: () => unknown) => fn()
+}))
+
+let mockEnabledNetworks: { chainId: number }[] = [
+  { chainId: 1 },
+  { chainId: 2 }
+]
+
+jest.mock('store/network/slice', () => ({
+  selectEnabledNetworks: () => mockEnabledNetworks
+}))
+jest.mock('store/wallet/slice', () => ({
+  selectWalletById: () => () => ({ id: 'wallet-1', type: 'mnemonic' })
+}))
+jest.mock('store/settings/currency/slice', () => ({
+  selectSelectedCurrency: () => 'USD'
+}))
+jest.mock('store/settings/advanced/filterSmallUtxosActive', () => ({
+  selectIsFilterSmallUtxosActive: () => false
+}))
+jest.mock('hooks/useXPAddresses/useXPAddresses', () => ({
+  useXPAddresses: () => ({ xpAddresses: [] })
+}))
+jest.mock('common/hooks/useOnlineStatus', () => ({
+  useOnlineStatus: () => true
+}))
+jest.mock('services/balance/BalanceService', () => ({
+  __esModule: true,
+  default: { getBalancesForAccount: jest.fn() }
+}))
+jest.mock('utils/getAddressesFromXpubXP/getAddressesFromXpubXP', () => ({
+  getXpubXPIfAvailable: jest.fn()
+}))
+jest.mock('../store', () => ({
+  useIsRefetchingAccountBalances: () => [{}, jest.fn()]
+}))
+
+const { useQuery } = jest.requireMock('@tanstack/react-query')
+
+const account = { id: 'acc-1', walletId: 'wallet-1', index: 0 } as never
+const accountB = { id: 'acc-2', walletId: 'wallet-1', index: 1 } as never
+
+describe('useAccountBalances isLoading gate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEnabledNetworks = [{ chainId: 1 }, { chainId: 2 }]
+  })
+
+  it('stays loading while a fetch is still in flight and data is incomplete', () => {
+    useQuery.mockReturnValue({
+      data: [{ chainId: 1, tokens: [], dataAccurate: true, error: null }],
+      isFetching: true,
+      isError: false,
+      isPaused: false,
+      refetch: jest.fn()
+    })
+
+    const { result } = renderHook(() => useAccountBalances(account))
+
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('counts a network that never reports back as resolved once the fetch settles, instead of sticking forever', () => {
+    // Simulates the real-world hazard this fix targets: one enabled network
+    // (chainId 2) never produces a success OR error entry in `data`, so
+    // `data.length` (1) never catches up to `enabledNetworks.length` (2).
+    useQuery.mockReturnValue({
+      data: [{ chainId: 1, tokens: [], dataAccurate: true, error: null }],
+      isFetching: true,
+      isError: false,
+      isPaused: false,
+      refetch: jest.fn()
+    })
+
+    const { result, rerender } = renderHook(() => useAccountBalances(account))
+    expect(result.current.isLoading).toBe(true)
+
+    // BalanceService's promise (with all internal per-network retries)
+    // settles: react-query flips isFetching back to false, but the missing
+    // network's entry never arrived.
+    useQuery.mockReturnValue({
+      data: [{ chainId: 1, tokens: [], dataAccurate: true, error: null }],
+      isFetching: false,
+      isError: false,
+      isPaused: false,
+      refetch: jest.fn()
+    })
+    rerender()
+
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('happy path: isLoading clears as soon as every enabled network has an entry (output-identical)', () => {
+    useQuery.mockReturnValue({
+      data: [
+        { chainId: 1, tokens: [], dataAccurate: true, error: null },
+        { chainId: 2, tokens: [], dataAccurate: true, error: null }
+      ],
+      isFetching: false,
+      isError: false,
+      isPaused: false,
+      refetch: jest.fn()
+    })
+
+    const { result } = renderHook(() => useAccountBalances(account))
+
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('does not reopen once settled, even across a later refetchInterval poll with the same network still missing', () => {
+    // This is the property the settle latch exists for. A naive
+    // `isLoading = isFetching` (no latch) would pass every other test above
+    // but fails this one: chainId 2 never arrives on the FIRST fetch attempt
+    // either, so once react-query starts its next periodic `refetchInterval`
+    // poll (isFetching flips true again) a no-latch gate reopens the shimmer
+    // — exactly the flicker-forever regression the latch is meant to avoid.
+    useQuery.mockReturnValue({
+      data: [{ chainId: 1, tokens: [], dataAccurate: true, error: null }],
+      isFetching: true,
+      isError: false,
+      isPaused: false,
+      refetch: jest.fn()
+    })
+    const { result, rerender } = renderHook(() => useAccountBalances(account))
+    expect(result.current.isLoading).toBe(true)
+
+    // First fetch attempt settles; chainId 2 never showed up.
+    useQuery.mockReturnValue({
+      data: [{ chainId: 1, tokens: [], dataAccurate: true, error: null }],
+      isFetching: false,
+      isError: false,
+      isPaused: false,
+      refetch: jest.fn()
+    })
+    rerender()
+    expect(result.current.isLoading).toBe(false)
+
+    // A later refetchInterval tick starts a new background fetch attempt —
+    // isFetching flips true again — for the SAME query (same account, same
+    // enabled-network set). chainId 2 is still missing from `data`.
+    useQuery.mockReturnValue({
+      data: [{ chainId: 1, tokens: [], dataAccurate: true, error: null }],
+      isFetching: true,
+      isError: false,
+      isPaused: false,
+      refetch: jest.fn()
+    })
+    rerender()
+    expect(result.current.isLoading).toBe(false)
+
+    // ...and settles again the same way. Still false throughout.
+    useQuery.mockReturnValue({
+      data: [{ chainId: 1, tokens: [], dataAccurate: true, error: null }],
+      isFetching: false,
+      isError: false,
+      isPaused: false,
+      refetch: jest.fn()
+    })
+    rerender()
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('resets the settle latch when the account changes', () => {
+    useQuery.mockReturnValue({
+      data: [{ chainId: 1, tokens: [], dataAccurate: true, error: null }],
+      isFetching: false,
+      isError: false,
+      isPaused: false,
+      refetch: jest.fn()
+    })
+    const { result, rerender } = renderHook(
+      (acc: typeof account) => useAccountBalances(acc),
+      { initialProps: account }
+    )
+    expect(result.current.isLoading).toBe(false)
+
+    // Switch accounts: react-query hands us a brand new query key with no
+    // data yet, mid-first-fetch for the new account.
+    useQuery.mockReturnValue({
+      data: undefined,
+      isFetching: true,
+      isError: false,
+      isPaused: false,
+      refetch: jest.fn()
+    })
+    rerender(accountB)
+
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('resets the settle latch when the enabled-network set changes', () => {
+    useQuery.mockReturnValue({
+      data: [{ chainId: 1, tokens: [], dataAccurate: true, error: null }],
+      isFetching: false,
+      isError: false,
+      isPaused: false,
+      refetch: jest.fn()
+    })
+    const { result, rerender } = renderHook(() => useAccountBalances(account))
+    expect(result.current.isLoading).toBe(false)
+
+    // User enables a third network: a new query key, mid-first-fetch.
+    mockEnabledNetworks = [{ chainId: 1 }, { chainId: 2 }, { chainId: 3 }]
+    useQuery.mockReturnValue({
+      data: undefined,
+      isFetching: true,
+      isError: false,
+      isPaused: false,
+      refetch: jest.fn()
+    })
+    rerender()
+
+    expect(result.current.isLoading).toBe(true)
+  })
+})

--- a/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalances.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalances.ts
@@ -4,7 +4,7 @@ import {
   useQueryClient
 } from '@tanstack/react-query'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
 import BalanceService from 'services/balance/BalanceService'
 import { AdjustedNormalizedBalancesForAccount } from 'services/balance/types'
@@ -111,6 +111,21 @@ export function useAccountBalances(
 
   const enabled = !isNotReady
 
+  // Identifies the exact set of networks this account is currently fetching
+  // balances for. Mirrors the inputs of `balanceKey` (minus `filterOutDustUtxos`,
+  // tracked separately below) so the "has this fetch attempt settled" latch
+  // below resets whenever react-query would hand us a genuinely different
+  // query (new account, or the enabled-network set changed) rather than a
+  // routine background refetch of the same query.
+  const networksKey = useMemo(
+    () =>
+      enabledNetworks
+        .map(n => n.chainId)
+        .sort()
+        .join(','),
+    [enabledNetworks]
+  )
+
   const {
     data,
     isFetching,
@@ -171,16 +186,42 @@ export function useAccountBalances(
     }
   }, [isNotReady, isOnline, account?.id, setIsRefetching, refetchFn])
 
+  // `hasSettledFetch` latches on `isFetching` flipping false -- prevents a
+  // later background refetch of the same query from reopening the shimmer.
+  // Resets only when account or enabled-network-set changes. CP-14918.
+  const [hasSettledFetch, setHasSettledFetch] = useState(false)
+
+  // `lastResetKeyRef` guards against react-freeze's thaw re-running this
+  // effect from scratch -- only call `setHasSettledFetch(false)` when the
+  // dep key actually changed, not on every thaw. CP-14918.
+  const lastResetKeyRef = useRef<string | null>(null)
+  useEffect(() => {
+    const resetKey = `${account?.id ?? ''}|${networksKey}|${filterOutDustUtxos}`
+    if (lastResetKeyRef.current === resetKey) return
+    lastResetKeyRef.current = resetKey
+    setHasSettledFetch(false)
+  }, [account?.id, networksKey, filterOutDustUtxos])
+
+  useEffect(() => {
+    if (!isFetching && data !== undefined) {
+      setHasSettledFetch(true)
+    }
+  }, [isFetching, data])
+
   const isLoading = useMemo(() => {
     if (isError || !isOnline) return false
+    if (!account || !data) return true
+    if (hasSettledFetch) return false
 
-    return (
-      !account ||
-      !data ||
-      data.length === 0 ||
-      data.length < enabledNetworks.length
-    )
-  }, [account, data, enabledNetworks.length, isError, isOnline])
+    return data.length === 0 || data.length < enabledNetworks.length
+  }, [
+    account,
+    data,
+    enabledNetworks.length,
+    isError,
+    isOnline,
+    hasSettledFetch
+  ])
 
   return {
     data: data ?? [],


### PR DESCRIPTION
## Description

**Ticket: [CP-14918](https://ava-labs.atlassian.net/browse/CP-14918)**

Balance-gate hardening in `useAccountBalances.ts`. Root cause: `BalanceService.processBalanceBatches` only calls `onBalanceLoaded` on success, so a silent-fail chain for a network's balances never lands in `data` at all - there was no distinct error signal for "every network failed silently," so the UI rendered a confident empty ("no assets") state instead of an error state.

Fix: a `hasSettledFetch` latch that only flips once `isFetching` has gone false for the current account/network-set, preventing a later background refetch of the same query from reopening the loading shimmer. `isAllBalancesError` is extended to also catch `!isLoading && data.length === 0` (an all-networks-silent-fail case), not just an explicit query error. The latch resets when the account or the enabled-network-set changes (`lastResetKeyRef` thaw guard), so switching accounts doesn't get stuck showing a stale error/loading state from the previous account.

Residual, documented-not-fixed dependency: this relies on a `BalanceService` invariant (that a genuinely-successful load always calls `onBalanceLoaded`) - if that invariant is ever violated, the latch could still under- or over-fire. Not chased further in this PR.

No dependency on PR 1/2/4/6; can land independently.

## Screenshots/Videos

N/A - no visual change in the happy path; only changes what renders on the (previously silent) all-networks-failure path.

## Testing

**Dev Testing**

- Happy path: normal balance load across multiple networks, confirm no change in behavior or loading states.
- Force an all-networks-silent-fail (e.g. disable network mid-fetch, or mock `BalanceService` to never call `onBalanceLoaded` for any network) and confirm the UI now shows an error state instead of a confident "no assets" empty state.
- Switch accounts (or toggle an enabled network) while a fetch is in flight and confirm the latch resets correctly rather than carrying over a stale loading/error state to the new account.
- Trigger a background refetch of an already-loaded account and confirm it does not reopen the loading shimmer.
- `yarn workspace @avalabs/core-mobile test` - `useAccountBalances.test.ts` specifically; confirm the suite exits cleanly without `--forceExit`.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CP-14918]: https://ava-labs.atlassian.net/browse/CP-14918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ