### PR TITLE
CP-14918: freeze blurred tabs on iOS, exempting Browser

### DIFF
--- a/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(tabs)/_layout.tsx
@@ -39,12 +39,17 @@ const tabLabelStyle = {
 const tabBarInactiveTintOpacity = 0.6
 
 /**
- * On Android, we enable freezeOnBlur to improve performance.
- * On iOS, it remains disabled since performance is already good.
- * Additionally, our testing showed that enabling freezeOnBlur on iOS
- * caused issues with SegmentedControl and the Browser tab.
+ * Inactive tabs freeze via react-freeze (`freezeOnBlur = true`, flipped on
+ * for iOS -- CP-14918, doc §15.4/§15.9). Browser stays exempted
+ * (`browserFreezeOnBlur = false`): freezing it would suspend the effect that
+ * keeps `useEvmInjectedProvider.ts`'s `activeAccountRef` fresh while the
+ * WebView keeps running, letting a backgrounded dApp sign with an
+ * indefinitely stale account. Do NOT re-enable Browser's freeze until the
+ * signing path reads the account from `store.getState()` directly instead
+ * (separate ticket).
  */
-const freezeOnBlur = isIOS ? false : true
+const freezeOnBlur = true
+const browserFreezeOnBlur = false
 
 export default function TabLayout(): JSX.Element {
   const { theme } = useTheme()
@@ -136,7 +141,9 @@ export default function TabLayout(): JSX.Element {
           tabBarButtonTestID: 'browser_tab',
           title: 'Browser',
           tabBarIcon: () => browserIcon,
-          freezeOnBlur
+          // Exempted from freezeOnBlur - see comment above `freezeOnBlur`
+          // for why (stale activeAccountRef in the injected-provider bridge).
+          freezeOnBlur: browserFreezeOnBlur
         }}
       />
       <BottomTabs.Screen


### PR DESCRIPTION
## Description

**Ticket: [CP-14918](https://ava-labs.atlassian.net/browse/CP-14918)**

Flips `freezeOnBlur` to `true` on iOS in `(signedIn)/(tabs)/_layout.tsx`, with a per-screen exemption for the Browser tab.

Background: `react-native-bottom-tabs`'s `loaded` set is monotonic (once a tab is visited, it's never unloaded), and its freeze derivation is `!focused ? getFreezeOnBlur({route}) : false`. Before this change, `freezeOnBlur` was `isIOS ? false : true` - so for any user who has visited Track, Stake, Earn, Browser, Trade, and Activity, Android froze those six scene trees while blurred, but **iOS kept all of them live, forever**, silently absorbing every Redux dispatch and every React Query observer notification app-wide (including the pre-PR-4 93.7%-no-op watchlist fan-out). This scales with how much of the app a user has explored.

Git-archaeology on the existing iOS exemption first, per the investigation's own blocking rule: it traced to a bare CP-11923 comment from August 2025 against `bottom-tabs@0.10.1`, with no corroborating issue against the currently-installed `1.1.0` - cleared to flip.

**A real Critical was found and fixed before this could ship as a blanket flip:** freezing the Browser tab would suspend the `useEffect` that keeps `useEvmInjectedProvider.ts`'s `activeAccountRef` fresh, while the in-app browser's WebView JS keeps running underneath. A backgrounded dApp's async signing request could then fall back to a **stale account as signer** - bounded only by the granted-address check, and indefinitely (not the one-render-tick window CP-14385 already patched). Fix: `browserFreezeOnBlur = false`, exempting Browser specifically while flipping everywhere else on iOS.

**Bonus finding:** this exposure is already live in production on Android today - Android has always frozen the Browser tab uniformly. This PR incidentally closes it there while (correctly) surfacing the same risk if Browser's iOS exemption is ever removed. Follow-up tracked as [CP-14924](https://ava-labs.atlassian.net/browse/CP-14924): harden `useEvmInjectedProvider.ts`'s `getActiveAccount` to read `store.getState()` directly instead of the render-gated `activeAccountRef` - prerequisite for ever safely freezing Browser, and separately closes the live-in-prod-on-Android stale-signer exposure.

**iOS device QA is required before this merges** - this has not yet been verified on a real iOS device.

No dependency on other CP-14918 PRs; can land independently.

## Screenshots/Videos

N/A - no visual UI change (freeze/thaw is a background render-tree behavior, not visible unless something is broken).

## Testing

**Dev Testing**

- On iOS: visit each of Track, Stake, Earn, Browser, Trade, Activity, then switch away and back; confirm no state loss, no visible re-mount flash, and (with a render counter or profiler) confirm blurred tabs stop re-rendering on unrelated Redux/RQ activity.
- Confirm the Browser tab specifically does NOT freeze while blurred - background a dApp session mid-signing-request and confirm the active account used for signing stays correct (not stale) when the request resolves.

**QA Testing (iOS device required)**

- Portfolio/Earn `SegmentedControl` freeze/thaw: switch tabs away from and back to a screen with a `SegmentedControl` mid-interaction; confirm it re-hydrates correctly and doesn't lose its selected segment or get stuck in a frozen visual state.
- Android Browser: this PR DOES change Android behavior for the Browser tab specifically. Android previously froze Browser when blurred; the exemption un-freezes it (that is what closes the stale-signer exposure on Android). Confirm no perceptible Android perf regression from keeping the Browser tab live while blurred, and confirm signing from a backgrounded dApp session now uses the correct active account.
- General regression sweep across all six affected tabs on iOS: confirm no functional regression from freezing (e.g. in-flight timers, animations, or subscriptions that assumed the tab tree stays live while blurred).

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CP-14918]: https://ava-labs.atlassian.net/browse/CP-14918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-14924]: https://ava-labs.atlassian.net/browse/CP-14924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ