### PR TITLE
CP-14918: restructure PriceChart Skia rendering and VolumeRow highlight

### DIFF
--- a/packages/core-mobile/app/new/common/hooks/useTokenChartCandles.test.ts
+++ b/packages/core-mobile/app/new/common/hooks/useTokenChartCandles.test.ts
@@ -2,6 +2,8 @@ import { useQuery } from '@tanstack/react-query'
 import { renderHook } from '@testing-library/react-hooks'
 import { VsCurrencyType } from '@avalabs/core-coingecko-sdk'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
+import type { ChartRange } from '@avalabs/k2-alpine'
+import TokenService from 'services/token/TokenService'
 import { useTokenChartCandles } from './useTokenChartCandles'
 
 jest.mock('@tanstack/react-query', () => ({
@@ -128,9 +130,11 @@ describe('useTokenChartCandles', () => {
       ])
     })
 
-    it('produces 48 candles from 48 sub-points for the 1D range', () => {
+    // Halves the candle count rather than emitting one candle per source
+    // point, since a one-point bucket can only ever be flat.
+    it('buckets coarse data into fewer multi-point candles instead of one-point candles', () => {
       const points = Array.from({ length: 48 }, (_, i) =>
-        makePoint(i * 60_000, 100 + i)
+        makePoint(i * 60_000, 100 + (i % 2 === 0 ? i : -i))
       )
       setQueryResult({ data: { dataPoints: points, ranges: {} } })
 
@@ -142,16 +146,62 @@ describe('useTokenChartCandles', () => {
         })
       )
 
-      expect(result.current.candles.length).toBe(48)
-      const first = result.current.candles[0]
-      expect(first).toEqual(
-        expect.objectContaining({
-          open: 100,
-          close: 100,
-          high: 100,
-          low: 100,
-          volume: null
+      // 48 source points, bucket count 48 -> 24 buckets of 2 points each,
+      // so each candle opens on every other source point.
+      const { candles } = result.current
+      expect(candles.length).toBe(24)
+      expect(candles.map(c => c.ts)).toEqual(
+        Array.from({ length: 24 }, (_, i) => i * 2 * 60_000)
+      )
+      expect(candles[0]).toEqual(
+        expect.objectContaining({ open: 100, close: 99, high: 100, low: 99 })
+      )
+    })
+
+    // ~25 hourly points is what `days=1` degrades to if CoinGecko ever
+    // returns hourly instead of 5-minutely granularity.
+    it('produces real candles from a coarse hourly 1D response', () => {
+      const points = Array.from({ length: 25 }, (_, i) =>
+        makePoint(i * 3_600_000, i % 2 === 0 ? 100 + i : 100 - i)
+      )
+      setQueryResult({ data: { dataPoints: points, ranges: {} } })
+
+      const { result } = renderHook(() =>
+        useTokenChartCandles({
+          coingeckoId: 'bitcoin',
+          range: '1D',
+          currency: VsCurrencyType.USD
         })
+      )
+
+      const { candles } = result.current
+      expect(candles.length).toBeGreaterThan(1)
+      expect(candles.every(c => c.high >= c.low)).toBe(true)
+      expect(candles.some(c => c.high > c.low)).toBe(true)
+      expect(candles.some(c => c.close < c.open)).toBe(true)
+    })
+
+    it('merges a short trailing slice so the last candle is not flat', () => {
+      // 25 points into 12 affordable buckets = 3 per bucket, leaving a
+      // 1-point tail that has to be folded into the previous candle.
+      const points = Array.from({ length: 25 }, (_, i) =>
+        makePoint(i * 1000, i)
+      )
+      setQueryResult({ data: { dataPoints: points, ranges: {} } })
+
+      const { result } = renderHook(() =>
+        useTokenChartCandles({
+          coingeckoId: 'bitcoin',
+          range: '1D',
+          currency: VsCurrencyType.USD
+        })
+      )
+
+      const { candles } = result.current
+      const last = candles[candles.length - 1]
+      expect(candles.length).toBe(8)
+      expect(last).toEqual(
+        expect.objectContaining({ open: 21, close: 24, high: 24, low: 21 })
       )
     })
 
@@ -238,7 +288,41 @@ describe('useTokenChartCandles', () => {
         })
       )
 
-      expect(result.current.candles.map(c => c.close)).toEqual([0, 0])
+      expect(result.current.candles.map(c => c.close)).toEqual([0])
+    })
+  })
+
+  describe('endpoint selection', () => {
+    const runQueryFn = (range: ChartRange): void => {
+      renderHook(() =>
+        useTokenChartCandles({
+          coingeckoId: 'bitcoin',
+          range,
+          currency: VsCurrencyType.USD
+        })
+      )
+      const { queryFn } = mockUseQuery.mock.calls[0]?.[0] as unknown as {
+        queryFn: () => unknown
+      }
+      queryFn()
+    }
+
+    // The range endpoint only returns hourly granularity on our plan, which
+    // is too coarse to bucket a day into candles.
+    it('fetches 1D via days=1 rather than the range endpoint', () => {
+      runQueryFn('1D')
+      expect(TokenService.getChartDataForCoinId).toHaveBeenCalledWith(
+        expect.objectContaining({ days: 1 })
+      )
+      expect(TokenService.getChartDataForCoinRange).not.toHaveBeenCalled()
+    })
+
+    it('fetches 1H via the range endpoint over a 2h window', () => {
+      runQueryFn('1H')
+      expect(TokenService.getChartDataForCoinId).not.toHaveBeenCalled()
+      const arg = (TokenService.getChartDataForCoinRange as jest.Mock).mock
+        .calls[0]?.[0] as { from: number; to: number }
+      expect(arg.to - arg.from).toBe(2 * 60 * 60)
     })
   })
 

--- a/packages/core-mobile/app/new/common/hooks/useTokenChartCandles.ts
+++ b/packages/core-mobile/app/new/common/hooks/useTokenChartCandles.ts
@@ -5,13 +5,14 @@ import { useEffect, useMemo, useRef } from 'react'
 import { VsCurrencyType } from '@avalabs/core-coingecko-sdk'
 import TokenService from 'services/token/TokenService'
 
-// CoinGecko granularity by `days`: 2-90 → hourly, >90 → daily.
-// 1H and 1D use the range endpoint (null here) so we get 5-min data over a
-// fixed window (see RANGE_TO_WINDOW_SECONDS) — that's enough source points to
-// bucket into the target candle count without one-source-point-per-candle.
+// CoinGecko granularity by `days`: 1 → 5-minutely, 2-90 → hourly, >90 → daily.
+// The range endpoint only returns hourly points on our plan (5-minutely there
+// is an Enterprise feature), so 1D goes through `days=1` for 5-minutely
+// granularity. Only 1H uses the range endpoint (null here), where a sub-hour
+// window is the only way to ask for less than a day.
 const RANGE_TO_DAYS: Record<ChartRange, number | null> = {
   '1H': null,
-  '1D': null,
+  '1D': 1,
   '1W': 7,
   '1M': 30,
   '3M': 90,
@@ -29,8 +30,7 @@ const RANGE_TO_CANDLE_COUNT: Record<ChartRange, number> = {
 
 // Window passed to the range endpoint when `RANGE_TO_DAYS[range]` is null.
 const RANGE_TO_WINDOW_SECONDS: Partial<Record<ChartRange, number>> = {
-  '1H': 2 * 60 * 60,
-  '1D': 24 * 60 * 60
+  '1H': 2 * 60 * 60
 }
 
 type PriceDataPoint = { date: Date; value: number; volume?: number | null }
@@ -70,6 +70,11 @@ const sliceToCandle = (slice: PriceDataPoint[]): OhlcCandle | null => {
   }
 }
 
+// A one-point bucket yields open === close === high === low, which renders
+// as a flat 1px dash with no wick. Prefer fewer, fatter candles over
+// degenerate ones when upstream granularity is coarser than bucketCount.
+const MIN_POINTS_PER_CANDLE = 2
+
 // Approximate OHLC: upstream only provides close prices, so `open` is the
 // first close in the bucket and `close` is the last. Per-bucket volume is
 // summed when source points carry it (null when no point in the bucket has
@@ -79,11 +84,22 @@ const bucketPointsIntoCandles = (
   bucketCount: number
 ): OhlcCandle[] => {
   if (points.length === 0 || bucketCount <= 0) return []
-  const pointsPerBucket = Math.max(1, Math.ceil(points.length / bucketCount))
+  const affordable = Math.floor(points.length / MIN_POINTS_PER_CANDLE)
+  const buckets = Math.max(1, Math.min(bucketCount, affordable))
+  const pointsPerBucket = Math.max(1, Math.ceil(points.length / buckets))
   const candles: OhlcCandle[] = []
   for (let i = 0; i < points.length; i += pointsPerBucket) {
-    const candle = sliceToCandle(points.slice(i, i + pointsPerBucket))
+    const remaining = points.length - i
+    const tail = remaining - pointsPerBucket
+    // Fold a short trailing slice into this bucket rather than emitting a
+    // flat rightmost candle.
+    const end =
+      tail > 0 && tail < MIN_POINTS_PER_CANDLE
+        ? points.length
+        : i + pointsPerBucket
+    const candle = sliceToCandle(points.slice(i, end))
     if (candle) candles.push(candle)
+    if (end >= points.length) break
   }
   return candles
 }

--- a/packages/k2-alpine/src/components/Chart/PriceChart/ChartFooter.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/ChartFooter.tsx
@@ -13,7 +13,7 @@ import {
   formatLastUpdate,
   formatVolume as defaultFormatVolume
 } from './helpers'
-import { useActiveIndex } from './hooks'
+import { useActiveIndex, useIsFullFormatNeeded } from './hooks'
 import { OhlcCandle } from './types'
 
 type Props = {
@@ -45,10 +45,15 @@ export const ChartFooter: FC<Props> = ({
 }) => {
   const idx = useActiveIndex(activeIndex)
 
-  const formattedVolumes = useMemo(
-    () => candles.map(c => (c.volume != null ? formatVolume(c.volume) : '')),
-    [candles, formatVolume]
-  )
+  // `needsFull` also gates on `showVolume` -- in line mode (default) this
+  // text is permanently invisible; without the gate, a crosshair drag still
+  // pays the full O(candles) format cost for nothing visible. CP-14918
+  // (closes I3, §15.1).
+  const needsFull = useIsFullFormatNeeded(showVolume ? idx : null) && showVolume
+  const formattedVolumes = useMemo(() => {
+    if (!needsFull) return undefined
+    return candles.map(c => (c.volume != null ? formatVolume(c.volume) : ''))
+  }, [candles, formatVolume, needsFull])
   const idleText = useMemo(() => {
     const latest = candles[candles.length - 1]
     return latest ? formatLastUpdate(latest.ts) : ''
@@ -95,7 +100,7 @@ export const ChartFooter: FC<Props> = ({
     }
   })
 
-  const activeText = idx !== null ? formattedVolumes[idx] ?? '' : ''
+  const activeText = idx !== null ? formattedVolumes?.[idx] ?? '' : ''
 
   return (
     <View

--- a/packages/k2-alpine/src/components/Chart/PriceChart/ChartFooter.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/ChartFooter.tsx
@@ -45,10 +45,8 @@ export const ChartFooter: FC<Props> = ({
 }) => {
   const idx = useActiveIndex(activeIndex)
 
-  // `needsFull` also gates on `showVolume` -- in line mode (default) this
-  // text is permanently invisible; without the gate, a crosshair drag still
-  // pays the full O(candles) format cost for nothing visible. CP-14918
-  // (closes I3, §15.1).
+  // Also gated on `showVolume`: in line mode this text is never visible, so a
+  // crosshair drag shouldn't pay the O(candles) format at all. CP-14918.
   const needsFull = useIsFullFormatNeeded(showVolume ? idx : null) && showVolume
   const formattedVolumes = useMemo(() => {
     if (!needsFull) return undefined

--- a/packages/k2-alpine/src/components/Chart/PriceChart/ChartHeader.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/ChartHeader.tsx
@@ -217,12 +217,9 @@ export const ChartHeader: FC<Props> = memo(
       isActive
     )
 
-    // Crosshair-inactive state only ever reads the LAST candle (see `active`
-    // below), so the mount-time eager cost is a single O(1) format instead
-    // of formatting all ~48 candles. The full array (needed for crosshair
-    // drag lookups) is computed lazily by `fullFormatted` below.
+    // Inactive state only renders the last candle, so format just that one at
+    // mount; the full array (crosshair lookups) is deferred below.
     const lastFormatted = useMemo(
-      // CP-14918: eager mount-time cost — now O(1), one candle.
       () =>
         formatCandleDisplayStringAt(candles, candles.length - 1, formatPrice),
       [candles, formatPrice]
@@ -231,9 +228,8 @@ export const ChartHeader: FC<Props> = memo(
     const needsFull = useIsFullFormatNeeded(idx)
     const fullFormatted = useMemo(() => {
       if (!needsFull) return undefined
-      // CP-14918: the ~96-call Intl formatting cost, deferred off
-      // the mount path to an idle tick or the first crosshair activation
-      // (whichever comes first) — see `useIsFullFormatNeeded`.
+      // Full-array Intl cost (see `MONTH_ABBR` in helpers) kept off the mount
+      // path — see `useIsFullFormatNeeded`.
       return formatCandleDisplayStrings(candles, formatPrice)
     }, [candles, formatPrice, needsFull])
 

--- a/packages/k2-alpine/src/components/Chart/PriceChart/ChartHeader.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/ChartHeader.tsx
@@ -17,9 +17,10 @@ import { Text } from '../../Primitives'
 import { DURATIONS } from './constants'
 import {
   crosshairInnerAnchorTarget,
+  formatCandleDisplayStringAt,
   formatCandleDisplayStrings
 } from './helpers'
-import { useActiveIndex } from './hooks'
+import { useActiveIndex, useIsFullFormatNeeded } from './hooks'
 import { OhlcCandle } from './types'
 
 const useLayoutWidthHandler = (
@@ -216,13 +217,28 @@ export const ChartHeader: FC<Props> = memo(
       isActive
     )
 
-    const formatted = useMemo(
-      () => formatCandleDisplayStrings(candles, formatPrice),
+    // Crosshair-inactive state only ever reads the LAST candle (see `active`
+    // below), so the mount-time eager cost is a single O(1) format instead
+    // of formatting all ~48 candles. The full array (needed for crosshair
+    // drag lookups) is computed lazily by `fullFormatted` below.
+    const lastFormatted = useMemo(
+      // CP-14918: eager mount-time cost — now O(1), one candle.
+      () =>
+        formatCandleDisplayStringAt(candles, candles.length - 1, formatPrice),
       [candles, formatPrice]
     )
 
-    const lastCandle = formatted[formatted.length - 1]
-    const active = idx !== null ? formatted[idx] : undefined
+    const needsFull = useIsFullFormatNeeded(idx)
+    const fullFormatted = useMemo(() => {
+      if (!needsFull) return undefined
+      // CP-14918: the ~96-call Intl formatting cost, deferred off
+      // the mount path to an idle tick or the first crosshair activation
+      // (whichever comes first) — see `useIsFullFormatNeeded`.
+      return formatCandleDisplayStrings(candles, formatPrice)
+    }, [candles, formatPrice, needsFull])
+
+    const lastCandle = lastFormatted
+    const active = idx !== null ? fullFormatted?.[idx] : undefined
 
     const priceText =
       active?.priceText ??

--- a/packages/k2-alpine/src/components/Chart/PriceChart/PriceChart.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/PriceChart.tsx
@@ -109,9 +109,8 @@ const computeVolumes = (candles: OhlcCandle[]): Float32Array => {
   return vols
 }
 
-// `useFont` has no internal cache -- every call reallocates a native
-// `SkTypeface`. Module-scope singleton (`labelFontCache`/`labelFontPromise`),
-// shared across every mount. CP-14918.
+// `useFont` has no cache — every mount reallocates a native `SkTypeface`,
+// hence a module-scope singleton shared across mounts. CP-14918.
 const LABEL_FONT_SIZE = 11
 let labelFontCache: SkFont | null = null
 let labelFontPromise: Promise<SkFont | null> | null = null
@@ -136,8 +135,7 @@ const loadLabelFontOnce = (): Promise<SkFont | null> => {
       labelFontListeners.forEach(listener => listener())
       return font
     } catch {
-      // Don't cache a failed load forever -- clear `labelFontPromise` in the
-      // catch so the next mount retries. CP-14918.
+      // Don't cache a failed load — the next mount must be able to retry.
       labelFontPromise = null
       return null
     }
@@ -355,10 +353,9 @@ export const PriceChart: FC<Props> = ({
     [candles]
   )
 
-  // `lineYsSV`/`volumesSV`: worklets read a flattened `Float32Array`, not the
-  // full object array, to avoid a shareable-conversion per dep change.
-  // Lazy-inits from the CURRENT render's data (not empty) -- avoids a
-  // stale-length window on mount/range-switch. CP-14918.
+  // Worklets read a flattened `Float32Array` so a data change doesn't
+  // re-convert an array of objects to a shareable. Lazy-init reads the current
+  // render's data, so mount/range-switch never sees a zero-length window.
   const lineYsSV = useSharedValue<Float32Array>(() => computeLineYs(linePoints))
   useEffect(() => {
     lineYsSV.value = computeLineYs(linePoints)
@@ -425,10 +422,6 @@ export const PriceChart: FC<Props> = ({
   //     touch. Once LongPress has already activated, Pan accepts any
   //     direction so the user can drag the crosshair vertically without
   //     losing it.
-  //
-  // Gesture memo still bails from React Compiler -- a `SharedValue`-in-deps
-  // pattern shared by 3 effects in this file, not just here. Known, accepted
-  // limitation; out of scope for this pass. CP-14918 item 5.
   // eslint-disable-next-line sonarjs/cognitive-complexity
   const gesture = useMemo(() => {
     const clampX = (x: number): number => {

--- a/packages/k2-alpine/src/components/Chart/PriceChart/PriceChart.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/PriceChart.tsx
@@ -4,10 +4,10 @@ import {
   Group,
   Path,
   Skia,
-  useFont
+  type SkFont
 } from '@shopify/react-native-skia'
-import React, { FC, useEffect, useMemo } from 'react'
-import { ActivityIndicator, View } from 'react-native'
+import React, { FC, useEffect, useMemo, useState } from 'react'
+import { ActivityIndicator, Image, View } from 'react-native'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import Animated, {
   Easing,
@@ -91,6 +91,80 @@ const renderPlaceholderState = ({
   return null
 }
 
+// Module scope so the lazy shared-value init and the sync effect share the
+// same flattening logic. CP-14918.
+const computeLineYs = (points: { x: number; y: number }[]): Float32Array => {
+  const ys = new Float32Array(points.length)
+  points.forEach((p, i) => {
+    ys[i] = p.y
+  })
+  return ys
+}
+
+const computeVolumes = (candles: OhlcCandle[]): Float32Array => {
+  const vols = new Float32Array(candles.length)
+  candles.forEach((c, i) => {
+    vols[i] = c.volume ?? -1
+  })
+  return vols
+}
+
+// `useFont` has no internal cache -- every call reallocates a native
+// `SkTypeface`. Module-scope singleton (`labelFontCache`/`labelFontPromise`),
+// shared across every mount. CP-14918.
+const LABEL_FONT_SIZE = 11
+let labelFontCache: SkFont | null = null
+let labelFontPromise: Promise<SkFont | null> | null = null
+const labelFontListeners = new Set<() => void>()
+
+const loadLabelFontOnce = (): Promise<SkFont | null> => {
+  if (labelFontPromise) return labelFontPromise
+  labelFontPromise = (async (): Promise<SkFont | null> => {
+    try {
+      const source = require('../../../assets/fonts/Inter-Medium.ttf')
+      const uri = Image.resolveAssetSource(source).uri
+      const data = await Skia.Data.fromURI(uri)
+      const typeface = Skia.Typeface.MakeFreeTypeFaceFromData(data)
+      if (!typeface) {
+        // Same permanent-cache hazard as the catch block below — a failed
+        // (non-throwing) typeface creation must not stick around forever.
+        labelFontPromise = null
+        return null
+      }
+      const font = Skia.Font(typeface, LABEL_FONT_SIZE)
+      labelFontCache = font
+      labelFontListeners.forEach(listener => listener())
+      return font
+    } catch {
+      // Don't cache a failed load forever -- clear `labelFontPromise` in the
+      // catch so the next mount retries. CP-14918.
+      labelFontPromise = null
+      return null
+    }
+  })()
+  return labelFontPromise
+}
+
+/** Module-scoped singleton — see comment above `loadLabelFontOnce`. */
+const useLabelFont = (): SkFont | null => {
+  const [font, setFont] = useState<SkFont | null>(labelFontCache)
+
+  useEffect(() => {
+    if (labelFontCache) {
+      setFont(labelFontCache)
+      return
+    }
+    const listener = (): void => setFont(labelFontCache)
+    labelFontListeners.add(listener)
+    loadLabelFontOnce()
+    return () => {
+      labelFontListeners.delete(listener)
+    }
+  }, [])
+
+  return font
+}
+
 export const PriceChart: FC<Props> = ({
   candles,
   width,
@@ -106,10 +180,7 @@ export const PriceChart: FC<Props> = ({
 }) => {
   const { theme } = useTheme()
 
-  const labelFont = useFont(
-    require('../../../assets/fonts/Inter-Medium.ttf'),
-    11
-  )
+  const labelFont = useLabelFont()
 
   const { minPrice, maxPrice } = useMemo(() => rangeBounds(candles), [candles])
 
@@ -284,11 +355,27 @@ export const PriceChart: FC<Props> = ({
     [candles]
   )
 
+  // `lineYsSV`/`volumesSV`: worklets read a flattened `Float32Array`, not the
+  // full object array, to avoid a shareable-conversion per dep change.
+  // Lazy-inits from the CURRENT render's data (not empty) -- avoids a
+  // stale-length window on mount/range-switch. CP-14918.
+  const lineYsSV = useSharedValue<Float32Array>(() => computeLineYs(linePoints))
+  useEffect(() => {
+    lineYsSV.value = computeLineYs(linePoints)
+  }, [linePoints, lineYsSV])
+
+  // -1 sentinel for "no volume" (real volumes are always >= 0).
+  const volumesSV = useSharedValue<Float32Array>(() => computeVolumes(candles))
+  useEffect(() => {
+    volumesSV.value = computeVolumes(candles)
+  }, [candles, volumesSV])
+
   // Y on the close-price line at the crosshair X (linear interp between the
   // two neighboring close prices, so the dot glides vertically only).
   const activeLineY = useDerivedValue(() => {
-    if (linePoints.length === 0 || innerWidth === 0) return 0
-    const last = linePoints.length - 1
+    const ys = lineYsSV.value
+    const last = ys.length - 1
+    if (last < 0 || innerWidth === 0) return 0
     const fracIndex = Math.max(
       0,
       Math.min(last, ((crosshairX.value - chartInset) / innerWidth) * last)
@@ -296,17 +383,18 @@ export const PriceChart: FC<Props> = ({
     const lo = Math.floor(fracIndex)
     const hi = Math.ceil(fracIndex)
     const t = fracIndex - lo
-    const a = linePoints[lo]
-    const b = linePoints[hi]
-    if (!a || !b) return 0
-    return a.y + (b.y - a.y) * t
-  }, [linePoints, innerWidth])
+    const a = ys[lo]
+    const b = ys[hi]
+    if (a === undefined || b === undefined) return 0
+    return a + (b - a) * t
+  }, [innerWidth, chartInset])
 
   // Bottom inset for the crosshair line so it stops 8px above the active
   // volume bar; interpolated between adjacent bar heights for smoothness.
   const animatedBarHeight = useDerivedValue(() => {
-    if (candles.length === 0 || maxVolume === 0 || innerWidth === 0) return 0
-    const last = candles.length - 1
+    const vols = volumesSV.value
+    const last = vols.length - 1
+    if (last < 0 || maxVolume === 0 || innerWidth === 0) return 0
     const fracIndex =
       last > 0
         ? Math.max(
@@ -320,13 +408,13 @@ export const PriceChart: FC<Props> = ({
     const lo = Math.floor(fracIndex)
     const hi = Math.ceil(fracIndex)
     const t = fracIndex - lo
-    const a = candles[lo]
-    const b = candles[hi]
-    const ha = a && a.volume != null ? (a.volume / maxVolume) * volH : 0
-    const hb = b && b.volume != null ? (b.volume / maxVolume) * volH : 0
+    const va = vols[lo]
+    const vb = vols[hi]
+    const ha = va !== undefined && va >= 0 ? (va / maxVolume) * volH : 0
+    const hb = vb !== undefined && vb >= 0 ? (vb / maxVolume) * volH : 0
     const interp = ha + (hb - ha) * t
     return interp + 8
-  }, [candles, maxVolume, volH, innerWidth])
+  }, [maxVolume, volH, innerWidth, chartInset])
 
   // Two simultaneous gestures coordinate the crosshair interaction:
   //   - LongPress (≥200ms with <3px wander): activates the crosshair at the
@@ -337,6 +425,10 @@ export const PriceChart: FC<Props> = ({
   //     touch. Once LongPress has already activated, Pan accepts any
   //     direction so the user can drag the crosshair vertically without
   //     losing it.
+  //
+  // Gesture memo still bails from React Compiler -- a `SharedValue`-in-deps
+  // pattern shared by 3 effects in this file, not just here. Known, accepted
+  // limitation; out of scope for this pass. CP-14918 item 5.
   // eslint-disable-next-line sonarjs/cognitive-complexity
   const gesture = useMemo(() => {
     const clampX = (x: number): number => {

--- a/packages/k2-alpine/src/components/Chart/PriceChart/Series.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/Series.tsx
@@ -72,7 +72,7 @@ type CandlesProps = {
 /**
  * `Candles`: 4 `SkPath`s (up/down body, up/down wick) instead of 2N
  * `<Line>`+`<RoundedRect>` elements. Wicks draw before bodies so paint order
- * matches the original per-candle behavior. CP-14918 item 1.
+ * matches the original per-candle behavior. CP-14918.
  */
 export const Candles: FC<CandlesProps> = memo(
   ({
@@ -91,8 +91,8 @@ export const Candles: FC<CandlesProps> = memo(
       useMemo(() => {
         const bodies = { up: Skia.Path.Make(), down: Skia.Path.Make() }
         const wicks = { up: Skia.Path.Make(), down: Skia.Path.Make() }
-        // Constant across all candles (depends only on the shared `bodyWidth`
-        // prop) — matches the per-iteration computation it replaces exactly.
+        // Loop-invariant (depends only on bodyWidth) — same value the
+        // per-candle version computed each iteration.
         const stroke = Math.max(1, bodyWidth / 4)
 
         candles.forEach((c, i) => {

--- a/packages/k2-alpine/src/components/Chart/PriceChart/Series.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/Series.tsx
@@ -1,12 +1,11 @@
 import {
-  Line,
   LinearGradient,
   Path,
-  RoundedRect,
+  Skia,
   type SkPath,
   vec
 } from '@shopify/react-native-skia'
-import React, { FC, memo } from 'react'
+import React, { FC, memo, useMemo } from 'react'
 import Animated, {
   SharedValue,
   useAnimatedStyle
@@ -70,6 +69,11 @@ type CandlesProps = {
   downColor: string
 }
 
+/**
+ * `Candles`: 4 `SkPath`s (up/down body, up/down wick) instead of 2N
+ * `<Line>`+`<RoundedRect>` elements. Wicks draw before bodies so paint order
+ * matches the original per-candle behavior. CP-14918 item 1.
+ */
 export const Candles: FC<CandlesProps> = memo(
   ({
     candles,
@@ -82,67 +86,105 @@ export const Candles: FC<CandlesProps> = memo(
     priceMax,
     upColor,
     downColor
-  }) => (
-    <>
-      {candles.map((c, i) => {
-        const xCenter = indexToX(i, candles.length, innerWidth) + chartInset
-        const x = xCenter - bodyWidth / 2
-        const isUp = c.close >= c.open
-        const color = isUp ? upColor : downColor
-        const top =
-          priceToY({
-            price: Math.max(c.open, c.close),
-            priceMin,
-            priceMax,
-            height: priceAreaH
-          }) + priceTopPadding
-        const bottom =
-          priceToY({
-            price: Math.min(c.open, c.close),
-            priceMin,
-            priceMax,
-            height: priceAreaH
-          }) + priceTopPadding
-        const bodyHeight = Math.max(1, bottom - top)
-        const wickTop =
-          priceToY({
-            price: c.high,
-            priceMin,
-            priceMax,
-            height: priceAreaH
-          }) + priceTopPadding
-        const wickBottom =
-          priceToY({
-            price: c.low,
-            priceMin,
-            priceMax,
-            height: priceAreaH
-          }) + priceTopPadding
-        const bodyRadius = Math.min(bodyWidth, bodyHeight) / 2
-        const wickStroke = Math.max(1, bodyWidth / 4)
-        return (
-          <React.Fragment key={c.ts}>
-            <Line
-              p1={vec(xCenter, wickTop)}
-              p2={vec(xCenter, wickBottom)}
-              color={color}
-              strokeWidth={wickStroke}
-              strokeCap="round"
-              opacity={0.5}
-            />
-            <RoundedRect
-              x={x}
-              y={top}
-              width={bodyWidth}
-              height={bodyHeight}
-              r={bodyRadius}
-              color={color}
-            />
-          </React.Fragment>
-        )
-      })}
-    </>
-  )
+  }) => {
+    const { upBody, downBody, upWick, downWick, wickStrokeWidth } =
+      useMemo(() => {
+        const bodies = { up: Skia.Path.Make(), down: Skia.Path.Make() }
+        const wicks = { up: Skia.Path.Make(), down: Skia.Path.Make() }
+        // Constant across all candles (depends only on the shared `bodyWidth`
+        // prop) — matches the per-iteration computation it replaces exactly.
+        const stroke = Math.max(1, bodyWidth / 4)
+
+        candles.forEach((c, i) => {
+          const xCenter = indexToX(i, candles.length, innerWidth) + chartInset
+          const x = xCenter - bodyWidth / 2
+          const isUp = c.close >= c.open
+          const top =
+            priceToY({
+              price: Math.max(c.open, c.close),
+              priceMin,
+              priceMax,
+              height: priceAreaH
+            }) + priceTopPadding
+          const bottom =
+            priceToY({
+              price: Math.min(c.open, c.close),
+              priceMin,
+              priceMax,
+              height: priceAreaH
+            }) + priceTopPadding
+          const bodyHeight = Math.max(1, bottom - top)
+          const wickTop =
+            priceToY({
+              price: c.high,
+              priceMin,
+              priceMax,
+              height: priceAreaH
+            }) + priceTopPadding
+          const wickBottom =
+            priceToY({
+              price: c.low,
+              priceMin,
+              priceMax,
+              height: priceAreaH
+            }) + priceTopPadding
+          const bodyRadius = Math.min(bodyWidth, bodyHeight) / 2
+
+          const bodyPath = isUp ? bodies.up : bodies.down
+          bodyPath.addRRect(
+            Skia.RRectXY(
+              Skia.XYWHRect(x, top, bodyWidth, bodyHeight),
+              bodyRadius,
+              bodyRadius
+            )
+          )
+
+          const wickPath = isUp ? wicks.up : wicks.down
+          wickPath.moveTo(xCenter, wickTop)
+          wickPath.lineTo(xCenter, wickBottom)
+        })
+
+        return {
+          upBody: bodies.up,
+          downBody: bodies.down,
+          upWick: wicks.up,
+          downWick: wicks.down,
+          wickStrokeWidth: stroke
+        }
+      }, [
+        candles,
+        innerWidth,
+        chartInset,
+        bodyWidth,
+        priceAreaH,
+        priceTopPadding,
+        priceMin,
+        priceMax
+      ])
+
+    return (
+      <>
+        <Path
+          path={upWick}
+          color={upColor}
+          style="stroke"
+          strokeWidth={wickStrokeWidth}
+          strokeCap="round"
+          opacity={0.5}
+        />
+        <Path
+          path={downWick}
+          color={downColor}
+          style="stroke"
+          strokeWidth={wickStrokeWidth}
+          strokeCap="round"
+          opacity={0.5}
+        />
+        <Path path={upBody} color={upColor} style="fill" />
+        <Path path={downBody} color={downColor} style="fill" />
+      </>
+    )
+  }
 )
 
 type LineChartDotProps = {

--- a/packages/k2-alpine/src/components/Chart/PriceChart/VolumeRow.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/VolumeRow.tsx
@@ -35,16 +35,10 @@ const BAR_WIDTH_RATIO = 0.6
 type BarGeom = { x: number; barHeight: number; radius: number }
 
 /**
- * Bar highlight: one static `SkPath` for idle bars + two dynamic
- * `RoundedRect`s for the two nearest bars, driven by a single `SharedValue`
- * holding both indices and their crossfade weights (was: one `makeMutable`
- * per candle). Crossfades between the two nearest candles exactly like
- * main's original per-candle implementation — see `volumeCrosshairWeights`
- * in `helpers.ts` for the interpolation this restores. Because the
- * highlight rects paint on top of the idle `Path` (which already painted
- * those same bars), their opacity is compositing-compensated via
- * `crossfadeRectOpacity` so `idlePath + rect` composes to main's per-bar
- * target opacity exactly, not a double-counted overshoot. CP-14918 item 2.
+ * One static Path for all idle bars + two RoundedRects for the bars
+ * bracketing the crosshair, replacing one makeMutable and one rect per
+ * candle. Rect opacity is compositing-compensated (`crossfadeRectOpacity`)
+ * because it paints over bars the idle Path already drew. CP-14918.
  */
 export const VolumeRow: FC<Props> = ({
   candles,
@@ -95,8 +89,10 @@ export const VolumeRow: FC<Props> = ({
     return { barGeom: geom, idlePath: path }
   }, [candles, innerWidth, height, barWidth, maxVolume])
 
-  // Mirrored into a SharedValue via an effect rather than closed over
-  // directly inside the worklets below.
+  // Worklets capture by value: closing over `barGeom` would copy all N geoms
+  // into the UI runtime once per derived value, per render. One SharedValue
+  // copies once per geometry change — written in an effect, not during
+  // render, because Reanimated doesn't support SharedValue writes mid-render.
   const barGeomSV = useSharedValue<BarGeom[]>(barGeom)
   useEffect(() => {
     barGeomSV.value = barGeom
@@ -117,9 +113,8 @@ export const VolumeRow: FC<Props> = ({
     [candles.length, innerWidth]
   )
 
-  // Low bar — the candle at or just below the crosshair. Opacity is
-  // compositing-compensated (see `crossfadeRectOpacity`) since this rect
-  // paints on top of `idlePath`, which already painted the same bar.
+  // Low/high bar = the two candles bracketing the crosshair. Opacity goes
+  // through `crossfadeRectOpacity` because these paint over `idlePath`.
   const lowOpacity = useDerivedValue(() => {
     const c = crossfadeSV.value
     return c.lowIndex === NO_HIGHLIGHT_INDEX
@@ -151,8 +146,6 @@ export const VolumeRow: FC<Props> = ({
     return g ? g.radius : 0
   })
 
-  // High bar — the candle at or just above the crosshair. Same compositing
-  // compensation as `lowOpacity` above.
   const highOpacity = useDerivedValue(() => {
     const c = crossfadeSV.value
     return c.highIndex === NO_HIGHLIGHT_INDEX

--- a/packages/k2-alpine/src/components/Chart/PriceChart/VolumeRow.tsx
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/VolumeRow.tsx
@@ -1,30 +1,51 @@
-import { Canvas, RoundedRect } from '@shopify/react-native-skia'
-import React, { FC, useMemo } from 'react'
+import { Canvas, Path, RoundedRect, Skia } from '@shopify/react-native-skia'
+import React, { FC, useEffect, useMemo } from 'react'
 import { View } from 'react-native'
 import {
-  makeMutable,
   SharedValue,
-  useAnimatedReaction
+  useAnimatedReaction,
+  useDerivedValue,
+  useSharedValue
 } from 'react-native-reanimated'
 import { useTheme } from '../../../hooks'
 import { CHART_INSET } from './constants'
-import { indexToX } from './helpers'
+import {
+  crossfadeRectOpacity,
+  IDLE_VOLUME_CROSSFADE,
+  indexToX,
+  NO_HIGHLIGHT_INDEX,
+  VOLUME_IDLE_OPACITY,
+  volumeCrosshairWeights
+} from './helpers'
 import { OhlcCandle } from './types'
 
 type Props = {
   candles: OhlcCandle[]
   width: number
   height: number
-  /** When provided, each bar's opacity tracks the crosshair X — closest bars
-   * pop to full opacity, falling off linearly within one candle's distance. */
+  /** When provided, the two candles nearest the crosshair X crossfade —
+   * the closer one pops toward full opacity, the other falls back toward
+   * idle, linearly within one candle's distance. */
   crosshairX?: SharedValue<number>
   isActive?: SharedValue<boolean>
 }
 
 const BAR_WIDTH_RATIO = 0.6
-const IDLE_OPACITY = 0.1
-const ACTIVE_OPACITY = 1
 
+type BarGeom = { x: number; barHeight: number; radius: number }
+
+/**
+ * Bar highlight: one static `SkPath` for idle bars + two dynamic
+ * `RoundedRect`s for the two nearest bars, driven by a single `SharedValue`
+ * holding both indices and their crossfade weights (was: one `makeMutable`
+ * per candle). Crossfades between the two nearest candles exactly like
+ * main's original per-candle implementation — see `volumeCrosshairWeights`
+ * in `helpers.ts` for the interpolation this restores. Because the
+ * highlight rects paint on top of the idle `Path` (which already painted
+ * those same bars), their opacity is compositing-compensated via
+ * `crossfadeRectOpacity` so `idlePath + rect` composes to main's per-bar
+ * target opacity exactly, not a double-counted overshoot. CP-14918 item 2.
+ */
 export const VolumeRow: FC<Props> = ({
   candles,
   width,
@@ -34,44 +55,7 @@ export const VolumeRow: FC<Props> = ({
 }) => {
   const { theme } = useTheme()
 
-  // One SharedValue per bar so opacity updates stay on the UI thread.
-  const opacities = useMemo(
-    () =>
-      Array.from({ length: candles.length }, () => makeMutable(IDLE_OPACITY)),
-    [candles.length]
-  )
-
   const innerWidth = Math.max(0, width - 2 * CHART_INSET)
-
-  useAnimatedReaction(
-    () => ({
-      x: crosshairX?.value ?? 0,
-      active: isActive?.value ?? false
-    }),
-    ({ x, active }) => {
-      if (!active || candles.length <= 1 || innerWidth === 0) {
-        for (const o of opacities) {
-          o.value = IDLE_OPACITY
-        }
-        return
-      }
-      const last = candles.length - 1
-      const fracIndex = Math.max(
-        0,
-        Math.min(last, ((x - CHART_INSET) / innerWidth) * last)
-      )
-      for (let i = 0; i < opacities.length; i++) {
-        const o = opacities[i]
-        if (!o) continue
-        const distance = Math.abs(fracIndex - i)
-        o.value =
-          distance >= 1
-            ? IDLE_OPACITY
-            : ACTIVE_OPACITY - (ACTIVE_OPACITY - IDLE_OPACITY) * distance
-      }
-    },
-    [candles.length, innerWidth]
-  )
 
   const allNull = useMemo(
     () => candles.every(c => c.volume === null),
@@ -82,36 +66,148 @@ export const VolumeRow: FC<Props> = ({
     [candles]
   )
 
-  if (allNull || maxVolume === 0 || candles.length === 0) return null
-
-  const slotWidth = innerWidth / candles.length
+  const slotWidth = candles.length > 0 ? innerWidth / candles.length : 0
   const barWidth = slotWidth * BAR_WIDTH_RATIO
   const barColor = theme.colors.$textPrimary ?? '#28282E'
+
+  // Static per-bar geometry + one path covering every bar at
+  // VOLUME_IDLE_OPACITY.
+  const { barGeom, idlePath } = useMemo(() => {
+    const geom: BarGeom[] = []
+    const path = Skia.Path.Make()
+    if (maxVolume > 0) {
+      candles.forEach((c, i) => {
+        if (c.volume == null) {
+          geom.push({ x: 0, barHeight: 0, radius: 0 })
+          return
+        }
+        const xCenter = indexToX(i, candles.length, innerWidth) + CHART_INSET
+        const barHeight = (c.volume / maxVolume) * height
+        const x = xCenter - barWidth / 2
+        const y = height - barHeight
+        const radius = Math.min(barWidth, barHeight) / 2
+        geom.push({ x, barHeight, radius })
+        path.addRRect(
+          Skia.RRectXY(Skia.XYWHRect(x, y, barWidth, barHeight), radius, radius)
+        )
+      })
+    }
+    return { barGeom: geom, idlePath: path }
+  }, [candles, innerWidth, height, barWidth, maxVolume])
+
+  // Mirrored into a SharedValue via an effect rather than closed over
+  // directly inside the worklets below.
+  const barGeomSV = useSharedValue<BarGeom[]>(barGeom)
+  useEffect(() => {
+    barGeomSV.value = barGeom
+  }, [barGeom, barGeomSV])
+
+  const crossfadeSV = useSharedValue(IDLE_VOLUME_CROSSFADE)
+
+  useAnimatedReaction(
+    () => ({
+      x: crosshairX?.value ?? 0,
+      active: isActive?.value ?? false
+    }),
+    ({ x, active }) => {
+      crossfadeSV.value = active
+        ? volumeCrosshairWeights(x, candles.length, innerWidth)
+        : IDLE_VOLUME_CROSSFADE
+    },
+    [candles.length, innerWidth]
+  )
+
+  // Low bar — the candle at or just below the crosshair. Opacity is
+  // compositing-compensated (see `crossfadeRectOpacity`) since this rect
+  // paints on top of `idlePath`, which already painted the same bar.
+  const lowOpacity = useDerivedValue(() => {
+    const c = crossfadeSV.value
+    return c.lowIndex === NO_HIGHLIGHT_INDEX
+      ? 0
+      : crossfadeRectOpacity(c.lowWeight)
+  })
+  const lowX = useDerivedValue(() => {
+    const c = crossfadeSV.value
+    if (c.lowIndex === NO_HIGHLIGHT_INDEX) return 0
+    const g = barGeomSV.value[c.lowIndex]
+    return g ? g.x : 0
+  })
+  const lowY = useDerivedValue(() => {
+    const c = crossfadeSV.value
+    if (c.lowIndex === NO_HIGHLIGHT_INDEX) return 0
+    const g = barGeomSV.value[c.lowIndex]
+    return g ? height - g.barHeight : 0
+  })
+  const lowHeight = useDerivedValue(() => {
+    const c = crossfadeSV.value
+    if (c.lowIndex === NO_HIGHLIGHT_INDEX) return 0
+    const g = barGeomSV.value[c.lowIndex]
+    return g ? g.barHeight : 0
+  })
+  const lowRadius = useDerivedValue(() => {
+    const c = crossfadeSV.value
+    if (c.lowIndex === NO_HIGHLIGHT_INDEX) return 0
+    const g = barGeomSV.value[c.lowIndex]
+    return g ? g.radius : 0
+  })
+
+  // High bar — the candle at or just above the crosshair. Same compositing
+  // compensation as `lowOpacity` above.
+  const highOpacity = useDerivedValue(() => {
+    const c = crossfadeSV.value
+    return c.highIndex === NO_HIGHLIGHT_INDEX
+      ? 0
+      : crossfadeRectOpacity(c.highWeight)
+  })
+  const highX = useDerivedValue(() => {
+    const c = crossfadeSV.value
+    if (c.highIndex === NO_HIGHLIGHT_INDEX) return 0
+    const g = barGeomSV.value[c.highIndex]
+    return g ? g.x : 0
+  })
+  const highY = useDerivedValue(() => {
+    const c = crossfadeSV.value
+    if (c.highIndex === NO_HIGHLIGHT_INDEX) return 0
+    const g = barGeomSV.value[c.highIndex]
+    return g ? height - g.barHeight : 0
+  })
+  const highHeight = useDerivedValue(() => {
+    const c = crossfadeSV.value
+    if (c.highIndex === NO_HIGHLIGHT_INDEX) return 0
+    const g = barGeomSV.value[c.highIndex]
+    return g ? g.barHeight : 0
+  })
+  const highRadius = useDerivedValue(() => {
+    const c = crossfadeSV.value
+    if (c.highIndex === NO_HIGHLIGHT_INDEX) return 0
+    const g = barGeomSV.value[c.highIndex]
+    return g ? g.radius : 0
+  })
+
+  if (allNull || maxVolume === 0 || candles.length === 0) return null
 
   return (
     <View style={{ width, height }}>
       <Canvas style={{ width, height }}>
-        {candles.map((c, i) => {
-          if (c.volume == null) return null
-          const xCenter = indexToX(i, candles.length, innerWidth) + CHART_INSET
-          const x = xCenter - barWidth / 2
-          const barHeight = (c.volume / maxVolume) * height
-          const y = height - barHeight
-          const radius = Math.min(barWidth, barHeight) / 2
-          const opacity = opacities[i] ?? IDLE_OPACITY
-          return (
-            <RoundedRect
-              key={c.ts}
-              x={x}
-              y={y}
-              width={barWidth}
-              height={barHeight}
-              r={radius}
-              color={barColor}
-              opacity={opacity}
-            />
-          )
-        })}
+        <Path path={idlePath} color={barColor} opacity={VOLUME_IDLE_OPACITY} />
+        <RoundedRect
+          x={lowX}
+          y={lowY}
+          width={barWidth}
+          height={lowHeight}
+          r={lowRadius}
+          color={barColor}
+          opacity={lowOpacity}
+        />
+        <RoundedRect
+          x={highX}
+          y={highY}
+          width={barWidth}
+          height={highHeight}
+          r={highRadius}
+          color={barColor}
+          opacity={highOpacity}
+        />
       </Canvas>
     </View>
   )

--- a/packages/k2-alpine/src/components/Chart/PriceChart/helpers.test.ts
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/helpers.test.ts
@@ -1,13 +1,23 @@
+import { CHART_INSET } from './constants'
 import {
+  crossfadeRectOpacity,
+  IDLE_VOLUME_CROSSFADE,
+  NO_HIGHLIGHT_INDEX,
   priceToY,
   indexToX,
   touchXToIndex,
   rangeBounds,
+  VOLUME_ACTIVE_OPACITY,
+  VOLUME_IDLE_OPACITY,
+  volumeCrosshairWeights,
   yAxisTicks,
   traceSmoothLine,
   formatActiveTime,
+  formatCandleDisplayStringAt,
+  formatCandleDisplayStrings,
   formatLastUpdate,
-  formatVolume
+  formatVolume,
+  isFullFormatNeeded
 } from './helpers'
 
 // `traceSmoothLine` only invokes `path.moveTo(x, y)` and
@@ -97,6 +107,147 @@ describe('touchXToIndex', () => {
   })
 })
 
+// CP-14918: restores VolumeRow's original two-bar crosshair crossfade
+// (main), which the perf restructure had collapsed to a single-bar snap.
+// `volumeCrosshairWeights` is the pure interpolation this is built on —
+// exactly the two candles nearest the crosshair (`lowIndex`/`highIndex`)
+// ever get a non-zero weight; everything else is implicitly idle.
+describe('volumeCrosshairWeights', () => {
+  // 4 candles, last index 3, innerWidth 300 -> candle centers land at
+  // x = CHART_INSET + i * 100 for i in [0, 3].
+  const candleCount = 4
+  const innerWidth = 300
+  const xForIndex = (i: number): number => CHART_INSET + i * 100
+
+  it('gives full weight to that candle and zero to its neighbor when the crosshair sits exactly on a candle center', () => {
+    const result = volumeCrosshairWeights(xForIndex(1), candleCount, innerWidth)
+    expect(result.lowIndex).toBe(1)
+    expect(result.highIndex).toBe(2)
+    expect(result.lowWeight).toBe(1)
+    expect(result.highWeight).toBe(0)
+  })
+
+  it('splits weight 50/50 at the midpoint between two candle centers', () => {
+    const result = volumeCrosshairWeights(
+      xForIndex(1) + 50,
+      candleCount,
+      innerWidth
+    )
+    expect(result.lowIndex).toBe(1)
+    expect(result.highIndex).toBe(2)
+    expect(result.lowWeight).toBe(0.5)
+    expect(result.highWeight).toBe(0.5)
+  })
+
+  it('gives the first candle full weight at the left edge', () => {
+    const result = volumeCrosshairWeights(xForIndex(0), candleCount, innerWidth)
+    expect(result.lowIndex).toBe(0)
+    expect(result.highIndex).toBe(1)
+    expect(result.lowWeight).toBe(1)
+    expect(result.highWeight).toBe(0)
+  })
+
+  it('gives the last candle full weight at the right edge', () => {
+    const last = candleCount - 1
+    const result = volumeCrosshairWeights(
+      xForIndex(last),
+      candleCount,
+      innerWidth
+    )
+    expect(result.lowIndex).toBe(last)
+    expect(result.highIndex).toBe(last)
+    expect(result.lowWeight).toBe(1)
+    expect(result.highWeight).toBe(0)
+  })
+
+  it('clamps an out-of-range x below the track to the same result as the left edge', () => {
+    const edge = volumeCrosshairWeights(xForIndex(0), candleCount, innerWidth)
+    const belowRange = volumeCrosshairWeights(-1000, candleCount, innerWidth)
+    expect(belowRange).toEqual(edge)
+  })
+
+  it('clamps an out-of-range x beyond the track to the same result as the right edge', () => {
+    const last = candleCount - 1
+    const edge = volumeCrosshairWeights(
+      xForIndex(last),
+      candleCount,
+      innerWidth
+    )
+    const beyondRange = volumeCrosshairWeights(100_000, candleCount, innerWidth)
+    expect(beyondRange).toEqual(edge)
+  })
+
+  it('returns the idle sentinel for a single candle or fewer (nothing to crossfade between)', () => {
+    expect(volumeCrosshairWeights(0, 1, innerWidth)).toEqual(
+      IDLE_VOLUME_CROSSFADE
+    )
+    expect(volumeCrosshairWeights(0, 0, innerWidth)).toEqual(
+      IDLE_VOLUME_CROSSFADE
+    )
+    expect(volumeCrosshairWeights(0, 1, innerWidth).lowIndex).toBe(
+      NO_HIGHLIGHT_INDEX
+    )
+  })
+
+  it('returns the idle sentinel when innerWidth is non-positive', () => {
+    expect(volumeCrosshairWeights(50, candleCount, 0)).toEqual(
+      IDLE_VOLUME_CROSSFADE
+    )
+  })
+})
+
+// CP-14918: `VolumeRow` paints a highlight rect on top of its static idle
+// `Path`, which already painted that same bar at `VOLUME_IDLE_OPACITY`.
+// `crossfadeRectOpacity` compensates for that source-over stacking so the
+// two layers still composite to `volumeCrosshairWeights`'s target opacity
+// (`IDLE + (ACTIVE - IDLE) * weight`) exactly, rather than overshooting it.
+// This pins the compositing formula itself:
+// `1 - (1 - IDLE) * (1 - crossfadeRectOpacity(w)) === IDLE + (ACTIVE - IDLE) * w`.
+describe('crossfadeRectOpacity', () => {
+  const composite = (rectOpacity: number): number =>
+    1 - (1 - VOLUME_IDLE_OPACITY) * (1 - rectOpacity)
+  const target = (weight: number): number =>
+    VOLUME_IDLE_OPACITY + (VOLUME_ACTIVE_OPACITY - VOLUME_IDLE_OPACITY) * weight
+
+  it.each([0, 0.25, 0.5, 1])(
+    'composites to the exact per-candle target opacity for weight=%s',
+    weight => {
+      const rectOpacity = crossfadeRectOpacity(weight)
+      expect(composite(rectOpacity)).toBeCloseTo(target(weight), 12)
+    }
+  )
+
+  it('is 0 at weight=0 — a true no-op, leaving the idle bar exactly at VOLUME_IDLE_OPACITY', () => {
+    expect(crossfadeRectOpacity(0)).toBe(0)
+    expect(composite(crossfadeRectOpacity(0))).toBeCloseTo(
+      VOLUME_IDLE_OPACITY,
+      12
+    )
+  })
+
+  it('is 1 at weight=1 — fully opaque, matching VOLUME_ACTIVE_OPACITY regardless of stacking', () => {
+    expect(crossfadeRectOpacity(1)).toBe(1)
+    expect(composite(crossfadeRectOpacity(1))).toBeCloseTo(
+      VOLUME_ACTIVE_OPACITY,
+      12
+    )
+  })
+
+  it('simplifies to exactly `weight` for the current constants (ACTIVE=1, IDLE=0.1)', () => {
+    ;[0, 0.25, 0.5, 0.73, 1].forEach(weight => {
+      expect(crossfadeRectOpacity(weight)).toBeCloseTo(weight, 12)
+    })
+  })
+
+  it('the last-candle edge case (lowIndex === highIndex) still lands on full opacity once both rects are stacked', () => {
+    // lowWeight=1, highWeight=0 at the right edge (see `volumeCrosshairWeights`).
+    const afterLowRect = composite(crossfadeRectOpacity(1))
+    const afterBothRects =
+      1 - (1 - afterLowRect) * (1 - crossfadeRectOpacity(0))
+    expect(afterBothRects).toBe(VOLUME_ACTIVE_OPACITY)
+  })
+})
+
 describe('rangeBounds', () => {
   it('returns the min low and max high across all candles', () => {
     expect(rangeBounds(sampleCandles)).toEqual({ minPrice: 9, maxPrice: 14 })
@@ -173,6 +324,310 @@ describe('formatVolume', () => {
   })
   it('formats billions with B suffix', () => {
     expect(formatVolume(2_300_000_000)).toBe('Vol. $2.30B')
+  })
+  it('formats sub-1 volumes with two decimals', () => {
+    expect(formatVolume(0.5)).toBe('Vol. $0.50')
+  })
+  it('formats very large (multi-trillion, expressed as B) volumes', () => {
+    expect(formatVolume(4_200_000_000_000)).toBe('Vol. $4200.00B')
+  })
+})
+
+// CP-14918: ChartHeader/ChartFooter used to eagerly format ALL candles at
+// mount (for crosshair drag lookups) even though the crosshair-inactive
+// state only ever reads the LAST candle. `formatCandleDisplayStringAt` is
+// the O(1) mount-time replacement; it must never disagree with the
+// corresponding entry of the O(n) `formatCandleDisplayStrings` array that
+// the deferred/crosshair-active path uses, for every index the crosshair
+// can land on — a `formatPrice` sensitive to more than the raw close would
+// expose a regression here.
+describe('formatCandleDisplayStringAt — parity with formatCandleDisplayStrings', () => {
+  const formatPrice = (n: number): string => `$${n.toFixed(2)}`
+
+  it('matches the corresponding full-array entry for every index', () => {
+    const full = formatCandleDisplayStrings(sampleCandles, formatPrice)
+    sampleCandles.forEach((_, i) => {
+      expect(
+        formatCandleDisplayStringAt(sampleCandles, i, formatPrice)
+      ).toEqual(full[i])
+    })
+  })
+
+  it('matches the last-candle entry (the eager mount-time read path)', () => {
+    const full = formatCandleDisplayStrings(sampleCandles, formatPrice)
+    const lastIndex = sampleCandles.length - 1
+    expect(
+      formatCandleDisplayStringAt(sampleCandles, lastIndex, formatPrice)
+    ).toEqual(full[lastIndex])
+  })
+
+  it('returns undefined for an out-of-range index', () => {
+    expect(
+      formatCandleDisplayStringAt(sampleCandles, 99, formatPrice)
+    ).toBeUndefined()
+    expect(
+      formatCandleDisplayStringAt(sampleCandles, -1, formatPrice)
+    ).toBeUndefined()
+  })
+
+  it('returns undefined for empty candles, matching the full-array path', () => {
+    expect(formatCandleDisplayStringAt([], 0, formatPrice)).toBeUndefined()
+    expect(formatCandleDisplayStrings([], formatPrice)).toEqual([])
+  })
+})
+
+// CP-14918: `isFullFormatNeeded` is the pure gate behind `useIsFullFormatNeeded`
+// (hooks.ts), which decides when ChartHeader/ChartFooter compute the full
+// per-candle array instead of just the eagerly-formatted last candle. The
+// contract that matters most: the instant the crosshair activates (`idx`
+// goes non-null), the gate must flip to `true` regardless of whether the
+// post-mount idle tick has fired yet — so the consuming `useMemo` recomputes
+// SYNCHRONOUSLY in that same render and a drag can never read a `undefined`
+// entry for any in-range index.
+describe('isFullFormatNeeded', () => {
+  it('is false at mount before the idle tick fires and before any drag', () => {
+    expect(isFullFormatNeeded(false, null)).toBe(false)
+  })
+
+  it('becomes true once the idle tick fires, even with no active drag', () => {
+    expect(isFullFormatNeeded(true, null)).toBe(true)
+  })
+
+  it('becomes true the instant the crosshair activates, even pre-idle-tick', () => {
+    expect(isFullFormatNeeded(false, 0)).toBe(true)
+    expect(isFullFormatNeeded(false, 47)).toBe(true)
+  })
+
+  it('stays true once both conditions are true', () => {
+    expect(isFullFormatNeeded(true, 12)).toBe(true)
+  })
+
+  it('once true (crosshair active), the full array has a defined entry for every in-range index the crosshair can land on', () => {
+    const formatPrice = (n: number): string => `$${n.toFixed(2)}`
+    sampleCandles.forEach((_, idx) => {
+      // Mirrors ChartHeader/ChartFooter: `needsFull` gates whether the full
+      // array is computed at all; once gated open by activation, every
+      // valid index must resolve to a real entry, never `undefined`.
+      const needsFull = isFullFormatNeeded(false, idx)
+      expect(needsFull).toBe(true)
+      const full = formatCandleDisplayStrings(sampleCandles, formatPrice)
+      expect(full[idx]).toBeDefined()
+    })
+  })
+})
+
+// CP-14918: formatActiveTime/formatLastUpdate were changed from
+// `Intl.DateTimeFormat`-based formatting (first a fresh instance per call,
+// later a module-hoisted instance) to hand-rolled string formatting — the
+// `.format()` CALL itself, not the constructor, is what costs ~4ms on-device
+// (Hermes -> JSI -> Android ICU). `toLocaleDateString`/`toLocaleTimeString`
+// are specified (ECMA-402) to build an `Intl.DateTimeFormat(locale,
+// options)` internally and format with it, so these remain a live,
+// jest-cheap ground truth the hand-rolled implementation must match
+// byte-for-byte, run on Node's ICU (en-US) rather than device ICU.
+const intlFormatActiveTime = (ts: number, nowMs?: number): string => {
+  const d = new Date(ts)
+  const now = nowMs !== undefined ? new Date(nowMs) : new Date()
+  const sameDay =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate()
+  const datePart = sameDay
+    ? 'Today'
+    : d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  const timePart = d.toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: false
+  })
+  return `${datePart}, ${timePart}`
+}
+
+const intlFormatLastUpdate = (ts: number): string => {
+  const d = new Date(ts)
+  const datePart = d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  })
+  const timePart = d.toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit'
+  })
+  return `Last update: ${datePart} at ${timePart}`
+}
+
+// Node ICU renders midnight as "24:00" (h24); Hermes/Android ICU renders
+// "00:00" (h23), which is what `formatHour24Minute` (helpers.ts) emits. This
+// wrapper patches that one known divergence onto the Node-ICU reference
+// before comparing, so parity tests keep asserting real equivalence
+// everywhere else. CP-14918.
+const expectedActiveTime = (ts: number, nowMs?: number): string => {
+  const reference = intlFormatActiveTime(ts, nowMs)
+  const isMidnightHour = new Date(ts).getHours() === 0
+  return isMidnightHour ? reference.replace(/24:(\d{2})$/, '00:$1') : reference
+}
+
+// Hermes/Android ICU 72+ emits U+202F (narrow no-break space) between minutes
+// and AM/PM; Node's bundled ICU in this Jest environment emits ASCII 0x20. The
+// device behavior is the correct reference, so `formatHour12Minute` (helpers.ts)
+// emits U+202F. Same treatment as `expectedActiveTime` above: patch this one
+// known divergence onto the Node-ICU reference before comparing. CP-14918.
+const expectedLastUpdate = (ts: number): string =>
+  intlFormatLastUpdate(ts).replace(/ (AM|PM)$/, '\u202f$1')
+
+describe('formatActiveTime / formatLastUpdate — hand-rolled vs Intl parity', () => {
+  const cases: Array<[string, number, number | undefined]> = [
+    [
+      'same-day midnight',
+      new Date(2026, 4, 15, 0, 0, 0).getTime(),
+      new Date(2026, 4, 15, 12, 0, 0).getTime()
+    ],
+    [
+      'different-day midnight',
+      new Date(2026, 4, 14, 0, 0, 0).getTime(),
+      new Date(2026, 4, 15, 12, 0, 0).getTime()
+    ],
+    [
+      'year boundary (Dec 31 -> Jan 1)',
+      new Date(2025, 11, 31, 23, 59, 0).getTime(),
+      new Date(2026, 0, 1, 0, 30, 0).getTime()
+    ],
+    ['no explicit `now` (uses real Date.now())', Date.now(), undefined]
+  ]
+
+  it.each(cases)(
+    'formatActiveTime matches the live Intl implementation: %s',
+    (_label, ts, nowMs) => {
+      expect(formatActiveTime(ts, nowMs)).toBe(expectedActiveTime(ts, nowMs))
+    }
+  )
+
+  it.each(cases)(
+    'formatLastUpdate matches the live Intl implementation: %s',
+    (_label, ts) => {
+      expect(formatLastUpdate(ts)).toBe(expectedLastUpdate(ts))
+    }
+  )
+})
+
+// CP-14918: broad sweep of the hand-rolled formatters against live
+// `Intl`/`toLocale*` output (cheap here — Jest runs on Node, not the
+// Hermes->JSI->Android-ICU path this task removed from the hot path).
+// Covers year boundaries, leap-day, midnight/noon, single- vs double-digit
+// day/hour, the 1970 epoch, an invalid (NaN) timestamp, and — in a nested
+// describe that pins `process.env.TZ` — DST spring-forward/fall-back edges.
+describe('formatActiveTime / formatLastUpdate — Intl parity sweep', () => {
+  const originalTz = process.env.TZ
+
+  afterAll(() => {
+    process.env.TZ = originalTz
+  })
+
+  // Built from LOCAL date components (matching formatActiveTime's/
+  // formatLastUpdate's own local-time `Date` getters), so equality holds
+  // under whatever TZ the test runner happens to use.
+  const sweepTimestamps = (): number[] => {
+    const days: Array<[number, number, number]> = [
+      [2026, 0, 1], // New Year's Day
+      [2025, 11, 31], // New Year's Eve (year boundary, other side)
+      [2026, 1, 28], // non-leap Feb
+      [2028, 1, 29], // leap-day
+      [2026, 3, 5], // single-digit day
+      [2026, 3, 15], // double-digit day
+      [1970, 0, 1] // epoch date
+    ]
+    const hours = [0, 1, 9, 10, 12, 13, 23] // midnight, single/double-digit, noon
+    const minutes = [0, 5, 30, 59]
+    const timestamps: number[] = []
+    for (const [y, m, day] of days) {
+      for (const hour of hours) {
+        for (const minute of minutes) {
+          timestamps.push(new Date(y, m, day, hour, minute, 0).getTime())
+        }
+      }
+    }
+    return timestamps
+  }
+
+  it('formatActiveTime matches live Intl output across the sweep', () => {
+    const now = new Date(2026, 3, 15, 12, 0, 0).getTime()
+    for (const ts of sweepTimestamps()) {
+      expect(formatActiveTime(ts, now)).toBe(expectedActiveTime(ts, now))
+    }
+  })
+
+  it('formatLastUpdate matches live Intl output across the sweep', () => {
+    for (const ts of sweepTimestamps()) {
+      expect(formatLastUpdate(ts)).toBe(expectedLastUpdate(ts))
+    }
+  })
+
+  it('handles the 1970-01-01 epoch without throwing, matching Intl', () => {
+    const ts = new Date(1970, 0, 1, 0, 0, 0).getTime()
+    expect(formatActiveTime(ts, ts)).toBe(expectedActiveTime(ts, ts))
+    expect(formatLastUpdate(ts)).toBe(expectedLastUpdate(ts))
+  })
+
+  it('pins the AM/PM separator to U+202F (NNBSP), not an ASCII space — device-confirmed divergence from Node ICU', () => {
+    // This asserts the exact byte directly, NOT via `expectedLastUpdate`'s
+    // Node-ICU reference (which would just prove the normalization regex
+    // works, not that the hand-rolled formatter emits the right codepoint).
+    // Hermes/Android ICU emits U+202F between the minutes and AM/PM;
+    // Node's bundled ICU here still emits a plain ASCII space (0x20) for
+    // the same option bag — that's the whole reason this needed pinning
+    // rather than relying on Node-Intl parity. If a future change reverts
+    // `formatHour12Minute` to an ASCII space, this must fail loudly.
+    const nineOhFiveAm = new Date(2026, 3, 29, 9, 5, 0).getTime()
+    const noonNoon = new Date(2026, 3, 29, 12, 0, 0).getTime()
+
+    expect(formatLastUpdate(nineOhFiveAm)).toContain('9:05\u202fAM')
+    expect(formatLastUpdate(nineOhFiveAm)).not.toContain('9:05 AM') // ASCII-space regression guard
+    expect(formatLastUpdate(noonNoon)).toContain('12:00\u202fPM')
+    expect(formatLastUpdate(noonNoon)).not.toContain('12:00 PM') // ASCII-space regression guard
+  })
+
+  it('throws the same RangeError as raw Intl.DateTimeFormat#format for an invalid (NaN) timestamp', () => {
+    // NOTE: `Date.prototype.toLocaleDateString`/`toLocaleTimeString` special-case
+    // an invalid time value and return the string "Invalid Date" instead of
+    // throwing (ECMA-402 has an explicit NaN short-circuit before delegating
+    // to the internal formatter) — so `intlFormatActiveTime`/`intlFormatLastUpdate`
+    // above are NOT the right reference here. The actual pre-CP-14918
+    // production code called `Intl.DateTimeFormat(...).format(d)` directly
+    // (no such short-circuit), which DOES throw — that's the real contract
+    // the hand-rolled formatters must preserve.
+    const rawFormatter = new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric'
+    })
+    expect(() => formatActiveTime(NaN)).toThrow(RangeError)
+    expect(() => rawFormatter.format(new Date(NaN))).toThrow(RangeError)
+    expect(() => formatLastUpdate(NaN)).toThrow(RangeError)
+  })
+
+  describe('DST transitions (America/New_York)', () => {
+    beforeAll(() => {
+      process.env.TZ = 'America/New_York'
+    })
+
+    afterAll(() => {
+      process.env.TZ = originalTz
+    })
+
+    it('matches live Intl output across the 2026 spring-forward/fall-back edges', () => {
+      const dstTimestamps = [
+        new Date(2026, 2, 8, 1, 59, 0).getTime(), // just before spring-forward
+        new Date(2026, 2, 8, 3, 1, 0).getTime(), // just after (2-3am doesn't exist)
+        new Date(2026, 10, 1, 0, 30, 0).getTime(), // just before fall-back
+        new Date(2026, 10, 1, 1, 30, 0).getTime() // ambiguous hour (occurs twice)
+      ]
+      const now = new Date(2026, 2, 8, 12, 0, 0).getTime()
+      for (const ts of dstTimestamps) {
+        expect(formatActiveTime(ts, now)).toBe(expectedActiveTime(ts, now))
+        expect(formatLastUpdate(ts)).toBe(expectedLastUpdate(ts))
+      }
+    })
   })
 })
 

--- a/packages/k2-alpine/src/components/Chart/PriceChart/helpers.test.ts
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/helpers.test.ts
@@ -107,11 +107,8 @@ describe('touchXToIndex', () => {
   })
 })
 
-// CP-14918: restores VolumeRow's original two-bar crosshair crossfade
-// (main), which the perf restructure had collapsed to a single-bar snap.
-// `volumeCrosshairWeights` is the pure interpolation this is built on —
-// exactly the two candles nearest the crosshair (`lowIndex`/`highIndex`)
-// ever get a non-zero weight; everything else is implicitly idle.
+// Only the two candles bracketing the crosshair get a non-zero weight;
+// everything else stays idle.
 describe('volumeCrosshairWeights', () => {
   // 4 candles, last index 3, innerWidth 300 -> candle centers land at
   // x = CHART_INSET + i * 100 for i in [0, 3].
@@ -196,13 +193,8 @@ describe('volumeCrosshairWeights', () => {
   })
 })
 
-// CP-14918: `VolumeRow` paints a highlight rect on top of its static idle
-// `Path`, which already painted that same bar at `VOLUME_IDLE_OPACITY`.
-// `crossfadeRectOpacity` compensates for that source-over stacking so the
-// two layers still composite to `volumeCrosshairWeights`'s target opacity
-// (`IDLE + (ACTIVE - IDLE) * weight`) exactly, rather than overshooting it.
-// This pins the compositing formula itself:
-// `1 - (1 - IDLE) * (1 - crossfadeRectOpacity(w)) === IDLE + (ACTIVE - IDLE) * w`.
+// Pins the compositing invariant `crossfadeRectOpacity` exists to satisfy:
+// `1 - (1 - IDLE) * (1 - rect(w)) === IDLE + (ACTIVE - IDLE) * w`.
 describe('crossfadeRectOpacity', () => {
   const composite = (rectOpacity: number): number =>
     1 - (1 - VOLUME_IDLE_OPACITY) * (1 - rectOpacity)
@@ -333,14 +325,8 @@ describe('formatVolume', () => {
   })
 })
 
-// CP-14918: ChartHeader/ChartFooter used to eagerly format ALL candles at
-// mount (for crosshair drag lookups) even though the crosshair-inactive
-// state only ever reads the LAST candle. `formatCandleDisplayStringAt` is
-// the O(1) mount-time replacement; it must never disagree with the
-// corresponding entry of the O(n) `formatCandleDisplayStrings` array that
-// the deferred/crosshair-active path uses, for every index the crosshair
-// can land on — a `formatPrice` sensitive to more than the raw close would
-// expose a regression here.
+// The O(1) mount-time formatter must agree with the O(n) array at every
+// index, or a crosshair drag would show different text than mount rendered.
 describe('formatCandleDisplayStringAt — parity with formatCandleDisplayStrings', () => {
   const formatPrice = (n: number): string => `$${n.toFixed(2)}`
 
@@ -376,14 +362,8 @@ describe('formatCandleDisplayStringAt — parity with formatCandleDisplayStrings
   })
 })
 
-// CP-14918: `isFullFormatNeeded` is the pure gate behind `useIsFullFormatNeeded`
-// (hooks.ts), which decides when ChartHeader/ChartFooter compute the full
-// per-candle array instead of just the eagerly-formatted last candle. The
-// contract that matters most: the instant the crosshair activates (`idx`
-// goes non-null), the gate must flip to `true` regardless of whether the
-// post-mount idle tick has fired yet — so the consuming `useMemo` recomputes
-// SYNCHRONOUSLY in that same render and a drag can never read a `undefined`
-// entry for any in-range index.
+// Contract: activation must flip the gate within the same render, so the
+// gated `useMemo` can never hand a drag a missing entry.
 describe('isFullFormatNeeded', () => {
   it('is false at mount before the idle tick fires and before any drag', () => {
     expect(isFullFormatNeeded(false, null)).toBe(false)
@@ -416,15 +396,9 @@ describe('isFullFormatNeeded', () => {
   })
 })
 
-// CP-14918: formatActiveTime/formatLastUpdate were changed from
-// `Intl.DateTimeFormat`-based formatting (first a fresh instance per call,
-// later a module-hoisted instance) to hand-rolled string formatting — the
-// `.format()` CALL itself, not the constructor, is what costs ~4ms on-device
-// (Hermes -> JSI -> Android ICU). `toLocaleDateString`/`toLocaleTimeString`
-// are specified (ECMA-402) to build an `Intl.DateTimeFormat(locale,
-// options)` internally and format with it, so these remain a live,
-// jest-cheap ground truth the hand-rolled implementation must match
-// byte-for-byte, run on Node's ICU (en-US) rather than device ICU.
+// `toLocale*` is spec'd (ECMA-402) to build an `Intl.DateTimeFormat`
+// internally, so it's a live oracle for the hand-rolled formatters — cheap on
+// Node's ICU, expensive on the device path this replaced.
 const intlFormatActiveTime = (ts: number, nowMs?: number): string => {
   const d = new Date(ts)
   const now = nowMs !== undefined ? new Date(nowMs) : new Date()
@@ -461,8 +435,7 @@ const intlFormatLastUpdate = (ts: number): string => {
 // Node ICU renders midnight as "24:00" (h24); Hermes/Android ICU renders
 // "00:00" (h23), which is what `formatHour24Minute` (helpers.ts) emits. This
 // wrapper patches that one known divergence onto the Node-ICU reference
-// before comparing, so parity tests keep asserting real equivalence
-// everywhere else. CP-14918.
+// before comparing.
 const expectedActiveTime = (ts: number, nowMs?: number): string => {
   const reference = intlFormatActiveTime(ts, nowMs)
   const isMidnightHour = new Date(ts).getHours() === 0
@@ -470,10 +443,8 @@ const expectedActiveTime = (ts: number, nowMs?: number): string => {
 }
 
 // Hermes/Android ICU 72+ emits U+202F (narrow no-break space) between minutes
-// and AM/PM; Node's bundled ICU in this Jest environment emits ASCII 0x20. The
-// device behavior is the correct reference, so `formatHour12Minute` (helpers.ts)
-// emits U+202F. Same treatment as `expectedActiveTime` above: patch this one
-// known divergence onto the Node-ICU reference before comparing. CP-14918.
+// and AM/PM; Node's bundled ICU here emits ASCII 0x20. Device behavior is the
+// reference, so patch this divergence onto it as above.
 const expectedLastUpdate = (ts: number): string =>
   intlFormatLastUpdate(ts).replace(/ (AM|PM)$/, '\u202f$1')
 
@@ -512,12 +483,7 @@ describe('formatActiveTime / formatLastUpdate — hand-rolled vs Intl parity', (
   )
 })
 
-// CP-14918: broad sweep of the hand-rolled formatters against live
-// `Intl`/`toLocale*` output (cheap here — Jest runs on Node, not the
-// Hermes->JSI->Android-ICU path this task removed from the hot path).
-// Covers year boundaries, leap-day, midnight/noon, single- vs double-digit
-// day/hour, the 1970 epoch, an invalid (NaN) timestamp, and — in a nested
-// describe that pins `process.env.TZ` — DST spring-forward/fall-back edges.
+// Parity sweep against live Intl output.
 describe('formatActiveTime / formatLastUpdate — Intl parity sweep', () => {
   const originalTz = process.env.TZ
 
@@ -571,14 +537,9 @@ describe('formatActiveTime / formatLastUpdate — Intl parity sweep', () => {
   })
 
   it('pins the AM/PM separator to U+202F (NNBSP), not an ASCII space — device-confirmed divergence from Node ICU', () => {
-    // This asserts the exact byte directly, NOT via `expectedLastUpdate`'s
-    // Node-ICU reference (which would just prove the normalization regex
-    // works, not that the hand-rolled formatter emits the right codepoint).
-    // Hermes/Android ICU emits U+202F between the minutes and AM/PM;
-    // Node's bundled ICU here still emits a plain ASCII space (0x20) for
-    // the same option bag — that's the whole reason this needed pinning
-    // rather than relying on Node-Intl parity. If a future change reverts
-    // `formatHour12Minute` to an ASCII space, this must fail loudly.
+    // Asserts the exact codepoint directly, not via the Node-ICU reference —
+    // that would only prove the normalization regex works. Hermes emits U+202F
+    // here; Node emits ASCII 0x20, which is why this needs pinning.
     const nineOhFiveAm = new Date(2026, 3, 29, 9, 5, 0).getTime()
     const noonNoon = new Date(2026, 3, 29, 12, 0, 0).getTime()
 
@@ -589,14 +550,10 @@ describe('formatActiveTime / formatLastUpdate — Intl parity sweep', () => {
   })
 
   it('throws the same RangeError as raw Intl.DateTimeFormat#format for an invalid (NaN) timestamp', () => {
-    // NOTE: `Date.prototype.toLocaleDateString`/`toLocaleTimeString` special-case
-    // an invalid time value and return the string "Invalid Date" instead of
-    // throwing (ECMA-402 has an explicit NaN short-circuit before delegating
-    // to the internal formatter) — so `intlFormatActiveTime`/`intlFormatLastUpdate`
-    // above are NOT the right reference here. The actual pre-CP-14918
-    // production code called `Intl.DateTimeFormat(...).format(d)` directly
-    // (no such short-circuit), which DOES throw — that's the real contract
-    // the hand-rolled formatters must preserve.
+    // `toLocale*` short-circuits NaN to the string "Invalid Date" (ECMA-402)
+    // instead of throwing, so the wrappers above are the wrong oracle here.
+    // `Intl.DateTimeFormat#format` has no such short-circuit and throws —
+    // that's the contract the hand-rolled formatters preserve.
     const rawFormatter = new Intl.DateTimeFormat(undefined, {
       month: 'short',
       day: 'numeric'

--- a/packages/k2-alpine/src/components/Chart/PriceChart/helpers.ts
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/helpers.ts
@@ -55,16 +55,12 @@ export const NO_HIGHLIGHT_INDEX = -1
 export type VolumeCrossfade = {
   lowIndex: number
   highIndex: number
-  /** 1 when the crosshair sits exactly on `lowIndex`, 0 when it has drifted
-   * all the way to `highIndex`. */
+  /** Weight 1 = crosshair exactly on that index, 0 = fully drifted to the
+   * other. Sum is 1 whenever a highlight is active. */
   lowWeight: number
-  /** 1 when the crosshair sits exactly on `highIndex`, 0 when it has
-   * drifted all the way to `lowIndex`. `lowWeight + highWeight === 1`
-   * whenever a highlight is active. */
   highWeight: number
 }
 
-/** Nothing highlighted — both indices are the sentinel, both weights 0. */
 export const IDLE_VOLUME_CROSSFADE: VolumeCrossfade = {
   lowIndex: NO_HIGHLIGHT_INDEX,
   highIndex: NO_HIGHLIGHT_INDEX,
@@ -73,26 +69,11 @@ export const IDLE_VOLUME_CROSSFADE: VolumeCrossfade = {
 }
 
 /**
- * Two-bar crossfade weights for `VolumeRow`'s crosshair highlight —
- * restores main's original per-candle interpolation (each candle's opacity
- * was `ACTIVE - (ACTIVE - IDLE) * distance` for `distance = |fracIndex -
- * i| < 1`, `IDLE` otherwise, where `fracIndex` is the crosshair's position
- * in candle-index units) without reintroducing one `SharedValue` per
- * candle: at most two candles — `floor(fracIndex)` and `ceil(fracIndex)` —
- * can ever be within one candle-width of the crosshair, so this returns
- * just those two plus a 0-1 weight each. `IDLE + (ACTIVE - IDLE) * weight`
- * per side is main's target *composite* opacity for that candle (weight is
- * `1 - distance` for that side) — see `crossfadeRectOpacity` for how
- * `VolumeRow` actually paints a rect to land on that target once its
- * static idle `Path` (drawn underneath, at `VOLUME_IDLE_OPACITY`) is
- * composited in too.
- *
- * Purely geometric — callers gate on crosshair-active state themselves
- * (see `VolumeRow`'s `useAnimatedReaction`) and fall back to
- * `IDLE_VOLUME_CROSSFADE` when inactive, so this only needs to guard
- * against a degenerate track.
- *
- * Worklet — called from a `useAnimatedReaction` on the UI thread.
+ * Two-bar crossfade weights for VolumeRow's crosshair highlight. Only the
+ * two candles bracketing the crosshair can be within one candle-width of
+ * it, so returning just those two reproduces the per-candle opacity ramp
+ * without one SharedValue per candle. Purely geometric — callers gate on
+ * active state and substitute IDLE_VOLUME_CROSSFADE. Worklet.
  */
 export const volumeCrosshairWeights = (
   x: number,
@@ -118,38 +99,16 @@ export const volumeCrosshairWeights = (
 /** Idle opacity of every bar in `VolumeRow`'s static `Path` — including
  * the two candles a highlight rect may be drawn on top of. */
 export const VOLUME_IDLE_OPACITY = 0.1
-/** Fully-highlighted opacity a candle reaches when the crosshair sits
- * exactly on it. */
+/** Composite target opacity when the crosshair sits exactly on a candle. */
 export const VOLUME_ACTIVE_OPACITY = 1
 
 /**
- * `VolumeRow` paints a highlight rect ON TOP OF its static idle `Path`,
- * which already painted that same bar at `VOLUME_IDLE_OPACITY` — the two
- * source-over layers are the same color, so they don't blend hues, but
- * their alphas still combine as `1 - (1 - VOLUME_IDLE_OPACITY) * (1 -
- * rectOpacity)`. Painting the rect at the raw target opacity (`IDLE +
- * (ACTIVE - IDLE) * weight`, see `volumeCrosshairWeights`) would double-count
- * the idle layer's contribution and overshoot the target everywhere except
- * `weight` 0 and 1. Solving `1 - (1 - IDLE) * (1 - rectOpacity) = IDLE +
- * (ACTIVE - IDLE) * weight` for `rectOpacity` gives:
- *
- *   rectOpacity = (ACTIVE - IDLE) * weight / (1 - IDLE)
- *
- * With the current constants (`ACTIVE = 1`, `IDLE = 0.1`) the `(1 - IDLE)`
- * factors cancel and this simplifies to exactly `weight` — kept as the
- * general formula (rather than hardcoding that simplification) so the
- * compositing invariant survives either constant changing.
- *
- * `weight = 0` maps to `rectOpacity = 0` — a fully transparent rect is a
- * true no-op, so the bar is left showing exactly the idle `Path`'s
- * `VOLUME_IDLE_OPACITY`, not something inflated by a stray draw.
- * `weight = 1` maps to `rectOpacity = 1`, matching `VOLUME_ACTIVE_OPACITY`
- * (an opaque top layer fully occludes the idle layer beneath it, so
- * stacking order/count beyond that doesn't matter — this is also why the
- * last-candle edge case, where `lowIndex === highIndex` and both rects
- * draw at the same spot, still lands exactly on `VOLUME_ACTIVE_OPACITY`).
- *
- * Worklet — called from `useDerivedValue` callbacks on the UI thread.
+ * The highlight rect paints over the idle Path, so their alphas compose as
+ * 1 - (1 - IDLE) * (1 - rect). Solving that for the target
+ * IDLE + (ACTIVE - IDLE) * weight gives the expression below; painting the
+ * raw target instead double-counts the idle layer and overshoots.
+ * With today's constants it reduces to weight — left general so the
+ * invariant survives a constant change. Worklet.
  */
 export const crossfadeRectOpacity = (weight: number): number => {
   'worklet'
@@ -174,9 +133,10 @@ export const rangeBounds = (
   return { minPrice, maxPrice }
 }
 
-// Hand-rolled to avoid ~4ms/call Intl JSI crossings (~96 calls/mount).
-// Hardcodes en-US regardless of device locale -- Open decision #2 (doc
-// §15.7), not yet resolved. CP-14918.
+// Hand-rolled instead of Intl/toLocale*: each .format() call crosses
+// Hermes -> JSI -> native ICU (multiple ms per call on-device), and a
+// chart mount made ~96 of them. Trade-off: output is en-US regardless of
+// device locale. CP-14918.
 const MONTH_ABBR = [
   'Jan',
   'Feb',
@@ -211,30 +171,23 @@ const formatMonthDay = (d: Date): string => {
   return `${MONTH_ABBR[d.getMonth()]} ${d.getDate()}`
 }
 
-/**
- * `{ hour: 'numeric', minute: '2-digit', hour12: false }`-equivalent,
- * zero-padded to 2 digits, hours 0-23 (h23), e.g. midnight -> "00:00".
- *
- * Emits `00:00` for midnight, not Node ICU's `24:00` -- matches
- * Hermes/Android ICU (h23). Do not revert; `helpers.test.ts` pins this.
- * CP-14918.
- */
+/** en-US `{ hour: 'numeric', minute: '2-digit', hour12: false }`,
+ * zero-padded. Midnight is "00:00" (h23, matching Hermes/Android ICU), not
+ * Node ICU's "24:00" — `helpers.test.ts` pins this. */
 const formatHour24Minute = (d: Date): string => {
   assertValidDate(d)
   const hour = d.getHours()
   return `${pad2(hour)}:${pad2(d.getMinutes())}`
 }
 
+/** Must stay U+202F (narrow no-break space), not ASCII space — matches
+ * Hermes/Android ICU 72+. Byte-pinned by `helpers.test.ts`; do not "clean
+ * up" back to a plain space. CP-14918. */
+const AM_PM_SEPARATOR = '\u202f' // NARROW NO-BREAK SPACE
+
 /** en-US `{ hour: 'numeric', minute: '2-digit' }` (hour12 defaults to true
  * for en-US) — e.g. "9:41\u202fAM", "12:00\u202fPM". Hour is NOT
- * zero-padded; minute is.
- *
- * `AM_PM_SEPARATOR` must stay U+202F (narrow no-break space), not ASCII
- * space -- matches Hermes/Android ICU 72+. Byte-pinned by
- * `helpers.test.ts`; do not "clean up" back to a plain space. CP-14918.
- */
-const AM_PM_SEPARATOR = '\u202f' // NARROW NO-BREAK SPACE — see doc comment above.
-
+ * zero-padded; minute is. */
 const formatHour12Minute = (d: Date): string => {
   assertValidDate(d)
   const hour = d.getHours()
@@ -252,9 +205,9 @@ const formatWeekdayMonthDayYear = (d: Date): string => {
   } ${d.getDate()}, ${d.getFullYear()}`
 }
 
-/** e.g. "Last update: Wed, Apr 29, 2026 at 9:41\u202fAM" — the AM/PM
- * separator is U+202F (narrow no-break space), not an ASCII space; see
- * `AM_PM_SEPARATOR`. */
+/** e.g. "Last update: Wed, Apr 29, 2026 at 9:41\u202fAM" (U+202F before
+ * AM/PM, see `AM_PM_SEPARATOR`). Hand-rolled rather than Intl — see
+ * `MONTH_ABBR`. */
 export const formatLastUpdate = (ts: number): string => {
   const d = new Date(ts)
   const datePart = formatWeekdayMonthDayYear(d)
@@ -308,10 +261,8 @@ export const priceChangeStatusFromDelta = (
   return PriceChangeStatus.Neutral
 }
 
-/** Single-candle body shared by `formatCandleDisplayStrings` (all candles)
- * and `formatCandleDisplayStringAt` (one candle) so the two paths are
- * byte-for-byte identical — the deferred full-array computation must never
- * disagree with the eager single-candle one it stands in for at mount. */
+/** Shared by the O(n) and O(1) formatters so the deferred full array can
+ * never disagree with the single entry rendered eagerly at mount. */
 const formatCandleEntry = (
   candle: OhlcCandle,
   firstOpen: number,
@@ -344,12 +295,10 @@ export const formatCandleDisplayStrings = (
 }
 
 /**
- * O(1) variant of `formatCandleDisplayStrings` for a single candle index —
- * lets a mount-time render compute only the one entry it actually displays
- * (the crosshair-inactive state only ever reads the last candle) instead of
- * paying the ~96 `Intl.format()` calls for all candles up front. The full
- * array is computed lazily elsewhere (see `useIsFullFormatNeeded` in
- * `hooks.ts`) for crosshair-drag lookups.
+ * O(1) counterpart to `formatCandleDisplayStrings`. Mount only ever displays
+ * the last candle, so formatting all of them up front paid the full Intl
+ * cost (see `MONTH_ABBR`) for one visible row; the full array is deferred
+ * via `useIsFullFormatNeeded`.
  */
 export const formatCandleDisplayStringAt = (
   candles: OhlcCandle[],
@@ -375,10 +324,8 @@ export const crosshairInnerAnchorTarget = (
   return 0
 }
 
-/** e.g. "Today, 07:25" or "Apr 29, 07:25" — 24-hour (h23, midnight = "00"),
- * no AM/PM. See the CP-14918 comment above `MONTH_ABBR` for why this is
- * hand-rolled instead of an `Intl.DateTimeFormat`, and the comment above
- * `formatHour24Minute` for the h23-vs-h24 midnight correction. */
+/** e.g. "Today, 07:25" or "Apr 29, 07:25" — 24-hour, no AM/PM.
+ * Hand-rolled, not Intl; see `MONTH_ABBR` and `formatHour24Minute`. */
 export const formatActiveTime = (ts: number, nowMs?: number): string => {
   const d = new Date(ts)
   const now = nowMs !== undefined ? new Date(nowMs) : new Date()
@@ -391,14 +338,8 @@ export const formatActiveTime = (ts: number, nowMs?: number): string => {
   return `${datePart}, ${timePart}`
 }
 
-/**
- * Pure gating decision behind `useIsFullFormatNeeded` (hooks.ts), pulled out
- * here (no reanimated dependency) so it's unit-testable without mounting a
- * component — this package has no component-render test harness. The full
- * "format every candle" array is needed once EITHER the post-mount idle
- * tick has fired OR the crosshair has been activated at least once (`idx`
- * non-null) — whichever happens first.
- */
+/** Extracted from `useIsFullFormatNeeded` (hooks.ts) only so the gate is
+ * unit-testable — this package has no component-render harness. */
 export const isFullFormatNeeded = (
   idleReady: boolean,
   idx: number | null

--- a/packages/k2-alpine/src/components/Chart/PriceChart/helpers.ts
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/helpers.ts
@@ -1,6 +1,7 @@
 import type { Skia } from '@shopify/react-native-skia'
 import { PriceChangeStatus } from '../../PriceChangeIndicator/types'
 import {
+  CHART_INSET,
   HEADER_LEFT_ZONE_THRESHOLD,
   HEADER_RIGHT_ZONE_THRESHOLD
 } from './constants'
@@ -49,6 +50,117 @@ export const touchXToIndex = (
   return Math.max(0, Math.min(candleCount - 1, rounded))
 }
 
+/** Sentinel for "no candle is highlighted" in a `VolumeCrossfade` — no
+ * candle index is ever negative. */
+export const NO_HIGHLIGHT_INDEX = -1
+
+export type VolumeCrossfade = {
+  lowIndex: number
+  highIndex: number
+  /** 1 when the crosshair sits exactly on `lowIndex`, 0 when it has drifted
+   * all the way to `highIndex`. */
+  lowWeight: number
+  /** 1 when the crosshair sits exactly on `highIndex`, 0 when it has
+   * drifted all the way to `lowIndex`. `lowWeight + highWeight === 1`
+   * whenever a highlight is active. */
+  highWeight: number
+}
+
+/** Nothing highlighted — both indices are the sentinel, both weights 0. */
+export const IDLE_VOLUME_CROSSFADE: VolumeCrossfade = {
+  lowIndex: NO_HIGHLIGHT_INDEX,
+  highIndex: NO_HIGHLIGHT_INDEX,
+  lowWeight: 0,
+  highWeight: 0
+}
+
+/**
+ * Two-bar crossfade weights for `VolumeRow`'s crosshair highlight —
+ * restores main's original per-candle interpolation (each candle's opacity
+ * was `ACTIVE - (ACTIVE - IDLE) * distance` for `distance = |fracIndex -
+ * i| < 1`, `IDLE` otherwise, where `fracIndex` is the crosshair's position
+ * in candle-index units) without reintroducing one `SharedValue` per
+ * candle: at most two candles — `floor(fracIndex)` and `ceil(fracIndex)` —
+ * can ever be within one candle-width of the crosshair, so this returns
+ * just those two plus a 0-1 weight each. `IDLE + (ACTIVE - IDLE) * weight`
+ * per side is main's target *composite* opacity for that candle (weight is
+ * `1 - distance` for that side) — see `crossfadeRectOpacity` for how
+ * `VolumeRow` actually paints a rect to land on that target once its
+ * static idle `Path` (drawn underneath, at `VOLUME_IDLE_OPACITY`) is
+ * composited in too.
+ *
+ * Purely geometric — callers gate on crosshair-active state themselves
+ * (see `VolumeRow`'s `useAnimatedReaction`) and fall back to
+ * `IDLE_VOLUME_CROSSFADE` when inactive, so this only needs to guard
+ * against a degenerate track.
+ *
+ * Worklet — called from a `useAnimatedReaction` on the UI thread.
+ */
+export const volumeCrosshairWeights = (
+  x: number,
+  candleCount: number,
+  innerWidth: number
+): VolumeCrossfade => {
+  'worklet'
+  if (candleCount <= 1 || innerWidth <= 0) {
+    return IDLE_VOLUME_CROSSFADE
+  }
+  const last = candleCount - 1
+  const fracIndex = Math.max(
+    0,
+    Math.min(last, ((x - CHART_INSET) / innerWidth) * last)
+  )
+  const lowIndex = Math.floor(fracIndex)
+  const highIndex = Math.min(last, lowIndex + 1)
+  const highWeight = fracIndex - lowIndex
+  const lowWeight = 1 - highWeight
+  return { lowIndex, highIndex, lowWeight, highWeight }
+}
+
+/** Idle opacity of every bar in `VolumeRow`'s static `Path` — including
+ * the two candles a highlight rect may be drawn on top of. */
+export const VOLUME_IDLE_OPACITY = 0.1
+/** Fully-highlighted opacity a candle reaches when the crosshair sits
+ * exactly on it. */
+export const VOLUME_ACTIVE_OPACITY = 1
+
+/**
+ * `VolumeRow` paints a highlight rect ON TOP OF its static idle `Path`,
+ * which already painted that same bar at `VOLUME_IDLE_OPACITY` — the two
+ * source-over layers are the same color, so they don't blend hues, but
+ * their alphas still combine as `1 - (1 - VOLUME_IDLE_OPACITY) * (1 -
+ * rectOpacity)`. Painting the rect at the raw target opacity (`IDLE +
+ * (ACTIVE - IDLE) * weight`, see `volumeCrosshairWeights`) would double-count
+ * the idle layer's contribution and overshoot the target everywhere except
+ * `weight` 0 and 1. Solving `1 - (1 - IDLE) * (1 - rectOpacity) = IDLE +
+ * (ACTIVE - IDLE) * weight` for `rectOpacity` gives:
+ *
+ *   rectOpacity = (ACTIVE - IDLE) * weight / (1 - IDLE)
+ *
+ * With the current constants (`ACTIVE = 1`, `IDLE = 0.1`) the `(1 - IDLE)`
+ * factors cancel and this simplifies to exactly `weight` — kept as the
+ * general formula (rather than hardcoding that simplification) so the
+ * compositing invariant survives either constant changing.
+ *
+ * `weight = 0` maps to `rectOpacity = 0` — a fully transparent rect is a
+ * true no-op, so the bar is left showing exactly the idle `Path`'s
+ * `VOLUME_IDLE_OPACITY`, not something inflated by a stray draw.
+ * `weight = 1` maps to `rectOpacity = 1`, matching `VOLUME_ACTIVE_OPACITY`
+ * (an opaque top layer fully occludes the idle layer beneath it, so
+ * stacking order/count beyond that doesn't matter — this is also why the
+ * last-candle edge case, where `lowIndex === highIndex` and both rects
+ * draw at the same spot, still lands exactly on `VOLUME_ACTIVE_OPACITY`).
+ *
+ * Worklet — called from `useDerivedValue` callbacks on the UI thread.
+ */
+export const crossfadeRectOpacity = (weight: number): number => {
+  'worklet'
+  return (
+    ((VOLUME_ACTIVE_OPACITY - VOLUME_IDLE_OPACITY) * weight) /
+    (1 - VOLUME_IDLE_OPACITY)
+  )
+}
+
 export const rangeBounds = (
   candles: OhlcCandle[]
 ): { minPrice: number; maxPrice: number } => {
@@ -64,19 +176,89 @@ export const rangeBounds = (
   return { minPrice, maxPrice }
 }
 
+// Hand-rolled to avoid ~4ms/call Intl JSI crossings (~96 calls/mount).
+// Hardcodes en-US regardless of device locale -- Open decision #2 (doc
+// §15.7), not yet resolved. CP-14918.
+const MONTH_ABBR = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec'
+]
+const WEEKDAY_ABBR = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+const pad2 = (n: number): string => (n < 10 ? `0${n}` : `${n}`)
+
+/** Matches `Intl.DateTimeFormat.prototype.format`'s `RangeError: Invalid
+ * time value` for a NaN-time `Date`, so hand-rolled formatters fail the same
+ * way the Intl-based ones they replace did. */
+const assertValidDate = (d: Date): void => {
+  if (Number.isNaN(d.getTime())) {
+    throw new RangeError('Invalid time value')
+  }
+}
+
+/** en-US `{ month: 'short', day: 'numeric' }` — e.g. "Apr 29". No leading
+ * zero on day. */
+const formatMonthDay = (d: Date): string => {
+  assertValidDate(d)
+  return `${MONTH_ABBR[d.getMonth()]} ${d.getDate()}`
+}
+
+/**
+ * `{ hour: 'numeric', minute: '2-digit', hour12: false }`-equivalent,
+ * zero-padded to 2 digits, hours 0-23 (h23), e.g. midnight -> "00:00".
+ *
+ * Emits `00:00` for midnight, not Node ICU's `24:00` -- matches
+ * Hermes/Android ICU (h23). Do not revert; `helpers.test.ts` pins this.
+ * CP-14918.
+ */
+const formatHour24Minute = (d: Date): string => {
+  assertValidDate(d)
+  const hour = d.getHours()
+  return `${pad2(hour)}:${pad2(d.getMinutes())}`
+}
+
+/** en-US `{ hour: 'numeric', minute: '2-digit' }` (hour12 defaults to true
+ * for en-US) — e.g. "9:41\u202fAM", "12:00\u202fPM". Hour is NOT
+ * zero-padded; minute is.
+ *
+ * `AM_PM_SEPARATOR` must stay U+202F (narrow no-break space), not ASCII
+ * space -- matches Hermes/Android ICU 72+. Byte-pinned by
+ * `helpers.test.ts`; do not "clean up" back to a plain space. CP-14918.
+ */
+const AM_PM_SEPARATOR = '\u202f' // NARROW NO-BREAK SPACE — see doc comment above.
+
+const formatHour12Minute = (d: Date): string => {
+  assertValidDate(d)
+  const hour = d.getHours()
+  const period = hour < 12 ? 'AM' : 'PM'
+  const displayHour = hour % 12 === 0 ? 12 : hour % 12
+  return `${displayHour}:${pad2(d.getMinutes())}${AM_PM_SEPARATOR}${period}`
+}
+
+/** en-US `{ weekday: 'short', month: 'short', day: 'numeric', year:
+ * 'numeric' }` — e.g. "Wed, Apr 29, 2026". */
+const formatWeekdayMonthDayYear = (d: Date): string => {
+  assertValidDate(d)
+  return `${WEEKDAY_ABBR[d.getDay()]}, ${
+    MONTH_ABBR[d.getMonth()]
+  } ${d.getDate()}, ${d.getFullYear()}`
+}
+
 /** e.g. "Last update: Wed, Apr 29, 2026 at 9:41 AM" */
 export const formatLastUpdate = (ts: number): string => {
   const d = new Date(ts)
-  const datePart = d.toLocaleDateString(undefined, {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric'
-  })
-  const timePart = d.toLocaleTimeString(undefined, {
-    hour: 'numeric',
-    minute: '2-digit'
-  })
+  const datePart = formatWeekdayMonthDayYear(d)
+  const timePart = formatHour12Minute(d)
   return `Last update: ${datePart} at ${timePart}`
 }
 
@@ -126,29 +308,58 @@ export const priceChangeStatusFromDelta = (
   return PriceChangeStatus.Neutral
 }
 
+/** Single-candle body shared by `formatCandleDisplayStrings` (all candles)
+ * and `formatCandleDisplayStringAt` (one candle) so the two paths are
+ * byte-for-byte identical — the deferred full-array computation must never
+ * disagree with the eager single-candle one it stands in for at mount. */
+const formatCandleEntry = (
+  candle: OhlcCandle,
+  firstOpen: number,
+  formatPrice: (amount: number) => string
+): CandleDisplayStrings => {
+  const close = Number.isFinite(candle.close) ? candle.close : 0
+  const delta = close - firstOpen
+  const deltaPct =
+    Number.isFinite(firstOpen) && firstOpen !== 0
+      ? (delta / firstOpen) * 100
+      : 0
+  const safeDelta = Number.isFinite(delta) ? delta : 0
+  const safeDeltaPct = Number.isFinite(deltaPct) ? deltaPct : 0
+  return {
+    priceText: formatPrice(close),
+    timeText: formatActiveTime(candle.ts),
+    deltaPriceText: formatPrice(Math.abs(safeDelta)),
+    deltaPctText: `${Math.abs(safeDeltaPct).toFixed(2)}%`,
+    status: priceChangeStatusFromDelta(safeDelta)
+  }
+}
+
 /** Pre-compute header strings per candle for drag-time lookups. */
 export const formatCandleDisplayStrings = (
   candles: OhlcCandle[],
   formatPrice: (amount: number) => string
 ): CandleDisplayStrings[] => {
   const firstOpen = candles[0]?.open ?? 0
-  return candles.map(c => {
-    const close = Number.isFinite(c.close) ? c.close : 0
-    const delta = close - firstOpen
-    const deltaPct =
-      Number.isFinite(firstOpen) && firstOpen !== 0
-        ? (delta / firstOpen) * 100
-        : 0
-    const safeDelta = Number.isFinite(delta) ? delta : 0
-    const safeDeltaPct = Number.isFinite(deltaPct) ? deltaPct : 0
-    return {
-      priceText: formatPrice(close),
-      timeText: formatActiveTime(c.ts),
-      deltaPriceText: formatPrice(Math.abs(safeDelta)),
-      deltaPctText: `${Math.abs(safeDeltaPct).toFixed(2)}%`,
-      status: priceChangeStatusFromDelta(safeDelta)
-    }
-  })
+  return candles.map(c => formatCandleEntry(c, firstOpen, formatPrice))
+}
+
+/**
+ * O(1) variant of `formatCandleDisplayStrings` for a single candle index —
+ * lets a mount-time render compute only the one entry it actually displays
+ * (the crosshair-inactive state only ever reads the last candle) instead of
+ * paying the ~96 `Intl.format()` calls for all candles up front. The full
+ * array is computed lazily elsewhere (see `useIsFullFormatNeeded` in
+ * `hooks.ts`) for crosshair-drag lookups.
+ */
+export const formatCandleDisplayStringAt = (
+  candles: OhlcCandle[],
+  index: number,
+  formatPrice: (amount: number) => string
+): CandleDisplayStrings | undefined => {
+  const candle = candles[index]
+  if (!candle) return undefined
+  const firstOpen = candles[0]?.open ?? 0
+  return formatCandleEntry(candle, firstOpen, formatPrice)
 }
 
 /** 0 = flex-start, 0.5 = center, 1 = flex-end — worklet for header zone reaction. */
@@ -164,7 +375,10 @@ export const crosshairInnerAnchorTarget = (
   return 0
 }
 
-/** e.g. "Today, 7:25" or "Apr 29, 7:25" — 24-hour, no AM/PM. */
+/** e.g. "Today, 07:25" or "Apr 29, 07:25" — 24-hour (h23, midnight = "00"),
+ * no AM/PM. See the CP-14918 comment above `MONTH_ABBR` for why this is
+ * hand-rolled instead of an `Intl.DateTimeFormat`, and the comment above
+ * `formatHour24Minute` for the h23-vs-h24 midnight correction. */
 export const formatActiveTime = (ts: number, nowMs?: number): string => {
   const d = new Date(ts)
   const now = nowMs !== undefined ? new Date(nowMs) : new Date()
@@ -172,16 +386,23 @@ export const formatActiveTime = (ts: number, nowMs?: number): string => {
     d.getFullYear() === now.getFullYear() &&
     d.getMonth() === now.getMonth() &&
     d.getDate() === now.getDate()
-  const datePart = sameDay
-    ? 'Today'
-    : d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-  const timePart = d.toLocaleTimeString(undefined, {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: false
-  })
+  const datePart = sameDay ? 'Today' : formatMonthDay(d)
+  const timePart = formatHour24Minute(d)
   return `${datePart}, ${timePart}`
 }
+
+/**
+ * Pure gating decision behind `useIsFullFormatNeeded` (hooks.ts), pulled out
+ * here (no reanimated dependency) so it's unit-testable without mounting a
+ * component — this package has no component-render test harness. The full
+ * "format every candle" array is needed once EITHER the post-mount idle
+ * tick has fired OR the crosshair has been activated at least once (`idx`
+ * non-null) — whichever happens first.
+ */
+export const isFullFormatNeeded = (
+  idleReady: boolean,
+  idx: number | null
+): boolean => idleReady || idx !== null
 
 /** `count + 1` evenly-spaced values from min to max, inclusive. */
 export const yAxisTicks = (

--- a/packages/k2-alpine/src/components/Chart/PriceChart/helpers.ts
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/helpers.ts
@@ -1,4 +1,4 @@
-import type { Skia } from '@shopify/react-native-skia'
+import type { SkPath } from '@shopify/react-native-skia'
 import { PriceChangeStatus } from '../../PriceChangeIndicator/types'
 import {
   CHART_INSET,
@@ -6,8 +6,6 @@ import {
   HEADER_RIGHT_ZONE_THRESHOLD
 } from './constants'
 import { OhlcCandle } from './types'
-
-type SkPath = ReturnType<typeof Skia.Path.Make>
 
 /** Larger prices map to smaller y. Returns midpoint when min === max. */
 export const priceToY = ({
@@ -254,7 +252,9 @@ const formatWeekdayMonthDayYear = (d: Date): string => {
   } ${d.getDate()}, ${d.getFullYear()}`
 }
 
-/** e.g. "Last update: Wed, Apr 29, 2026 at 9:41 AM" */
+/** e.g. "Last update: Wed, Apr 29, 2026 at 9:41\u202fAM" — the AM/PM
+ * separator is U+202F (narrow no-break space), not an ASCII space; see
+ * `AM_PM_SEPARATOR`. */
 export const formatLastUpdate = (ts: number): string => {
   const d = new Date(ts)
   const datePart = formatWeekdayMonthDayYear(d)

--- a/packages/k2-alpine/src/components/Chart/PriceChart/hooks.ts
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/hooks.ts
@@ -25,24 +25,16 @@ export const useActiveIndex = (
 }
 
 /**
- * Gates an expensive "format every candle" computation (e.g.
- * `formatCandleDisplayStrings`, per-candle volume strings) so it never
- * blocks the initial synchronous chart mount. Resolves `true` once either a
- * post-mount macrotask tick has elapsed or the crosshair activates (`idx`
- * becomes non-null) — whichever comes first.
+ * Defers an O(candles) format off the synchronous mount path until either a
+ * post-mount macrotask or the first crosshair activation.
  *
- * If activation races the idle tick, `idx` flips to non-null in the same
- * render pass that reads this hook's return value, so a `useMemo` gated on
- * it recomputes SYNCHRONOUSLY in that same render — never a stale or
- * missing lookup on the frame the user first drags the crosshair. The
- * worst case is that render doing the full O(candles) format work inline
- * (see ChartHeader/ChartFooter for the measured cost).
+ * Gating on `idx` matters: activation flips this within the same render
+ * pass, so a `useMemo` behind it recomputes synchronously and a drag can
+ * never read a missing entry — at the cost of that one render doing the
+ * work inline.
  *
- * Uses a bare `setTimeout(0)` rather than
- * `InteractionManager.runAfterInteractions`: on the New Architecture the
- * latter is a deprecated stub with plain `setImmediate` semantics (see the
- * note in `StakingRewardChart`), so it buys nothing over a macrotask defer
- * while adding an import.
+ * `setTimeout(0)`, not `InteractionManager.runAfterInteractions`: on the New
+ * Architecture the latter is a deprecated `setImmediate` stub.
  */
 export const useIsFullFormatNeeded = (idx: number | null): boolean => {
   const [idleReady, setIdleReady] = useState(false)

--- a/packages/k2-alpine/src/components/Chart/PriceChart/hooks.ts
+++ b/packages/k2-alpine/src/components/Chart/PriceChart/hooks.ts
@@ -1,10 +1,11 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   runOnJS,
   SharedValue,
   useDerivedValue,
   useSharedValue
 } from 'react-native-reanimated'
+import { isFullFormatNeeded } from './helpers'
 
 /** Bridges UI-thread SharedValue to React state; dirty-check avoids per-frame setState. */
 export const useActiveIndex = (
@@ -21,4 +22,35 @@ export const useActiveIndex = (
   })
 
   return idx
+}
+
+/**
+ * Gates an expensive "format every candle" computation (e.g.
+ * `formatCandleDisplayStrings`, per-candle volume strings) so it never
+ * blocks the initial synchronous chart mount. Resolves `true` once either a
+ * post-mount macrotask tick has elapsed or the crosshair activates (`idx`
+ * becomes non-null) — whichever comes first.
+ *
+ * If activation races the idle tick, `idx` flips to non-null in the same
+ * render pass that reads this hook's return value, so a `useMemo` gated on
+ * it recomputes SYNCHRONOUSLY in that same render — never a stale or
+ * missing lookup on the frame the user first drags the crosshair. The
+ * worst case is that render doing the full O(candles) format work inline
+ * (see ChartHeader/ChartFooter for the measured cost).
+ *
+ * Uses a bare `setTimeout(0)` rather than
+ * `InteractionManager.runAfterInteractions`: on the New Architecture the
+ * latter is a deprecated stub with plain `setImmediate` semantics (see the
+ * note in `StakingRewardChart`), so it buys nothing over a macrotask defer
+ * while adding an import.
+ */
+export const useIsFullFormatNeeded = (idx: number | null): boolean => {
+  const [idleReady, setIdleReady] = useState(false)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setIdleReady(true), 0)
+    return () => clearTimeout(timer)
+  }, [])
+
+  return isFullFormatNeeded(idleReady, idx)
 }


### PR DESCRIPTION
## Description

**Ticket: [CP-14918](https://ava-labs.atlassian.net/browse/CP-14918)**

k2-alpine `PriceChart` performance restructure. The chart's mount commit was the single largest app-owned cost in the token-detail tap-to-paint window; this PR cuts its self-time from ~517-716ms to ~203ms median (dev rig, Pixel 8 Pro; absolute numbers are dev-build only, methodology in `docs/cp14918-portfolio-performance-session.md`). `PriceChart` is shared with Track (CP-14309), so both surfaces are affected.

Changes:

- `Series.tsx` - `Candles` collapses from 2N Skia elements (per-candle `<Line>` + `<RoundedRect>`) to 4 `SkPath`s (up/down bodies, up/down wicks). Wicks draw before bodies so paint order matches the original. `Candles` renders in both line and candlestick modes, so this helps the default path too.
- `PriceChart.tsx` - the label font becomes a module-level singleton (`useFont` has no internal cache; every mount was reallocating a native `SkTypeface`), with a retry on failed load (a failed promise is not cached forever). Worklets read `linePoints`/`candles` geometry from flattened `Float32Array` shared values instead of object-array closures, avoiding a shareable-conversion per dependency change.
- `VolumeRow.tsx` - bar highlight restructured from one `makeMutable` per candle to a single static idle `SkPath` plus two highlight `RoundedRect`s driven by one `SharedValue`. The original two-bar crossfade drag behavior is preserved: `volumeCrosshairWeights` (new pure worklet in `helpers.ts`, unit-tested) reproduces main's per-candle weight formula, and the rect opacity is compositing-compensated (`crossfadeRectOpacity`) so idle-path-plus-rect source-over composition lands on exactly the original per-bar opacity for every weight. The compensation identity is pinned by tests.
- `helpers.ts` - the four `Intl.DateTimeFormat().format()` call sites are replaced with hand-rolled month/weekday-table formatters (~4ms per Intl call, ~96 calls per mount). Two device-found parity divergences are handled and byte-pinned by tests: midnight renders `00:00` (Hermes/Android ICU h23, not Node ICU's `24:00`), and the AM/PM separator is U+202F (narrow no-break space, ICU 72+), not an ASCII space.
- `ChartHeader.tsx` / `ChartFooter.tsx` / `hooks.ts` - per-candle display strings are formatted lazily: the eager mount path formats only the last candle (O(1)); the full array computes on idle or first crosshair activation (`useIsFullFormatNeeded`). `ChartFooter`'s volume formatting is additionally gated on `showVolume`, since in line mode (the default) that text is never visible.

Known and accepted, called out for reviewers:

- The hand-rolled date formatters hardcode en-US; the app ships 11 UI languages. Four sibling screens already hardcode en-US, but a real product/i18n decision is tracked as [CP-14923](https://ava-labs.atlassian.net/browse/CP-14923).
- The gesture memo in `PriceChart.tsx` still bails from React Compiler (a `SharedValue`-in-deps pattern shared by three effects in this file); tracked in the compiler-bailout backlog [CP-14925](https://ava-labs.atlassian.net/browse/CP-14925).
- `lineYsSV`/`volumesSV` lazy-init closes the mount-window staleness but not the range-switch case (needs an in-progress drag during a range switch to trigger; bounds-safe and self-heals within one JS tick). Accepted as low severity.

No dependency on the core-mobile CP-14918 PRs; can land independently.

## Screenshots/Videos

To be added: chart render in line and candlestick modes, plus a crosshair-drag recording showing the volume-bar crossfade.

## Testing

**Dev Testing**

iOS: 9457
Android: 9458

- Open a token detail screen (line mode): chart renders, crosshair drag works, header values update while dragging.
- Switch to candlestick mode: candles and volume bars render correctly; drag the crosshair slowly between two bars and confirm the highlight crossfades (no snapping) and matches the pre-restructure behavior visually.
- Switch ranges (1D/1W/...) repeatedly, including mid-drag, and confirm no stale geometry or crash.
- Kill and relaunch with airplane mode toggled during first load to exercise the font-load retry path.
- `yarn workspace @avalabs/k2-alpine test` - full suite; `helpers.test.ts` carries the formatter byte-pinning and the crossfade/compositing identity tests.

**QA Testing**

- Verify chart date/time labels against a device set to a non-English locale: labels are expected to render in English (accepted, CP-14923) - confirm nothing renders blank or garbled.
- Compare crosshair drag behavior on this build vs production on the same token/range: bar highlight brightness and crossfade should be indistinguishable.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CP-14918]: https://ava-labs.atlassian.net/browse/CP-14918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-14923]: https://ava-labs.atlassian.net/browse/CP-14923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ