### PR TITLE
CP-14930: pin crypto-js to 4.2.0 to close CVE-2023-46233

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@scure/btc-signer/@noble/hashes": "1.8.0",
     "bip32": "3.0.1",
     "bip39": "3.1.0",
+    "crypto-js": "4.2.0",
     "lodash@4.17.3": "4.17.21",
     "@ledgerhq/hw-transport": "6.31.0",
     "@noble/curves": "patch:@noble/curves@npm%3A1.9.7#./.yarn/patches/@noble-curves-npm-1.9.7-2b9efc8ab4.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22892,13 +22892,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crypto-js@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "crypto-js@npm:4.1.1"
-  checksum: b3747c12ee3a7632fab3b3e171ea50f78b182545f0714f6d3e7e2858385f0f4101a15f2517e033802ce9d12ba50a391575ff4638c9de3dd9b2c4bc47768d5425
-  languageName: node
-  linkType: hard
-
 "css-line-break@npm:^2.1.0":
   version: 2.1.0
   resolution: "css-line-break@npm:2.1.0"


### PR DESCRIPTION
## Description

**Ticket: [CP-14930](https://ava-labs.atlassian.net/browse/CP-14930)**

Pins `crypto-js` to 4.2.0 across the monorepo via a root `resolutions` entry.

Before this change core-mobile carried two copies of crypto-js: 4.2.0, pulled in by `@ledgerhq/evm-tools`, and 4.1.1, nested under `redux-persist-transform-encrypt@4.0.0`, which declares `crypto-js: ^4.1.1`. Versions before 4.2.0 are affected by CVE-2023-46233, where PBKDF2 defaults to 1 iteration and SHA-1, making any password derived key cheap to brute force.

Nothing in the app calls crypto-js PBKDF2 today, so this is not an active exploit path. The point is to close the gap before a future call site or a transitive downgrade introduces one. The `resolutions` entry doubles as that guard: anything later asking for `^4.1.x` gets forced up to 4.2.0.

No dependencies introduced. This removes a duplicate copy rather than adding anything, and after the change there is exactly one crypto-js on disk, at 4.2.0.

### Why this is safe for existing users

`EncryptThenMacTransform` has a legacy branch that decrypts previously persisted state through `redux-persist-transform-encrypt`, which calls `AES.encrypt(value, passphrase)`. crypto-js derives that key with EvpKDF rather than PBKDF2, so the CVE never touched this path, and neither does the fix.

I diffed the full 4.1.1 and 4.2.0 tarballs to confirm nothing else moved:

- `pbkdf2.js`: the actual fix, SHA-1 to SHA-256 and 1 iteration to 250000
- `cipher-core.js`: adds an optional `hasher` parameter, inert when unset, which is our case
- `md5.js`: a comment typo
- `enc-base64url.js`: default parameters rewritten in ES5 form
- `blowfish.js`: new file, additive

AES and EvpKDF are byte identical between the two versions, so persisted state stays readable.

## Screenshots/Videos

Not applicable. There are no user facing or UI changes, this only touches dependency resolution.

## Testing

**Dev Testing (if applicable)**

iOS: 9446
Android: 9447

The regression risk worth caring about is existing users failing to decrypt their persisted Redux store after the bump. `app/store/transforms/EncryptThenMacTransform.test.ts` covers exactly that, including a case that round trips ciphertext produced by the old library.

Full unit suite on this branch: 362 suites, 4448 tests, all passing.

To sanity check on device: install a build from before this change, sign in and let the store persist, then install this branch over it and confirm the wallet rehydrates with accounts intact rather than dropping to onboarding.

**QA Testing (if applicable)**

The upgrade path is the thing to exercise. Expected behavior is that upgrading from a previous build preserves wallet state, accounts, settings and balances, with no forced re-onboarding and no PIN re-entry beyond the normal lock flow.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14930]: https://ava-labs.atlassian.net/browse/CP-14930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ