### PR TITLE
CP-14935: Batch balance-poll cache writes to stop the per-network re-render storm

### DIFF
--- a/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalances.test.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalances.test.ts
@@ -1,10 +1,15 @@
 import { renderHook } from '@testing-library/react-hooks'
-import { useAccountBalances } from './useAccountBalances'
+import { createBalanceBatcher, useAccountBalances } from './useAccountBalances'
+
+const mockQueryClient = {
+  setQueryData: jest.fn(),
+  getQueryData: jest.fn()
+}
 
 jest.mock('@tanstack/react-query', () => ({
   ...jest.requireActual('@tanstack/react-query'),
   useQuery: jest.fn(),
-  useQueryClient: () => ({ setQueryData: jest.fn() })
+  useQueryClient: () => mockQueryClient
 }))
 
 jest.mock('react-redux', () => ({
@@ -221,5 +226,191 @@ describe('useAccountBalances isLoading gate', () => {
     rerender()
 
     expect(result.current.isLoading).toBe(true)
+  })
+})
+
+describe('createBalanceBatcher', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  const balance = (chainId: number): never => ({ chainId } as never)
+
+  it('flushes the first balance immediately (leading edge)', () => {
+    const flush = jest.fn()
+    const batcher = createBalanceBatcher(flush)
+
+    batcher.add(balance(1))
+
+    expect(flush).toHaveBeenCalledTimes(1)
+    expect(flush).toHaveBeenCalledWith([balance(1)])
+  })
+
+  it('merges balances arriving within the window into one trailing flush', () => {
+    const flush = jest.fn()
+    const batcher = createBalanceBatcher(flush)
+
+    batcher.add(balance(1))
+    batcher.add(balance(2))
+    batcher.add(balance(3))
+    expect(flush).toHaveBeenCalledTimes(1)
+
+    jest.runOnlyPendingTimers()
+
+    expect(flush).toHaveBeenCalledTimes(2)
+    expect(flush).toHaveBeenLastCalledWith([balance(2), balance(3)])
+  })
+
+  it('re-arms the leading edge after a quiet window', () => {
+    const flush = jest.fn()
+    const batcher = createBalanceBatcher(flush)
+
+    batcher.add(balance(1))
+    jest.runOnlyPendingTimers()
+
+    batcher.add(balance(2))
+    batcher.add(balance(3))
+    jest.runAllTimers()
+
+    expect(flush).toHaveBeenCalledTimes(3)
+    expect(flush.mock.calls[1][0]).toEqual([balance(2)])
+    expect(flush).toHaveBeenLastCalledWith([balance(3)])
+  })
+
+  it('dispose drops buffered balances and cancels pending flushes', () => {
+    const flush = jest.fn()
+    const batcher = createBalanceBatcher(flush)
+
+    batcher.add(balance(1))
+    batcher.add(balance(2))
+    batcher.dispose()
+    batcher.add(balance(3))
+    jest.runAllTimers()
+
+    expect(flush).toHaveBeenCalledTimes(1)
+    expect(flush).toHaveBeenCalledWith([balance(1)])
+  })
+})
+
+describe('useAccountBalances queryFn cache-write batching', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+    mockEnabledNetworks = [{ chainId: 1 }, { chainId: 2 }, { chainId: 3 }]
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  const BalanceService = jest.requireMock(
+    'services/balance/BalanceService'
+  ).default
+
+  const renderAndCaptureQueryFn = (): (() => Promise<unknown>) => {
+    let captured: { queryFn: () => Promise<unknown> } | undefined
+    useQuery.mockImplementation((options: never) => {
+      captured = options
+      return {
+        data: undefined,
+        isFetching: false,
+        isError: false,
+        isPaused: false,
+        refetch: jest.fn()
+      }
+    })
+    renderHook(() => useAccountBalances(account))
+    if (!captured) throw new Error('useQuery options not captured')
+    return captured.queryFn
+  }
+
+  const balances = [{ chainId: 1 }, { chainId: 2 }, { chainId: 3 }] as never[]
+
+  it('warm refetch: no intermediate cache writes, only the atomic result', async () => {
+    mockQueryClient.getQueryData.mockReturnValue([{ chainId: 1 }])
+    BalanceService.getBalancesForAccount.mockImplementation(
+      async ({ onBalanceLoaded }: { onBalanceLoaded?: (b: never) => void }) => {
+        expect(onBalanceLoaded).toBeUndefined()
+        return balances
+      }
+    )
+
+    const queryFn = renderAndCaptureQueryFn()
+    await expect(queryFn()).resolves.toEqual(balances)
+
+    expect(mockQueryClient.setQueryData).not.toHaveBeenCalled()
+  })
+
+  it('cold load: per-chain arrivals are batched into few cache writes', async () => {
+    mockQueryClient.getQueryData.mockReturnValue(undefined)
+    BalanceService.getBalancesForAccount.mockImplementation(
+      async ({ onBalanceLoaded }: { onBalanceLoaded?: (b: never) => void }) => {
+        balances.forEach(b => onBalanceLoaded?.(b))
+        return balances
+      }
+    )
+
+    const queryFn = renderAndCaptureQueryFn()
+    await expect(queryFn()).resolves.toEqual(balances)
+
+    // 3 chains → 1 leading write; the trailing buffer is superseded by the
+    // atomic queryFn result and disposed, never written.
+    expect(mockQueryClient.setQueryData).toHaveBeenCalledTimes(1)
+    const updater = mockQueryClient.setQueryData.mock.calls[0][1]
+    expect(updater(undefined)).toEqual([{ chainId: 1 }])
+    expect(updater([{ chainId: 1, stale: true }, { chainId: 9 }])).toEqual([
+      { chainId: 9 },
+      { chainId: 1 }
+    ])
+  })
+
+  it('cold load: duplicate chainIds within one batch are deduped, last write wins', async () => {
+    mockQueryClient.getQueryData.mockReturnValue(undefined)
+    const first = { chainId: 1, version: 'stream' } as never
+    const second = { chainId: 1, version: 'vm-retry' } as never
+    BalanceService.getBalancesForAccount.mockImplementation(
+      async ({ onBalanceLoaded }: { onBalanceLoaded?: (b: never) => void }) => {
+        onBalanceLoaded?.(first)
+        jest.runOnlyPendingTimers()
+        onBalanceLoaded?.(second)
+        onBalanceLoaded?.(second)
+        jest.runOnlyPendingTimers()
+        return [second]
+      }
+    )
+
+    const queryFn = renderAndCaptureQueryFn()
+    await queryFn()
+
+    const lastUpdater = mockQueryClient.setQueryData.mock.calls.at(-1)[1]
+    expect(lastUpdater([first])).toEqual([second])
+  })
+
+  it('cold load: pending buffer is flushed, not dropped, when the fetch throws', async () => {
+    mockQueryClient.getQueryData.mockReturnValue(undefined)
+    const streamed = { chainId: 2 } as never
+    BalanceService.getBalancesForAccount.mockImplementation(
+      async ({ onBalanceLoaded }: { onBalanceLoaded?: (b: never) => void }) => {
+        onBalanceLoaded?.({ chainId: 1 } as never)
+        onBalanceLoaded?.(streamed)
+        throw new Error('balance api down')
+      }
+    )
+
+    const queryFn = renderAndCaptureQueryFn()
+    await expect(queryFn()).rejects.toThrow('balance api down')
+
+    // leading flush wrote chainId 1; the error-path flush must write the
+    // still-buffered chainId 2 instead of discarding it
+    expect(mockQueryClient.setQueryData).toHaveBeenCalledTimes(2)
+    const errorFlushUpdater = mockQueryClient.setQueryData.mock.calls.at(-1)[1]
+    expect(errorFlushUpdater([{ chainId: 1 }])).toEqual([
+      { chainId: 1 },
+      streamed
+    ])
   })
 })

--- a/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalances.ts
+++ b/packages/core-mobile/app/new/features/portfolio/hooks/useAccountBalances.ts
@@ -31,6 +31,71 @@ const staleTime = 20_000
  */
 const refetchInterval = __DEV__ ? 30_000 : 5_000
 
+/**
+ * Flush window for progressive first-load balance updates. Chains that
+ * resolve within the same window land in ONE cache write instead of one
+ * write (and one re-render of every balance subscriber) per chain.
+ */
+const PROGRESSIVE_FLUSH_MS = 150
+
+type BalanceBatcher = {
+  add: (balance: AdjustedNormalizedBalancesForAccount) => void
+  flushPending: () => void
+  dispose: () => void
+}
+
+/**
+ * Leading + trailing throttle: the first balance flushes immediately so the
+ * cold-load UI paints as soon as any chain resolves; balances arriving within
+ * the window after that are merged into a single trailing flush.
+ */
+export const createBalanceBatcher = (
+  flush: (balances: AdjustedNormalizedBalancesForAccount[]) => void
+): BalanceBatcher => {
+  let buffer: AdjustedNormalizedBalancesForAccount[] = []
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let disposed = false
+
+  const flushBuffer = (): void => {
+    if (buffer.length === 0) return
+    const batch = buffer
+    buffer = []
+    flush(batch)
+  }
+
+  const onWindowEnd = (): void => {
+    timer = null
+    if (disposed) return
+    if (buffer.length > 0) {
+      flushBuffer()
+      timer = setTimeout(onWindowEnd, PROGRESSIVE_FLUSH_MS)
+    }
+  }
+
+  return {
+    add: balance => {
+      if (disposed) return
+      buffer.push(balance)
+      if (timer === null) {
+        flushBuffer()
+        timer = setTimeout(onWindowEnd, PROGRESSIVE_FLUSH_MS)
+      }
+    },
+    flushPending: () => {
+      if (disposed) return
+      flushBuffer()
+    },
+    dispose: () => {
+      disposed = true
+      if (timer !== null) {
+        clearTimeout(timer)
+        timer = null
+      }
+      buffer = []
+    }
+  }
+}
+
 export const balanceKey = (
   account: Account | undefined,
   network: Network[] | undefined,
@@ -141,30 +206,62 @@ export function useAccountBalances(
     queryFn: async () => {
       if (isNotReady) return []
 
+      const queryKey = balanceKey(account, enabledNetworks, filterOutDustUtxos)
+
+      // Progressive per-chain cache writes only matter on a cold load, where
+      // the user is staring at an empty screen. On a background refetch the
+      // cache already has data, so intermediate writes would just re-render
+      // every balance subscriber once per chain (up to N times per poll) —
+      // skip them and let the returned result apply one atomic update.
+      const isColdLoad = queryClient.getQueryData(queryKey) === undefined
+      const batcher = isColdLoad
+        ? createBalanceBatcher(balances => {
+            // Dedupe within the batch too (last write wins): the service can
+            // report the same chain twice in one fetch (stream success, then
+            // a vm-module retry sweep when another batch threw), and a
+            // duplicate entry would briefly push data.length past
+            // enabledNetworks.length and mis-settle the isLoading gate.
+            const byChainId = new Map(balances.map(b => [b.chainId, b]))
+            queryClient.setQueryData(
+              queryKey,
+              (prev: AdjustedNormalizedBalancesForAccount[] | undefined) => {
+                const remaining =
+                  prev?.filter(p => !byChainId.has(p.chainId)) ?? []
+                return [...remaining, ...byChainId.values()]
+              }
+            )
+          })
+        : undefined
+
       const xpub = await getXpubXPIfAvailable({
         walletId: wallet.id,
         walletType: wallet.type,
         accountIndex: account.index
       })
 
-      return await BalanceService.getBalancesForAccount({
-        networks: enabledNetworks,
-        account,
-        currency: currency.toLowerCase(),
-        xpAddresses,
-        xpub,
-        filterOutDustUtxos,
-        onBalanceLoaded: balance => {
-          queryClient.setQueryData(
-            balanceKey(account, enabledNetworks, filterOutDustUtxos),
-            (prev: AdjustedNormalizedBalancesForAccount[] | undefined) => {
-              if (!prev) return [balance]
-              const filtered = prev.filter(p => p.chainId !== balance.chainId)
-              return [...filtered, balance]
-            }
-          )
-        }
-      })
+      try {
+        return await BalanceService.getBalancesForAccount({
+          networks: enabledNetworks,
+          account,
+          currency: currency.toLowerCase(),
+          xpAddresses,
+          xpub,
+          filterOutDustUtxos,
+          onBalanceLoaded: batcher && (balance => batcher.add(balance))
+        })
+      } catch (error) {
+        // On rejection there is no complete result coming — write whatever
+        // streamed in so partial progress isn't lost (matches the old
+        // per-chain-write behavior on the error path).
+        batcher?.flushPending()
+        throw error
+      } finally {
+        // On success the returned result IS the complete set (including
+        // vm-module retries), so a pending trailing flush is redundant — and
+        // letting it fire after the query settles would race react-query's
+        // own write.
+        batcher?.dispose()
+      }
     }
   })
 


### PR DESCRIPTION
## Description

**Ticket: [CP-14935](https://ava-labs.atlassian.net/browse/CP-14935)**

Eliminates the app-wide re-render storm caused by balance polling.

**Problem:** `useAccountBalances` refetches every 5s in prod, and its `onBalanceLoaded` callback did one `queryClient.setQueryData` per network as each chain resolved — so every poll cycle emitted ~10 successive cache writes, each re-rendering every mounted balance subscriber (portfolio, watchlist, buy flow, token lists). Any screen with expensive subscribers spent large fractions of wall time re-rendering while completely idle, and taps queued behind those commits.

**Change** (single file + tests):

- **Warm background refetches** (cache already has data): intermediate per-chain writes are skipped entirely; the queryFn's returned result — which `BalanceService.getBalancesForAccount` guarantees is the complete set, including vm-module retries — applies **one atomic cache update per poll**.
- **Cold loads** (no cached data — first load, account/network/flag change): progressive chain-by-chain painting is preserved, but writes go through a small leading+trailing 150ms batcher, so chains resolving close together land in one write. First chain still paints immediately.
- Within-batch dedupe by chainId (the service can report the same chain twice in one fetch via the vm-module retry sweep; a duplicate would transiently push `data.length` past `enabledNetworks.length` and mis-settle the loading gate).
- If the fetch rejects mid-stream, the pending buffer is flushed before disposal so partial progress isn't lost (matches the old per-chain-write behavior on the error path).

**Measured on device** — iPhone 14, dev build, both variants at prod cadence (`refetchInterval` pinned to 5000ms), identical probe (app-root `<Profiler>` + JS event-loop stall detector + React Query cache subscription), 3-minute hands-off idle windows (~39 poll cycles each):

| Idle 3min @5s polling | Portfolio before | Portfolio after | Buy-amount before | Buy-amount after |
| --- | --- | --- | --- | --- |
| Balance cache writes/poll | 10.5 | **0.9** | 5.6 | **0.9** |
| Total commit time | 17.9s | **8.4s** (−53%) | 122.7s | **51.6s** (−58%) |
| JS-blocked time (>150ms stalls) | 0.3s | **0s** | 123.1s | **47.2s** (−62%) |
| p95 commit | 56.5ms | **1.7ms** | 1,428ms | **3.1ms** |
| JS busy re-rendering | 9.2% | **4.3%** | 63.4% | **26.4%** |

Caveats stated plainly: absolute milliseconds are dev-build-inflated; the proven claim is the relative reduction in cache writes, commit time, and JS-blocked time at prod cadence on the same build/device. The buy-amount screen's remaining absolute cost is the 57k-token pipeline work fixed separately in #4033 — the two changes compose (one cheap write per poll × cheap subscriber trees).

Device-independent proof: unit tests assert the write counts directly (warm refetch → zero intermediate writes; cold load → leading write + batched trailing; dedupe; flush-on-error).

**Known pre-existing issue, unchanged:** a superseded refetch keeps running (no AbortSignal wiring in the queryFn/BalanceService) and can write stale data briefly; batching neither causes nor fixes it, and the atomic final write narrows the overall window.

No new dependencies. No breaking changes.

## Screenshots/Videos

N/A — no visual changes. Measurement methodology and results in the table above.

## Testing

**Dev Testing (if applicable)**

iOS: 9459
Andriod: 9460

Happy path:
1. Fresh app start (cold load): portfolio balances should appear progressively per network, as before — no long blank wait for the slowest chain
2. Leave portfolio idle for a few minutes: balances keep updating each poll (values change once per cycle rather than rippling chain-by-chain)
3. Switch accounts and toggle a network on/off: each produces a fresh cold load with progressive painting
4. Pull-to-refresh / manual refetch works as before

Edge cases:
- Airplane mode mid-session: no crash; balances freeze and resume on reconnect
- The small-UTXO filter toggle (new query key): cold load path, progressive paint

Unit tests: `yarn test app/new/features/portfolio/hooks/useAccountBalances.test.ts` (14 tests: 6 pre-existing loading-gate tests unchanged and passing, 8 new covering the batcher and both queryFn paths)

**QA Testing (if applicable)**

Regression-test balance display across portfolio, token detail, watchlist, and the buy/withdraw flows with a multi-network account: balances must appear on first load per network, stay current over time, and survive account switches and network toggles. Expected: identical data as before; visibly fewer UI hitches on lower-end devices.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation



[CP-14935]: https://ava-labs.atlassian.net/browse/CP-14935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ