### PR TITLE
CP-14963: Batch token-aggregator lookups into one request per tick

### DIFF
--- a/packages/core-mobile/app/new/common/hooks/useTokenLookup.batching.test.tsx
+++ b/packages/core-mobile/app/new/common/hooks/useTokenLookup.batching.test.tsx
@@ -1,0 +1,185 @@
+import React from 'react'
+import { renderHook } from '@testing-library/react-hooks'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useTokenLookup } from './useTokenLookup'
+
+// Deliberately does NOT mock @tanstack/react-query, unlike the sibling
+// useTokenLookup.test.ts. The point of this file is to drive the real
+// useQueries -> queryFn -> coalescer -> chunking -> client path, which is the
+// only way to prove N tokens produce one request.
+jest.mock('utils/api/generated/tokenAggregator/aggregatorApi.client', () => ({
+  postV1TokenLookup: jest.fn()
+}))
+
+jest.mock('utils/api/clients/aggregatedTokensApiClient', () => ({
+  tokenAggregatorApi: {}
+}))
+
+const { postV1TokenLookup } = jest.requireMock(
+  'utils/api/generated/tokenAggregator/aggregatorApi.client'
+) as { postV1TokenLookup: jest.Mock }
+
+const CAIP2 = 'eip155:43114'
+
+// Mixed-case addresses paired with lowercased response keys: the server
+// lowercases EVM keys, so this also proves the casing round-trip end to end.
+const addressAt = (index: number): string =>
+  `0xAbCdEf${index.toString().padStart(34, '0')}`
+
+const tokenAt = (index: number): { caip2Id: string; address: string } => ({
+  caip2Id: CAIP2,
+  address: addressAt(index)
+})
+
+const tokens = (count: number): Array<{ caip2Id: string; address: string }> =>
+  Array.from({ length: count }, (_, index) => tokenAt(index))
+
+const responseKey = (address: string): string =>
+  `${CAIP2}-${address}`.toLowerCase()
+
+const symbolFor = (address: string): string => `SYM${address.slice(-4)}`
+
+const echoRequestedTokens = (): void => {
+  postV1TokenLookup.mockImplementation(
+    (options: { body: { tokens: Array<{ address: string }> } }) =>
+      Promise.resolve({
+        data: {
+          data: Object.fromEntries(
+            options.body.tokens.map(({ address }) => [
+              responseKey(address),
+              { symbol: symbolFor(address), name: symbolFor(address) }
+            ])
+          )
+        }
+      })
+  )
+}
+
+const requestedAddresses = (callIndex: number): string[] =>
+  postV1TokenLookup.mock.calls[callIndex][0].body.tokens.map(
+    (token: { address: string }) => token.address
+  )
+
+const newWrapper = (
+  client: QueryClient
+): React.FC<{ children: React.ReactNode }> => {
+  // prettier-ignore
+  return ({ children }: { children: React.ReactNode }): JSX.Element => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}
+
+const clients: QueryClient[] = []
+
+const newClient = (): QueryClient => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  })
+  clients.push(client)
+  return client
+}
+
+describe('useTokenLookup batching', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    echoRequestedTokens()
+  })
+
+  // Release each client's cache rather than leaving it to gcTime. Note this
+  // does not silence Jest's "did not exit" warning -- that comes from the
+  // renderHook + real QueryClient pattern generally and predates this file
+  // (useFeatureAvailability.test.tsx needs --forceExit too).
+  afterEach(() => {
+    clients.forEach(client => {
+      client.clear()
+      client.unmount()
+    })
+    clients.length = 0
+  })
+
+  it('resolves eight tokens with a single request', async () => {
+    const requested = tokens(8)
+
+    const { result, waitFor } = renderHook(() => useTokenLookup(requested), {
+      wrapper: newWrapper(newClient())
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(postV1TokenLookup).toHaveBeenCalledTimes(1)
+    expect(requestedAddresses(0)).toEqual(requested.map(t => t.address))
+    expect(Object.keys(result.current.data)).toHaveLength(8)
+  })
+
+  it('exposes every token under its lowercased response key', async () => {
+    const requested = tokens(3)
+
+    const { result, waitFor } = renderHook(() => useTokenLookup(requested), {
+      wrapper: newWrapper(newClient())
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    requested.forEach(({ address }) => {
+      expect(result.current.data[responseKey(address)]).toEqual({
+        symbol: symbolFor(address),
+        name: symbolFor(address)
+      })
+    })
+  })
+
+  it('serves an already-cached token without a further request', async () => {
+    const client = newClient()
+    const wrapper = newWrapper(client)
+
+    const first = renderHook(() => useTokenLookup(tokens(3)), { wrapper })
+    await first.waitFor(() =>
+      expect(first.result.current.isLoading).toBe(false)
+    )
+    expect(postV1TokenLookup).toHaveBeenCalledTimes(1)
+
+    const second = renderHook(() => useTokenLookup([tokenAt(1)]), { wrapper })
+    await second.waitFor(() =>
+      expect(second.result.current.isLoading).toBe(false)
+    )
+
+    expect(postV1TokenLookup).toHaveBeenCalledTimes(1)
+    expect(second.result.current.data[responseKey(addressAt(1))]).toEqual({
+      symbol: symbolFor(addressAt(1)),
+      name: symbolFor(addressAt(1))
+    })
+  })
+
+  it('requests only the tokens an overlapping set has not already cached', async () => {
+    const client = newClient()
+    const wrapper = newWrapper(client)
+
+    const first = renderHook(() => useTokenLookup([tokenAt(0), tokenAt(1)]), {
+      wrapper
+    })
+    await first.waitFor(() =>
+      expect(first.result.current.isLoading).toBe(false)
+    )
+
+    const second = renderHook(() => useTokenLookup([tokenAt(1), tokenAt(2)]), {
+      wrapper
+    })
+    await second.waitFor(() =>
+      expect(second.result.current.isLoading).toBe(false)
+    )
+
+    expect(postV1TokenLookup).toHaveBeenCalledTimes(2)
+    expect(requestedAddresses(0)).toEqual([addressAt(0), addressAt(1)])
+    // Only the token the cache was missing.
+    expect(requestedAddresses(1)).toEqual([addressAt(2)])
+  })
+
+  it('makes no request for an empty token list', async () => {
+    const { result } = renderHook(() => useTokenLookup([]), {
+      wrapper: newWrapper(newClient())
+    })
+
+    expect(postV1TokenLookup).not.toHaveBeenCalled()
+    expect(result.current.data).toEqual({})
+  })
+})

--- a/packages/core-mobile/app/new/common/hooks/useTokenLookup.ts
+++ b/packages/core-mobile/app/new/common/hooks/useTokenLookup.ts
@@ -1,14 +1,13 @@
 import { useQueries } from '@tanstack/react-query'
 import { ReactQueryKeys } from 'consts/reactQueryKeys'
 import {
-  postV1TokenLookup,
   type Caip2IdAddressPair,
   type InternalId,
   type TokenInfo
 } from 'utils/api/generated/tokenAggregator/aggregatorApi.client'
-import { tokenAggregatorApi } from 'utils/api/clients/aggregatedTokensApiClient'
 import { useMemo } from 'react'
-import { tokenToKey } from './useTokensWithPrice'
+import { tokenToKey } from 'common/utils/tokenLookup'
+import { enqueueTokenLookup } from 'common/utils/tokenLookupQueue'
 
 export type { TokenInfo }
 
@@ -30,13 +29,7 @@ export function useTokenLookup(
   return useQueries({
     queries: uniqueTokens.map(token => ({
       queryKey: [ReactQueryKeys.TOKEN_LOOKUP, tokenToKey(token)],
-      queryFn: async () => {
-        const response = await postV1TokenLookup({
-          client: tokenAggregatorApi,
-          body: { tokens: [token] }
-        })
-        return response.data?.data ?? {}
-      },
+      queryFn: () => enqueueTokenLookup(token),
       staleTime: STALE_TIME
     })),
     combine: results => ({

--- a/packages/core-mobile/app/new/common/hooks/useTokensWithPrice.ts
+++ b/packages/core-mobile/app/new/common/hooks/useTokensWithPrice.ts
@@ -8,18 +8,12 @@ import {
   type TokenLookupWithPriceInfoResponse
 } from 'utils/api/generated/tokenAggregator/aggregatorApi.client'
 import { tokenAggregatorApi } from 'utils/api/clients/aggregatedTokensApiClient'
+import { tokenToKey } from 'common/utils/tokenLookup'
 
 export type TokenWithPriceData =
   TokenLookupWithPriceInfoResponse['data'][string]
 
 const STALE_TIME = 30 * 1000 // 30 seconds
-
-export const tokenToKey = (token: Caip2IdAddressPair | InternalId): string => {
-  if ('internalId' in token) {
-    return token.internalId.toLowerCase()
-  }
-  return `${token.caip2Id.toLowerCase()}:${token.address.toLowerCase()}`
-}
 
 /**
  * Fetches price and metadata for a list of tokens from the token aggregator.

--- a/packages/core-mobile/app/new/common/utils/chunkArray.test.ts
+++ b/packages/core-mobile/app/new/common/utils/chunkArray.test.ts
@@ -1,0 +1,104 @@
+import { chunkArray } from './chunkArray'
+
+describe('chunkArray', () => {
+  describe('invalid sizes', () => {
+    // 0 and negatives would hang rather than fail; the rest silently
+    // produce misshapen chunks. Both are worse than throwing.
+    it.each([0, -1, -500, NaN, Infinity, -Infinity, 2.5])(
+      'throws for a size of %p',
+      size => {
+        expect(() => chunkArray([1, 2, 3], size)).toThrow(
+          /size must be a positive integer/
+        )
+      }
+    )
+
+    it('throws before touching the array, even when it is empty', () => {
+      expect(() => chunkArray([], 0)).toThrow(/size must be a positive integer/)
+    })
+
+    it('names the offending value in the message', () => {
+      expect(() => chunkArray([1], 0)).toThrow('got 0')
+    })
+  })
+
+  it('returns no chunks for an empty array', () => {
+    expect(chunkArray([], 3)).toEqual([])
+  })
+
+  it('returns a single chunk when the size exceeds the array length', () => {
+    expect(chunkArray([1, 2, 3], 10)).toEqual([[1, 2, 3]])
+  })
+
+  it('returns one chunk per element for a size of 1', () => {
+    expect(chunkArray([1, 2, 3], 1)).toEqual([[1], [2], [3]])
+  })
+
+  it('splits evenly with no trailing empty chunk when the length is a multiple of the size', () => {
+    const chunks = chunkArray([1, 2, 3, 4, 5, 6], 3)
+
+    expect(chunks).toEqual([
+      [1, 2, 3],
+      [4, 5, 6]
+    ])
+    expect(chunks).toHaveLength(2)
+  })
+
+  it('puts the remainder in a short final chunk', () => {
+    expect(chunkArray([1, 2, 3, 4, 5, 6, 7], 3)).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7]
+    ])
+  })
+
+  it('never produces an empty chunk', () => {
+    for (let length = 0; length <= 20; length++) {
+      const input = Array.from({ length }, (_, i) => i)
+
+      for (let size = 1; size <= 7; size++) {
+        const chunks = chunkArray(input, size)
+
+        chunks.forEach(chunk => expect(chunk.length).toBeGreaterThan(0))
+      }
+    }
+  })
+
+  it('preserves every element exactly once, in order', () => {
+    const input = Array.from({ length: 1200 }, (_, i) => i)
+
+    expect(chunkArray(input, 500).flat()).toEqual(input)
+  })
+
+  it('caps every chunk at the requested size', () => {
+    const chunks = chunkArray(
+      Array.from({ length: 1200 }, (_, i) => i),
+      500
+    )
+
+    expect(chunks.map(chunk => chunk.length)).toEqual([500, 500, 200])
+  })
+
+  it('does not mutate the input array', () => {
+    const input = [1, 2, 3, 4, 5]
+    const before = [...input]
+
+    chunkArray(input, 2)
+
+    expect(input).toEqual(before)
+  })
+
+  it('carries element references rather than copies', () => {
+    const a = { id: 'a' }
+    const b = { id: 'b' }
+
+    const chunks = chunkArray([a, b], 1)
+
+    expect(chunks[0]?.[0]).toBe(a)
+    expect(chunks[1]?.[0]).toBe(b)
+  })
+
+  it('chunks a single-element array', () => {
+    expect(chunkArray(['only'], 500)).toEqual([['only']])
+  })
+})

--- a/packages/core-mobile/app/new/common/utils/chunkArray.ts
+++ b/packages/core-mobile/app/new/common/utils/chunkArray.ts
@@ -1,0 +1,15 @@
+export const chunkArray = <T>(array: T[], size: number): T[][] => {
+  // A size of 0 or a negative one never advances `i`, so the loop below would
+  // spin forever instead of returning a wrong answer -- a hang is far more
+  // expensive to diagnose than a throw. NaN, Infinity and fractional sizes are
+  // rejected by the same check: they all produce silently misshapen chunks.
+  if (!Number.isInteger(size) || size < 1) {
+    throw new Error(`chunkArray: size must be a positive integer, got ${size}`)
+  }
+
+  const chunks: T[][] = []
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size))
+  }
+  return chunks
+}

--- a/packages/core-mobile/app/new/common/utils/tokenLookup.ts
+++ b/packages/core-mobile/app/new/common/utils/tokenLookup.ts
@@ -1,7 +1,7 @@
 import { BlockchainNamespace } from '@avalabs/core-chains-sdk'
 import {
-  Caip2IdAddressPair,
-  InternalId
+  type Caip2IdAddressPair,
+  type InternalId
 } from 'utils/api/generated/tokenAggregator/aggregatorApi.client'
 
 const EVM_NAMESPACE_PREFIX = `${BlockchainNamespace.EIP155}:`

--- a/packages/core-mobile/app/new/common/utils/tokenLookup.ts
+++ b/packages/core-mobile/app/new/common/utils/tokenLookup.ts
@@ -1,4 +1,8 @@
 import { BlockchainNamespace } from '@avalabs/core-chains-sdk'
+import {
+  Caip2IdAddressPair,
+  InternalId
+} from 'utils/api/generated/tokenAggregator/aggregatorApi.client'
 
 const EVM_NAMESPACE_PREFIX = `${BlockchainNamespace.EIP155}:`
 
@@ -27,3 +31,17 @@ export const tokenLookupKey = (caip2Id: string, address: string): string => {
   const key = `${caip2Id}-${address}`
   return isEvmCaip2Id(caip2Id) ? key.toLowerCase() : key
 }
+
+export const tokenToKey = (token: Caip2IdAddressPair | InternalId): string => {
+  if ('internalId' in token) {
+    return token.internalId.toLowerCase()
+  }
+  return `${token.caip2Id.toLowerCase()}:${token.address.toLowerCase()}`
+}
+
+export const tokenLookupResponseKey = (
+  token: Caip2IdAddressPair | InternalId
+): string =>
+  'internalId' in token
+    ? token.internalId.toLowerCase()
+    : tokenLookupKey(token.caip2Id, token.address)

--- a/packages/core-mobile/app/new/common/utils/tokenLookupQueue.test.ts
+++ b/packages/core-mobile/app/new/common/utils/tokenLookupQueue.test.ts
@@ -1,0 +1,190 @@
+import { enqueueTokenLookup } from './tokenLookupQueue'
+import type { LookupToken, TokenLookupResult } from './tokenLookupRequest'
+
+jest.mock('./tokenLookupRequest', () => ({
+  lookupTokens: jest.fn()
+}))
+
+const { lookupTokens } = jest.requireMock('./tokenLookupRequest') as {
+  lookupTokens: jest.Mock
+}
+
+const CAIP2 = 'eip155:43114'
+
+const A: LookupToken = { caip2Id: CAIP2, address: '0xAAA' }
+const B: LookupToken = { caip2Id: CAIP2, address: '0xBBB' }
+const C: LookupToken = { caip2Id: CAIP2, address: '0xCCC' }
+
+const keyOf = (token: LookupToken): string =>
+  'internalId' in token
+    ? token.internalId.toLowerCase()
+    : `${token.caip2Id}-${token.address}`.toLowerCase()
+
+const info = (symbol: string): { symbol: string } => ({ symbol })
+
+const succeed = (entries: Array<[LookupToken, string]>): TokenLookupResult =>
+  ({
+    data: Object.fromEntries(
+      entries.map(([token, symbol]) => [keyOf(token), info(symbol)])
+    ),
+    failedTokens: []
+  } as unknown as TokenLookupResult)
+
+const tokensOf = (callIndex: number): LookupToken[] =>
+  lookupTokens.mock.calls[callIndex][0]
+
+// Every test below drains the queue it creates, and `flush` clears both the
+// queue and the scheduled flag even on failure, so the module-level state is
+// clean between tests without resetting modules.
+describe('enqueueTokenLookup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('coalescing', () => {
+    it('sends every token enqueued in the same tick as one request', async () => {
+      lookupTokens.mockResolvedValue(
+        succeed([
+          [A, 'AAA'],
+          [B, 'BBB'],
+          [C, 'CCC']
+        ])
+      )
+
+      await Promise.all([
+        enqueueTokenLookup(A),
+        enqueueTokenLookup(B),
+        enqueueTokenLookup(C)
+      ])
+
+      expect(lookupTokens).toHaveBeenCalledTimes(1)
+      expect(tokensOf(0)).toEqual([A, B, C])
+    })
+
+    it('gives each caller only its own entry', async () => {
+      lookupTokens.mockResolvedValue(
+        succeed([
+          [A, 'AAA'],
+          [B, 'BBB']
+        ])
+      )
+
+      const [resultA, resultB] = await Promise.all([
+        enqueueTokenLookup(A),
+        enqueueTokenLookup(B)
+      ])
+
+      expect(resultA).toEqual({ [keyOf(A)]: info('AAA') })
+      expect(resultB).toEqual({ [keyOf(B)]: info('BBB') })
+    })
+
+    it('starts a fresh batch once the previous one has settled', async () => {
+      lookupTokens.mockResolvedValue(succeed([[A, 'AAA']]))
+      await enqueueTokenLookup(A)
+
+      lookupTokens.mockResolvedValue(succeed([[B, 'BBB']]))
+      await enqueueTokenLookup(B)
+
+      expect(lookupTokens).toHaveBeenCalledTimes(2)
+      expect(tokensOf(0)).toEqual([A])
+      expect(tokensOf(1)).toEqual([B])
+    })
+  })
+
+  describe('tokens the server did not return', () => {
+    it('resolves empty rather than rejecting', async () => {
+      lookupTokens.mockResolvedValue(succeed([[A, 'AAA']]))
+
+      const [resultA, resultB] = await Promise.all([
+        enqueueTokenLookup(A),
+        enqueueTokenLookup(B)
+      ])
+
+      expect(resultA).toEqual({ [keyOf(A)]: info('AAA') })
+      expect(resultB).toEqual({})
+    })
+  })
+
+  describe('failures', () => {
+    it('rejects the failed tokens and resolves the rest', async () => {
+      lookupTokens.mockResolvedValue({
+        data: { [keyOf(A)]: info('AAA') },
+        failedTokens: [B]
+      })
+
+      const settled = await Promise.allSettled([
+        enqueueTokenLookup(A),
+        enqueueTokenLookup(B)
+      ])
+
+      expect(settled[0]).toEqual({
+        status: 'fulfilled',
+        value: { [keyOf(A)]: info('AAA') }
+      })
+      expect(settled[1]?.status).toBe('rejected')
+    })
+
+    it('rejects every caller when the request itself throws', async () => {
+      const boom = new Error('network down')
+      lookupTokens.mockRejectedValue(boom)
+
+      const settled = await Promise.allSettled([
+        enqueueTokenLookup(A),
+        enqueueTokenLookup(B)
+      ])
+
+      expect(settled.map(result => result.status)).toEqual([
+        'rejected',
+        'rejected'
+      ])
+      settled.forEach(result => {
+        expect((result as PromiseRejectedResult).reason).toBe(boom)
+      })
+    })
+
+    it('settles every caller even when a batch fails, leaving nothing pending', async () => {
+      lookupTokens.mockRejectedValue(new Error('network down'))
+
+      // If flush left promises unsettled these awaits would hang rather than
+      // fail, so reaching the assertion at all is the point of this test.
+      await Promise.allSettled([enqueueTokenLookup(A), enqueueTokenLookup(B)])
+
+      lookupTokens.mockResolvedValue(succeed([[C, 'CCC']]))
+
+      await expect(enqueueTokenLookup(C)).resolves.toEqual({
+        [keyOf(C)]: info('CCC')
+      })
+    })
+  })
+
+  describe('a token enqueued while a request is in flight', () => {
+    it('goes into the next batch instead of being dropped', async () => {
+      let releaseFirst!: (value: TokenLookupResult) => void
+      lookupTokens
+        .mockImplementationOnce(
+          () =>
+            new Promise<TokenLookupResult>(resolve => {
+              releaseFirst = resolve
+            })
+        )
+        .mockResolvedValueOnce(succeed([[B, 'BBB']]))
+
+      const first = enqueueTokenLookup(A)
+
+      // Let the scheduled flush run: it takes A, clears the queue, and awaits.
+      await Promise.resolve()
+      expect(lookupTokens).toHaveBeenCalledTimes(1)
+
+      const second = enqueueTokenLookup(B)
+
+      releaseFirst(succeed([[A, 'AAA']]))
+
+      await expect(first).resolves.toEqual({ [keyOf(A)]: info('AAA') })
+      await expect(second).resolves.toEqual({ [keyOf(B)]: info('BBB') })
+
+      expect(lookupTokens).toHaveBeenCalledTimes(2)
+      expect(tokensOf(0)).toEqual([A])
+      expect(tokensOf(1)).toEqual([B])
+    })
+  })
+})

--- a/packages/core-mobile/app/new/common/utils/tokenLookupQueue.ts
+++ b/packages/core-mobile/app/new/common/utils/tokenLookupQueue.ts
@@ -1,0 +1,64 @@
+import { tokenLookupResponseKey } from './tokenLookup'
+import {
+  lookupTokens,
+  type LookupChunkResult,
+  type LookupToken
+} from './tokenLookupRequest'
+
+type PendingLookup = {
+  token: LookupToken
+  resolve: (value: LookupChunkResult) => void
+  reject: (reason: unknown) => void
+}
+
+let queue: PendingLookup[] = []
+let flushScheduled = false
+
+const flush = async (): Promise<void> => {
+  const batch = queue
+  queue = []
+  flushScheduled = false
+
+  if (batch.length === 0) return
+
+  try {
+    const { data, failedTokens } = await lookupTokens(
+      batch.map(pending => pending.token)
+    )
+
+    const failed = new Set<LookupToken>(failedTokens)
+
+    batch.forEach(pending => {
+      if (failed.has(pending.token)) {
+        pending.reject(new Error('Token lookup failed for this batch'))
+        return
+      }
+
+      const key = tokenLookupResponseKey(pending.token)
+      const info = data[key]
+      pending.resolve(info ? { [key]: info } : {})
+    })
+  } catch (error) {
+    batch.forEach(pending => pending.reject(error))
+  }
+}
+
+export const enqueueTokenLookup = (
+  token: LookupToken
+): Promise<LookupChunkResult> => {
+  return new Promise((resolve, reject) => {
+    queue.push({ token, resolve, reject })
+
+    if (!flushScheduled) {
+      flushScheduled = true
+      // Run after this tick so concurrent enqueues (e.g. several useQueries
+      // queryFns in the same render) land in one batch / one request.
+      queueMicrotask(() => {
+        flush().catch(() => {
+          // flush settles every entry itself; this only stops an unhandled
+          // rejection escaping the microtask.
+        })
+      })
+    }
+  })
+}

--- a/packages/core-mobile/app/new/common/utils/tokenLookupRequest.test.ts
+++ b/packages/core-mobile/app/new/common/utils/tokenLookupRequest.test.ts
@@ -1,0 +1,196 @@
+import {
+  lookupTokens,
+  TOKEN_LOOKUP_CHUNK_SIZE,
+  type LookupToken
+} from './tokenLookupRequest'
+
+jest.mock('utils/api/generated/tokenAggregator/aggregatorApi.client', () => ({
+  postV1TokenLookup: jest.fn()
+}))
+
+jest.mock('utils/api/clients/aggregatedTokensApiClient', () => ({
+  tokenAggregatorApi: {}
+}))
+
+const { postV1TokenLookup } = jest.requireMock(
+  'utils/api/generated/tokenAggregator/aggregatorApi.client'
+) as { postV1TokenLookup: jest.Mock }
+
+const CAIP2 = 'eip155:43114'
+const SOLANA_CAIP2 = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
+const USDC_SOLANA_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+
+const pair = (n: number): LookupToken => ({
+  caip2Id: CAIP2,
+  address: `0x${n.toString(16).padStart(40, '0')}`
+})
+
+const pairs = (count: number): LookupToken[] =>
+  Array.from({ length: count }, (_, n) => pair(n))
+
+const resolved = (data: Record<string, unknown> = {}): unknown => ({
+  data: { data }
+})
+
+const bodyTokensOf = (callIndex: number): LookupToken[] =>
+  postV1TokenLookup.mock.calls[callIndex][0].body.tokens
+
+describe('lookupTokens', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    postV1TokenLookup.mockResolvedValue(resolved())
+  })
+
+  describe('empty input', () => {
+    it('makes no request and returns an empty result', async () => {
+      const result = await lookupTokens([])
+
+      expect(postV1TokenLookup).not.toHaveBeenCalled()
+      expect(result).toEqual({ data: {}, failedTokens: [] })
+    })
+  })
+
+  describe('chunking', () => {
+    it.each([
+      [TOKEN_LOOKUP_CHUNK_SIZE - 1, 1],
+      [TOKEN_LOOKUP_CHUNK_SIZE, 1],
+      [TOKEN_LOOKUP_CHUNK_SIZE + 1, 2]
+    ])('splits %i tokens into %i request(s)', async (count, expected) => {
+      await lookupTokens(pairs(count))
+
+      expect(postV1TokenLookup).toHaveBeenCalledTimes(expected)
+    })
+
+    it('never exceeds the chunk size in a single request body', async () => {
+      await lookupTokens(pairs(1200))
+
+      expect(postV1TokenLookup).toHaveBeenCalledTimes(3)
+      expect(bodyTokensOf(0)).toHaveLength(TOKEN_LOOKUP_CHUNK_SIZE)
+      expect(bodyTokensOf(1)).toHaveLength(TOKEN_LOOKUP_CHUNK_SIZE)
+      expect(bodyTokensOf(2)).toHaveLength(200)
+    })
+
+    it('sends every token exactly once, in order', async () => {
+      const tokens = pairs(TOKEN_LOOKUP_CHUNK_SIZE + 3)
+
+      await lookupTokens(tokens)
+
+      expect([...bodyTokensOf(0), ...bodyTokensOf(1)]).toEqual(tokens)
+    })
+  })
+
+  describe('request shape', () => {
+    it('posts through the aggregator client', async () => {
+      const tokens = [pair(1)]
+
+      await lookupTokens(tokens)
+
+      expect(postV1TokenLookup).toHaveBeenCalledWith({
+        client: {},
+        body: { tokens }
+      })
+    })
+
+    it('accepts internalId tokens', async () => {
+      const tokens: LookupToken[] = [{ internalId: 'NATIVE-AVAX' }]
+
+      await lookupTokens(tokens)
+
+      expect(bodyTokensOf(0)).toEqual(tokens)
+    })
+  })
+
+  describe('successful responses', () => {
+    it('merges the entries of every chunk', async () => {
+      postV1TokenLookup
+        .mockResolvedValueOnce(resolved({ 'key-a': { symbol: 'AAA' } }))
+        .mockResolvedValueOnce(resolved({ 'key-b': { symbol: 'BBB' } }))
+
+      const { data, failedTokens } = await lookupTokens(
+        pairs(TOKEN_LOOKUP_CHUNK_SIZE + 1)
+      )
+
+      expect(data).toEqual({
+        'key-a': { symbol: 'AAA' },
+        'key-b': { symbol: 'BBB' }
+      })
+      expect(failedTokens).toEqual([])
+    })
+
+    it('leaves response keys in the casing the server returned', async () => {
+      const serverKey = `${SOLANA_CAIP2}-${USDC_SOLANA_MINT}`
+      postV1TokenLookup.mockResolvedValue(
+        resolved({ [serverKey]: { symbol: 'USDC' } })
+      )
+
+      const { data } = await lookupTokens([
+        { caip2Id: SOLANA_CAIP2, address: USDC_SOLANA_MINT }
+      ])
+
+      expect(Object.keys(data)).toEqual([serverKey])
+    })
+
+    it('treats a token missing from a successful response as absent, not failed', async () => {
+      postV1TokenLookup.mockResolvedValue(resolved())
+
+      const { data, failedTokens } = await lookupTokens([pair(1)])
+
+      expect(data).toEqual({})
+      expect(failedTokens).toEqual([])
+    })
+
+    it('tolerates a response with no data payload', async () => {
+      postV1TokenLookup.mockResolvedValue({ data: null })
+
+      const { data, failedTokens } = await lookupTokens([pair(1)])
+
+      expect(data).toEqual({})
+      expect(failedTokens).toEqual([])
+    })
+  })
+
+  describe('failed chunks', () => {
+    it('keeps a fulfilled chunk and reports only the failed chunk’s tokens', async () => {
+      const tokens = pairs(TOKEN_LOOKUP_CHUNK_SIZE + 2)
+      postV1TokenLookup
+        .mockResolvedValueOnce(resolved({ 'key-a': { symbol: 'AAA' } }))
+        .mockRejectedValueOnce(new Error('INVALID_PAYLOAD'))
+
+      const { data, failedTokens } = await lookupTokens(tokens)
+
+      expect(data).toEqual({ 'key-a': { symbol: 'AAA' } })
+      expect(failedTokens).toEqual(tokens.slice(TOKEN_LOOKUP_CHUNK_SIZE))
+    })
+
+    it('reports the caller’s own token objects so they can be matched by identity', async () => {
+      const tokens = pairs(TOKEN_LOOKUP_CHUNK_SIZE + 1)
+      postV1TokenLookup
+        .mockResolvedValueOnce(resolved())
+        .mockRejectedValueOnce(new Error('network down'))
+
+      const { failedTokens } = await lookupTokens(tokens)
+
+      expect(failedTokens).toHaveLength(1)
+      expect(failedTokens[0]).toBe(tokens[TOKEN_LOOKUP_CHUNK_SIZE])
+    })
+
+    it('returns every token as failed when all chunks fail', async () => {
+      const tokens = pairs(TOKEN_LOOKUP_CHUNK_SIZE + 1)
+      postV1TokenLookup.mockRejectedValue(new Error('network down'))
+
+      const { data, failedTokens } = await lookupTokens(tokens)
+
+      expect(data).toEqual({})
+      expect(failedTokens).toEqual(tokens)
+    })
+
+    it('does not reject when a chunk fails', async () => {
+      postV1TokenLookup.mockRejectedValue(new Error('network down'))
+
+      await expect(lookupTokens([pair(1)])).resolves.toEqual({
+        data: {},
+        failedTokens: [pair(1)]
+      })
+    })
+  })
+})

--- a/packages/core-mobile/app/new/common/utils/tokenLookupRequest.test.ts
+++ b/packages/core-mobile/app/new/common/utils/tokenLookupRequest.test.ts
@@ -192,5 +192,28 @@ describe('lookupTokens', () => {
         failedTokens: [pair(1)]
       })
     })
+
+    it('treats a resolved response carrying an error as failed, not absent', async () => {
+      postV1TokenLookup.mockResolvedValue({
+        error: { message: 'Internal Server Error' }
+      })
+
+      const { data, failedTokens } = await lookupTokens([pair(1)])
+
+      expect(data).toEqual({})
+      expect(failedTokens).toEqual([pair(1)])
+    })
+
+    it('keeps a fulfilled chunk when another chunk resolves with an error', async () => {
+      const tokens = pairs(TOKEN_LOOKUP_CHUNK_SIZE + 1)
+      postV1TokenLookup
+        .mockResolvedValueOnce(resolved({ 'key-a': { symbol: 'AAA' } }))
+        .mockResolvedValueOnce({ error: 'boom' })
+
+      const { data, failedTokens } = await lookupTokens(tokens)
+
+      expect(data).toEqual({ 'key-a': { symbol: 'AAA' } })
+      expect(failedTokens).toEqual(tokens.slice(TOKEN_LOOKUP_CHUNK_SIZE))
+    })
   })
 })

--- a/packages/core-mobile/app/new/common/utils/tokenLookupRequest.ts
+++ b/packages/core-mobile/app/new/common/utils/tokenLookupRequest.ts
@@ -26,6 +26,21 @@ export const lookupChunk = async (
     client: tokenAggregatorApi,
     body: { tokens }
   })
+
+  /**
+   * `tokenAggregatorApi` is created with `throwOnError: true`, so a 500 or a
+   * surviving 401 already threw before we got here and `error` is undefined.
+   * Guard anyway: the generated signature still models `error` (its
+   * `ThrowOnError` generic defaults to `false`), so nothing but that one client
+   * flag stands between us and returning `{}` for a failed request -- which
+   * would cache "these tokens do not exist" instead of retrying.
+   */
+  if (response.error !== undefined) {
+    throw new Error(
+      `Token lookup request failed: ${JSON.stringify(response.error)}`
+    )
+  }
+
   return response.data?.data ?? {}
 }
 
@@ -49,10 +64,14 @@ export const lookupTokens = async (
     }
 
     /**
-     * This chunks request never landed so we know nothing about its tokens
-     * this is different than when the request succeeds but we don't have that token in the catalog on the backend
-     * Callers must reject these rather than resolve empty so that it can retry, otherwise it will React Query will
-     * cache this as empty until the next staleTime or garbage collection when a simple retry may have re populated it
+     * This chunk's request never landed, so we know nothing about its tokens.
+     * That is different from a request that succeeded without carrying a
+     * token, which tells us the backend catalog genuinely has no entry for it.
+     *
+     * Callers must reject these rather than resolve them empty. Resolving
+     * empty would have React Query cache "this token does not exist" until the
+     * next staleTime or garbage collection, skipping the retry that would have
+     * repopulated it.
      */
     failedTokens.push(...(chunks[index] ?? []))
   })

--- a/packages/core-mobile/app/new/common/utils/tokenLookupRequest.ts
+++ b/packages/core-mobile/app/new/common/utils/tokenLookupRequest.ts
@@ -1,0 +1,61 @@
+import {
+  postV1TokenLookup,
+  type Caip2IdAddressPair,
+  type InternalId,
+  type TokenInfo
+} from 'utils/api/generated/tokenAggregator/aggregatorApi.client'
+
+import { chunkArray } from 'common/utils/chunkArray'
+import { tokenAggregatorApi } from 'utils/api/clients/aggregatedTokensApiClient'
+
+export type LookupToken = Caip2IdAddressPair | InternalId
+
+export type LookupChunkResult = { [key: string]: TokenInfo }
+
+export type TokenLookupResult = {
+  data: LookupChunkResult
+  failedTokens: LookupToken[]
+}
+
+export const TOKEN_LOOKUP_CHUNK_SIZE = 500
+
+export const lookupChunk = async (
+  tokens: LookupToken[]
+): Promise<LookupChunkResult> => {
+  const response = await postV1TokenLookup({
+    client: tokenAggregatorApi,
+    body: { tokens }
+  })
+  return response.data?.data ?? {}
+}
+
+export const lookupTokens = async (
+  tokens: LookupToken[]
+): Promise<TokenLookupResult> => {
+  if (tokens.length === 0) {
+    return { data: {}, failedTokens: [] }
+  }
+
+  const chunks = chunkArray(tokens, TOKEN_LOOKUP_CHUNK_SIZE)
+  const settled = await Promise.allSettled(chunks.map(lookupChunk))
+
+  const data: LookupChunkResult = {}
+  const failedTokens: LookupToken[] = []
+
+  settled.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
+      Object.assign(data, result.value)
+      return
+    }
+
+    /**
+     * This chunks request never landed so we know nothing about its tokens
+     * this is different than when the request succeeds but we don't have that token in the catalog on the backend
+     * Callers must reject these rather than resolve empty so that it can retry, otherwise it will React Query will
+     * cache this as empty until the next staleTime or garbage collection when a simple retry may have re populated it
+     */
+    failedTokens.push(...(chunks[index] ?? []))
+  })
+
+  return { data, failedTokens }
+}

--- a/packages/core-mobile/app/services/activity/ActivityService.test.ts
+++ b/packages/core-mobile/app/services/activity/ActivityService.test.ts
@@ -703,6 +703,22 @@ describe('ActivityService', () => {
       expect(result.transactions[CHUNK_SIZE]!.tokens[0]!.symbol).toBe('Unknown')
     })
 
+    it('warns when a chunk fails, since lookupTokens resolves rather than throwing', async () => {
+      const { default: Logger } = jest.requireMock('utils/Logger') as {
+        default: { warn: jest.Mock }
+      }
+      const addresses = mints(CHUNK_SIZE + 1)
+      mockPostV1TokenLookup
+        .mockResolvedValueOnce(makeLookupResponse([]))
+        .mockRejectedValueOnce(new Error('INVALID_PAYLOAD'))
+
+      await activityFor(addresses)
+
+      expect(Logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Token lookup failed for 1 of 501 tokens')
+      )
+    })
+
     it('chunks unique mints rather than transactions', async () => {
       echoEveryRequestedToken()
       const repeated = Array.from({ length: 600 }, (_, index) =>

--- a/packages/core-mobile/app/services/activity/ActivityService.test.ts
+++ b/packages/core-mobile/app/services/activity/ActivityService.test.ts
@@ -587,4 +587,132 @@ describe('ActivityService', () => {
       expect(result.nextPageToken).toBe('page2')
     })
   })
+
+  describe('chunking the token lookup', () => {
+    // The endpoint rejects bodies over 500 tokens with INVALID_PAYLOAD. Before
+    // chunking, one oversized batch failed wholesale and left EVERY symbol in
+    // it as "Unknown", not just the ones past the limit.
+    const CHUNK_SIZE = 500
+
+    const mintAt = (index: number): string =>
+      `Mint${index}AaBbCcDdEeFfGgHhJjKkLmNnPpQqRrSs`
+
+    const mints = (count: number): string[] =>
+      Array.from({ length: count }, (_, index) => mintAt(index))
+
+    const symbolFor = (address: string): string => `SYM-${address}`
+
+    const echoEveryRequestedToken = (): void => {
+      mockPostV1TokenLookup.mockImplementation(
+        (options: { body: { tokens: Array<{ address: string }> } }) =>
+          Promise.resolve(
+            makeLookupResponse(
+              options.body.tokens.map(({ address }) => ({
+                address,
+                symbol: symbolFor(address),
+                name: symbolFor(address)
+              }))
+            )
+          )
+      )
+    }
+
+    const activityFor = async (
+      addresses: string[]
+    ): Promise<Awaited<ReturnType<ActivityService['getActivities']>>> => {
+      const module = makeModule({
+        transactions: addresses.map(address =>
+          makeTx([makeUnknownTxToken(address, '1')])
+        ),
+        nextPageToken: undefined
+      })
+      mockLoadModuleByNetwork.mockResolvedValue(module)
+
+      return service.getActivities({
+        network: makeSvmNetwork(),
+        account: {} as any
+      })
+    }
+
+    const requestedTokenCounts = (): number[] =>
+      mockPostV1TokenLookup.mock.calls.map(
+        ([options]) => options.body.tokens.length
+      )
+
+    it.each([
+      [1, 1],
+      [CHUNK_SIZE - 1, 1],
+      [CHUNK_SIZE, 1],
+      [CHUNK_SIZE + 1, 2],
+      [CHUNK_SIZE * 2, 2],
+      [CHUNK_SIZE * 2 + 1, 3]
+    ])(
+      'splits %i unknown mints into %i request(s)',
+      async (mintCount, expectedRequests) => {
+        echoEveryRequestedToken()
+
+        await activityFor(mints(mintCount))
+
+        expect(mockPostV1TokenLookup).toHaveBeenCalledTimes(expectedRequests)
+        expect(requestedTokenCounts().every(count => count <= CHUNK_SIZE)).toBe(
+          true
+        )
+        expect(
+          requestedTokenCounts().reduce((sum, count) => sum + count, 0)
+        ).toBe(mintCount)
+      }
+    )
+
+    it('resolves symbols from every chunk, not just the first', async () => {
+      echoEveryRequestedToken()
+      const addresses = mints(CHUNK_SIZE + 10)
+
+      const result = await activityFor(addresses)
+
+      // First, last, and the one straddling the chunk boundary.
+      expect(result.transactions[0]!.tokens[0]!.symbol).toBe(
+        symbolFor(addresses[0]!)
+      )
+      expect(result.transactions[CHUNK_SIZE]!.tokens[0]!.symbol).toBe(
+        symbolFor(addresses[CHUNK_SIZE]!)
+      )
+      expect(result.transactions[CHUNK_SIZE + 9]!.tokens[0]!.symbol).toBe(
+        symbolFor(addresses[CHUNK_SIZE + 9]!)
+      )
+    })
+
+    it('keeps the surviving chunk when another chunk fails', async () => {
+      const addresses = mints(CHUNK_SIZE + 1)
+      mockPostV1TokenLookup
+        .mockResolvedValueOnce(
+          makeLookupResponse(
+            addresses.slice(0, CHUNK_SIZE).map(address => ({
+              address,
+              symbol: symbolFor(address),
+              name: symbolFor(address)
+            }))
+          )
+        )
+        .mockRejectedValueOnce(new Error('INVALID_PAYLOAD'))
+
+      const result = await activityFor(addresses)
+
+      expect(result.transactions[0]!.tokens[0]!.symbol).toBe(
+        symbolFor(addresses[0]!)
+      )
+      expect(result.transactions[CHUNK_SIZE]!.tokens[0]!.symbol).toBe('Unknown')
+    })
+
+    it('chunks unique mints rather than transactions', async () => {
+      echoEveryRequestedToken()
+      const repeated = Array.from({ length: 600 }, (_, index) =>
+        index % 2 === 0 ? USDC_MINT : PUMP_MINT
+      )
+
+      await activityFor(repeated)
+
+      expect(mockPostV1TokenLookup).toHaveBeenCalledTimes(1)
+      expect(requestedTokenCounts()).toEqual([2])
+    })
+  })
 })

--- a/packages/core-mobile/app/services/activity/ActivityService.tsx
+++ b/packages/core-mobile/app/services/activity/ActivityService.tsx
@@ -189,7 +189,16 @@ export class ActivityService {
         address
       }))
 
-      const { data } = await lookupTokens(tokens)
+      const { data, failedTokens } = await lookupTokens(tokens)
+
+      if (failedTokens.length > 0) {
+        // `lookupTokens` resolves on a chunk failure instead of throwing, so a
+        // partial outage never reaches the catch below. Left unlogged, those
+        // mints would just render as "Unknown" with nothing in telemetry.
+        Logger.warn(
+          `Token lookup failed for ${failedTokens.length} of ${tokens.length} tokens; their symbols stay unresolved`
+        )
+      }
 
       for (const address of addresses) {
         const info = data[tokenLookupKey(caip2Id, address)]

--- a/packages/core-mobile/app/services/activity/ActivityService.tsx
+++ b/packages/core-mobile/app/services/activity/ActivityService.tsx
@@ -15,12 +15,9 @@ import { isAvalancheCChainId } from 'services/network/utils/isAvalancheNetwork'
 import GlacierService from 'services/glacier/GlacierService'
 import type { Transaction } from 'store/transaction/types'
 import { getSolanaCaip2ChainId } from 'utils/caip2ChainIds'
-import {
-  postV1TokenLookup,
-  type Caip2IdAddressPair
-} from 'utils/api/generated/tokenAggregator/aggregatorApi.client'
-import { tokenAggregatorApi } from 'utils/api/clients/aggregatedTokensApiClient'
+import { type Caip2IdAddressPair } from 'utils/api/generated/tokenAggregator/aggregatorApi.client'
 import { tokenLookupKey } from 'common/utils/tokenLookup'
+import { lookupTokens } from 'common/utils/tokenLookupRequest'
 import { ActivityResponse, GetActivitiesForAccountParams } from './types'
 import { convertTransaction } from './utils/convertTransaction'
 import { convertCChainAtomicTransaction } from './utils/convertCChainAtomicTransaction'
@@ -191,11 +188,8 @@ export class ActivityService {
         caip2Id,
         address
       }))
-      const response = await postV1TokenLookup({
-        client: tokenAggregatorApi,
-        body: { tokens }
-      })
-      const data = response.data?.data ?? {}
+
+      const { data } = await lookupTokens(tokens)
 
       for (const address of addresses) {
         const info = data[tokenLookupKey(caip2Id, address)]

--- a/packages/core-mobile/app/services/balance/utils/buildRequestItemsForAccounts.ts
+++ b/packages/core-mobile/app/services/balance/utils/buildRequestItemsForAccounts.ts
@@ -15,6 +15,7 @@ import {
   GetBalancesRequestBody,
   SvmGetBalancesRequestItem
 } from 'utils/api/generated/balanceApi.client'
+import { chunkArray } from 'common/utils/chunkArray'
 
 /**
  * Maximum number of EVM references allowed per request item
@@ -300,26 +301,5 @@ export const buildRequestItemsForAccounts = ({
     ...evmItems
   ]
 
-  // Pack items into batches of max 5
-  const finalBatches: GetBalancesRequestBody['data'][] = []
-  for (let i = 0; i < allItems.length; i += MAX_NAMESPACES_PER_BATCH) {
-    const chunk = allItems.slice(i, i + MAX_NAMESPACES_PER_BATCH)
-    if (chunk.length > 0) {
-      finalBatches.push(chunk)
-    }
-  }
-
-  return finalBatches
-}
-
-const chunkArray = <T>(arr: T[], size: number): T[][] => {
-  if (size <= 0) return []
-  const chunks: T[][] = []
-  for (let i = 0; i < arr.length; i += size) {
-    const chunk = arr.slice(i, i + size)
-    if (chunk.length > 0) {
-      chunks.push(chunk)
-    }
-  }
-  return chunks
+  return chunkArray(allItems, MAX_NAMESPACES_PER_BATCH)
 }


### PR DESCRIPTION
## Description

**Ticket: [CP-14963](https://ava-labs.atlassian.net/browse/CP-14963)**

`useTokenLookup` issues **one HTTP request per token**. Five call sites use it and three of them pass arrays, so a screen showing 8 tokens makes 8 requests. Copilot flagged this on `RecurringSchedulesScreen` during CP-14936 review and the agreed plan was a batched variant that seeds the per-token cache entries. This is that.

No call site changes. Query keys, `staleTime`, dedupe and `combine` are untouched.

### The problem is a false trade-off

This repo already contains both halves of the answer, in two sibling hooks for two sibling endpoints:

| | requests | cache sharing |
|---|---|---|
| `useTokenLookup` (per-token queries) | **N** | per-token ✅ |
| `useTokensWithPrice` (one array-keyed query) | 1 | none ❌ |

Per-token queries are deliberate: a token resolved anywhere is free everywhere, and a set that changes by one member refetches only that member. `useTokensWithPrice` keys its query on the whole array, so it makes one request but shares nothing and refetches everything when membership changes.

We want both. So the fan-out stays and the *fetches* get merged underneath it.

```mermaid
flowchart TB
    subgraph before["BEFORE - 8 tokens, 8 requests"]
        direction TB
        B0["useTokenLookup([A..H])"]
        B0 --> BQ1["query A"] --> BH1["POST /v1/token/lookup"]
        B0 --> BQ2["query B"] --> BH2["POST /v1/token/lookup"]
        B0 --> BQ3["query C..H"] --> BH3["POST x 6 more"]
    end
    subgraph after["AFTER - 8 tokens, 1 request"]
        direction TB
        A0["useTokenLookup([A..H])"]
        A0 --> AQ1["query A"]
        A0 --> AQ2["query B"]
        A0 --> AQ3["query C..H"]
        AQ1 --> CO["coalescer"]
        AQ2 --> CO
        AQ3 --> CO
        CO --> AH["1 x POST /v1/token/lookup<br/>tokens: [A..H]"]
    end
```

Same 8 cache entries in both. Only the network calls collapse.

### How the coalescer works

Each `queryFn` stops fetching and instead enqueues its token, returning a promise that the flush settles later. All the `queryFn`s in a render pass land in the same queue, one microtask later the queue is drained into a single request, and each waiter gets its own slice of the response.

```mermaid
sequenceDiagram
    participant RQ as React Query
    participant Q as coalescer
    participant LT as lookupTokens
    participant API as POST /v1/token/lookup

    RQ->>Q: enqueue(A) - schedules flush
    RQ->>Q: enqueue(B)
    RQ->>Q: enqueue(C)
    Note over Q: microtask fires<br/>queue swapped out BEFORE awaiting
    Q->>LT: lookupTokens([A,B,C])
    LT->>API: tokens: [A,B,C]
    API-->>LT: { keyA:..., keyB:..., keyC:... }
    LT-->>Q: merged data + failedTokens
    Q-->>RQ: resolve A with { keyA }
    Q-->>RQ: resolve B with { keyB }
    Q-->>RQ: resolve C with { keyC }
    Note over RQ: 3 independent cache entries
```

Two details worth a reviewer's eye:

- **The queue is swapped out before the `await`.** A token enqueued mid-flight belongs to the next batch. Clearing afterwards would discard it without settling its promise, stranding that query in `isLoading` forever with no error and no retry.
- **Each waiter gets a slice, not the whole map.** Handing everyone the merged map would produce the same rendered result, but token A's cache entry would then physically contain a snapshot of token B, and `combine`'s `Object.assign` ordering could let a stale copy overwrite a fresh entry.

### Why coalesce at all

Because the endpoint's cost is almost entirely per-request, not per-token. Measured against the live endpoint from an internal build on a physical Pixel 8 Pro:

| tokens in one request | latency |
|---:|---:|
| 1 | 68 ms |
| 10 | 65 ms |
| 50 | 89 ms |
| 100 | 148 ms |
| 200 | 167 ms |
| 300 | 186 ms |
| 500 | 241 ms |

**500x the data for 3.5x the time.** On top of that, every request separately pays an App Check token fetch across the native bridge in `appCheckFetch`, plus a possible 401/403 path that repeats the whole request. On mobile, N scattered requests also hold the cellular radio awake where one would not.

The same probe established the ceiling: the endpoint accepts at most **500 tokens** and rejects more with `INVALID_PAYLOAD` / `too_big` (`maximum: 500, inclusive: true`). That number is now a named constant with the server's error recorded next to it.

### Bug fixed on the way

`ActivityService.populateFromTokenLookup` sent an **unbounded** token array inside a `try/catch` that only warns. A Solana account whose activity batch contained more than 500 distinct unknown mints got `INVALID_PAYLOAD`, the catch swallowed it, and **every** symbol in that batch silently stayed `"Unknown"` — not just the ones past the limit. It now chunks, and a partial failure keeps the chunks that succeeded.

### Unresolved is not the same as absent

```mermaid
flowchart LR
    R{"token's chunk"} -->|"request succeeded,<br/>token present"| F["resolve with its entry"]
    R -->|"request succeeded,<br/>token absent"| E["resolve empty<br/>(genuinely not in catalog)"]
    R -->|"request failed"| X["REJECT<br/>(unknown - let React Query retry)"]
```

This is why the primitive reports failed tokens separately instead of just returning data. Resolving a failed token as empty would let React Query cache *"this token does not exist"* for the whole `staleTime` and skip the retry that would have fixed it — turning a network blip into tokens silently missing from a list.

### Also in here

- `chunkArray` promoted from a private helper in `buildRequestItemsForAccounts` (7 call sites, unchanged) to a shared util. It gained a guard: a size of `0` or negative previously **hung in an infinite loop**, and `NaN` produced a bogus `[[]]`.
- `tokenToKey` moved from `useTokensWithPrice` to `common/utils/tokenLookup`, so all three key functions live together. They are easy to confuse and must not be crossed:

| function | purpose | format |
|---|---|---|
| `tokenToKey` | React Query **cache** key | `caip2:address`, all lowercase |
| `tokenLookupResponseKey` | reading the **response** map | `caip2-address`, Solana case preserved |
| `tokenLookupKey` | the address-pair half of the above | same |

No new dependencies. Not breaking.

## Screenshots/Videos

JS-only change with no UI surface of its own. Verified on a physical Pixel 8 Pro against a funded multi-chain wallet; every affected screen renders identically, with names, symbols, icons and network badges resolved off batched data.

## Testing

**Dev Testing**

iOS: n/a
Android: verified on a physical Pixel 8 Pro (internal debug build via Metro, real wallet)

Temporary instrumentation counted tokens enqueued vs HTTP requests issued, then reverted:

| Screen | tokens enqueued | HTTP requests | before |
|---|---:|---:|---:|
| Earn / DeFi market | 7, then 8 | **1 + 1** | 15 |
| Meld Buy → token picker | 1 | **1** | 1 |
| Swap | 3 | **1** | 3 |
| Borrow | 0 | **0** (all cache hits) | — |
| Portfolio, DeFi portfolio | 0 | 0 | 0 |

**21 requests became 3.** The DeFi market trace shows it plainly — seven separate `queryFn` calls, one flush, one request:

```
CP14936_ENQ queued=1 ... queued=7
CP14936_BATCH tokens=7
CP14936_HTTP  tokens=7
```

Borrow returning **zero** requests is the other half of the proof: its tokens were already cached from Deposit, so the per-token sharing served the whole screen with no network, and it still rendered LINK.e on Aave with icon, health score and APY.

Automated coverage — 32 suites / 365 tests, real `tsc -p .` clean, eslint `--max-warnings=0` clean:

- `tokenLookupRequest` (16) — chunk boundaries at 499/500/501, no body over 500, partial-chunk failure keeps the survivor's data, Solana response keys keep their casing.
- `tokenLookupQueue` (8) — N tokens in one tick produce one call, each caller gets only its own slice, failed tokens reject while batch-mates resolve, a thrown request leaves nothing pending, and a token enqueued mid-flight lands in the next batch.
- `useTokenLookup.batching` (5) — drives the **real** React Query rather than mocking `useQueries`: 8 tokens → 1 request; an already-cached token costs nothing; an overlapping set `[0,1]` then `[1,2]` requests only token 2.
- `chunkArray` (20) — including 9 invalid-size cases that now throw instead of hanging.
- `ActivityService` (20, 9 new) — 1/499/500 → 1 request, 501/1000 → 2, 1001 → 3; symbols resolve from every chunk; a failed chunk still resolves the survivor; unique mints are chunked rather than transactions.

Each non-obvious behaviour was mutation-tested — I broke the implementation and confirmed the right tests failed:

| mutation | caught by |
|---|---|
| clear the queue *after* the await | 2 coalescer tests (one as a 5s hang) |
| resolve with the whole map instead of a slice | 2 coalescer tests |
| chunking disabled | 3 ActivityService tests |

**Not verified on device:** `ActivityService`'s lookup path. This wallet has no Solana transaction history, so `resolveUnknownTokenSymbols` short-circuits with nothing to resolve. It stays covered by unit tests only; exercising it for real needs a wallet with SPL activity.

**QA Testing**

- Portfolio, Send, Activity, Swap, Earn (Deposit and Borrow), Buy and Recurring Swap should all be visually unchanged.
- Token names, symbols and logos must still resolve everywhere — the regression shape here is tokens quietly rendering without a symbol or icon, not an error.
- Navigate between Earn → Deposit → Borrow: the second screen should populate without a loading flash, since its tokens are already cached.
- Solana account with SPL activity: Activity symbols must resolve rather than showing "Unknown". Worth targeting an account with a lot of distinct unknown mints, as that is the chunking path.
- Airplane-mode mid-navigation, then restore: affected rows should recover on retry rather than staying permanently blank.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CP-14963]: https://ava-labs.atlassian.net/browse/CP-14963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ