### PR TITLE
CP-14966: Optimize Bitrise Android builds (Gradle build cache, NPM cache fallback, fast SDK guard)

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -31,10 +31,10 @@ workflows:
               #!/usr/bin/env bash
               set -ex
               sudo apt-get install -y build-essential autoconf automake libtool tar
-    - install-missing-android-tools@3:
+    - script-runner@0:
+        title: Ensure Android SDK components
         inputs:
-        - ndk_version: 27.1.12297006
-        - gradlew_path: $ANDROID_PROJECT_LOCATION/gradlew
+        - file_path: scripts/bitrise/ensureAndroidTools.sh
     - restore-gradle-cache@1: {}
     - android-build@1:
         inputs:
@@ -85,10 +85,10 @@ workflows:
               #!/usr/bin/env bash
               set -ex
               sudo apt-get install -y build-essential autoconf automake libtool tar
-    - install-missing-android-tools@3:
+    - script-runner@0:
+        title: Ensure Android SDK components
         inputs:
-        - ndk_version: 27.1.12297006
-        - gradlew_path: $ANDROID_PROJECT_LOCATION/gradlew
+        - file_path: scripts/bitrise/ensureAndroidTools.sh
     - restore-gradle-cache@1: {}
     - android-build@1:
         inputs:
@@ -142,10 +142,10 @@ workflows:
               #!/usr/bin/env bash
               set -ex
               sudo apt-get install -y build-essential autoconf automake libtool tar
-    - install-missing-android-tools@3:
+    - script-runner@0:
+        title: Ensure Android SDK components
         inputs:
-        - ndk_version: 27.1.12297006
-        - gradlew_path: $ANDROID_PROJECT_LOCATION/gradlew
+        - file_path: scripts/bitrise/ensureAndroidTools.sh
     - restore-gradle-cache@1: {}
     - android-build@1:
         inputs:
@@ -324,7 +324,9 @@ workflows:
     - restore-cache@1:
         title: Restore NPM Cache
         inputs:
-        - key: '{{ .OS }}-{{ .Arch }}-npm-cache-{{ checksum "yarn.lock" }}'
+        - key: |-
+            {{ .OS }}-{{ .Arch }}-npm-cache-{{ checksum "yarn.lock" }}
+            {{ .OS }}-{{ .Arch }}-npm-cache-
     - script-runner@0:
         title: Yarn Setup
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -39,7 +39,11 @@ workflows:
     - restore-cache@1:
         # restore/save-gradle-cache only persist dependencies, never task outputs
         # (build-cache-1 is excluded in the step source), so org.gradle.caching
-        # needs this separate pair. Content-addressed cache -> rolling prefix key.
+        # needs this separate pair. Static key, shared across branches: Gradle's
+        # cache is content-addressed, and the save step updates the key's content
+        # only when the archive checksum changes. Do NOT add is_key_unique here:
+        # with a non-checksum key it makes every post-restore save skip, freezing
+        # the cache at its first-ever contents.
         title: Restore Gradle Build Cache
         inputs:
         - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
@@ -55,7 +59,6 @@ workflows:
     - save-cache@1:
         title: Save Gradle Build Cache
         inputs:
-        - is_key_unique: "true"
         - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
         - paths: ~/.gradle/caches/build-cache-1
     - sign-apk@1:
@@ -119,7 +122,6 @@ workflows:
     - save-cache@1:
         title: Save Gradle Build Cache
         inputs:
-        - is_key_unique: "true"
         - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
         - paths: ~/.gradle/caches/build-cache-1
     - sign-apk@1:
@@ -186,7 +188,6 @@ workflows:
     - save-cache@1:
         title: Save Gradle Build Cache
         inputs:
-        - is_key_unique: "true"
         - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
         - paths: ~/.gradle/caches/build-cache-1
     - sign-apk@1:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -36,6 +36,13 @@ workflows:
         inputs:
         - file_path: scripts/bitrise/ensureAndroidTools.sh
     - restore-gradle-cache@1: {}
+    - restore-cache@1:
+        # restore/save-gradle-cache only persist dependencies, never task outputs
+        # (build-cache-1 is excluded in the step source), so org.gradle.caching
+        # needs this separate pair. Content-addressed cache -> rolling prefix key.
+        title: Restore Gradle Build Cache
+        inputs:
+        - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
     - android-build@1:
         inputs:
         - project_location: $ANDROID_PROJECT_LOCATION
@@ -45,6 +52,12 @@ workflows:
         - variant: $ANDROID_BUILD_VARIANT
         - arguments: $ANDROID_GRADLE_ARGS
     - save-gradle-cache@1: {}
+    - save-cache@1:
+        title: Save Gradle Build Cache
+        inputs:
+        - is_key_unique: "true"
+        - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
+        - paths: ~/.gradle/caches/build-cache-1
     - sign-apk@1:
         inputs:
         - android_app: $BITRISE_AAB_PATH
@@ -90,6 +103,10 @@ workflows:
         inputs:
         - file_path: scripts/bitrise/ensureAndroidTools.sh
     - restore-gradle-cache@1: {}
+    - restore-cache@1:
+        title: Restore Gradle Build Cache
+        inputs:
+        - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
     - android-build@1:
         inputs:
         - project_location: $ANDROID_PROJECT_LOCATION
@@ -99,6 +116,12 @@ workflows:
         - variant: $ANDROID_BUILD_VARIANT
         - arguments: -PreactNativeArchitectures=armeabi-v7a,arm64-v8a,x86_64
     - save-gradle-cache@1: {}
+    - save-cache@1:
+        title: Save Gradle Build Cache
+        inputs:
+        - is_key_unique: "true"
+        - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
+        - paths: ~/.gradle/caches/build-cache-1
     - sign-apk@1:
         inputs:
         - android_app: $BITRISE_APK_PATH
@@ -147,6 +170,10 @@ workflows:
         inputs:
         - file_path: scripts/bitrise/ensureAndroidTools.sh
     - restore-gradle-cache@1: {}
+    - restore-cache@1:
+        title: Restore Gradle Build Cache
+        inputs:
+        - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
     - android-build@1:
         inputs:
         - project_location: $ANDROID_PROJECT_LOCATION
@@ -156,6 +183,12 @@ workflows:
         - variant: $ANDROID_BUILD_VARIANT
         - arguments: -PreactNativeArchitectures=armeabi-v7a,arm64-v8a,x86_64
     - save-gradle-cache@1: {}
+    - save-cache@1:
+        title: Save Gradle Build Cache
+        inputs:
+        - is_key_unique: "true"
+        - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
+        - paths: ~/.gradle/caches/build-cache-1
     - sign-apk@1:
         inputs:
         - android_app: $BITRISE_APK_PATH

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -36,17 +36,6 @@ workflows:
         inputs:
         - file_path: scripts/bitrise/ensureAndroidTools.sh
     - restore-gradle-cache@1: {}
-    - restore-cache@1:
-        # restore/save-gradle-cache only persist dependencies, never task outputs
-        # (build-cache-1 is excluded in the step source), so org.gradle.caching
-        # needs this separate pair. Static key, shared across branches: Gradle's
-        # cache is content-addressed, and the save step updates the key's content
-        # only when the archive checksum changes. Do NOT add is_key_unique here:
-        # with a non-checksum key it makes every post-restore save skip, freezing
-        # the cache at its first-ever contents.
-        title: Restore Gradle Build Cache
-        inputs:
-        - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
     - android-build@1:
         inputs:
         - project_location: $ANDROID_PROJECT_LOCATION
@@ -56,11 +45,6 @@ workflows:
         - variant: $ANDROID_BUILD_VARIANT
         - arguments: $ANDROID_GRADLE_ARGS
     - save-gradle-cache@1: {}
-    - save-cache@1:
-        title: Save Gradle Build Cache
-        inputs:
-        - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
-        - paths: ~/.gradle/caches/build-cache-1
     - sign-apk@1:
         inputs:
         - android_app: $BITRISE_AAB_PATH
@@ -106,10 +90,6 @@ workflows:
         inputs:
         - file_path: scripts/bitrise/ensureAndroidTools.sh
     - restore-gradle-cache@1: {}
-    - restore-cache@1:
-        title: Restore Gradle Build Cache
-        inputs:
-        - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
     - android-build@1:
         inputs:
         - project_location: $ANDROID_PROJECT_LOCATION
@@ -119,11 +99,6 @@ workflows:
         - variant: $ANDROID_BUILD_VARIANT
         - arguments: -PreactNativeArchitectures=armeabi-v7a,arm64-v8a,x86_64
     - save-gradle-cache@1: {}
-    - save-cache@1:
-        title: Save Gradle Build Cache
-        inputs:
-        - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
-        - paths: ~/.gradle/caches/build-cache-1
     - sign-apk@1:
         inputs:
         - android_app: $BITRISE_APK_PATH
@@ -172,10 +147,6 @@ workflows:
         inputs:
         - file_path: scripts/bitrise/ensureAndroidTools.sh
     - restore-gradle-cache@1: {}
-    - restore-cache@1:
-        title: Restore Gradle Build Cache
-        inputs:
-        - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
     - android-build@1:
         inputs:
         - project_location: $ANDROID_PROJECT_LOCATION
@@ -185,11 +156,6 @@ workflows:
         - variant: $ANDROID_BUILD_VARIANT
         - arguments: -PreactNativeArchitectures=armeabi-v7a,arm64-v8a,x86_64
     - save-gradle-cache@1: {}
-    - save-cache@1:
-        title: Save Gradle Build Cache
-        inputs:
-        - key: '{{ .OS }}-{{ .Arch }}-gradle-build-cache-'
-        - paths: ~/.gradle/caches/build-cache-1
     - sign-apk@1:
         inputs:
         - android_app: $BITRISE_APK_PATH

--- a/packages/core-mobile/android/gradle.properties
+++ b/packages/core-mobile/android/gradle.properties
@@ -19,7 +19,10 @@ org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1g
 org.gradle.parallel=true
 
 # Enable the Gradle build cache so task outputs are reused across builds.
-# CI persists ~/.gradle via the restore/save-gradle-cache Bitrise steps.
+# CI persists the cache dir via the dedicated "Restore/Save Gradle Build Cache"
+# steps in bitrise.yml — NOT the pre-existing restore/save-gradle-cache steps,
+# which exclude build-cache-1 (they only save dependencies). Removing that
+# step pair silently disables cross-build reuse. See docs/ci_android_build_caching.md.
 org.gradle.caching=true
 
 # AndroidX package structure to make it clearer which packages are bundled with the

--- a/packages/core-mobile/android/gradle.properties
+++ b/packages/core-mobile/android/gradle.properties
@@ -18,11 +18,10 @@ org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1g
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
-# Enable the Gradle build cache so task outputs are reused across builds.
-# CI persists the cache dir via the dedicated "Restore/Save Gradle Build Cache"
-# steps in bitrise.yml — NOT the pre-existing restore/save-gradle-cache steps,
-# which exclude build-cache-1 (they only save dependencies). Removing that
-# step pair silently disables cross-build reuse. See docs/ci_android_build_caching.md.
+# Enable the Gradle build cache. Benefits local dev builds and same-build task
+# dedupe in CI. Cross-build persistence in CI was measured as ~neutral while the
+# CMake/NDK C++ compile dominates the critical path, so it ships with the ccache
+# work instead (CP-14974). See docs/ci_android_build_caching.md.
 org.gradle.caching=true
 
 # AndroidX package structure to make it clearer which packages are bundled with the

--- a/packages/core-mobile/android/gradle.properties
+++ b/packages/core-mobile/android/gradle.properties
@@ -18,6 +18,10 @@ org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1g
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
+# Enable the Gradle build cache so task outputs are reused across builds.
+# CI persists ~/.gradle via the restore/save-gradle-cache Bitrise steps.
+org.gradle.caching=true
+
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn

--- a/packages/core-mobile/docs/ci_android_build_caching.md
+++ b/packages/core-mobile/docs/ci_android_build_caching.md
@@ -6,24 +6,30 @@ Context for the caching setup introduced in CP-14966 (PR #4041), which cut `andr
 
 | Piece | Where | What it does |
 | --- | --- | --- |
-| `org.gradle.caching=true` | `android/gradle.properties` | Enables Gradle task-output caching (Kotlin/Java compile, resource processing) |
-| `Restore/Save Gradle Build Cache` steps | `bitrise.yml` (all 3 Android build workflows) | Persist `~/.gradle/caches/build-cache-1` between CI builds on a rolling prefix key |
+| `org.gradle.caching=true` | `android/gradle.properties` | Enables Gradle task-output caching — benefits local dev builds and same-build dedupe in CI (cross-build persistence deferred to CP-14974, see below) |
 | `Restore/Save Gradle Cache` steps (pre-existing) | `bitrise.yml` | Persist dependencies only (jars, modules, wrapper, JDKs) |
 | NPM cache fallback key | `bitrise.yml` `_install-and-set-env` | A `yarn.lock` change restores the previous cache and downloads only the delta |
 | `ensureAndroidTools.sh` | `scripts/bitrise/` | Replaces the `install-missing-android-tools` step (3.5 min Gradle pass → ~4 s); self-heals NDK, SDK platform, and build-tools from the versions pinned in `android/build.gradle` |
 
-Two non-obvious facts that shaped this design:
+## Cross-build task-output persistence: deferred to CP-14974
 
-- **Bitrise's `restore/save-gradle-cache` steps exclude `build-cache-1` by design** (verified in the step source — they persist dependencies only; task outputs are what the paid Bitrise Build Cache add-on covers). `org.gradle.caching=true` does nothing across CI builds without the separate save/restore pair.
-- **The Gradle build cache is content-addressed**, so the build-cache pair uses a rolling prefix key (`gradle-build-cache-`) with no checksum. This also sidesteps the fact that version-code stamping rewrites `app/build.gradle` every build, which makes any checksum-of-gradle-files key unmatchable.
+A `restore-cache`/`save-cache` pair persisting `~/.gradle/caches/build-cache-1` was built and measured on this branch, then **removed before merge**: warm builds reused 1,149 of 2,903 tasks yet moved wall-clock by ~0 min, because the critical path is the CMake/NDK C++ compile (skia, reanimated, quick-crypto, nitro modules), which Gradle's build cache cannot cache. The cached Kotlin/Java tasks were filling other cores in parallel, not the bottleneck. The pair only pays off once ccache shortens the C++ chain, so both ship together under **CP-14974**.
+
+Hard-won facts recorded for that re-add:
+
+- **Bitrise's `restore/save-gradle-cache` steps exclude `build-cache-1` by design** (verified in the step source — they persist dependencies only; task outputs are what the paid Bitrise Build Cache add-on covers). `org.gradle.caching=true` does nothing across CI builds without a separate save/restore-cache pair.
+- **Use a static rolling prefix key** (`{{ .OS }}-{{ .Arch }}-gradle-build-cache-`), no checksum: the Gradle build cache is content-addressed, and version-code stamping rewrites `app/build.gradle` every build, which makes any checksum-of-gradle-files key unmatchable.
+- **Never set `is_key_unique: true` on that save step.** It means "skip saving when this workflow restored the same key" — correct only for checksum-unique keys. With the static key it froze the archive at its first-ever save (proven on builds #9480/#9481: the warm build's save skipped in 1.37s and its new outputs were never persisted).
+- **Concurrency is safe**: archives are immutable blobs and the key is a pointer; parallel builds restore whatever was latest, last writer wins the pointer, and a "losing" build's entries are regenerated and saved next round. Sharing one key across branches is deliberate — content addressing makes a PR branch safely reuse main's outputs.
+- **Growth is self-limiting**: Gradle prunes `build-cache-1` entries unused for 7 days (gc timestamps live inside the cached dir, so cleanup carries across CI builds), and Bitrise expires unused archives.
 
 ## Trade-offs & what to do if something breaks
 
-### Gradle build cache
+### Gradle build cache (`org.gradle.caching=true`)
 
-- Pro: warm builds reuse ~1,100 of ~2,900 task outputs; also speeds up local dev builds.
+- Pro: speeds up local dev builds and deduplicates identical tasks within a CI build. No cross-build persistence in CI until CP-14974.
 - Risk: a task with misdeclared inputs (usually a third-party Gradle plugin) can serve a stale output — the symptom is a *weird build artifact*, not an error, which makes it easy to blame the wrong thing.
-- If it goes wrong: delete the `gradle-build-cache-*` entries in Bitrise → Workflow Editor → Caches and rebuild. Locally, build once with `--no-build-cache` to confirm the cache is the culprit before digging elsewhere.
+- If it goes wrong: locally, build once with `--no-build-cache` to confirm the cache is the culprit before digging elsewhere. In CI each build starts with an empty `build-cache-1`, so stale-output bugs cannot cross builds.
 
 ### NPM cache fallback key
 
@@ -45,4 +51,4 @@ Two non-obvious facts that shaped this design:
 
 ## Known limits / next levers
 
-Warm-cache measurements showed the remaining ~16 min Gradle step is bounded by the CMake/NDK C++ compile (skia, reanimated, quick-crypto, nitro modules), which Gradle's build cache **cannot** cache — 1,149 cached tasks moved wall-clock by roughly nothing. Identified next levers, in order: ccache for the C++ compile, per-destination ABI trimming on E2E workflows (armeabi-v7a is dead weight there), machine-size bump. See CP-14966 comments for the measured data.
+The remaining ~16 min Gradle step is bounded by the CMake/NDK C++ compile. Next levers, in order: **CP-14974** (ccache for the C++ compile + re-adding the build-cache persistence pair per the notes above — they only pay off together), per-destination ABI trimming on E2E workflows (armeabi-v7a is dead weight there), machine-size bump. See CP-14966 comments for the measured data.

--- a/packages/core-mobile/docs/ci_android_build_caching.md
+++ b/packages/core-mobile/docs/ci_android_build_caching.md
@@ -1,0 +1,48 @@
+# CI Android Build Caching (Bitrise)
+
+Context for the caching setup introduced in CP-14966 (PR #4041), which cut `android-internal` builds from ~31.5 min to ~24 min. Read this before changing the cache steps in `bitrise.yml`, `android/gradle.properties`, or `scripts/bitrise/ensureAndroidTools.sh` — and when a CI build produces a result that looks haunted.
+
+## What's in place
+
+| Piece | Where | What it does |
+| --- | --- | --- |
+| `org.gradle.caching=true` | `android/gradle.properties` | Enables Gradle task-output caching (Kotlin/Java compile, resource processing) |
+| `Restore/Save Gradle Build Cache` steps | `bitrise.yml` (all 3 Android build workflows) | Persist `~/.gradle/caches/build-cache-1` between CI builds on a rolling prefix key |
+| `Restore/Save Gradle Cache` steps (pre-existing) | `bitrise.yml` | Persist dependencies only (jars, modules, wrapper, JDKs) |
+| NPM cache fallback key | `bitrise.yml` `_install-and-set-env` | A `yarn.lock` change restores the previous cache and downloads only the delta |
+| `ensureAndroidTools.sh` | `scripts/bitrise/` | Replaces the `install-missing-android-tools` step (3.5 min Gradle pass → ~4 s); self-heals NDK, SDK platform, and build-tools from the versions pinned in `android/build.gradle` |
+
+Two non-obvious facts that shaped this design:
+
+- **Bitrise's `restore/save-gradle-cache` steps exclude `build-cache-1` by design** (verified in the step source — they persist dependencies only; task outputs are what the paid Bitrise Build Cache add-on covers). `org.gradle.caching=true` does nothing across CI builds without the separate save/restore pair.
+- **The Gradle build cache is content-addressed**, so the build-cache pair uses a rolling prefix key (`gradle-build-cache-`) with no checksum. This also sidesteps the fact that version-code stamping rewrites `app/build.gradle` every build, which makes any checksum-of-gradle-files key unmatchable.
+
+## Trade-offs & what to do if something breaks
+
+### Gradle build cache
+
+- Pro: warm builds reuse ~1,100 of ~2,900 task outputs; also speeds up local dev builds.
+- Risk: a task with misdeclared inputs (usually a third-party Gradle plugin) can serve a stale output — the symptom is a *weird build artifact*, not an error, which makes it easy to blame the wrong thing.
+- If it goes wrong: delete the `gradle-build-cache-*` entries in Bitrise → Workflow Editor → Caches and rebuild. Locally, build once with `--no-build-cache` to confirm the cache is the culprit before digging elsewhere.
+
+### NPM cache fallback key
+
+- Pro: lockfile changes no longer trigger a fully cold install.
+- Risk: minimal — `yarn install --immutable` validates against the lockfile, so a stale restore costs download time, not correctness.
+- If it goes wrong: delete the `npm-cache-*` entries in Bitrise cache management; the next build re-seeds.
+
+### `ensureAndroidTools.sh`
+
+- Pro: self-healing is proven, not theoretical — build-tools 36.0.0 was genuinely missing from the stack image and the script installed it on the fly.
+- Risk: coverage is narrower than the old step. It self-heals only the NDK, SDK platform, and build-tools versions pinned in `android/build.gradle`. Any *other* newly required SDK component (a cmdline-tools bump, system images, etc.) will hard-fail the Gradle step with a "missing component" error instead of silently installing.
+- If it goes wrong: add the component to the script (check dir → `sdkmanager "<component>"`), same pattern as the existing three. If the `compileSdkVersion`/`buildToolsVersion` declaration format in `build.gradle` ever changes, the script fails loudly with an explicit parse error — update its grep pattern.
+- Shell gotcha, do not "simplify" it back: installs run with stdin closed (`< /dev/null`) and licenses pre-accepted instead of the usual `yes | sdkmanager` idiom. Under `set -o pipefail`, `yes` dies with SIGPIPE (exit 141) when `sdkmanager` exits first, failing the build *after a successful install* (this happened on build #9476).
+
+### General
+
+- The first build after any cache wipe is **slower** (seeding + a bigger save step). Judge changes from the second build onward.
+- Full rollback = revert PR #4041. Partial: the build cache alone can be disabled by flipping `org.gradle.caching=false` without touching the rest.
+
+## Known limits / next levers
+
+Warm-cache measurements showed the remaining ~16 min Gradle step is bounded by the CMake/NDK C++ compile (skia, reanimated, quick-crypto, nitro modules), which Gradle's build cache **cannot** cache — 1,149 cached tasks moved wall-clock by roughly nothing. Identified next levers, in order: ccache for the C++ compile, per-destination ABI trimming on E2E workflows (armeabi-v7a is dead weight there), machine-size bump. See CP-14966 comments for the measured data.

--- a/packages/core-mobile/scripts/bitrise/ensureAndroidTools.sh
+++ b/packages/core-mobile/scripts/bitrise/ensureAndroidTools.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fast replacement for install-missing-android-tools@3.
+# That step ran a full Gradle configuration pass (~3.5 min) on every build even
+# though the Bitrise Android stack already ships the NDK and SDK we need. This
+# script verifies the NDK, SDK platform, and build-tools are present and only
+# installs whichever of them is missing.
+
+# Must match ndkVersion in packages/core-mobile/android/build.gradle
+NDK_VERSION="27.1.12297006"
+
+echo "Ensuring android/gradlew is executable..."
+chmod +x android/gradlew
+
+SDK_ROOT="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-/opt/android-sdk-linux}}"
+echo "Using Android SDK root: $SDK_ROOT"
+
+if [ -x "$SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]; then
+    SDKMANAGER="$SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+elif command -v sdkmanager >/dev/null 2>&1; then
+    SDKMANAGER="$(command -v sdkmanager)"
+else
+    echo "ERROR: could not find sdkmanager in $SDK_ROOT/cmdline-tools/latest/bin or on PATH" >&2
+    exit 1
+fi
+echo "Using sdkmanager: $SDKMANAGER"
+
+if [ -d "$SDK_ROOT/ndk/$NDK_VERSION" ]; then
+    echo "NDK $NDK_VERSION already installed at $SDK_ROOT/ndk/$NDK_VERSION, skipping install."
+else
+    echo "NDK $NDK_VERSION not found, installing..."
+    yes | "$SDKMANAGER" "ndk;$NDK_VERSION"
+    echo "NDK $NDK_VERSION installed."
+fi
+
+BUILD_GRADLE="android/build.gradle"
+
+COMPILE_SDK_VERSION="$(grep -E '^[[:space:]]*compileSdkVersion[[:space:]]*=[[:space:]]*[0-9]+' "$BUILD_GRADLE" | head -1 | sed -E 's/^[[:space:]]*compileSdkVersion[[:space:]]*=[[:space:]]*([0-9]+).*/\1/')"
+if [ -z "$COMPILE_SDK_VERSION" ]; then
+    echo "ERROR: could not parse compileSdkVersion from $BUILD_GRADLE" >&2
+    exit 1
+fi
+
+BUILD_TOOLS_VERSION="$(grep -E '^[[:space:]]*buildToolsVersion[[:space:]]*=[[:space:]]*"[^"]+"' "$BUILD_GRADLE" | head -1 | sed -E 's/^[[:space:]]*buildToolsVersion[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')"
+if [ -z "$BUILD_TOOLS_VERSION" ]; then
+    echo "ERROR: could not parse buildToolsVersion from $BUILD_GRADLE" >&2
+    exit 1
+fi
+
+if [ -d "$SDK_ROOT/platforms/android-$COMPILE_SDK_VERSION" ]; then
+    echo "SDK platform android-$COMPILE_SDK_VERSION already installed, skipping install."
+else
+    echo "SDK platform android-$COMPILE_SDK_VERSION not found, installing..."
+    yes | "$SDKMANAGER" "platforms;android-$COMPILE_SDK_VERSION"
+    echo "SDK platform android-$COMPILE_SDK_VERSION installed."
+fi
+
+if [ -d "$SDK_ROOT/build-tools/$BUILD_TOOLS_VERSION" ]; then
+    echo "Build-tools $BUILD_TOOLS_VERSION already installed, skipping install."
+else
+    echo "Build-tools $BUILD_TOOLS_VERSION not found, installing..."
+    yes | "$SDKMANAGER" "build-tools;$BUILD_TOOLS_VERSION"
+    echo "Build-tools $BUILD_TOOLS_VERSION installed."
+fi
+
+echo "Accepting Android SDK licenses..."
+yes | "$SDKMANAGER" --licenses > /dev/null 2>&1 || true
+echo "Done ensuring Android SDK components."

--- a/packages/core-mobile/scripts/bitrise/ensureAndroidTools.sh
+++ b/packages/core-mobile/scripts/bitrise/ensureAndroidTools.sh
@@ -26,11 +26,19 @@ else
 fi
 echo "Using sdkmanager: $SDKMANAGER"
 
+# Accept licenses BEFORE any install so installs never prompt. Installs below
+# run with stdin closed (< /dev/null) instead of `yes |`: under pipefail, `yes`
+# dies with SIGPIPE (exit 141) when sdkmanager exits first, failing the build
+# even when the install succeeded. With licenses pre-accepted, a prompt should
+# never appear; if one ever does, the install fails fast instead of hanging.
+echo "Accepting Android SDK licenses..."
+yes | "$SDKMANAGER" --licenses > /dev/null 2>&1 || true
+
 if [ -d "$SDK_ROOT/ndk/$NDK_VERSION" ]; then
     echo "NDK $NDK_VERSION already installed at $SDK_ROOT/ndk/$NDK_VERSION, skipping install."
 else
     echo "NDK $NDK_VERSION not found, installing..."
-    yes | "$SDKMANAGER" "ndk;$NDK_VERSION"
+    "$SDKMANAGER" "ndk;$NDK_VERSION" < /dev/null
     echo "NDK $NDK_VERSION installed."
 fi
 
@@ -52,7 +60,7 @@ if [ -d "$SDK_ROOT/platforms/android-$COMPILE_SDK_VERSION" ]; then
     echo "SDK platform android-$COMPILE_SDK_VERSION already installed, skipping install."
 else
     echo "SDK platform android-$COMPILE_SDK_VERSION not found, installing..."
-    yes | "$SDKMANAGER" "platforms;android-$COMPILE_SDK_VERSION"
+    "$SDKMANAGER" "platforms;android-$COMPILE_SDK_VERSION" < /dev/null
     echo "SDK platform android-$COMPILE_SDK_VERSION installed."
 fi
 
@@ -60,10 +68,8 @@ if [ -d "$SDK_ROOT/build-tools/$BUILD_TOOLS_VERSION" ]; then
     echo "Build-tools $BUILD_TOOLS_VERSION already installed, skipping install."
 else
     echo "Build-tools $BUILD_TOOLS_VERSION not found, installing..."
-    yes | "$SDKMANAGER" "build-tools;$BUILD_TOOLS_VERSION"
+    "$SDKMANAGER" "build-tools;$BUILD_TOOLS_VERSION" < /dev/null
     echo "Build-tools $BUILD_TOOLS_VERSION installed."
 fi
 
-echo "Accepting Android SDK licenses..."
-yes | "$SDKMANAGER" --licenses > /dev/null 2>&1 || true
 echo "Done ensuring Android SDK components."

--- a/packages/core-mobile/scripts/bitrise/ensureAndroidTools.sh
+++ b/packages/core-mobile/scripts/bitrise/ensureAndroidTools.sh
@@ -5,10 +5,8 @@ set -euo pipefail
 # That step ran a full Gradle configuration pass (~3.5 min) on every build even
 # though the Bitrise Android stack already ships the NDK and SDK we need. This
 # script verifies the NDK, SDK platform, and build-tools are present and only
-# installs whichever of them is missing.
-
-# Must match ndkVersion in packages/core-mobile/android/build.gradle
-NDK_VERSION="27.1.12297006"
+# installs whichever of them is missing. All three versions are parsed from
+# android/build.gradle so a Gradle-side bump self-heals here too.
 
 echo "Ensuring android/gradlew is executable..."
 chmod +x android/gradlew
@@ -26,13 +24,41 @@ else
 fi
 echo "Using sdkmanager: $SDKMANAGER"
 
+BUILD_GRADLE="android/build.gradle"
+
+# The `|| true` inside each substitution keeps a no-match grep (exit 1, fatal
+# under set -e/pipefail) from killing the script before the explicit parse
+# error below can fire.
+NDK_VERSION="$(grep -E '^[[:space:]]*ndkVersion[[:space:]]*=[[:space:]]*"[^"]+"' "$BUILD_GRADLE" | head -1 | sed -E 's/^[[:space:]]*ndkVersion[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/' || true)"
+if [ -z "$NDK_VERSION" ]; then
+    echo "ERROR: could not parse ndkVersion from $BUILD_GRADLE" >&2
+    exit 1
+fi
+
+COMPILE_SDK_VERSION="$(grep -E '^[[:space:]]*compileSdkVersion[[:space:]]*=[[:space:]]*[0-9]+' "$BUILD_GRADLE" | head -1 | sed -E 's/^[[:space:]]*compileSdkVersion[[:space:]]*=[[:space:]]*([0-9]+).*/\1/' || true)"
+if [ -z "$COMPILE_SDK_VERSION" ]; then
+    echo "ERROR: could not parse compileSdkVersion from $BUILD_GRADLE" >&2
+    exit 1
+fi
+
+BUILD_TOOLS_VERSION="$(grep -E '^[[:space:]]*buildToolsVersion[[:space:]]*=[[:space:]]*"[^"]+"' "$BUILD_GRADLE" | head -1 | sed -E 's/^[[:space:]]*buildToolsVersion[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/' || true)"
+if [ -z "$BUILD_TOOLS_VERSION" ]; then
+    echo "ERROR: could not parse buildToolsVersion from $BUILD_GRADLE" >&2
+    exit 1
+fi
+
 # Accept licenses BEFORE any install so installs never prompt. Installs below
 # run with stdin closed (< /dev/null) instead of `yes |`: under pipefail, `yes`
 # dies with SIGPIPE (exit 141) when sdkmanager exits first, failing the build
-# even when the install succeeded. With licenses pre-accepted, a prompt should
-# never appear; if one ever does, the install fails fast instead of hanging.
+# even when the install succeeded. Pipefail is dropped around the licenses call
+# for the same reason — without it the pipeline reports sdkmanager's own exit
+# code, so only a real sdkmanager failure trips the warning, not yes's SIGPIPE.
 echo "Accepting Android SDK licenses..."
-yes | "$SDKMANAGER" --licenses > /dev/null 2>&1 || true
+set +o pipefail
+if ! yes | "$SDKMANAGER" --licenses > /dev/null 2>&1; then
+    echo "WARNING: sdkmanager --licenses failed; continuing. If a license is genuinely missing, the matching install below will fail with an explicit error." >&2
+fi
+set -o pipefail
 
 if [ -d "$SDK_ROOT/ndk/$NDK_VERSION" ]; then
     echo "NDK $NDK_VERSION already installed at $SDK_ROOT/ndk/$NDK_VERSION, skipping install."
@@ -40,20 +66,6 @@ else
     echo "NDK $NDK_VERSION not found, installing..."
     "$SDKMANAGER" "ndk;$NDK_VERSION" < /dev/null
     echo "NDK $NDK_VERSION installed."
-fi
-
-BUILD_GRADLE="android/build.gradle"
-
-COMPILE_SDK_VERSION="$(grep -E '^[[:space:]]*compileSdkVersion[[:space:]]*=[[:space:]]*[0-9]+' "$BUILD_GRADLE" | head -1 | sed -E 's/^[[:space:]]*compileSdkVersion[[:space:]]*=[[:space:]]*([0-9]+).*/\1/')"
-if [ -z "$COMPILE_SDK_VERSION" ]; then
-    echo "ERROR: could not parse compileSdkVersion from $BUILD_GRADLE" >&2
-    exit 1
-fi
-
-BUILD_TOOLS_VERSION="$(grep -E '^[[:space:]]*buildToolsVersion[[:space:]]*=[[:space:]]*"[^"]+"' "$BUILD_GRADLE" | head -1 | sed -E 's/^[[:space:]]*buildToolsVersion[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')"
-if [ -z "$BUILD_TOOLS_VERSION" ]; then
-    echo "ERROR: could not parse buildToolsVersion from $BUILD_GRADLE" >&2
-    exit 1
 fi
 
 if [ -d "$SDK_ROOT/platforms/android-$COMPILE_SDK_VERSION" ]; then


### PR DESCRIPTION
## Description

**Ticket: [CP-14966](https://ava-labs.atlassian.net/browse/CP-14966)**

Android builds on Bitrise took ~31.5 min. Per-step timing from build #9474 (`android-internal`) showed where the time actually goes. Three changes, no app behavior change:

1. **Replace `install-missing-android-tools` with `ensureAndroidTools.sh`** — the old step spent ~3.5 min running a Gradle configuration pass to detect missing SDK components. The script self-heals NDK, SDK platform, and build-tools from the versions parsed out of `android/build.gradle` (fails loudly on parse failure). Installs run with stdin closed and licenses pre-accepted rather than `yes |` piping, which dies with SIGPIPE (exit 141) under `set -o pipefail` even when the install succeeds — that exact failure occurred on build #9476 when build-tools 36.0.0 was genuinely missing from the stack image.
2. **NPM cache fallback key** — the previous exact-checksum-only key meant any `yarn.lock` change went fully cold.
3. **`org.gradle.caching=true`** (`gradle.properties`) — benefits local dev builds and same-build task dedupe in CI.

**What was tried and deliberately dropped:** a `restore/save-cache` pair persisting Gradle's `build-cache-1` across CI builds. It worked (warm builds reused 1,149 of 2,903 tasks) but moved wall-clock by ~0 min, because the critical path is the CMake/NDK C++ compile (skia, reanimated, quick-crypto, nitro modules), which Gradle's build cache cannot cache. It only pays off once ccache shortens the C++ chain, so both ship together under [CP-14974](https://ava-labs.atlassian.net/browse/CP-14974). The measured findings and re-add playbook (including the `is_key_unique` freeze trap found during review — thanks @gergelylovas) are recorded in `packages/core-mobile/docs/ci_android_build_caching.md`, added in this PR.

## Measured results (branch builds, `android-internal`, g2.linux.large)

| Step | Baseline #9474 | This branch |
|---|---|---|
| **Total** | **31.5 min** | **~24 min** |
| Install SDK components | 3.5 min | ~4 sec |
| Yarn Setup | 4.5 min (cache miss) | 2.2–2.5 min (cache hit) |
| Android Build (Gradle) | 17.5 min | 15.9–16.3 min |

## Trade-offs & what to do if something breaks

**`ensureAndroidTools.sh` replacing `install-missing-android-tools` (3.5 min → ~4 s)**
- Pro: self-healing is proven, not theoretical — build-tools 36.0.0 was genuinely missing from the stack image and the script installed it on the fly (#9480).
- Risk: coverage is narrower than the old step. It self-heals only the NDK, SDK platform, and build-tools versions from `android/build.gradle`. Any *other* newly-required SDK component (cmdline-tools bump, system images, etc.) will hard-fail the Gradle step with a "missing component" error instead of silently installing.
- If it goes wrong: the fix is a two-line addition to the script (check dir → `sdkmanager "<component>"`), same pattern as the existing three. If the `compileSdkVersion`/`buildToolsVersion`/`ndkVersion` declaration format in `build.gradle` ever changes, the script fails loudly with an explicit parse error — update its grep pattern.

**NPM cache fallback key**
- Pro: a `yarn.lock` change now restores the previous cache and only downloads the delta instead of going fully cold.
- Risk: minimal — `yarn install --immutable` validates against the lockfile, so a stale restore costs download time, not correctness.
- If it goes wrong: delete the `npm-cache-*` entries in Bitrise cache management; next build re-seeds.

**`org.gradle.caching=true`**
- Pro: faster local dev builds; same-build task dedupe in CI.
- Risk: a task with misdeclared inputs (usually a third-party Gradle plugin) can serve a stale output locally. In CI each build starts with an empty build cache, so stale outputs cannot cross builds.
- If it goes wrong locally: build once with `--no-build-cache` to confirm before digging elsewhere.

## Screenshots/Videos

N/A — CI configuration only; no app code touched.

## Testing

Verified across seven triggered builds on this branch:

- #9476: exposed the SIGPIPE bug (fixed) and proved the guard script's self-healing works — build-tools 36.0.0 was genuinely absent from the stack and installed on the fly.
- #9477 (26.2 min), #9479 (28.3 min): confirmed guard step + NPM cache behavior.
- #9480 (23.9 min) / #9481 (24.5 min): steady state ~7 min under baseline; also produced the build-cache neutrality data that led to deferring persistence to CP-14974.

**QA Testing (if applicable)**

N/A — no app behavior change; standard smoke on the resulting build is sufficient.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [x] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CP-14966]: https://ava-labs.atlassian.net/browse/CP-14966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-14974]: https://ava-labs.atlassian.net/browse/CP-14974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ