### PR TITLE
CP-14967: Add keystone-onboarding feature flag to gate new Keystone imports

### DIFF
--- a/packages/core-mobile/app/new/routes/accessWallet.tsx
+++ b/packages/core-mobile/app/new/routes/accessWallet.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'expo-router'
 import React, { useCallback, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import {
-  selectIsKeystoneBlocked,
+  selectIsKeystoneOnboardingBlocked,
   selectIsLedgerSupportBlocked
 } from 'store/posthog'
 import AnalyticsService from 'services/analytics/AnalyticsService'
@@ -14,7 +14,7 @@ import AnalyticsService from 'services/analytics/AnalyticsService'
 const AccessWalletScreen = (): JSX.Element => {
   const { theme } = useTheme()
   const { navigate } = useRouter()
-  const isKeystoneBlocked = useSelector(selectIsKeystoneBlocked)
+  const isKeystoneBlocked = useSelector(selectIsKeystoneOnboardingBlocked)
   const isLedgerBlocked = useSelector(selectIsLedgerSupportBlocked)
 
   const handleEnterRecoveryPhrase = useCallback((): void => {

--- a/packages/core-mobile/app/new/routes/onboarding/keystone/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/onboarding/keystone/_layout.tsx
@@ -4,16 +4,26 @@ import { PageControl } from '@avalabs/k2-alpine'
 import { stackNavigatorScreenOptions } from 'common/consts/screenOptions'
 import {
   NativeStackNavigationOptions,
+  Redirect,
   useNavigation,
   useRootNavigationState
 } from 'expo-router'
 import { NavigationState } from 'expo-router/react-navigation'
 import { Platform } from 'react-native'
+import { useStore } from 'react-redux'
+import { RootState } from 'store/types'
+import { selectIsKeystoneOnboardingBlocked } from 'store/posthog'
 
 export default function KeystoneOnboardingLayout(): JSX.Element {
   const navigation = useNavigation()
   const [currentPage, setCurrentPage] = useState(0)
   const rootState: NavigationState = useRootNavigationState()
+  const store = useStore<RootState>()
+  // Latched at mount: a mid-flow flag flip must not eject a user who has
+  // already persisted a wallet secret (createPin stores it before login)
+  const [isKeystoneOnboardingBlocked] = useState(() =>
+    selectIsKeystoneOnboardingBlocked(store.getState())
+  )
 
   const screens = useMemo(() => KEYSTONE_ONBOARDING_SCREENS, [])
 
@@ -44,6 +54,11 @@ export default function KeystoneOnboardingLayout(): JSX.Element {
       navigation.getParent()?.setOptions(navigationOptions)
     }
   }, [navigation, renderPageControl])
+
+  // accessWallet only hides the entry button; this also covers deep links
+  if (isKeystoneOnboardingBlocked) {
+    return <Redirect href="/accessWallet" />
+  }
 
   return (
     <Stack

--- a/packages/core-mobile/app/services/posthog/types.ts
+++ b/packages/core-mobile/app/services/posthog/types.ts
@@ -23,6 +23,10 @@ export enum FeatureGates {
   MELD_ONRAMP = 'meld-onramp',
   MELD_OFFRAMP = 'meld-offramp',
   KEYSTONE = 'keystone',
+  // Keystone sunset phase 1: gates only NEW Keystone wallet imports during
+  // onboarding. The `keystone` gate above remains the master kill-switch —
+  // turning IT off also auto-rejects signing for existing Keystone wallets.
+  KEYSTONE_ONBOARDING = 'keystone-onboarding',
   SWAP_SOLANA = 'swap-solana',
   IN_APP_UPDATE_ANDROID = 'in-app-update-android',
   ENABLE_MELD_SANDBOX = 'enable-meld-sandbox',

--- a/packages/core-mobile/app/store/posthog/slice.ts
+++ b/packages/core-mobile/app/store/posthog/slice.ts
@@ -317,6 +317,21 @@ export const selectIsKeystoneBlocked = (state: RootState): boolean => {
   )
 }
 
+// Gates NEW Keystone imports only — deliberately includes the master
+// `keystone` gate so flipping that one still kills onboarding too, while
+// signing for existing wallets stays governed solely by selectIsKeystoneBlocked
+// (KeystoneSignerScreen auto-rejects when it flips).
+export const selectIsKeystoneOnboardingBlocked = (
+  state: RootState
+): boolean => {
+  const { featureFlags } = state.posthog
+  return (
+    !featureFlags[FeatureGates.KEYSTONE_ONBOARDING] ||
+    !featureFlags[FeatureGates.KEYSTONE] ||
+    !featureFlags[FeatureGates.EVERYTHING]
+  )
+}
+
 export const selectFusionFeeUnitsMarginBps = (state: RootState): number => {
   const { featureFlags } = state.posthog
   return parseIntFlag(


### PR DESCRIPTION
## Description

**Ticket: [CP-14967](https://ava-labs.atlassian.net/browse/CP-14967)**

Phase 1 of the Keystone sunset: stop new Keystone wallet imports without touching existing Keystone users.

Today the single `keystone` PostHog gate covers both the onboarding entry point and `KeystoneSignerScreen`, which auto-rejects every signing request when blocked. Flipping that flag would immediately break transaction signing (send, swap, bridge, stake, dApp/WalletConnect) for everyone who already has a Keystone wallet, not just block new imports. This PR splits the gate:

- New PostHog boolean gate `keystone-onboarding` (`FeatureGates.KEYSTONE_ONBOARDING`).
- New selector `selectIsKeystoneOnboardingBlocked`: blocked when `keystone-onboarding`, the master `keystone` gate, or `everything` is off, so the existing kill-switch still covers onboarding too.
- `accessWallet.tsx` now hides the "Add using Keystone" row via the new selector.
- New deep-link guard in `onboarding/keystone/_layout.tsx` that redirects to `/accessWallet` when blocked (previously only the entry button was hidden; the routes themselves stayed reachable). The blocked value is latched at mount so a mid-flow flag flip cannot eject a user who already persisted a wallet secret at `createPin` (it stores the secret before `confirmation` logs in).

Existing Keystone wallets are unaffected: balances, activity, receive, account-adding (local xpub derivation), and signing (still governed solely by the `keystone` gate) all keep working.

No new dependencies. Not breaking.

**Rollout note:** the new flag is deliberately NOT in `DefaultFeatureFlagConfig` (matching the `keystone` gate), so a missing flag evaluates as blocked. The `keystone-onboarding` flag has been created in PostHog (dev + prod) and is intentionally **disabled** in both: Keystone onboarding turns off in the first release containing this PR, and the flag exists as the switch to turn it back on if needed. QA: enable the flag in the dev PostHog project temporarily to test the flag-on path. Flipping the master `keystone` flag later remains the full signing kill-switch for phase 2 — it must stay ON until then or existing Keystone users lose transaction signing.

## Screenshots/Videos

N/A — the only visual change is the "Add using Keystone" row disappearing from the access-wallet screen when the flag is off.

## Testing

**Dev Testing (if applicable)**

Happy path (flag ON in PostHog):
1. Fresh install → "Access existing wallet" → confirm "Add using Keystone" row is present and the Keystone onboarding flow works as before.

Flag OFF:
1. Turn `keystone-onboarding` off → "Add using Keystone" row is hidden on the access-wallet screen.
2. Deep link to `/onboarding/keystone/termsAndConditions` → redirected to `/accessWallet`.
3. With an existing Keystone wallet: unlock, view balances/activity, add an account to the wallet, and sign a send — all unaffected (signing is still gated only by the master `keystone` flag).

Edge case:
- Start Keystone onboarding with the flag ON, flip it OFF mid-flow → the in-progress flow is NOT interrupted (blocked state is latched at mount); only the next entry attempt is blocked.

Verified locally: full `tsc` clean, `eslint --max-warnings=0` clean on changed files, all posthog store unit tests pass (66/66).

**QA Testing (if applicable)**

Toggle the `keystone-onboarding` flag in PostHog and confirm: OFF hides the Keystone option at onboarding and blocks the deep link; ON restores the full import flow. In both states, existing Keystone wallets must keep balances, activity, account-adding, and transaction signing.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CP-14967]: https://ava-labs.atlassian.net/browse/CP-14967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
