### PR TITLE
CP-14964: Validate Ledger device address/pubkey replies — BLE frame corruption fails closed instead of persisting a bare P- address

### DIFF
--- a/packages/core-mobile/app/new/common/utils/stripAddressPrefix.test.ts
+++ b/packages/core-mobile/app/new/common/utils/stripAddressPrefix.test.ts
@@ -1,4 +1,4 @@
-import { stripAddressPrefix } from './stripAddressPrefix'
+import { isBareChainPrefix, stripAddressPrefix } from './stripAddressPrefix'
 
 describe('stripAddressPrefix', () => {
   it('should remove the prefix from the address', () => {
@@ -17,5 +17,26 @@ describe('stripAddressPrefix', () => {
     const address = ''
     const result = stripAddressPrefix(address)
     expect(result).toBe('')
+  })
+})
+
+describe('isBareChainPrefix', () => {
+  it.each(['P-', 'X-', 'C-'])('detects a bare %s prefix', prefix => {
+    expect(isBareChainPrefix(prefix)).toBe(true)
+  })
+
+  it.each([
+    ['a prefixed address', 'P-avax1qurswpc8qurswpc8qurswpc8qurswpc8x32neu'],
+    ['an unprefixed address', 'avax1qurswpc8qurswpc8qurswpc8qurswpc8x32neu'],
+    ['an EVM address', '0x449b3fFFE66378227DbBd05539B6542E5cA75A28'],
+    ['an empty string', ''],
+    ['a lone hyphen', '-'],
+    ['an unknown alias', 'Z-']
+  ])('returns false for %s', (_name, address) => {
+    expect(isBareChainPrefix(address)).toBe(false)
+  })
+
+  it('returns false for undefined', () => {
+    expect(isBareChainPrefix(undefined)).toBe(false)
   })
 })

--- a/packages/core-mobile/app/new/common/utils/stripAddressPrefix.ts
+++ b/packages/core-mobile/app/new/common/utils/stripAddressPrefix.ts
@@ -3,3 +3,13 @@
  */
 export const stripAddressPrefix = (address: string): string =>
   address.replace(/^[XPC]-/, '')
+
+/**
+ * True when the value is a chain alias and nothing else, e.g. `'P-'`.
+ *
+ * Such a value is truthy, so `!address` guards accept it and pass it on as if
+ * it were a real address. Callers validating an address they did not derive
+ * themselves need this alongside the falsy check. See CP-14964.
+ */
+export const isBareChainPrefix = (address: string | undefined): boolean =>
+  address !== undefined && /^[XPC]-$/.test(address)

--- a/packages/core-mobile/app/new/features/swap/hooks/useQuoteStreaming.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useQuoteStreaming.test.ts
@@ -125,4 +125,36 @@ describe('useQuoteStreaming', () => {
     expect(mockCaptureMessage).toHaveBeenCalledTimes(1)
     expect(result.current.error).not.toBeNull()
   })
+
+  // A bare chain-alias address (e.g. from an unvalidated Ledger reply, see
+  // CP-14964) is truthy, so only the isBareChainPrefix check stops it here.
+  it('does not create a quoter when toAddress is a bare chain prefix', () => {
+    const { result } = renderHook(() =>
+      useQuoteStreaming({
+        ...baseParams,
+        toAddress: 'P-',
+        fromAmount: 100n
+      })
+    )
+
+    // A corrupted address must surface as a real error, not fail silently —
+    // it gets the same alert + Sentry treatment as a stream-level no-quotes.
+    expect(mockGetQuoter).not.toHaveBeenCalled()
+    expect(result.current.error).not.toBeNull()
+    expect(mockCaptureMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not create a quoter when fromAddress is a bare chain prefix', () => {
+    const { result } = renderHook(() =>
+      useQuoteStreaming({
+        ...baseParams,
+        fromAddress: 'P-',
+        fromAmount: 100n
+      })
+    )
+
+    expect(mockGetQuoter).not.toHaveBeenCalled()
+    expect(result.current.error).not.toBeNull()
+    expect(mockCaptureMessage).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/core-mobile/app/new/features/swap/hooks/useQuoteStreaming.test.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useQuoteStreaming.test.ts
@@ -129,32 +129,38 @@ describe('useQuoteStreaming', () => {
   // A bare chain-alias address (e.g. from an unvalidated Ledger reply, see
   // CP-14964) is truthy, so only the isBareChainPrefix check stops it here.
   it('does not create a quoter when toAddress is a bare chain prefix', () => {
+    const onNoQuotesError = jest.fn()
+
     const { result } = renderHook(() =>
       useQuoteStreaming({
         ...baseParams,
         toAddress: 'P-',
-        fromAmount: 100n
+        fromAmount: 100n,
+        onNoQuotesError
       })
     )
 
     // A corrupted address must surface as a real error, not fail silently —
-    // it gets the same alert + Sentry treatment as a stream-level no-quotes.
+    // it gets the same alert as a stream-level no-quotes result.
     expect(mockGetQuoter).not.toHaveBeenCalled()
     expect(result.current.error).not.toBeNull()
-    expect(mockCaptureMessage).toHaveBeenCalledTimes(1)
+    expect(onNoQuotesError).toHaveBeenCalledTimes(1)
   })
 
   it('does not create a quoter when fromAddress is a bare chain prefix', () => {
+    const onNoQuotesError = jest.fn()
+
     const { result } = renderHook(() =>
       useQuoteStreaming({
         ...baseParams,
         fromAddress: 'P-',
-        fromAmount: 100n
+        fromAmount: 100n,
+        onNoQuotesError
       })
     )
 
     expect(mockGetQuoter).not.toHaveBeenCalled()
     expect(result.current.error).not.toBeNull()
-    expect(mockCaptureMessage).toHaveBeenCalledTimes(1)
+    expect(onNoQuotesError).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core-mobile/app/new/features/swap/hooks/useQuoteStreaming.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useQuoteStreaming.ts
@@ -5,9 +5,10 @@ import { NetworkWithCaip2ChainId } from 'store/network'
 import { isSdkError } from '@avalabs/fusion-sdk'
 import SentryService from 'services/sentry/SentryService'
 import { SentryTag } from 'services/sentry/types'
+import { isBareChainPrefix } from 'common/utils/stripAddressPrefix'
 import FusionService from '../services/FusionService'
 import { toSwappableAsset, toChain } from '../utils/fusionTypeConverters'
-import { fusionErrors } from '../utils/fusionErrors'
+import { fusionErrors, FusionQuoteError } from '../utils/fusionErrors'
 import { logSdkError } from '../utils/fusionLogger'
 import {
   useBestQuote,
@@ -33,6 +34,47 @@ interface UseQuoteStreamingParams {
 interface UseQuoteStreamingResult {
   isLoading: boolean
   error: Error | null
+}
+
+/**
+ * Handles a quoter-creation failure (side effect moved out of the useMemo).
+ * The bare-prefix guard below reuses fusionErrors.noQuotes() so it gets the
+ * same alert + Sentry treatment as a genuine stream-level no-quotes result,
+ * rather than failing silently. Split out of the subscription effect to keep
+ * that effect's cognitive complexity down.
+ */
+function handleQuoterCreationError(params: {
+  error: Error
+  setError: (error: Error | null) => void
+  clearQuotes: () => void
+  onNoQuotesError?: (retry: () => void) => void
+  retry: () => void
+  fromAddress: string | undefined
+  toAddress: string | undefined
+}): void {
+  const {
+    error,
+    setError,
+    clearQuotes,
+    onNoQuotesError,
+    retry,
+    fromAddress,
+    toAddress
+  } = params
+  setError(error)
+  clearQuotes()
+
+  if (error instanceof FusionQuoteError && error.reason === 'no-quotes') {
+    onNoQuotesError?.(retry)
+    SentryService.captureMessage(
+      'Fusion quoter: bare chain-alias address (CP-14964)',
+      {
+        fromAddressIsBarePrefix: isBareChainPrefix(fromAddress),
+        toAddressIsBarePrefix: isBareChainPrefix(toAddress)
+      },
+      { source: SentryTag.FusionSdk }
+    )
+  }
 }
 
 /**
@@ -91,6 +133,14 @@ export function useQuoteStreaming(
       return { quoter: null, error: null }
     }
 
+    // Unlike the empty-input case above, a bare chain-alias address (e.g.
+    // 'P-') is a corrupted Ledger reply, not the user still typing (CP-14964).
+    // A null error here would be indistinguishable from that in-progress-input
+    // case and drop the quotes-unavailable alert + Sentry capture below.
+    if (isBareChainPrefix(fromAddress) || isBareChainPrefix(toAddress)) {
+      return { quoter: null, error: fusionErrors.noQuotes() }
+    }
+
     try {
       Logger.info('Creating Quoter instance', { attempt: retryCount + 1 })
 
@@ -143,10 +193,19 @@ export function useQuoteStreaming(
   useEffect(() => {
     // Handle error from quoter creation (side effect moved from useMemo)
     if (quoterResult.error) {
-      setError(quoterResult.error)
-      setBestQuote(null)
-      setAllQuotes([])
-      setIsLoading(false)
+      handleQuoterCreationError({
+        error: quoterResult.error,
+        setError,
+        clearQuotes: () => {
+          setBestQuote(null)
+          setAllQuotes([])
+          setIsLoading(false)
+        },
+        onNoQuotesError,
+        retry,
+        fromAddress,
+        toAddress
+      })
       return
     }
 
@@ -234,7 +293,9 @@ export function useQuoteStreaming(
     onNoQuotesError,
     retry,
     allowZeroAmount,
-    fromAmount
+    fromAmount,
+    fromAddress,
+    toAddress
   ])
 
   return {

--- a/packages/core-mobile/app/new/features/swap/hooks/useQuoteStreaming.ts
+++ b/packages/core-mobile/app/new/features/swap/hooks/useQuoteStreaming.ts
@@ -8,7 +8,7 @@ import { SentryTag } from 'services/sentry/types'
 import { isBareChainPrefix } from 'common/utils/stripAddressPrefix'
 import FusionService from '../services/FusionService'
 import { toSwappableAsset, toChain } from '../utils/fusionTypeConverters'
-import { fusionErrors, FusionQuoteError } from '../utils/fusionErrors'
+import { fusionErrors, isNoQuotesError } from '../utils/fusionErrors'
 import { logSdkError } from '../utils/fusionLogger'
 import {
   useBestQuote,
@@ -36,44 +36,15 @@ interface UseQuoteStreamingResult {
   error: Error | null
 }
 
-/**
- * Handles a quoter-creation failure (side effect moved out of the useMemo).
- * The bare-prefix guard below reuses fusionErrors.noQuotes() so it gets the
- * same alert + Sentry treatment as a genuine stream-level no-quotes result,
- * rather than failing silently. Split out of the subscription effect to keep
- * that effect's cognitive complexity down.
- */
-function handleQuoterCreationError(params: {
-  error: Error
-  setError: (error: Error | null) => void
-  clearQuotes: () => void
-  onNoQuotesError?: (retry: () => void) => void
+// Wraps the predicate so the subscription effect stays under the
+// cognitive-complexity limit.
+function alertIfNoQuotes(
+  error: Error,
+  onNoQuotesError: UseQuoteStreamingParams['onNoQuotesError'],
   retry: () => void
-  fromAddress: string | undefined
-  toAddress: string | undefined
-}): void {
-  const {
-    error,
-    setError,
-    clearQuotes,
-    onNoQuotesError,
-    retry,
-    fromAddress,
-    toAddress
-  } = params
-  setError(error)
-  clearQuotes()
-
-  if (error instanceof FusionQuoteError && error.reason === 'no-quotes') {
+): void {
+  if (isNoQuotesError(error)) {
     onNoQuotesError?.(retry)
-    SentryService.captureMessage(
-      'Fusion quoter: bare chain-alias address (CP-14964)',
-      {
-        fromAddressIsBarePrefix: isBareChainPrefix(fromAddress),
-        toAddressIsBarePrefix: isBareChainPrefix(toAddress)
-      },
-      { source: SentryTag.FusionSdk }
-    )
   }
 }
 
@@ -193,19 +164,11 @@ export function useQuoteStreaming(
   useEffect(() => {
     // Handle error from quoter creation (side effect moved from useMemo)
     if (quoterResult.error) {
-      handleQuoterCreationError({
-        error: quoterResult.error,
-        setError,
-        clearQuotes: () => {
-          setBestQuote(null)
-          setAllQuotes([])
-          setIsLoading(false)
-        },
-        onNoQuotesError,
-        retry,
-        fromAddress,
-        toAddress
-      })
+      setError(quoterResult.error)
+      setBestQuote(null)
+      setAllQuotes([])
+      setIsLoading(false)
+      alertIfNoQuotes(quoterResult.error, onNoQuotesError, retry)
       return
     }
 
@@ -293,9 +256,7 @@ export function useQuoteStreaming(
     onNoQuotesError,
     retry,
     allowZeroAmount,
-    fromAmount,
-    fromAddress,
-    toAddress
+    fromAmount
   ])
 
   return {

--- a/packages/core-mobile/app/new/features/swap/utils/fusionErrors.ts
+++ b/packages/core-mobile/app/new/features/swap/utils/fusionErrors.ts
@@ -228,6 +228,16 @@ export function isGasOnlyNetworkFeeError(error: FusionQuoteError): boolean {
   return error.kind === 'network-fee-only'
 }
 
+/**
+ * Matches more than a genuine empty quote set: the bare chain-alias address
+ * guard in useQuoteStreaming deliberately reuses `fusionErrors.noQuotes()` so
+ * a corrupted stored address inherits the same "Quotes unavailable" alert
+ * instead of failing silently.
+ */
+export function isNoQuotesError(error: unknown): boolean {
+  return error instanceof FusionQuoteError && error.reason === 'no-quotes'
+}
+
 // EIP-1193 standard code for a user-rejected request. The rejection can reach
 // us either as an Error instance OR as a plain JSON-RPC error object — e.g.
 // `providerErrors.userRejectedRequest()` serialized to `{ code, message }`

--- a/packages/core-mobile/app/services/ledger/LedgerService.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.ts
@@ -3,6 +3,8 @@ import Transport from '@ledgerhq/hw-transport'
 import AppAvalanche from '@avalabs/hw-app-avalanche'
 import AppSolana from '@ledgerhq/hw-app-solana'
 import { NetworkVMType } from '@avalabs/core-chains-sdk'
+import * as Sentry from '@sentry/react-native'
+import { AllowedSentryBreadcrumbCategory } from 'services/sentry/types'
 import {
   getAddressDerivationPath,
   handleLedgerError
@@ -102,7 +104,9 @@ class LedgerService {
         await new Promise(res => setTimeout(res, LEDGER_TIMEOUTS.REQUEST_DELAY))
       }
       try {
-        return await originalExchange(apdu)
+        const reply = await originalExchange(apdu)
+        this.recordApduBreadcrumb(apdu, reply)
+        return reply
       } catch (error) {
         // If error is still due to busy transport, reconnect
         if (
@@ -118,11 +122,52 @@ class LedgerService {
           await new Promise(res =>
             setTimeout(res, LEDGER_TIMEOUTS.REQUEST_DELAY)
           )
-          return await originalExchange(apdu)
+          const reply = await originalExchange(apdu)
+          this.recordApduBreadcrumb(apdu, reply)
+          return reply
         }
         // Other errors should be thrown immediately
         throw error
       }
+    }
+  }
+
+  // Frame-metadata-only breadcrumb (never payload bytes) for every APDU
+  // exchange. Sentry attaches recent breadcrumbs to any error captured
+  // afterwards, so a later validateDeviceAddress capture carries the reply
+  // length and status word — the signal that distinguishes a truncated
+  // transport frame from a device/app that legitimately returned empty (CP-14964).
+  private recordApduBreadcrumb(apdu: Buffer, reply: Buffer): void {
+    try {
+      Sentry.addBreadcrumb({
+        category: AllowedSentryBreadcrumbCategory.LedgerApdu,
+        level: 'info',
+        data: {
+          cla: (apdu[0] ?? 0).toString(16).padStart(2, '0'),
+          ins: (apdu[1] ?? 0).toString(16).padStart(2, '0'),
+          replyLength: reply.length,
+          statusWord: reply.subarray(-2).toString('hex')
+        }
+      })
+    } catch {
+      // Breadcrumb capture must never break a real APDU exchange.
+    }
+  }
+
+  // Session-global Sentry tags so any later Ledger error (e.g. a
+  // validateDeviceAddress capture) carries the app that produced it —
+  // distinguishes "this Avalanche app version returns empty addresses" from
+  // transport-layer frame corruption (CP-14964).
+  private recordLedgerAppSentryTags(
+    appType: LedgerAppType,
+    version: string
+  ): void {
+    try {
+      const scope = Sentry.getGlobalScope()
+      scope.setTag('ledgerAppType', appType)
+      scope.setTag('ledgerAppVersion', version)
+    } catch {
+      // Tagging must never break the connect/poll flow.
     }
   }
 
@@ -235,6 +280,7 @@ class LedgerService {
         Logger.info(`Immediately detected app type: ${detectedAppType}`)
         this.currentAppType = detectedAppType
         this.currentAppVersion = testAppInfo.version
+        this.recordLedgerAppSentryTags(detectedAppType, testAppInfo.version)
       } catch (error) {
         Logger.info(
           'Immediate get current app info failed, will rely on polling'
@@ -406,6 +452,7 @@ class LedgerService {
           this.currentAppType = newAppType
         }
         this.currentAppVersion = appInfo.version
+        this.recordLedgerAppSentryTags(newAppType, appInfo.version)
       } catch (error) {
         Logger.error('Error polling app info', error)
         // Don't stop polling on error, just log it
@@ -623,6 +670,7 @@ class LedgerService {
         this.currentAppType = detectedAppType
       }
       this.currentAppVersion = appInfo.version
+      this.recordLedgerAppSentryTags(detectedAppType, appInfo.version)
 
       if (this.isAppCompatible(this.currentAppType, appType)) {
         Logger.info(
@@ -863,6 +911,10 @@ class LedgerService {
           evmAvalancheAddressResponse,
           networkHrp
         )}`
+        const coreEthPublicKey = assertDevicePublicKey(
+          'getAddressAndPubKey(coreEth)',
+          evmAvalancheAddressResponse
+        )
         addresses.push({
           id: `${LedgerAddressType.AVALANCHE_CORE_ETH}-${i}`,
           type: LedgerAddressType.AVALANCHE_CORE_ETH,
@@ -909,10 +961,7 @@ class LedgerService {
         // Bitcoin addresses - derive from the Avalanche app public key at the
         // EVM derivation path (matching the browser extension behavior).
         const btcAddress = getBtcAddressFromPubKey(
-          Buffer.from(
-            evmAvalancheAddressResponse.publicKey.toString('hex'),
-            'hex'
-          ),
+          coreEthPublicKey,
           isTestnet ? networks.testnet : networks.bitcoin
         )
 

--- a/packages/core-mobile/app/services/ledger/LedgerService.ts
+++ b/packages/core-mobile/app/services/ledger/LedgerService.ts
@@ -19,10 +19,15 @@ import bs58 from 'bs58'
 import { DERIVATION_PATHS, LEDGER_TIMEOUTS } from 'new/features/ledger/consts'
 import { isBitcoinCompatibleApp } from 'new/features/ledger/utils'
 import { Curve } from 'utils/publicKeys'
-import { stripAddressPrefix } from 'common/utils/stripAddressPrefix'
 import { derivePublicKey, extendedPublicKeyToXpub } from 'utils/bip32'
 import { BluetoothState } from 'services/bluetooth/types'
 import BluetoothService from 'services/bluetooth/BluetoothService'
+import {
+  assertDeviceBech32Address,
+  assertDeviceEvmAddress,
+  assertDevicePublicKey,
+  assertDeviceSolanaAddress
+} from './validateDeviceAddress'
 import {
   AddressInfo,
   LedgerAddressType,
@@ -811,6 +816,9 @@ class LedgerService {
   }
 
   // Get all addresses from Avalanche app (EVM, AVM, Bitcoin)
+  // Pre-existing 4-arg signature; disabled rather than reshaped here because
+  // changing it would touch every caller and is unrelated to CP-14964.
+  // eslint-disable-next-line max-params
   async getAllAddresses(
     startIndex: number,
     count: number,
@@ -834,7 +842,9 @@ class LedgerService {
         addresses.push({
           id: `${LedgerAddressType.EVM}-${i}`,
           type: LedgerAddressType.EVM,
-          address: getAddress(evmAddressResponse.address),
+          address: getAddress(
+            assertDeviceEvmAddress('getETHAddress', evmAddressResponse)
+          ),
           derivationPath: evmPath
         })
 
@@ -848,8 +858,10 @@ class LedgerService {
         // underlying curve.
         const evmAvalancheAddressResponse =
           await avalancheApp.getAddressAndPubKey(evmPath, false, networkHrp)
-        const coreEthAddress = `C-${stripAddressPrefix(
-          evmAvalancheAddressResponse.address
+        const coreEthAddress = `C-${assertDeviceBech32Address(
+          'getAddressAndPubKey(coreEth)',
+          evmAvalancheAddressResponse,
+          networkHrp
         )}`
         addresses.push({
           id: `${LedgerAddressType.AVALANCHE_CORE_ETH}-${i}`,
@@ -874,8 +886,10 @@ class LedgerService {
             networkHrp
           )
 
-        const addressWithoutPrefix = stripAddressPrefix(
-          avalancheChainAddressResponse.address
+        const addressWithoutPrefix = assertDeviceBech32Address(
+          'getAddressAndPubKey(XP)',
+          avalancheChainAddressResponse,
+          networkHrp
         )
 
         addresses.push({
@@ -1042,9 +1056,10 @@ class LedgerService {
       // Remove 'm/' prefix if present (Ledger expects path without prefix)
       const ledgerDerivationPath = derivationPath.replace(/^m\//, '')
       const result = await solanaApp.getAddress(ledgerDerivationPath, false)
+      const address = assertDeviceSolanaAddress('getAddress(solana)', result)
 
       // Convert the Buffer to base58 format (Solana address format)
-      const solanaAddress = bs58.encode(new Uint8Array(result.address))
+      const solanaAddress = bs58.encode(new Uint8Array(address))
 
       Logger.info('Successfully got Solana address', solanaAddress)
 
@@ -1077,8 +1092,20 @@ class LedgerService {
       derivationPath
     )
 
-    const findAddress = (type: LedgerAddressType): string =>
-      addresses.find(addr => addr.type === type)?.address || ''
+    // Fails closed rather than defaulting to ''. An empty string here reads as
+    // a legitimately absent address downstream, which is how a corrupt XP
+    // address reached persistence unnoticed (CP-14964).
+    const findAddress = (type: LedgerAddressType): string => {
+      const address = addresses.find(addr => addr.type === type)?.address
+
+      if (!address) {
+        throw new Error(
+          `Ledger did not return a ${type} address for account ${accountIndex}`
+        )
+      }
+
+      return address
+    }
 
     const evmAddress = findAddress(LedgerAddressType.EVM)
     const coreEthAddress = findAddress(LedgerAddressType.AVALANCHE_CORE_ETH)
@@ -1163,6 +1190,14 @@ class LedgerService {
         false,
         'avax'
       )
+      const evmPublicKey = assertDevicePublicKey(
+        'getAddressAndPubKey(evm)',
+        evmKeyResponse
+      )
+      const avalanchePublicKey = assertDevicePublicKey(
+        'getAddressAndPubKey(avalanche)',
+        avalancheKeyResponse
+      )
 
       return {
         addresses: {
@@ -1178,12 +1213,12 @@ class LedgerService {
         },
         publicKeys: [
           {
-            key: evmKeyResponse.publicKey.toString('hex'),
+            key: evmPublicKey.toString('hex'),
             derivationPath: evmPath,
             curve: Curve.SECP256K1
           },
           {
-            key: avalancheKeyResponse.publicKey.toString('hex'),
+            key: avalanchePublicKey.toString('hex'),
             derivationPath: avalanchePath,
             curve: Curve.SECP256K1
           }
@@ -1365,10 +1400,18 @@ class LedgerService {
             false,
             'avax'
           )
+          const evmPublicKey = assertDevicePublicKey(
+            'getAddressAndPubKey(evm)',
+            evmResponse
+          )
+          const avalanchePublicKey = assertDevicePublicKey(
+            'getAddressAndPubKey(avalanche)',
+            avalancheResponse
+          )
 
           results.push({
-            evmPubKey: evmResponse.publicKey.toString('hex'),
-            avalanchePubKey: avalancheResponse.publicKey.toString('hex'),
+            evmPubKey: evmPublicKey.toString('hex'),
+            avalanchePubKey: avalanchePublicKey.toString('hex'),
             evmPath,
             avalanchePath
           })

--- a/packages/core-mobile/app/services/ledger/validateDeviceAddress.test.ts
+++ b/packages/core-mobile/app/services/ledger/validateDeviceAddress.test.ts
@@ -2,6 +2,7 @@ import { utils } from '@avalabs/avalanchejs'
 import AppAvalanche from '@avalabs/hw-app-avalanche'
 import type Transport from '@ledgerhq/hw-transport'
 import { stripAddressPrefix } from 'common/utils/stripAddressPrefix'
+import { SentryTag } from 'services/sentry/types'
 import { LedgerReturnCode } from './types'
 import {
   assertDeviceBech32Address,
@@ -9,6 +10,18 @@ import {
   assertDevicePublicKey,
   assertDeviceSolanaAddress
 } from './validateDeviceAddress'
+
+const mockCaptureMessage = jest.fn()
+jest.mock('services/sentry/SentryService', () => ({
+  __esModule: true,
+  default: {
+    captureMessage: (...args: unknown[]) => mockCaptureMessage(...args)
+  }
+}))
+
+beforeEach(() => {
+  mockCaptureMessage.mockClear()
+})
 
 const VALID_BODY = utils.formatBech32('avax', new Uint8Array(20).fill(7))
 const VALID_EVM = '0x449b3fFFE66378227DbBd05539B6542E5cA75A28'
@@ -42,6 +55,16 @@ describe('assertDeviceBech32Address', () => {
     expect(() =>
       assertDeviceBech32Address('XP', { ...okBech32, address: '' })
     ).toThrow(/XP/)
+  })
+
+  // The address preview must not alter this documented text: previewing an
+  // empty string has to be a no-op or `(raw: "")` would change shape.
+  it('keeps the exact documented text for an empty address', () => {
+    expect(() =>
+      assertDeviceBech32Address('XP', { ...okBech32, address: '' })
+    ).toThrow(
+      'Ledger XP returned an invalid address: empty address body (raw: "")'
+    )
   })
 
   it('throws when the address is only a chain-alias prefix', () => {
@@ -223,6 +246,22 @@ describe('assertDevicePublicKey', () => {
     ).toThrow(/invalid public key/)
   })
 
+  it('reports subject "public key" to Sentry on a truncated key', () => {
+    expect(() =>
+      assertDevicePublicKey('getAddressAndPubKey(evm)', {
+        publicKey: Buffer.alloc(16).fill(2),
+        returnCode: LedgerReturnCode.SUCCESS
+      })
+    ).toThrow()
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      'Ledger device reply failed validation',
+      expect.objectContaining({ subject: 'public key' }),
+      { source: SentryTag.Ledger },
+      ['ledger-reply-validation', 'getAddressAndPubKey(evm)', 'public key']
+    )
+  })
+
   it('throws on an uncompressed (65-byte) public key', () => {
     expect(() =>
       assertDevicePublicKey('getAddressAndPubKey(evm)', {
@@ -248,6 +287,20 @@ describe('assertDevicePublicKey', () => {
         errorMessage: 'Instruction not supported'
       })
     ).toThrow(/6a80/)
+  })
+
+  // getAllAddresses reuses the coreEth getAddressAndPubKey reply's publicKey
+  // to derive the persisted BTC address (CP-14964); the call label here must
+  // match the one LedgerService passes so a truncated/empty key on that reply
+  // fails closed with a message identifying the coreEth call, not the bech32
+  // address check that already runs on the same reply.
+  it('throws on a truncated coreEth public key, identifying the coreEth call', () => {
+    expect(() =>
+      assertDevicePublicKey('getAddressAndPubKey(coreEth)', {
+        publicKey: Buffer.alloc(0),
+        returnCode: LedgerReturnCode.SUCCESS
+      })
+    ).toThrow(/getAddressAndPubKey\(coreEth\)/)
   })
 })
 
@@ -343,5 +396,71 @@ describe('truncated BLE frame', () => {
     expect(() =>
       assertDeviceBech32Address('getAddressAndPubKey(XP)', reply)
     ).toThrow(/empty address body/)
+  })
+
+  // This is the CP-14964 discriminator: publicKey (33B) + hash (20B) present
+  // alongside an empty address means the frame was cut exactly at the address
+  // boundary, distinguishing it from a device/app that legitimately returned
+  // empty — a distinction we previously had zero telemetry to make.
+  it('reports publicKeyLength and hashLength to Sentry', async () => {
+    const reply = await appFor(truncatedFrame).getAddressAndPubKey(
+      "m/44'/9000'/0'/0/0",
+      false,
+      'avax'
+    )
+
+    expect(() =>
+      assertDeviceBech32Address('getAddressAndPubKey(XP)', reply)
+    ).toThrow()
+
+    expect(mockCaptureMessage).toHaveBeenCalledTimes(1)
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      'Ledger device reply failed validation',
+      expect.objectContaining({
+        call: 'getAddressAndPubKey(XP)',
+        subject: 'address',
+        publicKeyLength: PUBLIC_KEY_LENGTH,
+        hashLength: HASH_LENGTH
+      }),
+      { source: SentryTag.Ledger },
+      ['ledger-reply-validation', 'getAddressAndPubKey(XP)', 'address']
+    )
+  })
+})
+
+describe('Sentry telemetry on validation failure', () => {
+  it('reports the stable message and fingerprint for a bech32 failure', () => {
+    expect(() =>
+      assertDeviceBech32Address('XP', { ...okBech32, address: '' })
+    ).toThrow()
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      'Ledger device reply failed validation',
+      expect.objectContaining({ call: 'XP', subject: 'address' }),
+      { source: SentryTag.Ledger },
+      ['ledger-reply-validation', 'XP', 'address']
+    )
+  })
+
+  // A genuine bech32 address can reach this failure branch (e.g. wrong hrp),
+  // and Sentry's scrubber does not redact addresses, so the preview -- not
+  // the full value -- must be what leaves the process.
+  it('truncates a long address in telemetry and in the thrown message', () => {
+    const longAddress = `P-${'a'.repeat(50)}`
+    let thrown: Error | undefined
+
+    try {
+      assertDeviceBech32Address('XP', { ...okBech32, address: longAddress })
+    } catch (error) {
+      thrown = error as Error
+    }
+
+    expect(thrown?.message).toContain('…')
+    expect(thrown?.message).not.toContain(longAddress)
+
+    const lastCall = mockCaptureMessage.mock.calls.at(-1)
+    const context = lastCall?.[1] as { addressPreview?: string }
+    expect(context.addressPreview).not.toBe(longAddress)
+    expect(context.addressPreview?.length).toBeLessThanOrEqual(13)
   })
 })

--- a/packages/core-mobile/app/services/ledger/validateDeviceAddress.test.ts
+++ b/packages/core-mobile/app/services/ledger/validateDeviceAddress.test.ts
@@ -168,6 +168,22 @@ describe('assertDeviceEvmAddress', () => {
       assertDeviceEvmAddress('getETHAddress', { address: `P-${VALID_BODY}` })
     ).toThrow(/getETHAddress/)
   })
+
+  it('accepts an all-lowercase address', () => {
+    const lowercased = VALID_EVM.toLowerCase()
+    expect(
+      assertDeviceEvmAddress('getETHAddress', { address: lowercased })
+    ).toBe(lowercased)
+  })
+
+  // viem's isAddress defaults to strict:true, which enforces EIP-55 on
+  // mixed-case input -- stricter than the old hex-shape-only regex.
+  it('throws on a mixed-case address with a bad EIP-55 checksum', () => {
+    const badChecksum = `0x449b3ffFE66378227DbBd05539B6542E5cA75A28`
+    expect(() =>
+      assertDeviceEvmAddress('getETHAddress', { address: badChecksum })
+    ).toThrow(/getETHAddress/)
+  })
 })
 
 describe('assertDevicePublicKey', () => {
@@ -196,6 +212,15 @@ describe('assertDevicePublicKey', () => {
         returnCode: LedgerReturnCode.SUCCESS
       })
     ).toThrow(/16 bytes/)
+  })
+
+  it('reports a truncated public key as an invalid public key, not an address', () => {
+    expect(() =>
+      assertDevicePublicKey('getAddressAndPubKey(evm)', {
+        publicKey: Buffer.alloc(16).fill(2),
+        returnCode: LedgerReturnCode.SUCCESS
+      })
+    ).toThrow(/invalid public key/)
   })
 
   it('throws on an uncompressed (65-byte) public key', () => {

--- a/packages/core-mobile/app/services/ledger/validateDeviceAddress.test.ts
+++ b/packages/core-mobile/app/services/ledger/validateDeviceAddress.test.ts
@@ -1,0 +1,322 @@
+import { utils } from '@avalabs/avalanchejs'
+import AppAvalanche from '@avalabs/hw-app-avalanche'
+import type Transport from '@ledgerhq/hw-transport'
+import { stripAddressPrefix } from 'common/utils/stripAddressPrefix'
+import { LedgerReturnCode } from './types'
+import {
+  assertDeviceBech32Address,
+  assertDeviceEvmAddress,
+  assertDevicePublicKey,
+  assertDeviceSolanaAddress
+} from './validateDeviceAddress'
+
+const VALID_BODY = utils.formatBech32('avax', new Uint8Array(20).fill(7))
+const VALID_EVM = '0x449b3fFFE66378227DbBd05539B6542E5cA75A28'
+const VALID_PUBLIC_KEY = Buffer.alloc(33).fill(2)
+const VALID_SOLANA_ADDRESS = Buffer.alloc(32).fill(3)
+
+// Shape the Avalanche Ledger app actually returns, captured from a Ledger Flex
+// on CP-14964: getAddressAndPubKey replies carry a returnCode and prefix the
+// address, getETHAddress replies carry neither.
+const okBech32 = {
+  address: `P-${VALID_BODY}`,
+  returnCode: LedgerReturnCode.SUCCESS,
+  errorMessage: 'No errors'
+}
+const okEvm = { address: VALID_EVM }
+
+describe('assertDeviceBech32Address', () => {
+  it('returns the prefix-stripped body on a healthy reply', () => {
+    expect(assertDeviceBech32Address('XP', okBech32)).toBe(VALID_BODY)
+  })
+
+  it('accepts an unprefixed body', () => {
+    expect(
+      assertDeviceBech32Address('XP', { ...okBech32, address: VALID_BODY })
+    ).toBe(VALID_BODY)
+  })
+
+  // The bug: an empty body yielded `P-${''}` === 'P-', a truthy string that
+  // passed every downstream emptiness guard.
+  it('throws on an empty address rather than yielding a bare prefix', () => {
+    expect(() =>
+      assertDeviceBech32Address('XP', { ...okBech32, address: '' })
+    ).toThrow(/XP/)
+  })
+
+  it('throws when the address is only a chain-alias prefix', () => {
+    expect(() =>
+      assertDeviceBech32Address('XP', { ...okBech32, address: 'P-' })
+    ).toThrow(/XP/)
+  })
+
+  it('throws on an absent address', () => {
+    expect(() =>
+      assertDeviceBech32Address('XP', {
+        returnCode: LedgerReturnCode.SUCCESS
+      })
+    ).toThrow(/XP/)
+  })
+
+  it('throws on a non-bech32 address body', () => {
+    expect(() =>
+      assertDeviceBech32Address('XP', { ...okBech32, address: 'P-not-bech32' })
+    ).toThrow(/XP/)
+  })
+
+  // getAllAddresses previously performed no returnCode check at all, unlike its
+  // sibling getExtendedPubKey.
+  it.each([
+    ['APP_NOT_OPEN', LedgerReturnCode.APP_NOT_OPEN],
+    ['DEVICE_LOCKED', LedgerReturnCode.DEVICE_LOCKED],
+    ['USER_REJECTED', LedgerReturnCode.USER_REJECTED]
+  ])('throws on a non-success return code (%s)', (_name, code) => {
+    expect(() =>
+      assertDeviceBech32Address('XP', { ...okBech32, returnCode: code })
+    ).toThrow(new RegExp(code.toString(16)))
+  })
+
+  it('throws on a non-success return code even when the address looks valid', () => {
+    expect(() =>
+      assertDeviceBech32Address('XP', {
+        address: `P-${VALID_BODY}`,
+        returnCode: LedgerReturnCode.APP_NOT_OPEN,
+        errorMessage: 'Instruction not supported'
+      })
+    ).toThrow(/6a80/)
+  })
+
+  // Real mainnet/fuji-bodied addresses (CP-14964): a Ledger session on the
+  // wrong network hrp still passes the bech32/prefix checks above, so only an
+  // explicit expectedHrp comparison catches the mismatch.
+  describe('expectedHrp', () => {
+    const AVAX_BODY = 'avax16n9mgjanxmst06eh7hk7tg747qamqqjwm5s2vk'
+    const FUJI_BODY = 'fuji16n9mgjanxmst06eh7hk7tg747qamqqjwhx54qf'
+
+    it('throws when expecting avax but the device replied with a fuji body', () => {
+      expect(() =>
+        assertDeviceBech32Address(
+          'XP',
+          { ...okBech32, address: `P-${FUJI_BODY}` },
+          'avax'
+        )
+      ).toThrow(/XP/)
+    })
+
+    it('throws when expecting fuji but the device replied with an avax body', () => {
+      expect(() =>
+        assertDeviceBech32Address(
+          'XP',
+          { ...okBech32, address: `P-${AVAX_BODY}` },
+          'fuji'
+        )
+      ).toThrow(/XP/)
+    })
+
+    it('passes when the decoded hrp matches expectedHrp', () => {
+      expect(
+        assertDeviceBech32Address(
+          'XP',
+          { ...okBech32, address: `P-${AVAX_BODY}` },
+          'avax'
+        )
+      ).toBe(AVAX_BODY)
+    })
+
+    it('skips the hrp check when expectedHrp is omitted', () => {
+      expect(
+        assertDeviceBech32Address('XP', {
+          ...okBech32,
+          address: `P-${FUJI_BODY}`
+        })
+      ).toBe(FUJI_BODY)
+    })
+  })
+})
+
+describe('assertDeviceEvmAddress', () => {
+  it('returns the address on a healthy reply', () => {
+    expect(assertDeviceEvmAddress('getETHAddress', okEvm)).toBe(VALID_EVM)
+  })
+
+  // getETHAddress replies have no returnCode field, so the check must not
+  // reject them for its absence.
+  it('does not require a returnCode', () => {
+    expect(() => assertDeviceEvmAddress('getETHAddress', okEvm)).not.toThrow()
+  })
+
+  it('throws on an empty address', () => {
+    expect(() =>
+      assertDeviceEvmAddress('getETHAddress', { address: '' })
+    ).toThrow(/getETHAddress/)
+  })
+
+  it('throws on an absent address', () => {
+    expect(() => assertDeviceEvmAddress('getETHAddress', {})).toThrow(
+      /getETHAddress/
+    )
+  })
+
+  it('throws on a malformed hex address', () => {
+    expect(() =>
+      assertDeviceEvmAddress('getETHAddress', { address: '0xdeadbeef' })
+    ).toThrow(/getETHAddress/)
+  })
+
+  it('throws on a bech32 address delivered to the EVM call', () => {
+    expect(() =>
+      assertDeviceEvmAddress('getETHAddress', { address: `P-${VALID_BODY}` })
+    ).toThrow(/getETHAddress/)
+  })
+})
+
+describe('assertDevicePublicKey', () => {
+  it('returns the public key on a healthy 33-byte reply', () => {
+    expect(
+      assertDevicePublicKey('getAddressAndPubKey(evm)', {
+        publicKey: VALID_PUBLIC_KEY,
+        returnCode: LedgerReturnCode.SUCCESS
+      })
+    ).toBe(VALID_PUBLIC_KEY)
+  })
+
+  it('throws on an empty public key', () => {
+    expect(() =>
+      assertDevicePublicKey('getAddressAndPubKey(evm)', {
+        publicKey: Buffer.alloc(0),
+        returnCode: LedgerReturnCode.SUCCESS
+      })
+    ).toThrow(/getAddressAndPubKey\(evm\)/)
+  })
+
+  it('throws on a truncated (16-byte) public key', () => {
+    expect(() =>
+      assertDevicePublicKey('getAddressAndPubKey(evm)', {
+        publicKey: Buffer.alloc(16).fill(2),
+        returnCode: LedgerReturnCode.SUCCESS
+      })
+    ).toThrow(/16 bytes/)
+  })
+
+  it('throws on an uncompressed (65-byte) public key', () => {
+    expect(() =>
+      assertDevicePublicKey('getAddressAndPubKey(evm)', {
+        publicKey: Buffer.alloc(65).fill(4),
+        returnCode: LedgerReturnCode.SUCCESS
+      })
+    ).toThrow(/65 bytes/)
+  })
+
+  it('throws on an absent public key', () => {
+    expect(() =>
+      assertDevicePublicKey('getAddressAndPubKey(evm)', {
+        returnCode: LedgerReturnCode.SUCCESS
+      })
+    ).toThrow(/getAddressAndPubKey\(evm\)/)
+  })
+
+  it('throws on a non-success return code before checking the key', () => {
+    expect(() =>
+      assertDevicePublicKey('getAddressAndPubKey(evm)', {
+        publicKey: Buffer.alloc(0),
+        returnCode: LedgerReturnCode.APP_NOT_OPEN,
+        errorMessage: 'Instruction not supported'
+      })
+    ).toThrow(/6a80/)
+  })
+})
+
+describe('assertDeviceSolanaAddress', () => {
+  it('returns the address on a healthy 32-byte reply', () => {
+    expect(
+      assertDeviceSolanaAddress('getAddress(solana)', {
+        address: VALID_SOLANA_ADDRESS
+      })
+    ).toBe(VALID_SOLANA_ADDRESS)
+  })
+
+  it('throws on an empty address', () => {
+    expect(() =>
+      assertDeviceSolanaAddress('getAddress(solana)', {
+        address: Buffer.alloc(0)
+      })
+    ).toThrow(/getAddress\(solana\)/)
+  })
+
+  it('throws on a 31-byte address', () => {
+    expect(() =>
+      assertDeviceSolanaAddress('getAddress(solana)', {
+        address: Buffer.alloc(31).fill(3)
+      })
+    ).toThrow(/31 bytes/)
+  })
+
+  it('throws on an absent address', () => {
+    expect(() => assertDeviceSolanaAddress('getAddress(solana)', {})).toThrow(
+      /getAddress\(solana\)/
+    )
+  })
+})
+
+describe('truncated BLE frame', () => {
+  const PUBLIC_KEY_LENGTH = 33
+  const HASH_LENGTH = 20
+
+  /**
+   * A frame that lost its address bytes in transit but kept its trailing status
+   * word. Both affected users onboarded during a BLE failure storm that
+   * included `TransportError: Invalid tag 8` and a failed subscription to the
+   * Ledger notify characteristic — i.e. frame-level corruption of the channel
+   * the device replies on.
+   */
+  const truncatedFrame = Buffer.concat([
+    new Uint8Array([PUBLIC_KEY_LENGTH]),
+    new Uint8Array(PUBLIC_KEY_LENGTH).fill(0xab),
+    new Uint8Array(HASH_LENGTH).fill(0xcd),
+    new Uint8Array([0x90, 0x00])
+  ])
+
+  const appFor = (frame: Buffer): AppAvalanche =>
+    new AppAvalanche({
+      send: jest.fn().mockResolvedValue(frame),
+      decorateAppAPIMethods: jest.fn()
+    } as unknown as Transport)
+
+  /**
+   * The status word survives at the tail, so the reply parses as SUCCESS while
+   * the address comes back empty. A returnCode check alone therefore cannot
+   * catch this — validating the address body is what closes it.
+   */
+  it('parses as SUCCESS with an empty address', async () => {
+    const reply = await appFor(truncatedFrame).getAddressAndPubKey(
+      "m/44'/9000'/0'/0/0",
+      false,
+      'avax'
+    )
+
+    expect(reply.returnCode).toBe(LedgerReturnCode.SUCCESS)
+    expect(reply.address).toBe('')
+  })
+
+  it('produced the bare "P-" that reached production', async () => {
+    const reply = await appFor(truncatedFrame).getAddressAndPubKey(
+      "m/44'/9000'/0'/0/0",
+      false,
+      'avax'
+    )
+
+    expect(`P-${stripAddressPrefix(reply.address)}`).toBe('P-')
+  })
+
+  it('is rejected by the validator', async () => {
+    const reply = await appFor(truncatedFrame).getAddressAndPubKey(
+      "m/44'/9000'/0'/0/0",
+      false,
+      'avax'
+    )
+
+    expect(() =>
+      assertDeviceBech32Address('getAddressAndPubKey(XP)', reply)
+    ).toThrow(/empty address body/)
+  })
+})

--- a/packages/core-mobile/app/services/ledger/validateDeviceAddress.ts
+++ b/packages/core-mobile/app/services/ledger/validateDeviceAddress.ts
@@ -1,22 +1,79 @@
 import { utils } from '@avalabs/avalanchejs'
 import { stripAddressPrefix } from 'common/utils/stripAddressPrefix'
 import { isAddress } from 'viem'
+import SentryService from 'services/sentry/SentryService'
+import { SentryTag } from 'services/sentry/types'
 import { LedgerReturnCode } from './types'
 
 /**
  * The two address calls return different shapes. `getAddressAndPubKey` carries
- * `returnCode`/`errorMessage`; `getETHAddress` carries neither, so the return
- * code can only be enforced when it is actually present.
+ * `returnCode`/`errorMessage`, a `hash` Buffer, and a `publicKey` Buffer;
+ * `getETHAddress` carries neither `returnCode` nor `hash`, and its
+ * `publicKey` is a hex string rather than a Buffer (see `processGetAddrResponse`
+ * vs. `getETHAddress` in `@avalabs/hw-app-avalanche`). `publicKey` is typed as
+ * the union of both so this one interface can describe either reply; callers
+ * that care about its byte length narrow with `Buffer.isBuffer` first.
  */
 export interface LedgerAddressReply {
   address?: string
   returnCode?: number
   errorMessage?: string
+  hash?: Buffer
+  publicKey?: Buffer | string
 }
 
 type ReplySubject = 'address' | 'public key'
 
-const fail = (call: string, subject: ReplySubject, reason: string): never => {
+const PREVIEW_MAX_LENGTH = 12
+
+/**
+ * Previews a string for logs/telemetry: at most 12 characters, with an
+ * ellipsis appended when truncated. A genuine bech32/EVM address can reach
+ * these failure branches, and Sentry's scrubber does not redact addresses, so
+ * every raw-value mention in a thrown message or in telemetry goes through
+ * this first. An empty string is returned unchanged so the documented
+ * `(raw: "")` error text stays stable.
+ */
+const previewString = (value: string): string =>
+  value.length > PREVIEW_MAX_LENGTH
+    ? `${value.slice(0, PREVIEW_MAX_LENGTH)}…`
+    : value
+
+interface FailDiagnostics {
+  returnCode?: number
+  addressType?: string
+  addressLength?: number
+  addressPreview?: string
+  publicKeyLength?: number
+  hashLength?: number
+}
+
+type FailDetails = FailDiagnostics & { reason: string }
+
+/**
+ * Reports a validation failure to Sentry before throwing. The message is a
+ * stable string (reason/diagnostics carry the variable part) and the
+ * fingerprint omits `reason` so differing failure text doesn't fragment
+ * grouping — every failure for the same call+subject lands in one issue.
+ */
+const fail = (
+  call: string,
+  subject: ReplySubject,
+  details: FailDetails
+): never => {
+  const { reason, ...diagnostics } = details
+
+  try {
+    SentryService.captureMessage(
+      'Ledger device reply failed validation',
+      { call, subject, reason, ...diagnostics },
+      { source: SentryTag.Ledger },
+      ['ledger-reply-validation', call, subject]
+    )
+  } catch {
+    // Telemetry must never mask the real validation error.
+  }
+
   throw new Error(`Ledger ${call} returned an invalid ${subject}: ${reason}`)
 }
 
@@ -46,40 +103,57 @@ export const assertDeviceBech32Address = (
   assertReturnCode(call, reply)
 
   const address = reply?.address
+  const publicKey = reply?.publicKey
+  // publicKey (33B) + hash (20B) present alongside an empty address means the
+  // frame was cut exactly at the address boundary; a short publicKey instead
+  // points at a different kind of corruption (CP-14964).
+  const diagnostics: FailDiagnostics = {
+    returnCode: reply?.returnCode,
+    addressType: typeof address,
+    addressLength: typeof address === 'string' ? address.length : undefined,
+    addressPreview:
+      typeof address === 'string' ? previewString(address) : undefined,
+    publicKeyLength: Buffer.isBuffer(publicKey) ? publicKey.length : undefined,
+    hashLength: reply?.hash?.length
+  }
 
   if (typeof address !== 'string') {
-    return fail(call, 'address', `expected a string, got ${typeof address}`)
+    return fail(call, 'address', {
+      reason: `expected a string, got ${typeof address}`,
+      ...diagnostics
+    })
   }
 
   const body = stripAddressPrefix(address)
 
   if (body.length === 0) {
-    return fail(
-      call,
-      'address',
-      `empty address body (raw: ${JSON.stringify(address)})`
-    )
+    return fail(call, 'address', {
+      reason: `empty address body (raw: ${JSON.stringify(
+        previewString(address)
+      )})`,
+      ...diagnostics
+    })
   }
 
   let hrp: string
   try {
     ;[hrp] = utils.parseBech32(body)
   } catch {
-    return fail(
-      call,
-      'address',
-      `not a valid bech32 address (raw: ${JSON.stringify(address)})`
-    )
+    return fail(call, 'address', {
+      reason: `not a valid bech32 address (raw: ${JSON.stringify(
+        previewString(address)
+      )})`,
+      ...diagnostics
+    })
   }
 
   if (expectedHrp !== undefined && hrp !== expectedHrp) {
-    return fail(
-      call,
-      'address',
-      `expected hrp "${expectedHrp}", got "${hrp}" (raw: ${JSON.stringify(
-        address
-      )})`
-    )
+    return fail(call, 'address', {
+      reason: `expected hrp "${expectedHrp}", got "${hrp}" (raw: ${JSON.stringify(
+        previewString(address)
+      )})`,
+      ...diagnostics
+    })
   }
 
   return body
@@ -96,17 +170,31 @@ export const assertDeviceEvmAddress = (
   assertReturnCode(call, reply)
 
   const address = reply?.address
+  const publicKey = reply?.publicKey
+  const diagnostics: FailDiagnostics = {
+    returnCode: reply?.returnCode,
+    addressType: typeof address,
+    addressLength: typeof address === 'string' ? address.length : undefined,
+    addressPreview:
+      typeof address === 'string' ? previewString(address) : undefined,
+    publicKeyLength: Buffer.isBuffer(publicKey) ? publicKey.length : undefined,
+    hashLength: reply?.hash?.length
+  }
 
   if (typeof address !== 'string') {
-    return fail(call, 'address', `expected a string, got ${typeof address}`)
+    return fail(call, 'address', {
+      reason: `expected a string, got ${typeof address}`,
+      ...diagnostics
+    })
   }
 
   if (!isAddress(address)) {
-    return fail(
-      call,
-      'address',
-      `not a valid EVM address (raw: ${JSON.stringify(address)})`
-    )
+    return fail(call, 'address', {
+      reason: `not a valid EVM address (raw: ${JSON.stringify(
+        previewString(address)
+      )})`,
+      ...diagnostics
+    })
   }
 
   return address
@@ -134,21 +222,23 @@ export const assertDevicePublicKey = (
   assertReturnCode(call, reply as LedgerAddressReply | undefined)
 
   const publicKey = reply?.publicKey
+  const diagnostics: FailDiagnostics = {
+    returnCode: reply?.returnCode,
+    publicKeyLength: Buffer.isBuffer(publicKey) ? publicKey.length : undefined
+  }
 
   if (!Buffer.isBuffer(publicKey)) {
-    return fail(
-      call,
-      'public key',
-      `expected a Buffer, got ${typeof publicKey}`
-    )
+    return fail(call, 'public key', {
+      reason: `expected a Buffer, got ${typeof publicKey}`,
+      ...diagnostics
+    })
   }
 
   if (publicKey.length !== COMPRESSED_SECP256K1_PUBLIC_KEY_LENGTH) {
-    return fail(
-      call,
-      'public key',
-      `expected a ${COMPRESSED_SECP256K1_PUBLIC_KEY_LENGTH}-byte compressed public key, got ${publicKey.length} bytes`
-    )
+    return fail(call, 'public key', {
+      reason: `expected a ${COMPRESSED_SECP256K1_PUBLIC_KEY_LENGTH}-byte compressed public key, got ${publicKey.length} bytes`,
+      ...diagnostics
+    })
   }
 
   return publicKey
@@ -173,17 +263,24 @@ export const assertDeviceSolanaAddress = (
   assertReturnCode(call, reply as LedgerAddressReply | undefined)
 
   const address = reply?.address
+  const diagnostics: FailDiagnostics = {
+    returnCode: reply?.returnCode,
+    addressType: typeof address,
+    addressLength: Buffer.isBuffer(address) ? address.length : undefined
+  }
 
   if (!Buffer.isBuffer(address)) {
-    return fail(call, 'address', `expected a Buffer, got ${typeof address}`)
+    return fail(call, 'address', {
+      reason: `expected a Buffer, got ${typeof address}`,
+      ...diagnostics
+    })
   }
 
   if (address.length !== SOLANA_ADDRESS_LENGTH) {
-    return fail(
-      call,
-      'address',
-      `expected a ${SOLANA_ADDRESS_LENGTH}-byte address, got ${address.length} bytes`
-    )
+    return fail(call, 'address', {
+      reason: `expected a ${SOLANA_ADDRESS_LENGTH}-byte address, got ${address.length} bytes`,
+      ...diagnostics
+    })
   }
 
   return address

--- a/packages/core-mobile/app/services/ledger/validateDeviceAddress.ts
+++ b/packages/core-mobile/app/services/ledger/validateDeviceAddress.ts
@@ -1,0 +1,185 @@
+/**
+ * Validation for address replies from the Avalanche Ledger app.
+ *
+ * `getAllAddresses` used to trust these replies unconditionally, so a reply
+ * carrying an empty address string was persisted as a bare chain alias
+ * (`P-${''}` === `'P-'`). That is truthy, so it survived every downstream
+ * emptiness guard and only surfaced much later as an unexplained "No routes"
+ * on a C->P transfer. See CP-14964.
+ */
+import { utils } from '@avalabs/avalanchejs'
+import { stripAddressPrefix } from 'common/utils/stripAddressPrefix'
+import { LedgerReturnCode } from './types'
+
+/**
+ * The two address calls return different shapes. `getAddressAndPubKey` carries
+ * `returnCode`/`errorMessage`; `getETHAddress` carries neither, so the return
+ * code can only be enforced when it is actually present.
+ */
+export interface LedgerAddressReply {
+  address?: string
+  returnCode?: number
+  errorMessage?: string
+}
+
+const EVM_ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/
+
+const fail = (call: string, reason: string): never => {
+  throw new Error(`Ledger ${call} returned an invalid address: ${reason}`)
+}
+
+const assertReturnCode = (call: string, reply?: LedgerAddressReply): void => {
+  const code = reply?.returnCode
+
+  if (typeof code === 'number' && code !== LedgerReturnCode.SUCCESS) {
+    throw new Error(
+      `Ledger ${call} failed with status 0x${code.toString(16)}: ${
+        reply?.errorMessage ?? 'unknown error'
+      }`
+    )
+  }
+}
+
+/**
+ * Validates a bech32 address reply and returns it with the chain alias
+ * stripped, ready for the caller to re-prefix for its target chain. The device
+ * prefixes every bech32 reply with `P-` regardless of the derivation path
+ * requested, so both the X/P and CoreEth call sites go through here.
+ */
+export const assertDeviceBech32Address = (
+  call: string,
+  reply?: LedgerAddressReply,
+  expectedHrp?: string
+): string => {
+  assertReturnCode(call, reply)
+
+  const address = reply?.address
+
+  if (typeof address !== 'string') {
+    return fail(call, `expected a string, got ${typeof address}`)
+  }
+
+  const body = stripAddressPrefix(address)
+
+  if (body.length === 0) {
+    return fail(call, `empty address body (raw: ${JSON.stringify(address)})`)
+  }
+
+  let hrp: string
+  try {
+    ;[hrp] = utils.parseBech32(body)
+  } catch {
+    return fail(
+      call,
+      `not a valid bech32 address (raw: ${JSON.stringify(address)})`
+    )
+  }
+
+  if (expectedHrp !== undefined && hrp !== expectedHrp) {
+    return fail(
+      call,
+      `expected hrp "${expectedHrp}", got "${hrp}" (raw: ${JSON.stringify(
+        address
+      )})`
+    )
+  }
+
+  return body
+}
+
+/**
+ * Validates an EVM address reply. Kept separate from the bech32 path because
+ * `getETHAddress` has no `returnCode` to check and its address is 0x-hex.
+ */
+export const assertDeviceEvmAddress = (
+  call: string,
+  reply?: LedgerAddressReply
+): string => {
+  assertReturnCode(call, reply)
+
+  const address = reply?.address
+
+  if (typeof address !== 'string') {
+    return fail(call, `expected a string, got ${typeof address}`)
+  }
+
+  if (!EVM_ADDRESS_REGEX.test(address)) {
+    return fail(
+      call,
+      `not a 20-byte hex address (raw: ${JSON.stringify(address)})`
+    )
+  }
+
+  return address
+}
+
+const COMPRESSED_SECP256K1_PUBLIC_KEY_LENGTH = 33
+const SOLANA_ADDRESS_LENGTH = 32
+
+export interface LedgerPublicKeyReply {
+  publicKey?: Buffer
+  returnCode?: number
+  errorMessage?: string
+}
+
+/**
+ * Validates a public key reply from `getAddressAndPubKey`. The secp256k1
+ * pubkey-to-bech32 derivation downstream does not check length itself, so a
+ * truncated (or empty) `publicKey` that still carries SUCCESS would otherwise
+ * silently derive a well-formed address nobody controls. See CP-14964.
+ */
+export const assertDevicePublicKey = (
+  call: string,
+  reply?: LedgerPublicKeyReply
+): Buffer => {
+  assertReturnCode(call, reply as LedgerAddressReply | undefined)
+
+  const publicKey = reply?.publicKey
+
+  if (!Buffer.isBuffer(publicKey)) {
+    return fail(call, `expected a Buffer, got ${typeof publicKey}`)
+  }
+
+  if (publicKey.length !== COMPRESSED_SECP256K1_PUBLIC_KEY_LENGTH) {
+    return fail(
+      call,
+      `expected a ${COMPRESSED_SECP256K1_PUBLIC_KEY_LENGTH}-byte compressed public key, got ${publicKey.length} bytes`
+    )
+  }
+
+  return publicKey
+}
+
+export interface LedgerSolanaAddressReply {
+  address?: Buffer
+  returnCode?: number
+  errorMessage?: string
+}
+
+/**
+ * Validates a Solana address reply. Unlike the Avalanche bech32/EVM calls,
+ * `getAddress` returns the raw 32-byte ed25519 public key as a Buffer rather
+ * than an encoded string, so it needs its own length check ahead of the
+ * base58 encode.
+ */
+export const assertDeviceSolanaAddress = (
+  call: string,
+  reply?: LedgerSolanaAddressReply
+): Buffer => {
+  assertReturnCode(call, reply as LedgerAddressReply | undefined)
+
+  const address = reply?.address
+
+  if (!Buffer.isBuffer(address)) {
+    return fail(call, `expected a Buffer, got ${typeof address}`)
+  }
+
+  if (address.length !== SOLANA_ADDRESS_LENGTH) {
+    return fail(
+      call,
+      `expected a ${SOLANA_ADDRESS_LENGTH}-byte address, got ${address.length} bytes`
+    )
+  }
+
+  return address
+}

--- a/packages/core-mobile/app/services/ledger/validateDeviceAddress.ts
+++ b/packages/core-mobile/app/services/ledger/validateDeviceAddress.ts
@@ -1,14 +1,6 @@
-/**
- * Validation for address replies from the Avalanche Ledger app.
- *
- * `getAllAddresses` used to trust these replies unconditionally, so a reply
- * carrying an empty address string was persisted as a bare chain alias
- * (`P-${''}` === `'P-'`). That is truthy, so it survived every downstream
- * emptiness guard and only surfaced much later as an unexplained "No routes"
- * on a C->P transfer. See CP-14964.
- */
 import { utils } from '@avalabs/avalanchejs'
 import { stripAddressPrefix } from 'common/utils/stripAddressPrefix'
+import { isAddress } from 'viem'
 import { LedgerReturnCode } from './types'
 
 /**
@@ -22,10 +14,10 @@ export interface LedgerAddressReply {
   errorMessage?: string
 }
 
-const EVM_ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/
+type ReplySubject = 'address' | 'public key'
 
-const fail = (call: string, reason: string): never => {
-  throw new Error(`Ledger ${call} returned an invalid address: ${reason}`)
+const fail = (call: string, subject: ReplySubject, reason: string): never => {
+  throw new Error(`Ledger ${call} returned an invalid ${subject}: ${reason}`)
 }
 
 const assertReturnCode = (call: string, reply?: LedgerAddressReply): void => {
@@ -56,13 +48,17 @@ export const assertDeviceBech32Address = (
   const address = reply?.address
 
   if (typeof address !== 'string') {
-    return fail(call, `expected a string, got ${typeof address}`)
+    return fail(call, 'address', `expected a string, got ${typeof address}`)
   }
 
   const body = stripAddressPrefix(address)
 
   if (body.length === 0) {
-    return fail(call, `empty address body (raw: ${JSON.stringify(address)})`)
+    return fail(
+      call,
+      'address',
+      `empty address body (raw: ${JSON.stringify(address)})`
+    )
   }
 
   let hrp: string
@@ -71,6 +67,7 @@ export const assertDeviceBech32Address = (
   } catch {
     return fail(
       call,
+      'address',
       `not a valid bech32 address (raw: ${JSON.stringify(address)})`
     )
   }
@@ -78,6 +75,7 @@ export const assertDeviceBech32Address = (
   if (expectedHrp !== undefined && hrp !== expectedHrp) {
     return fail(
       call,
+      'address',
       `expected hrp "${expectedHrp}", got "${hrp}" (raw: ${JSON.stringify(
         address
       )})`
@@ -100,13 +98,14 @@ export const assertDeviceEvmAddress = (
   const address = reply?.address
 
   if (typeof address !== 'string') {
-    return fail(call, `expected a string, got ${typeof address}`)
+    return fail(call, 'address', `expected a string, got ${typeof address}`)
   }
 
-  if (!EVM_ADDRESS_REGEX.test(address)) {
+  if (!isAddress(address)) {
     return fail(
       call,
-      `not a 20-byte hex address (raw: ${JSON.stringify(address)})`
+      'address',
+      `not a valid EVM address (raw: ${JSON.stringify(address)})`
     )
   }
 
@@ -137,12 +136,17 @@ export const assertDevicePublicKey = (
   const publicKey = reply?.publicKey
 
   if (!Buffer.isBuffer(publicKey)) {
-    return fail(call, `expected a Buffer, got ${typeof publicKey}`)
+    return fail(
+      call,
+      'public key',
+      `expected a Buffer, got ${typeof publicKey}`
+    )
   }
 
   if (publicKey.length !== COMPRESSED_SECP256K1_PUBLIC_KEY_LENGTH) {
     return fail(
       call,
+      'public key',
       `expected a ${COMPRESSED_SECP256K1_PUBLIC_KEY_LENGTH}-byte compressed public key, got ${publicKey.length} bytes`
     )
   }
@@ -171,12 +175,13 @@ export const assertDeviceSolanaAddress = (
   const address = reply?.address
 
   if (!Buffer.isBuffer(address)) {
-    return fail(call, `expected a Buffer, got ${typeof address}`)
+    return fail(call, 'address', `expected a Buffer, got ${typeof address}`)
   }
 
   if (address.length !== SOLANA_ADDRESS_LENGTH) {
     return fail(
       call,
+      'address',
       `expected a ${SOLANA_ADDRESS_LENGTH}-byte address, got ${address.length} bytes`
     )
   }

--- a/packages/core-mobile/app/services/sentry/types.ts
+++ b/packages/core-mobile/app/services/sentry/types.ts
@@ -44,7 +44,8 @@ export const SentryTag = {
   ProfileApi: 'profile-api',
   GasStation: 'gas-station',
   Proxy: 'proxy',
-  SchemaMigration: 'schemaMigration'
+  SchemaMigration: 'schemaMigration',
+  Ledger: 'ledger'
 } as const
 
 /**
@@ -56,7 +57,8 @@ export const SentryTag = {
 export const AllowedSentryBreadcrumbCategory = {
   ListenerMigration: 'listenerMigration',
   ListenerReconciler: 'listenerReconciler',
-  FeeEstimationUserState: 'feeEstimationUserState'
+  FeeEstimationUserState: 'feeEstimationUserState',
+  LedgerApdu: 'ledgerApdu'
 } as const
 
 export type AllowedSentryBreadcrumbCategory =

--- a/packages/core-mobile/app/services/wallet/AvalancheWalletService.test.ts
+++ b/packages/core-mobile/app/services/wallet/AvalancheWalletService.test.ts
@@ -402,4 +402,47 @@ describe('WalletService', () => {
       expect(getAtomicUTXOsMock).toHaveBeenCalledTimes(6)
     })
   })
+
+  describe('getReadOnlySigner', () => {
+    // Exercises the real method (unlike the specs above, which spy it away)
+    // so the addressPVM/addressCoreEth guards actually run. Only the network
+    // provider lookup is stubbed; it's an unrelated RPC dependency the guards
+    // don't need.
+    beforeEach(() => {
+      jest
+        .spyOn(NetworkService, 'getAvalancheProviderXP')
+        // @ts-ignore
+        .mockResolvedValue({})
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('throws when addressPVM is a bare chain prefix', async () => {
+      await expect(
+        AvalancheWalletService.getReadOnlySigner({
+          account: {
+            addressPVM: 'P-',
+            addressCoreEth: 'C-avaxvalidbodyaddress'
+          } as Account,
+          isTestnet: true,
+          xpAddresses: []
+        })
+      ).rejects.toThrow('P-Chain address not available for account')
+    })
+
+    it('throws when addressCoreEth is a bare chain prefix', async () => {
+      await expect(
+        AvalancheWalletService.getReadOnlySigner({
+          account: {
+            addressPVM: 'P-avaxvalidbodyaddress',
+            addressCoreEth: 'C-'
+          } as Account,
+          isTestnet: true,
+          xpAddresses: []
+        })
+      ).rejects.toThrow('CoreEth address not available for account')
+    })
+  })
 })

--- a/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
+++ b/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
@@ -654,8 +654,6 @@ class AvalancheWalletService {
     isTestnet: boolean
     xpAddresses: string[]
   }): Promise<Avalanche.AddressWallet> {
-    const provXP = await NetworkService.getAvalancheProviderXP(isTestnet)
-
     if (!account.addressPVM || isBareChainPrefix(account.addressPVM)) {
       throw new Error('P-Chain address not available for account')
     }
@@ -663,6 +661,8 @@ class AvalancheWalletService {
     if (!account.addressCoreEth || isBareChainPrefix(account.addressCoreEth)) {
       throw new Error('CoreEth address not available for account')
     }
+
+    const provXP = await NetworkService.getAvalancheProviderXP(isTestnet)
 
     return new Avalanche.AddressWallet(
       account.addressC,

--- a/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
+++ b/packages/core-mobile/app/services/wallet/AvalancheWalletService.ts
@@ -1,5 +1,8 @@
 import { Avalanche } from '@avalabs/core-wallets-sdk'
-import { stripAddressPrefix } from 'common/utils/stripAddressPrefix'
+import {
+  isBareChainPrefix,
+  stripAddressPrefix
+} from 'common/utils/stripAddressPrefix'
 import NetworkService from 'services/network/NetworkService'
 import { Account } from 'store/account'
 import { pvm, UnsignedTx, utils } from '@avalabs/avalanchejs'
@@ -653,8 +656,12 @@ class AvalancheWalletService {
   }): Promise<Avalanche.AddressWallet> {
     const provXP = await NetworkService.getAvalancheProviderXP(isTestnet)
 
-    if (!account.addressPVM) {
+    if (!account.addressPVM || isBareChainPrefix(account.addressPVM)) {
       throw new Error('P-Chain address not available for account')
+    }
+
+    if (!account.addressCoreEth || isBareChainPrefix(account.addressCoreEth)) {
+      throw new Error('CoreEth address not available for account')
     }
 
     return new Avalanche.AddressWallet(


### PR DESCRIPTION
## Description

**Ticket: [CP-14964]**

A Ledger BLE frame that loses its payload bytes in transit but keeps the trailing status word parses in `@avalabs/hw-app-avalanche` as **success with an empty address** (`returnCode 0x9000`, `address: ""`). The app persisted that as `` `P-${""}` `` → the literal string `"P-"` for the wallet's X/P/CoreEth addresses. `"P-"` is truthy, so it passed every `!address` guard, and because stored Ledger addresses are never re-derived, the corruption was permanent, surfacing only as an unexplained "No routes" on C→P transfers (plus Sentry BA1/BA2 and API 400s). Two production users are affected.

This PR validates device replies at the boundary instead of trusting them:

- **New `app/services/ledger/validateDeviceAddress.ts`**: validators for every reply shape the Avalanche/Eth/Solana Ledger apps return.
  - `assertDeviceBech32Address`: return-code check (only when present, since `getETHAddress` replies legitimately lack one), non-empty body, strict bech32 parse, and **HRP match** against the requested network (`avax`/`fuji`), so a valid-but-wrong-network body also fails closed.
  - `assertDeviceEvmAddress`: viem's `isAddress`, which accepts all-lowercase addresses and enforces EIP-55 on mixed-case ones, composing with the existing `ethers.getAddress` checksum layer at the call site.
  - `assertDevicePublicKey` (33-byte compressed SECP256K1) and `assertDeviceSolanaAddress` (32 bytes): a truncated reply can also deliver a short or empty **pubkey** with `0x9000`, and pubkey→bech32 hashing does not validate length, so an empty pubkey silently derives a *well-formed* address nobody controls. That is a strictly worse failure than `"P-"` because it never surfaces an error. Wired into `getPublicKeysForRange`, the `getAvalancheKeys` Ledger Live branch, and `getSolanaKeys`.
- **`LedgerService.getAllAddresses`**: all three call sites validated (EVM, CoreEth, XP). The device returns a `P-` prefixed bech32 on the CoreEth path too, so it is corruptible identically. `getAvalancheKeys` now fails closed instead of `|| ''`.
- **`AvalancheWalletService.getReadOnlySigner`**: rejects bare-prefix `addressPVM` *and* `addressCoreEth` before handing them to the wallets-SDK, and now does so before the XP provider lookup so a corrupt stored address cannot be masked by an RPC error.
- **`stripAddressPrefix.ts`**: new `isBareChainPrefix` helper (`/^[XPC]-$/`).
- **`useQuoteStreaming`**: bare-prefix from/to addresses are blocked before reaching the Fusion SDK and surface the standard quotes-unavailable error plus a distinct Sentry message, preserving the telemetry that identified the affected users instead of leaving a silent blank state.
- **Diagnostic telemetry**, so the next occurrence in the wild identifies the cause rather than leaving it inferred. Each APDU exchange adds a Sentry breadcrumb carrying frame metadata only (`cla`, `ins`, `replyLength`, `statusWord`, never payload bytes), and a validation failure captures a structured event under a stable fingerprint with `publicKeyLength` and `hashLength`. Those two fields are the discriminator: a 33-byte pubkey and 20-byte hash alongside an empty address means the frame was cut exactly at the address boundary, whereas a device returning an empty address looks different. `ledgerAppType` and `ledgerAppVersion` are set on the Sentry scope for the same reason. Address values are capped to a 12-character preview so a real address cannot leak into Sentry.

**Root cause and verification.** `processGetAddrResponse` reads the status word from the reply's last two bytes and takes the address as whatever sits between the 20-byte hash and that status word. A frame that loses its address bytes but keeps its tail therefore parses as `returnCode 0x9000` with `address: ""`. Unit tests drive the real parser through a scripted transport to demonstrate this, which is also why a return-code check cannot catch it.

Production confirms the consequence. Issue BA1 carries `queryHash: [..., [""]]`, an `xpAddresses` array holding a single empty string, thrown from `getReadOnlySigner`. The same user's events run from `1.0.36+9322` through `1.0.37+9465`, so an app update does not clear it: stored Ledger addresses are never re-derived, which is why the state is permanent and why the repair migration is tracked separately in CP-14970.

On hardware (Pixel 8 Pro + Ledger Flex), with a dev-only truncation harness injecting that frame at the transport layer: unpatched, onboarding completes silently and persists `"P-"`, then emits the same bech32 error and recurring API 400s seen in production. Patched, the same fault stops onboarding with `empty address body` and persists nothing. With injection off, onboarding is unchanged and matches the device's known-good addresses, including after the review changes that route EVM validation through viem's `isAddress`.

Scope of that result: the harness supplies the corrupt frame, so it establishes that the mechanism is sufficient and that the guard covers it. Which fault produced the two users' value is a separate question and remains open. One user shows `TransportError: Invalid tag 8`, a genuine framing failure, fifty seconds before their first bad-address error; the other shows only connect-level failures. A device or app version returning an empty address with a success code is not excluded. This is deliberately why the change validates the reply rather than diagnosing the cause: any input that yields an empty or malformed address at this boundary now fails closed, including causes we have not characterised.

The xpub-based derivation path needs no guard: `bip32.fromPublicKey` strictly rejects truncated key material, verified empirically. That asymmetry, xpubs validated by bip32 while addresses were string-concatenated raw, was the whole bug.

**Adversarial review** (two independent passes plus a delta re-review) additionally verified: no partial persistence before the new throws, no transport-state wedge, and no cold-start regression for already-corrupted accounts. Review feedback is addressed in `a86562a22`. Deliberately deferred to **CP-14970** to keep this reviewable: the repair migration for the two corrupted users, consumption-side guards (`transformXPAddresses`, the `getAddressByNetwork` chokepoint and friends), validator-specific error copy on `AppConnectionScreen`, and Sentry `walletType` tagging.

No new dependencies (viem is already a direct dependency). Not breaking; no migration.

## Screenshots/Videos

- Unpatched + injected fault: onboarding completes normally, then Account Settings shows the corrupt state, with recurring `Malformed address` API 400s in the logs.
- Patched + injected fault: onboarding fails with a retryable error at the connect step and nothing is persisted.
- Patched + healthy device: addresses screen shows the correct `P-avax1…`, matching the device baseline.

## Testing

**Dev Testing (if applicable)**

Happy path:
1. Onboard a Ledger (BLE, Avalanche app open) → wallet created, Account Settings → Addresses shows real `0x…`, `avax1…`, `bc1…` values.
2. Swap C→P (AVAX → AVAX on P-Chain) with a healthy wallet → quotes stream normally.

Edge/error states (require the truncation harness from the ticket notes, or the unit tests):
1. Truncated XP `getAddressAndPubKey` reply during onboarding → onboarding fails with `Ledger getAddressAndPubKey(XP) returned an invalid address: empty address body`, and retry works once the fault clears.
2. Account with persisted `"P-"` → swap shows the quotes-unavailable error rather than a blank screen and emits the CP-14964 Sentry message; staking reads throw a clear address-not-available error.
3. Unit suites: `validateDeviceAddress.test.ts` (truncated frames through the real parser, HRP mismatch, pubkey and Solana lengths, telemetry fingerprint and address-preview redaction), `stripAddressPrefix.test.ts`, `useQuoteStreaming.test.ts` (bare-prefix blocks plus error surfaced), `AvalancheWalletService.test.ts` (real `getReadOnlySigner` throws).

**QA Testing (if applicable)**

Regression focus: Ledger onboarding (BIP44 and Ledger Live derivation, mainnet and testnet), add-account, Solana enable, C→P and P→C transfers, and staking flows on a Ledger wallet. Expected: no behaviour change on healthy devices, and any device-reply corruption now fails the operation with an explicit error instead of persisting it.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation


[CP-14964]: https://ava-labs.atlassian.net/browse/CP-14964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
