### PR TITLE
CP-14968: Warn Keystone users in-app when the keystone feature flag is off

### DIFF
--- a/packages/core-mobile/app/new/features/keystone/hooks/useKeystoneDeprecation.test.ts
+++ b/packages/core-mobile/app/new/features/keystone/hooks/useKeystoneDeprecation.test.ts
@@ -1,0 +1,116 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { WalletType } from 'services/wallet/types'
+import {
+  useIsActiveWalletKeystoneDeprecated,
+  useKeystoneDeprecation
+} from './useKeystoneDeprecation'
+
+const mockNavigate = jest.fn()
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ navigate: mockNavigate })
+}))
+
+let mockIsKeystoneBlocked = false
+let mockActiveWallet: { type: WalletType } | undefined
+
+jest.mock('store/posthog', () => ({
+  selectIsKeystoneBlocked: () => mockIsKeystoneBlocked
+}))
+
+jest.mock('store/wallet/slice', () => ({
+  selectActiveWallet: () => mockActiveWallet
+}))
+
+// The selectors above are already stubbed to ignore state, so useSelector just
+// needs to invoke them; a real store would add nothing to these assertions.
+jest.mock('react-redux', () => ({
+  useSelector: (selector: (state: unknown) => unknown) => selector({})
+}))
+
+describe('useKeystoneDeprecation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsKeystoneBlocked = false
+    mockActiveWallet = undefined
+  })
+
+  it('does not warn for a Keystone wallet while the gate is on', () => {
+    mockIsKeystoneBlocked = false
+
+    const { result } = renderHook(() => useKeystoneDeprecation())
+
+    expect(result.current.isKeystoneDeprecated).toBe(false)
+    expect(result.current.shouldWarnForWalletType(WalletType.KEYSTONE)).toBe(
+      false
+    )
+  })
+
+  it('warns only for Keystone wallets once the gate is off', () => {
+    mockIsKeystoneBlocked = true
+
+    const { result } = renderHook(() => useKeystoneDeprecation())
+
+    expect(result.current.shouldWarnForWalletType(WalletType.KEYSTONE)).toBe(
+      true
+    )
+    expect(result.current.shouldWarnForWalletType(WalletType.MNEMONIC)).toBe(
+      false
+    )
+    expect(result.current.shouldWarnForWalletType(WalletType.LEDGER)).toBe(
+      false
+    )
+  })
+
+  it('routes to the deprecation modal', () => {
+    const { result } = renderHook(() => useKeystoneDeprecation())
+
+    result.current.openDeprecationInfo()
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: '/keystoneDeprecation'
+    })
+  })
+})
+
+describe('useIsActiveWalletKeystoneDeprecated', () => {
+  beforeEach(() => {
+    mockIsKeystoneBlocked = false
+    mockActiveWallet = undefined
+  })
+
+  it('is true only when the gate is off AND the active wallet is Keystone', () => {
+    mockIsKeystoneBlocked = true
+    mockActiveWallet = { type: WalletType.KEYSTONE }
+
+    expect(
+      renderHook(() => useIsActiveWalletKeystoneDeprecated()).result.current
+    ).toBe(true)
+  })
+
+  it('is false when a non-Keystone wallet is active, even with the gate off', () => {
+    mockIsKeystoneBlocked = true
+    mockActiveWallet = { type: WalletType.MNEMONIC }
+
+    expect(
+      renderHook(() => useIsActiveWalletKeystoneDeprecated()).result.current
+    ).toBe(false)
+  })
+
+  it('is false while the gate is on, even with a Keystone wallet active', () => {
+    mockIsKeystoneBlocked = false
+    mockActiveWallet = { type: WalletType.KEYSTONE }
+
+    expect(
+      renderHook(() => useIsActiveWalletKeystoneDeprecated()).result.current
+    ).toBe(false)
+  })
+
+  it('is false when there is no active wallet', () => {
+    mockIsKeystoneBlocked = true
+    mockActiveWallet = undefined
+
+    expect(
+      renderHook(() => useIsActiveWalletKeystoneDeprecated()).result.current
+    ).toBe(false)
+  })
+})

--- a/packages/core-mobile/app/new/features/keystone/hooks/useKeystoneDeprecation.ts
+++ b/packages/core-mobile/app/new/features/keystone/hooks/useKeystoneDeprecation.ts
@@ -1,0 +1,53 @@
+import { useCallback } from 'react'
+import { useRouter } from 'expo-router'
+import { useSelector } from 'react-redux'
+import { WalletType } from 'services/wallet/types'
+import { selectIsKeystoneBlocked } from 'store/posthog'
+import { selectActiveWallet } from 'store/wallet/slice'
+import { RootState } from 'store/types'
+
+/**
+ * Deliberately does NOT subscribe to the active wallet. This runs inside
+ * `WalletHeaderRow`, once per row in the wallet list, and `selectActiveWallet`
+ * is unmemoized — subscribing here would re-render every row on any
+ * active-wallet change, defeating that component's `arePropsEqual` comparator
+ * (a `useSelector` inside a memoized component bypasses it entirely).
+ * Callers that need the active wallet use `useIsActiveWalletKeystoneDeprecated`.
+ */
+export const useKeystoneDeprecation = (): {
+  isKeystoneDeprecated: boolean
+  shouldWarnForWalletType: (walletType: WalletType) => boolean
+  openDeprecationInfo: () => void
+} => {
+  const { navigate } = useRouter()
+  const isKeystoneDeprecated = useSelector(selectIsKeystoneBlocked)
+
+  const shouldWarnForWalletType = useCallback(
+    (walletType: WalletType): boolean =>
+      isKeystoneDeprecated && walletType === WalletType.KEYSTONE,
+    [isKeystoneDeprecated]
+  )
+
+  const openDeprecationInfo = useCallback((): void => {
+    navigate({ pathname: '/keystoneDeprecation' })
+  }, [navigate])
+
+  return {
+    isKeystoneDeprecated,
+    shouldWarnForWalletType,
+    openDeprecationInfo
+  }
+}
+
+// Selects the type alone rather than the wallet object so the subscription
+// compares a primitive; `selectActiveWallet` returns a fresh reference whenever
+// the active wallet record changes.
+const selectActiveWalletType = (state: RootState): WalletType | undefined =>
+  selectActiveWallet(state)?.type
+
+export const useIsActiveWalletKeystoneDeprecated = (): boolean => {
+  const isKeystoneDeprecated = useSelector(selectIsKeystoneBlocked)
+  const activeWalletType = useSelector(selectActiveWalletType)
+
+  return isKeystoneDeprecated && activeWalletType === WalletType.KEYSTONE
+}

--- a/packages/core-mobile/app/new/features/keystone/screens/KeystoneSignerScreen/index.tsx
+++ b/packages/core-mobile/app/new/features/keystone/screens/KeystoneSignerScreen/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Text, useTheme, View } from '@avalabs/k2-alpine'
 import React, { FC, useCallback, useEffect, useState } from 'react'
 import { KeystoneSignerParams } from 'features/keystone/services/keystoneParamsCache'
-import { useNavigation } from 'expo-router'
+import { useNavigation, useRouter } from 'expo-router'
 import { ScrollScreen } from 'common/components/ScrollScreen'
 import { UREncoder } from '@ngraveio/bc-ur'
 import { Space } from 'common/components/Space'
@@ -25,6 +25,7 @@ const KeystoneSignerScreen = ({
   params: KeystoneSignerParams
 }): JSX.Element => {
   const navigation = useNavigation()
+  const { replace } = useRouter()
   const { request, responseURTypes, onApprove, onReject } = params
   const [currentStep, setCurrentStep] = useState(KeystoneSignerStep.QR)
   const [signningUr, setSigningUr] = useState<string>('(null)')
@@ -50,9 +51,15 @@ const KeystoneSignerScreen = ({
 
   useEffect(() => {
     if (isKeystoneBlocked) {
-      rejectAndClose()
+      // Reject, then REPLACE this modal with the deprecation explainer rather
+      // than going back: a bare reject surfaces only the generic signing
+      // failure, which reads as a bug instead of an intentional sunset.
+      // `replace` also keeps the `beforeRemove` POP listener above from firing
+      // a second onReject.
+      onReject()
+      replace('/keystoneDeprecation')
     }
-  }, [isKeystoneBlocked, rejectAndClose])
+  }, [isKeystoneBlocked, onReject, replace])
 
   useEffect(() => {
     const onBackPress = (): boolean => {

--- a/packages/core-mobile/app/new/features/keystone/screens/keystoneDeprecation/index.tsx
+++ b/packages/core-mobile/app/new/features/keystone/screens/keystoneDeprecation/index.tsx
@@ -1,0 +1,87 @@
+import React, { useCallback } from 'react'
+import { Linking } from 'react-native'
+import { useNavigation } from 'expo-router'
+import { Button, Icons, Text, useTheme, View } from '@avalabs/k2-alpine'
+import { ScrollScreen } from 'common/components/ScrollScreen'
+import {
+  DOCS_KEYSTONE_DEPRECATION_URL,
+  KEYSTONE_DEPRECATION_DATE
+} from 'resources/Constants'
+import Logger from 'utils/Logger'
+
+const KeystoneDeprecationScreen = (): JSX.Element => {
+  const navigation = useNavigation()
+  const {
+    theme: { colors }
+  } = useTheme()
+
+  const openArticle = useCallback((): void => {
+    Linking.openURL(DOCS_KEYSTONE_DEPRECATION_URL).catch(Logger.error)
+  }, [])
+
+  const dismiss = useCallback((): void => {
+    navigation.goBack()
+  }, [navigation])
+
+  const renderFooter = useCallback(
+    (): React.ReactNode => (
+      <View sx={{ gap: 20 }}>
+        <Button
+          testID="keystoneDeprecation_learnMore_btn"
+          size="large"
+          type="primary"
+          onPress={openArticle}>
+          Learn more
+        </Button>
+        <Button
+          testID="keystoneDeprecation_dismiss_btn"
+          size="large"
+          type="tertiary"
+          onPress={dismiss}>
+          Dismiss
+        </Button>
+      </View>
+    ),
+    [openArticle, dismiss]
+  )
+
+  return (
+    <ScrollScreen
+      isModal
+      showNavigationHeaderTitle={false}
+      renderFooter={renderFooter}
+      contentContainerStyle={{
+        padding: 16,
+        flex: 1
+      }}>
+      <View sx={{ alignItems: 'center', flex: 1, justifyContent: 'center' }}>
+        <Icons.Alert.ErrorOutline
+          color={colors.$textDanger}
+          width={62.5}
+          height={62.5}
+        />
+        <View sx={{ alignItems: 'center', gap: 20, marginTop: 40 }}>
+          <Text
+            variant="heading3"
+            sx={{ textAlign: 'center', color: colors.$textPrimary }}>
+            Keystone support has ended
+          </Text>
+          <Text
+            variant="subtitle1"
+            sx={{ textAlign: 'center', color: colors.$textSecondary }}>
+            {`Core ended support for Keystone wallets on ${KEYSTONE_DEPRECATION_DATE}. You can still see your Keystone accounts and balances, but Keystone transactions can no longer be signed in Core.`}
+          </Text>
+          <Text
+            variant="subtitle1"
+            sx={{ textAlign: 'center', color: colors.$textSecondary }}>
+            Your funds are safe and your Keystone device still controls them. To
+            keep using Core, you will need to move the funds to a wallet type
+            that Core supports.
+          </Text>
+        </View>
+      </View>
+    </ScrollScreen>
+  )
+}
+
+export default KeystoneDeprecationScreen

--- a/packages/core-mobile/app/new/features/portfolio/components/KeystoneDeprecationBanner.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/components/KeystoneDeprecationBanner.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { TouchableOpacity } from 'react-native'
+import { Icons, Text, View, useTheme } from '@avalabs/k2-alpine'
+import {
+  useIsActiveWalletKeystoneDeprecated,
+  useKeystoneDeprecation
+} from 'features/keystone/hooks/useKeystoneDeprecation'
+import { KEYSTONE_DEPRECATION_DATE } from 'resources/Constants'
+
+/**
+ * Portfolio notice that Keystone signing has been retired. Renders only when the
+ * active wallet is Keystone and the master `keystone` gate is off, and reserves
+ * no space otherwise, so callers should pass margins via `sx` rather than
+ * wrapping it in a spacing container.
+ */
+export const KeystoneDeprecationBanner = ({
+  sx
+}: {
+  sx?: React.ComponentProps<typeof View>['sx']
+} = {}): JSX.Element | null => {
+  const {
+    theme: { colors }
+  } = useTheme()
+  const { openDeprecationInfo } = useKeystoneDeprecation()
+  const shouldWarn = useIsActiveWalletKeystoneDeprecated()
+
+  if (!shouldWarn) {
+    return null
+  }
+
+  return (
+    <View sx={sx}>
+      <TouchableOpacity
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        testID="keystoneDeprecationBanner"
+        onPress={openDeprecationInfo}>
+        <View
+          sx={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 6,
+            paddingVertical: 4
+          }}>
+          <Icons.Alert.Error
+            color={colors.$textDanger}
+            width={16}
+            height={16}
+          />
+          <Text
+            variant="caption"
+            sx={{
+              color: '$textDanger',
+              flex: 1,
+              fontSize: 13,
+              lineHeight: 17
+            }}>
+            {`Keystone wallet support was deprecated on ${KEYSTONE_DEPRECATION_DATE}. Click here for more information.`}
+          </Text>
+        </View>
+      </TouchableOpacity>
+    </View>
+  )
+}

--- a/packages/core-mobile/app/new/features/portfolio/screens/PortfolioScreen.tsx
+++ b/packages/core-mobile/app/new/features/portfolio/screens/PortfolioScreen.tsx
@@ -30,6 +30,7 @@ import { ActionButtonTitle } from 'features/portfolio/assets/consts'
 import { CollectibleFilterAndSortInitialState } from 'features/portfolio/collectibles/hooks/useCollectiblesFilterAndSort'
 import { CollectiblesScreen } from 'features/portfolio/collectibles/screens/CollectiblesScreen'
 import { BalanceHeaderSection } from 'features/portfolio/components/BalanceHeaderSection'
+import { KeystoneDeprecationBanner } from 'features/portfolio/components/KeystoneDeprecationBanner'
 import { StuckFundsBanner } from 'features/swap/components/StuckFundsBanner'
 import { DeFiScreen } from 'features/portfolio/defi/components/DeFiScreen'
 import { ActivityScreen } from 'features/activity/screens/ActivityScreen'
@@ -357,6 +358,12 @@ const PortfolioHomeScreen = (): JSX.Element => {
           isDeveloperMode={isDeveloperMode}
           renderMaskView={renderMaskView}
           backgroundColor={theme.colors.$surfacePrimary}
+        />
+
+        {/* Self-hides unless the active wallet is Keystone and the master
+            `keystone` flag is off. */}
+        <KeystoneDeprecationBanner
+          sx={{ marginHorizontal: 16, marginTop: 12 }}
         />
 
         {/* Stuck-funds banner — stranded cross-chain AVAX. Self-hides (and

--- a/packages/core-mobile/app/new/features/wallets/components/WalletHeaderRow.tsx
+++ b/packages/core-mobile/app/new/features/wallets/components/WalletHeaderRow.tsx
@@ -7,6 +7,7 @@ import {
   View
 } from '@avalabs/k2-alpine'
 import { useManageWallet } from 'common/hooks/useManageWallet'
+import { useKeystoneDeprecation } from 'features/keystone/hooks/useKeystoneDeprecation'
 import { WalletDisplayData } from 'common/types'
 import { getEnabledNetworksForAccount } from 'features/portfolio/utils/getEnabledNetworksForAccount'
 import { useWalletBalances } from 'features/portfolio/hooks/useWalletBalances'
@@ -58,6 +59,12 @@ const WalletHeaderRow = ({
   )
   const { data: walletBalancesData, isError: isBalancesError } =
     useWalletBalances(accountIds)
+
+  // Read inside the row rather than taking it as a prop: `arePropsEqual` below
+  // does a field-level compare and would swallow a prop-borne flag change.
+  const { shouldWarnForWalletType, openDeprecationInfo } =
+    useKeystoneDeprecation()
+  const isDeprecated = shouldWarnForWalletType(wallet.type)
 
   const enabledNetworks = useSelector(selectEnabledNetworks)
   const enabledNetworksMap = useSelector(selectEnabledNetworksMap)
@@ -141,6 +148,20 @@ const WalletHeaderRow = ({
                       borderRadius: 100
                     }}
                   />
+                )}
+                {isDeprecated && (
+                  <TouchableOpacity
+                    testID={`keystone_deprecated_badge__${wallet.name}`}
+                    accessibilityRole="button"
+                    accessibilityLabel="Keystone support has ended"
+                    hitSlop={10}
+                    onPress={openDeprecationInfo}>
+                    <Icons.Alert.Error
+                      color={colors.$textDanger}
+                      width={16}
+                      height={16}
+                    />
+                  </TouchableOpacity>
                 )}
               </View>
               <Text

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/keystoneDeprecation/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/keystoneDeprecation/_layout.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Stack } from 'common/components/Stack'
+import {
+  modalFirstScreenOptions,
+  modalStackNavigatorScreenOptions
+} from 'common/consts/screenOptions'
+
+export default function KeystoneDeprecationLayout(): JSX.Element {
+  return (
+    <Stack screenOptions={modalStackNavigatorScreenOptions}>
+      <Stack.Screen name="index" options={modalFirstScreenOptions} />
+    </Stack>
+  )
+}

--- a/packages/core-mobile/app/new/routes/(signedIn)/(modals)/keystoneDeprecation/index.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/(modals)/keystoneDeprecation/index.tsx
@@ -1,0 +1,1 @@
+export { default } from 'features/keystone/screens/keystoneDeprecation'

--- a/packages/core-mobile/app/new/routes/(signedIn)/_layout.tsx
+++ b/packages/core-mobile/app/new/routes/(signedIn)/_layout.tsx
@@ -117,6 +117,10 @@ export default function WalletLayout(): JSX.Element {
                 options={secondaryModalScreensOptions}
               />
               <Stack.Screen
+                name="(modals)/keystoneDeprecation"
+                options={secondaryModalScreensOptions}
+              />
+              <Stack.Screen
                 name="(modals)/receive"
                 options={modalScreensOptions}
               />

--- a/packages/core-mobile/app/resources/Constants.ts
+++ b/packages/core-mobile/app/resources/Constants.ts
@@ -17,6 +17,12 @@ export const DOCS_BRIDGE_FAQS_URL =
 export const DOCS_KEYSTONE_SIGNING_ERROR_URL =
   'https://support.core.app/en/articles/13251923-keystone-why-can-t-i-send-avax-on-the-x-or-p-chain'
 
+export const DOCS_KEYSTONE_DEPRECATION_URL =
+  'https://support.core.app/en/articles/16559552-does-core-support-keystone-wallets'
+
+// TODO: confirm the final sunset date with product before this ships.
+export const KEYSTONE_DEPRECATION_DATE = 'September 1st'
+
 export const BUNDLE_ID_IOS = 'org.avalabs.corewallet'
 export const BUNDLE_ID_ANDROID = 'com.avaxwallet'
 export const BUNDLE_ID = Platform.select({


### PR DESCRIPTION
## Description

**Ticket: [CP-14968](https://ava-labs.atlassian.net/browse/CP-14968)**

Keystone is being retired across all Core platforms. Today, turning the master `keystone` PostHog gate off only disables signing: `KeystoneSignerScreen` mounts and immediately rejects, so the user sees a generic transaction failure that reads like a bug rather than an intentional sunset. Accounts and balances keep displaying normally, with no explanation anywhere in the app.

This adds in-app deprecation messaging so a user holding a Keystone wallet understands what happened and what to do next.

**What's in here**

- **Portfolio banner** — red inline notice under the balance header, shown only when the active wallet is Keystone *and* the master `keystone` gate is off. Tapping it opens the explainer.
- **Wallets screen badge** — red alert icon on Keystone wallet rows, opening the same explainer. The flag is read inside the row rather than passed as a prop, because `WalletHeaderRow`'s hand-written `arePropsEqual` does a field-level compare and would swallow a prop-borne flag change.
- **Shared explainer modal** — new `keystoneDeprecation` modal built on the same `ScrollScreen` + `renderFooter` pattern as `TransactionSuccessfulScreen`. Explains that signing is retired, that funds are safe, and that continuing with Core means moving funds to a supported wallet type. Links to the support article.
- **Signing path** — the flag-off branch in `KeystoneSignerScreen` now rejects and *replaces* the route with the explainer, instead of silently rejecting and going back. `replace` rather than `goBack` also keeps the existing `beforeRemove` POP listener from firing a second `onReject`.
**Deliberately out of scope: the X/P missing-signatures alert**

An earlier revision of this branch also rewrote the "Having trouble signing with Keystone?" alert in `vmModule/handlers/avalancheSendTransaction.ts` and deleted `DOCS_KEYSTONE_SIGNING_ERROR_URL`. That was reverted before review, and this PR no longer touches that file at all — the constant and its call site are unchanged from `main`.

The reason: that branch is gated on `walletType === KEYSTONE && !hasAllSignatures()`, **not** on the flag, and it is only reachable while Keystone is still enabled. With the gate off, `KeystoneSignerScreen` rejects on mount, so `await walletService.sign(...)` throws and control jumps to the handler's `catch` — the alert is never evaluated. So its "visit core.app" guidance only ever renders for a user whose Keystone wallet still works, which is the genuine multi-UTXO limitation it was written for and the guidance we want to keep there.

Whether that copy should change once Keystone is retired on every platform is a real question, but it is a different code path with a different trigger and belongs in its own ticket.

**Motivation and context**

Follows the Slack thread on what a user with one Keystone wallet experiences when the flag flips. The conclusion there was that behavior is acceptable but needs explicit deprecation warnings, and the treatment below matches the mock Amanda posted.

**Dependencies introduced:** none. Gated entirely on the existing `selectIsKeystoneBlocked` selector, with no feature-flag or selector changes. New Keystone imports remain separately gated by `keystone-onboarding` (CP-14967).

**Not breaking.** Nothing is hidden or blocked that wasn't already; this only adds explanation to a state that already existed.

## Screenshots/Videos

Captured on a physical Pixel 8 Pro (Android). iOS not captured.

1. **Portfolio banner** — renders under the balance header, alert icon vertically centred against the wrapped text.
2. **Explainer modal** — icon centred above the title, content vertically centred, actions pinned to the bottom.
3. **Wallets screen badge** — alert icon on the Keystone wallet row only; the mnemonic wallet below it is unmarked.
4. **Badge → modal** — tapping the badge opens the explainer without toggling row expansion.

## Testing

**Dev Testing**

Happy path (no Keystone wallet, or flag on):
1. With the `keystone` gate ON, confirm no banner on Portfolio, no badge in the wallets list, and Keystone signing behaves exactly as before.

Deprecation path:
1. Turn the master `keystone` gate OFF in PostHog.
2. With a Keystone wallet active, open Portfolio → red banner appears under the balance. Tap it → explainer modal, with Learn more opening the support article and Dismiss closing.
3. Open the wallets screen → red alert badge on the Keystone wallet row. Tap the badge → same explainer. Confirm tapping the badge does not toggle row expansion.
4. Trigger a transaction from the Keystone wallet → instead of the generic signing failure, the explainer modal appears and the request is rejected once.

Edge cases:
1. Switch the active wallet from Keystone to a mnemonic wallet → banner disappears; the badge remains on the Keystone row in the wallets list.
2. Multiple wallets where Keystone is NOT active → no Portfolio banner, but the badge still marks the Keystone row.
3. Flip the gate at runtime while Portfolio is mounted → banner appears/disappears without a restart.

**Verified on device** (physical Pixel 8 Pro, Android, gate forced off locally):

- Banner renders on Portfolio for the active Keystone wallet, and opens the explainer on tap.
- Badge appears on the Keystone wallet row and **not** on the mnemonic wallet row, confirming the per-row gating. Tapping it opens the explainer and does not toggle row expansion.
- Explainer modal layout confirmed against the design pattern used by `TransactionSuccessfulScreen`.

Not yet exercised on device: the dapp-send path through `KeystoneSignerScreen`. Reviewers should know one open question there — `ApprovalScreen` pops on an un-awaited `onApprove`, so it is worth confirming no stale `/approval` modal is left underneath the deprecation screen. Static tracing through expo-router 56.2.11 and `@react-navigation/core` 7.14.0 confirmed the reject path itself cannot hang or double-settle a request: `replace` delivers `REPLACE` (not `POP`) to the outgoing screen, so the `beforeRemove` guard correctly does not re-reject, and both promises are settle-once regardless.

**QA Testing**

Expected behavior: a user with a Keystone wallet can still see all accounts and balances after the flag flips. They cannot sign. Every path that previously dead-ended in a generic failure now explains the deprecation and links to the support article. Users with no Keystone wallet see no change anywhere.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have verified the code works (Android, physical Pixel 8 Pro)
- [ ] I have included screenshots / videos of android and ios — Android only; iOS not captured
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation — n/a


[CP-14968]: https://ava-labs.atlassian.net/browse/CP-14968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ