### PR TITLE
CP-14976: Fix Android form-sheet dismissing on scroll-up by making nestedScrollEnabled static

### DIFF
--- a/packages/core-mobile/app/new/common/components/ScrollScreen.test.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.test.tsx
@@ -336,16 +336,6 @@ describe('ScrollScreen content minHeight', () => {
 // header with `marginTop`, leaving the grabber/header strip permanently
 // draggable.
 describe('ScrollScreen Android form-sheet swipe-to-dismiss (non-keyboard branch)', () => {
-  const fireContentSizeChange = async (
-    instance: ReactTestRenderer,
-    height: number
-  ): Promise<void> => {
-    const scrollView = instance.root.findByType(ScrollView)
-    await act(async () => {
-      scrollView.props.onContentSizeChange(390, height)
-    })
-  }
-
   const fireScroll = async (
     instance: ReactTestRenderer,
     offsetY: number
@@ -383,70 +373,44 @@ describe('ScrollScreen Android form-sheet swipe-to-dismiss (non-keyboard branch)
       expect(getContentContainerPaddingTop(instance)).toBe(0)
     })
 
-    it('leaves nested scrolling off while the content fits, so a body swipe dismisses', async () => {
+    // CP-14976: nested scrolling must be a STATIC `true` for a modal, not
+    // gated on content overflow or scroll position (two earlier, narrower
+    // attempts both regressed to the same failure — see the prop's
+    // declaration in ScrollScreen.tsx for why). Android's
+    // `BottomSheetBehavior` resolves its nested-scrolling child exactly once,
+    // at the sheet's first native layout, by caching whichever child already
+    // reports `isNestedScrollingEnabled() === true` at that moment — a flag
+    // that only becomes `true` after a layout/content-size event fires is
+    // always too late, so it must already be `true` before either ever
+    // fires.
+    it('enables nested scrolling for a modal from the very first render, before any layout or content-size event', async () => {
       const instance = await render({ isModal: true })
-
-      await fireScrollViewLayout(instance, MEASURED_VIEWPORT_HEIGHT)
-      await fireContentSizeChange(instance, MEASURED_VIEWPORT_HEIGHT)
-
-      expect(
-        instance.root.findByType(ScrollView).props.nestedScrollEnabled
-      ).toBe(false)
-    })
-
-    // CP-14765 follow-up: overflow alone must NOT disable dismissal. Gating
-    // only on overflow made dismissal depend on content height — the delegate
-    // "How long do you want to stake?" step renders one extra caption that Fast
-    // Stake doesn't, which was enough to kill swipe-to-dismiss on that screen
-    // while the identical Fast Stake screen kept it.
-    it('keeps nested scrolling off while overflowing content sits at the top, so a body swipe still dismisses', async () => {
-      const instance = await render({ isModal: true })
-
-      await fireScrollViewLayout(instance, MEASURED_VIEWPORT_HEIGHT)
-      await fireContentSizeChange(instance, MEASURED_VIEWPORT_HEIGHT * 2)
-
-      expect(
-        instance.root.findByType(ScrollView).props.nestedScrollEnabled
-      ).toBe(false)
-    })
-
-    it('turns nested scrolling on once overflowing content is scrolled away from the top, so a body swipe scrolls', async () => {
-      const instance = await render({ isModal: true })
-
-      await fireScrollViewLayout(instance, MEASURED_VIEWPORT_HEIGHT)
-      await fireContentSizeChange(instance, MEASURED_VIEWPORT_HEIGHT * 2)
-      await fireScroll(instance, 120)
 
       expect(
         instance.root.findByType(ScrollView).props.nestedScrollEnabled
       ).toBe(true)
     })
 
-    it('hands dismissal back once the user scrolls to the top again', async () => {
+    it('keeps nested scrolling on even when the content fits (native BottomSheetBehavior owns the scroll-vs-dismiss split)', async () => {
       const instance = await render({ isModal: true })
 
       await fireScrollViewLayout(instance, MEASURED_VIEWPORT_HEIGHT)
-      await fireContentSizeChange(instance, MEASURED_VIEWPORT_HEIGHT * 2)
+
+      expect(
+        instance.root.findByType(ScrollView).props.nestedScrollEnabled
+      ).toBe(true)
+    })
+
+    it('keeps nested scrolling on regardless of scroll position', async () => {
+      const instance = await render({ isModal: true })
+
+      await fireScrollViewLayout(instance, MEASURED_VIEWPORT_HEIGHT)
       await fireScroll(instance, 120)
       await fireScroll(instance, 0)
 
       expect(
         instance.root.findByType(ScrollView).props.nestedScrollEnabled
-      ).toBe(false)
-    })
-
-    // Android reports sub-pixel offsets while settling; those must still read
-    // as "at the top" or the sheet silently loses dismissal at rest.
-    it('treats a sub-pixel resting offset as the top', async () => {
-      const instance = await render({ isModal: true })
-
-      await fireScrollViewLayout(instance, MEASURED_VIEWPORT_HEIGHT)
-      await fireContentSizeChange(instance, MEASURED_VIEWPORT_HEIGHT * 2)
-      await fireScroll(instance, 0.5)
-
-      expect(
-        instance.root.findByType(ScrollView).props.nestedScrollEnabled
-      ).toBe(false)
+      ).toBe(true)
     })
 
     it('leaves non-modal screens under the transparent header', async () => {

--- a/packages/core-mobile/app/new/common/components/ScrollScreen.test.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.test.tsx
@@ -413,6 +413,20 @@ describe('ScrollScreen Android form-sheet swipe-to-dismiss (non-keyboard branch)
       ).toBe(true)
     })
 
+    // The keyboard-aware branch renders a different scroll component but must
+    // carry the identical static flag — the two branches gained it at
+    // different times before (CP-14679 vs CP-14765) and drifted.
+    it('enables nested scrolling statically on the keyboard-aware branch too', async () => {
+      const instance = await render({
+        isModal: true,
+        shouldAvoidKeyboard: true
+      })
+
+      expect(
+        instance.root.findByType(ScrollView).props.nestedScrollEnabled
+      ).toBe(true)
+    })
+
     it('leaves non-modal screens under the transparent header', async () => {
       const instance = await render({ isModal: false })
 

--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -197,63 +197,27 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
     const subtitleHeight = useSharedValue<number>(0)
 
     const SCROLL_END_THRESHOLD = 20
-    // Offsets at or below this count as "parked at the top" (see
-    // `isAtScrollTop`). Small enough that a real scroll never reads as top.
-    const SCROLL_TOP_EPSILON = 1
 
-    // Whether the content actually overflows the viewport. Drives Android
-    // `nestedScrollEnabled` on the keyboard-aware branch: when the content
-    // scrolls, the plain RN ScrollView must participate in the parent form
-    // sheet's nested scrolling so a downward swipe scrolls to the top instead
-    // of being captured by the sheet's drag-to-dismiss. When the content fits,
-    // we leave it off so a short modal stays swipe-to-dismiss. (CP-14679)
-    const [isScrollable, setIsScrollable] = useState(false)
-
-    // Whether the scroll offset is parked at the very top. Combined with
-    // `isScrollable` to decide who owns a downward drag on an Android form
-    // sheet (see `nestedScrollEnabled` below).
-    //
-    // `isScrollable` alone was too coarse: it handed EVERY downward drag on
-    // overflowing content to the ScrollView, so a form sheet lost
-    // swipe-to-dismiss entirely the moment its content grew past the viewport.
-    // That made dismissal depend on content height — the delegate
-    // "How long do you want to stake?" step renders one extra node-end caption
-    // that Fast Stake doesn't, which was enough to cross the threshold and kill
-    // dismissal on that screen alone (CP-14765).
-    //
-    // Android reads `nestedScrollEnabled` at touch-down, so gating on the
-    // offset assigns the whole gesture up front, which is what we want:
-    //   • at the top   → nested scrolling off, the sheet takes the downward
-    //                    drag and dismisses. Dragging UP still scrolls, since
-    //                    this flag only governs nested-scroll participation
-    //                    with the parent, not the ScrollView's own scrolling.
-    //   • scrolled     → nested scrolling on, so a downward drag scrolls back
-    //                    toward the top instead of being captured by the
-    //                    sheet's drag-to-dismiss (the CP-14679 behaviour).
-    const [isAtScrollTop, setIsAtScrollTop] = useState(true)
-
-    const updateIsScrollable = useCallback(() => {
-      // Only the Android form-sheet nested-scroll path reads this (see
-      // `nestedScrollEnabled` below): it negotiates with a parent
-      // `BottomSheetBehavior`, which only exists when the screen is a modal.
-      // BOTH branches consume it now — the non-keyboard branch takes the same
-      // treatment as of CP-14765. iOS / non-modal screens have no sheet to
-      // negotiate with, so skip the state update there to avoid renders for a
-      // value nothing reads. Keep this gate in sync with `scrollBelowHeader`
-      // and `nestedScrollEnabled` below.
-      if (Platform.OS !== 'android' || !isModal) return
-      // Wait until BOTH the viewport and the content have been measured before
-      // computing scrollability. `onLayout` and `onContentSizeChange` fire in
-      // either order; acting on a half-measured state (e.g. content known but
-      // `scrollViewHeight` still 0) would make `maxScroll` equal the full
-      // content height and wrongly mark short content as scrollable, briefly
-      // enabling `nestedScrollEnabled` and breaking swipe-to-dismiss.
-      if (scrollViewHeight.current <= 0 || scrollContentHeight.current <= 0)
-        return
-      const maxScroll = scrollContentHeight.current - scrollViewHeight.current
-      const scrollable = maxScroll > 0
-      setIsScrollable(prev => (prev === scrollable ? prev : scrollable))
-    }, [isModal])
+    // Android `nestedScrollEnabled` (both branches, see each branch's
+    // `scrollBelowHeader`) is a STATIC flag, not gated on content overflow
+    // or scroll offset. Two narrower attempts (offset-gated, then
+    // overflow-gated) both still let every downward drag dismiss the sheet,
+    // because Android's `BottomSheetBehavior` resolves its nested-scrolling
+    // child only during native layout passes — in `onLayoutChild`, by caching
+    // whichever child reports `isNestedScrollingEnabled() === true` at that
+    // moment (`findScrollingChild`). A later change to this prop does not
+    // trigger a layout pass, so it never refreshes that cache; both gated
+    // versions derive from `onLayout`/`onContentSizeChange`,
+    // which only fire AFTER the ScrollView's own first native layout is
+    // reported back across the bridge — so they cannot possibly be `true`
+    // yet at whatever layout pass the sheet last resolved its child in, and
+    // the cache locked in "no scrolling child" permanently (CP-14976).
+    // Static-`true` from mount is the only way to guarantee the flag is set
+    // before that resolution runs — the same pattern `ListScreenV2` already
+    // uses unconditionally for its Android nested scroll (CP-14376). From
+    // there, Android's own `onNestedPreScroll` (only consumes a downward
+    // drag when the child reports `canScrollVertically(-1) === false`)
+    // handles the scroll-vs-dismiss split (CP-14679, CP-14765, CP-14976).
 
     const checkScrolledToEnd = useCallback(
       (contentOffsetY: number) => {
@@ -286,7 +250,6 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
       (_w: number, h: number) => {
         const prevHeight = scrollContentHeight.current
         scrollContentHeight.current = h
-        updateIsScrollable()
 
         if (!onScrolledToEnd) return
 
@@ -296,7 +259,7 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
           checkScrollableAfterLayout()
         }
       },
-      [onScrolledToEnd, checkScrollableAfterLayout, updateIsScrollable]
+      [onScrolledToEnd, checkScrollableAfterLayout]
     )
 
     const handleScrollViewLayout = useCallback(
@@ -304,10 +267,9 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
         const { height } = e.nativeEvent.layout
         scrollViewHeight.current = height
         setScrollViewLayoutHeight(prev => (prev === height ? prev : height))
-        updateIsScrollable()
         checkScrollableAfterLayout()
       },
-      [checkScrollableAfterLayout, updateIsScrollable]
+      [checkScrollableAfterLayout]
     )
 
     // Run the internal tracking and then forward to any caller-provided
@@ -377,11 +339,6 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
       showNavigationHeaderTitle
     })
 
-    // Only the Android form-sheet path reads `isAtScrollTop`; matches the
-    // `updateIsScrollable` gate so iOS / non-modal screens never re-render for
-    // a value nothing consumes.
-    const tracksScrollTop = Platform.OS === 'android' && Boolean(isModal)
-
     const onScroll = useCallback(
       (
         event:
@@ -391,7 +348,7 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
       ) => {
         onFadingScroll(event)
 
-        if (onScrolledToEnd || tracksScrollTop) {
+        if (onScrolledToEnd) {
           let offsetY = 0
           if (typeof event === 'number') {
             offsetY = event
@@ -400,20 +357,10 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
           } else {
             offsetY = event.contentOffset.y
           }
-          if (onScrolledToEnd) {
-            checkScrolledToEnd(offsetY)
-          }
-          if (tracksScrollTop) {
-            // Epsilon rather than `=== 0`: Android reports sub-pixel offsets
-            // when settling, which would otherwise read as "scrolled" and keep
-            // dismissal disabled at rest. Only commit on a change so this
-            // doesn't re-render on every scroll frame.
-            const atTop = offsetY <= SCROLL_TOP_EPSILON
-            setIsAtScrollTop(prev => (prev === atTop ? prev : atTop))
-          }
+          checkScrolledToEnd(offsetY)
         }
       },
-      [onFadingScroll, onScrolledToEnd, checkScrolledToEnd, tracksScrollTop]
+      [onFadingScroll, onScrolledToEnd, checkScrolledToEnd]
     )
 
     // Snap the header on release, mirroring ListScreenV2's `onScrollEndDrag`:
@@ -735,15 +682,13 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
       // while the body scrolls. iOS/non-modal keep the under-header layout so
       // content still scrolls beneath the transparent header. (CP-14679)
       const scrollBelowHeader = Platform.OS === 'android' && Boolean(isModal)
-      // Attach the internal composed content-size handler only when its work
-      // is needed: `onScrolledToEnd` (scroll-to-end tracking) or
-      // `scrollBelowHeader` (the Android modal nested-scroll path, which needs
-      // `isScrollable`). Otherwise the caller's callback is passed through
-      // directly so keyboard-avoiding screens don't run JS on every
-      // content-size change for a no-op. (CP-14679) `onLayout` is always
-      // composed: it measures the viewport that drives `minHeight`.
+      // Attach the internal composed content-size handler only when
+      // `onScrolledToEnd` (scroll-to-end tracking) needs it; otherwise the
+      // caller's callback is passed through directly so screens without that
+      // prop don't run extra JS on every content-size change. `onLayout` is
+      // always composed: it measures the viewport that drives `minHeight`.
       const pickScrollHandler = <T,>(composed: T, passthrough: T): T =>
-        onScrolledToEnd || scrollBelowHeader ? composed : passthrough
+        onScrolledToEnd ? composed : passthrough
       return (
         <View style={{ flex: 1 }} collapsable={false}>
           <KeyboardScrollView
@@ -755,17 +700,10 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
             keyboardShouldPersistTaps="handled"
             showsVerticalScrollIndicator={false}
             {...props}
-            // On an Android form sheet, `nestedScrollEnabled` lets this plain
-            // RN ScrollView participate in the parent sheet's nested scrolling
-            // so a vertical swipe scrolls the content instead of being captured
-            // by the sheet's drag-to-dismiss gesture. Enabled only for a modal
-            // (`scrollBelowHeader`, no-op otherwise) and only while the content
-            // actually overflows — a short modal keeps swipe-to-dismiss. (The
-            // gesture-handler ScrollView branch below arbitrates this on its own
-            // and doesn't need the prop.) (CP-14679)
-            nestedScrollEnabled={
-              scrollBelowHeader && isScrollable && !isAtScrollTop
-            }
+            // Static — see `scrollBelowHeader`'s declaration above for why
+            // this can't be gated on overflow or scroll position.
+            // (CP-14679, CP-14976)
+            nestedScrollEnabled={scrollBelowHeader}
             // `props.style` is merged last so a caller's style is preserved
             // (it would otherwise be dropped: `{...props}` spreads `style` but
             // this explicit `style` prop replaces it). Defaults come first so
@@ -824,9 +762,9 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
     //     ancestors as soon as it takes the touch. That locks the parent
     //     `BottomSheetBehavior` out of the vertical drag, so dragging down does
     //     nothing at all — it neither scrolls nor dismisses. A plain RN
-    //     ScrollView instead lets the sheet negotiate through Android's nested
-    //     scrolling (opted into via `nestedScrollEnabled` only while the content
-    //     actually overflows, exactly like the keyboard branch).
+    //     ScrollView instead lets the sheet negotiate through Android's
+    //     nested scrolling (opted into via a static `nestedScrollEnabled`,
+    //     exactly like the keyboard branch — see its declaration above).
     //  2. It spanned the full sheet height and only inset its content
     //     (`paddingTop`), so it covered the grabber/header strip too and there
     //     was nowhere left to grab the sheet. Offsetting with `marginTop` keeps
@@ -849,10 +787,9 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
           keyboardShouldPersistTaps="handled"
           {...props}
           // See (1) above — only meaningful on the Android modal path, where a
-          // parent sheet exists to negotiate with.
-          nestedScrollEnabled={
-            scrollBelowHeader && isScrollable && !isAtScrollTop
-          }
+          // parent sheet exists to negotiate with. Static — see
+          // `scrollBelowHeader`'s declaration above (CP-14976).
+          nestedScrollEnabled={scrollBelowHeader}
           // Defaults first so `flex: 1` still applies unless the caller
           // overrides it (previous behaviour: `props.style` replaced it
           // outright), and the Android modal offset last so the fix can't be
@@ -879,10 +816,8 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
           ]}
           onScroll={onScroll}
           onScrollEndDrag={handleScrollEndDrag}
-          // `scrollBelowHeader` needs the composed handler too: it's what keeps
-          // `isScrollable` (and therefore `nestedScrollEnabled`) up to date.
           onContentSizeChange={
-            onScrolledToEnd || scrollBelowHeader
+            onScrolledToEnd
               ? handleContentSizeChangeComposed
               : onContentSizeChangeProp
           }

--- a/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
+++ b/packages/core-mobile/app/new/common/components/ScrollScreen.tsx
@@ -215,9 +215,13 @@ export const ScrollScreen = forwardRef<ScrollView, ScrollScreenProps>(
     // Static-`true` from mount is the only way to guarantee the flag is set
     // before that resolution runs — the same pattern `ListScreenV2` already
     // uses unconditionally for its Android nested scroll (CP-14376). From
-    // there, Android's own `onNestedPreScroll` (only consumes a downward
-    // drag when the child reports `canScrollVertically(-1) === false`)
-    // handles the scroll-vs-dismiss split (CP-14679, CP-14765, CP-14976).
+    // there the scroll-vs-dismiss split is arbitrated natively in two layers
+    // (CP-14679, CP-14765, CP-14976): our react-native-screens patch
+    // (`GestureAwareBottomSheetBehavior`, see patches/) first declines the
+    // whole gesture for the sheet when it starts with the content scrolled,
+    // and for gestures that do start at the top, Android's own
+    // `onNestedPreScroll` only hands the sheet a downward drag while the
+    // child reports `canScrollVertically(-1) === false`.
 
     const checkScrolledToEnd = useCallback(
       (contentOffsetY: number) => {

--- a/packages/core-mobile/patches/react-native-screens+4.25.2.patch
+++ b/packages/core-mobile/patches/react-native-screens+4.25.2.patch
@@ -53,3 +53,43 @@ diff --git a/node_modules/react-native-screens/android/src/main/java/com/swmansi
                  val isImeVisible =
                      WindowInsetsCompat
                          .toWindowInsetsCompat(bottomSheet.rootWindowInsets)
+diff --git a/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt b/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+--- a/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
++++ b/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt
+@@ -388,7 +388,7 @@ class ScreenStackFragment :
+         return sheetDelegate.createSheetExitAnimator(sheetAnimationContext)
+     }
+ 
+-    private fun createBottomSheetBehaviour(): BottomSheetBehavior<Screen> = BottomSheetBehavior<Screen>()
++    private fun createBottomSheetBehaviour(): BottomSheetBehavior<Screen> = GestureAwareBottomSheetBehavior<Screen>()
+ 
+     private fun resolveBackgroundColor(screen: Screen): Int? {
+         val screenColor =
+@@ -596,3 +596,27 @@ class ScreenStackFragment :
+         return bottomSheetWindowInsetListenerChain!!
+     }
+ }
++
++// Patched (CP-14976): stock BottomSheetBehavior hands a gesture off to the sheet
++// (onNestedPreScroll moves it, onStopNestedScroll -> shouldHide dismisses it unconditionally
++// when skipCollapsed=true) as soon as the target can't scroll up further *at any point* during
++// the gesture. That lets a drag which starts mid-list reach the top and keep going into a
++// dismiss. Declining nested-scroll participation up front for any gesture (touch or fling) that
++// starts already scrolled means the behavior never receives those callbacks for it, so the
++// ScrollView just scrolls/flings and clamps at top on its own; a gesture that starts at the top
++// is unaffected and still hands off normally.
++private class GestureAwareBottomSheetBehavior<V : View> : BottomSheetBehavior<V>() {
++    override fun onStartNestedScroll(
++        coordinatorLayout: CoordinatorLayout,
++        child: V,
++        directTargetChild: View,
++        target: View,
++        axes: Int,
++        type: Int,
++    ): Boolean {
++        if (target.canScrollVertically(-1)) {
++            return false
++        }
++        return super.onStartNestedScroll(coordinatorLayout, child, directTargetChild, target, axes, type)
++    }
++}


### PR DESCRIPTION
## Description

**Ticket: [CP-14976](https://ava-labs.atlassian.net/browse/CP-14976)**

v38 RC1 regression: on Android, the main Settings form sheet could not be scrolled back up. Any downward drag dismissed the sheet, even mid-list.

This PR fixes it in two parts.

**Part 1 (`ScrollScreen.tsx`): make `nestedScrollEnabled` static.** Material's `BottomSheetBehavior` resolves its nested-scrolling child during native layout passes only (`onLayoutChild` caches `findScrollingChild`, which requires `isNestedScrollingEnabled() == true` at that exact moment). Our `nestedScrollEnabled` was gated on JS state (`isAtScrollTop` from #4022, `isScrollable` from #4019) derived from `onLayout`/`onContentSizeChange`, which only fire after the ScrollView's first native layout has been reported back over the bridge. So the flag could never be true when the sheet resolved its child, the cache locked in "no scrolling child", and the sheet's drag helper captured every downward drag. This same caching quirk is what #4022 was chasing on the stake duration screen (CP-14765). The fix sets the flag statically (`Platform.OS === 'android' && isModal`) on both ScrollScreen branches, the same pattern `ListScreenV2` already ships (CP-14376), and removes the `isScrollable`/`isAtScrollTop` machinery (net -101 lines). Android's own `onNestedPreScroll` arbitration then handles scroll-vs-dismiss natively.

**Part 2 (react-native-screens patch): only dismiss when the drag starts at the top.** With part 1 in place, one bad behavior remained: a single long drag that scrolls the list to the very top and keeps going handed the remainder to the sheet, and because rn-screens' single-detent config sets `skipCollapsed = true`, Material's `shouldHide` returns true unconditionally (no velocity/position threshold), so the sheet dismissed. Fixed by extending our existing `react-native-screens+4.25.2` patch: the sheet's behavior is now a `GestureAwareBottomSheetBehavior` that declines nested-scroll participation for any gesture that begins with the content scrolled (`target.canScrollVertically(-1)`). A drag starting mid-list now clamps at the top; a drag starting at the top still dismisses; flicks/flings and grabber drags are unaffected (the sheet ignores non-touch scroll types, and the grabber uses the ViewDragHelper path).

Known limitation (not reachable today): if we ever add a multi-detent form sheet, expand-via-content-scroll-up while scrolled would be declined by this gate. Both current `sheetAllowedDetents` configs are single-detent, so nothing shipped is affected.

No new dependencies. rn-screens 4.26/4.27 were checked and contain no upstream fix for either mechanism.

## Screenshots/Videos

Verified on a Pixel 8 Pro (screenshots from the device run available on request). iOS is untouched: the ScrollScreen change is gated on `Platform.OS === 'android' && isModal`, and the rn-screens patch is Android-only source.

## Testing

**Dev Testing**

Verified on hardware (Pixel 8 Pro, dev client, patched native build):

- Settings modal: scroll to bottom, then scroll back up (slow drags, fast flicks, mid-list reversals). Scrolls correctly with fling momentum, never dismisses.
- Long single drag from the bottom that reaches the top mid-gesture: clamps at the top, does not dismiss.
- Downward drag starting with the list at the top: dismisses.
- Grabber/header drag dismisses, including with content scrolled mid-list.
- Patch integrity: the updated `react-native-screens+4.25.2.patch` applies cleanly to the pristine npm tarball (verified with `patch -p1` dry-run and byte-compare), so `yarn install` is safe for everyone.
- `ScrollScreen.test.tsx` 20/20, tsc and eslint clean.

**QA Testing**

- Regression focus: Android form-sheet modals rendered via ScrollScreen. Main Settings page (the bug), Account, Security & Privacy, Advanced.
- Please explicitly re-run the original CP-14765 repro: Stake -> Delegate -> "How long do you want to stake?", drag down at rest, the sheet should dismiss. The dev wallet used for verification could not reach this screen (25 AVAX staking minimum), so it needs QA coverage.
- Short (non-overflowing) form sheets should still swipe-to-dismiss from anywhere (CP-14679).
- Sanity-pass other Android form sheets (send/receive/token select) for scroll + dismiss feel, since the rn-screens behavior change applies to all of them.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CP-14976]: https://ava-labs.atlassian.net/browse/CP-14976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ