### PR TITLE
CP-14986: Set explicit Appium launch activity so Android e2e sessions survive the MainActivityDefault launcher alias

### DIFF
--- a/packages/core-mobile/e2e-appium/wdio.conf.ts
+++ b/packages/core-mobile/e2e-appium/wdio.conf.ts
@@ -62,6 +62,7 @@ const allCaps = [
     'appium:deviceName': androidResolved.deviceName,
     'appium:platformVersion': androidResolved.platformVersion,
     'appium:automationName': 'UiAutomator2',
+    'appium:appActivity': 'com.avaxwallet.MainActivityDefault',
     'appium:appWaitActivity': '*',
     'appium:app': androidAppPath,
     ...(androidResolved.deviceUdid

--- a/packages/core-mobile/e2e-appium/wdio.devicefarm.conf.ts
+++ b/packages/core-mobile/e2e-appium/wdio.devicefarm.conf.ts
@@ -52,6 +52,7 @@ const allCaps = [
     'appium:deviceName': androidResolved.deviceName,
     'appium:platformVersion': androidResolved.platformVersion,
     'appium:automationName': 'UiAutomator2',
+    'appium:appActivity': 'com.avaxwallet.MainActivityDefault',
     'appium:app': appPath,
     ...(androidResolved.deviceUdid
       ? { 'appium:udid': androidResolved.deviceUdid }


### PR DESCRIPTION
## Description

**Ticket: [CP-14986](https://ava-labs.atlassian.net/browse/CP-14986)**

The `appium-android` regression stage has failed on every run since 2026-07-01 (build #9055; last green #9025 on 2026-06-29). All 47 specs die at Appium session creation with:

```
Error: Intent matches multiple activities; can't stop: Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] ... }
```

The Expo 56 / RN 0.85 upgrade (dbbfbd252, CP-14221) moved the `MAIN`/`LAUNCHER` intent-filter off `.MainActivity` onto the `.MainActivityDefault` activity-alias (part of the app-icon alias set). UiAutomator2 was launching the app with an implicit MAIN/LAUNCHER intent, which now resolves ambiguously, so adb refuses to launch and no session is ever created. Because TestRail reporting lives in the wdio `beforeTest`/`afterTest` hooks, nothing was posted to TestRail either, so the runs went silent there.

The fix is two added lines: set an explicit `'appium:appActivity': 'com.avaxwallet.MainActivityDefault'` in the Android caps of both wdio configs, so appium-adb launches the exact component (`am start -n <pkg>/<activity>`) and bypasses intent-filter resolution entirely.

Two things a reviewer might question, both verified:

- `appium:appWaitActivity` deliberately stays `'*'`. A precise value (`com.avaxwallet.MainActivity`) looks more correct but breaks session creation: Android reports the focused activity as the alias name (`MainActivityDefault`), not its target, at least on API 36 (`dumpsys window` shows `mFocusedApp ... MainActivityDefault`), so appium-adb's `waitForActivity` times out. Reproduced both the timeout with the precise value and instant matching with `'*'` against a real emulator.
- `appium:appPackage` is intentionally not set: appium derives it from the built APK (`aapt2 dump badging`), so it resolves per-flavor (`com.avaxwallet.internal` internal, `com.avaxwallet` external) while the activity class is always under the `com.avaxwallet` namespace.

Also checked: the app-icon-switch spec (which enables a different alias mid-run) is unaffected. Session creation reinstalls the APK (no `noReset`), restoring the manifest default alias, and mid-session restarts use `activateApp`, which re-resolves the enabled alias dynamically. `wdio.devicefarm.conf.ts` gets the same change because `package-tests.sh` copies it over `wdio.conf.ts` in the Device Farm bundle.

No dependencies introduced, no breaking changes (CI test config only, no app code touched).

## Screenshots/Videos

N/A (CI e2e configuration change).

## Testing

**Dev Testing (if applicable)**

- `./node_modules/.bin/tsc --noEmit -p e2e-appium/tsconfig.json` exits 0.
- Verified end-to-end locally against the signed `app-internal-e2e-bitrise-signed.apk` artifact from the last successful `android-internal-e2e` Bitrise build, on an Android emulator with a real Appium 3.1.2 + uiautomator2 6.7.9 server:
  - Reproduced the exact CI failure verbatim with the old implicit launch (`Intent matches multiple activities`).
  - With this branch's config, `wdio run wdio.conf.ts --spec metaMaskWallet.spec.ts` **created the session** (explicit `-n com.avaxwallet.internal/com.avaxwallet.MainActivityDefault` launch, session ID returned) and the spec body executed, stopping only at expected local-only gaps (`E2E_MNEMONIC` unset, no TestRail creds) — which also confirms the TestRail hooks fire again once sessions exist.
- Final CI confirmation will come from the next `full-regression-runs` pipeline on a tag containing this change (running the bare `appium-android` workflow standalone doesn't work — it has no upstream `android-internal-e2e` stage to pull the APK from, which is what build #9489 showed).

**QA Testing (if applicable)**

- No app-facing behavior change. Confirm the next full regression run's Android stage goes green and results appear in TestRail again.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CP-14986]: https://ava-labs.atlassian.net/browse/CP-14986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ