### PR TITLE
CP-14977: Force numeric PIN keyboard on Android (Samsung full-keyboard fallback)

### DIFF
--- a/packages/k2-alpine/src/components/PinInput/PinInput.tsx
+++ b/packages/k2-alpine/src/components/PinInput/PinInput.tsx
@@ -200,8 +200,12 @@ export const PinInput = forwardRef<PinInputActions, PinInputProps>(
           style={[StyleSheet.absoluteFill, { opacity: 0 }]}
           value={value}
           onChangeText={handleInputChange}
-          keyboardType={Platform.OS === 'ios' ? 'number-pad' : undefined}
-          inputMode={Platform.OS === 'android' ? 'numeric' : undefined}
+          keyboardType="number-pad"
+          // RN 0.85 Android merges the default autoCapitalize='sentences' into
+          // the numeric inputType (fixed upstream in 0.86 by react-native#55786);
+          // explicit 'none' keeps it purely numeric so Samsung Keyboard shows
+          // the number pad.
+          autoCapitalize="none"
           autoFocus={autoFocus}
           maxLength={length}
           allowFontScaling={false}


### PR DESCRIPTION
## Description

**Ticket: [CP-14977](https://ava-labs.atlassian.net/browse/CP-14977)**

On Samsung devices (reported on a Galaxy A17 running v38 RC1), the onboarding create-PIN screen shows the full qwerty keyboard instead of a numeric pad. iOS and Pixel/Gboard show the numeric pad correctly. Letters were never accepted into the PIN value (the input handler strips non-digits), so this is a UX bug, not a weak-PIN bug.

Root cause, traced through the RN 0.85.3 source rather than guessed: React Native defaults an unset `autoCapitalize` to `sentences` on every Android TextInput, and in 0.85.3 the native prop setters commit `TYPE_CLASS_NUMBER | TYPE_TEXT_FLAG_CAP_SENTENCES` (0x4002), a malformed inputType. Gboard tolerates it and still renders a number pad, which is why the bug only shows on Samsung Keyboard (it falls back to qwerty). Meta fixed this upstream in react-native#55786, which is in RN 0.86.0+ but was never backported to 0.85.x. First shipped in v38 because that is our first release on RN 0.85.

The fix in `PinInput` (k2-alpine):

- `autoCapitalize="none"` on the hidden TextInput. This is the actual fix: it clears the colliding bits and leaves a clean numeric inputType.
- `keyboardType="number-pad"` on both platforms, replacing the previous iOS ternary plus `inputMode="numeric"` pair. RN mapped that pair to `number-pad` internally anyway, so this is equivalent but removes the indirection.

No dependencies introduced, not breaking. The CP-13724 Samsung S25 touch fix (container/z-order) is untouched. The workaround can be dropped once we are on RN 0.86+.

## Screenshots/Videos

Not reproducible on available hardware: on a Pixel 8 Pro the corrupted inputType still renders as a numeric pad because Gboard ignores the stray flag. The visual symptom needs a Samsung device with Samsung Keyboard, so before/after screenshots have to come from QA's A17 (see QA testing below).

## Testing

**Dev Testing (if applicable)**

- Verified root cause and fix against the installed RN 0.85.3 source (`ReactTextInputManager.kt` bitmasks, `TextInput.js` autoCapitalize default and inputMode mapping).
- `tsc` and eslint clean, k2-alpine jest suite 248/248 passing.
- Onboarding walked end to end on a Pixel 8 Pro: numeric pad on the create-PIN screen, unchanged behavior.
- Bitrise internal build to be triggered on this branch.

**QA Testing (if applicable)**

- On a Samsung device with Samsung Keyboard as the active IME (bug was reported on a Galaxy A17): go through onboarding (new wallet or import) to the create-PIN screen.
- Expected: the numeric keypad appears, no qwerty keyboard. Same expectation on the confirm-PIN step and the unlock/enter-PIN screen, which use the same component.
- Regression check for CP-13724: on a Samsung S25, tapping the PIN dots area must still focus the input and bring up the keyboard.
- Sanity check on any Gboard device and iOS: numeric pad, unchanged.

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [ ] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [ ] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CP-14977]: https://ava-labs.atlassian.net/browse/CP-14977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ