### PR TITLE
CP-15034: Meld onramp: fall back to a quotable payment method instead of dead-ending on NO_VALID_QUOTES

### DIFF
--- a/packages/core-mobile/app/new/features/meld/components/SelectPaymentMethod.tsx
+++ b/packages/core-mobile/app/new/features/meld/components/SelectPaymentMethod.tsx
@@ -21,7 +21,7 @@ import {
   ServiceProviderCategories,
   PaymentMethodTimeLimits
 } from '../consts'
-import { useMeldPaymentMethod } from '../store'
+import { useMeldPaymentMethod, useMeldPaymentMethodIsManual } from '../store'
 import { useServiceProviders } from '../hooks/useServiceProviders'
 import { PaymentMethodIcon } from './PaymentMethodIcon'
 
@@ -39,6 +39,7 @@ export const SelectPaymentMethod = ({
   } = useTheme()
   const { back, canGoBack } = useRouter()
   const [meldPaymentMethod, setMeldPaymentMethod] = useMeldPaymentMethod()
+  const [, setPaymentMethodIsManual] = useMeldPaymentMethodIsManual()
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<
     string | undefined
   >(meldPaymentMethod)
@@ -156,6 +157,7 @@ export const SelectPaymentMethod = ({
           if (paymentMethod.paymentMethod) {
             setSelectedPaymentMethod(paymentMethod.paymentMethod)
             setMeldPaymentMethod(paymentMethod.paymentMethod)
+            setPaymentMethodIsManual(true)
           }
         },
         accessory:
@@ -171,7 +173,8 @@ export const SelectPaymentMethod = ({
     supportedPaymentMethods,
     selectedPaymentMethod,
     colors.$textPrimary,
-    setMeldPaymentMethod
+    setMeldPaymentMethod,
+    setPaymentMethodIsManual
   ])
 
   const renderContent = useCallback(() => {

--- a/packages/core-mobile/app/new/features/meld/hooks/useCreateCryptoQuote.ts
+++ b/packages/core-mobile/app/new/features/meld/hooks/useCreateCryptoQuote.ts
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 import MeldService from '../services/MeldService'
 import { CreateCryptoQuote, CreateCryptoQuoteParams } from '../types'
 import { ServiceProviderCategories } from '../consts'
+import { shouldRetryCryptoQuote } from '../utils'
 import { useSearchServiceProviders } from './useSearchServiceProviders'
 import { useFiatSourceAmount } from './useFiatSourceAmount'
 
@@ -52,6 +53,7 @@ export const useCreateCryptoQuote = ({
 
   return useQuery<CreateCryptoQuote | undefined>({
     enabled,
+    retry: shouldRetryCryptoQuote,
     queryKey: [
       ReactQueryKeys.MELD_CREATE_CRYPTO_QUOTE,
       category,

--- a/packages/core-mobile/app/new/features/meld/hooks/useSelectAmount.tsx
+++ b/packages/core-mobile/app/new/features/meld/hooks/useSelectAmount.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useLayoutEffect, useMemo } from 'react'
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState
+} from 'react'
 import { View, Text, useTheme, alpha } from '@avalabs/k2-alpine'
 import { SubTextNumber } from 'common/components/SubTextNumber'
 import { selectSelectedCurrency } from 'store/settings/currency'
@@ -84,6 +90,13 @@ export const useSelectAmount = ({
     isLoadingTradeLimits
   } = useFiatSourceAmount({ category })
   const [countryCode] = useMeldCountryCode()
+
+  // Payment methods already tried via the NO_VALID_QUOTES auto-adopt path this
+  // round. Keeps adoption from ping-ponging between methods that each fail as
+  // an explicit filter — see resolveNoValidQuotesFallback.
+  const [attemptedFallbackMethods, setAttemptedFallbackMethods] = useState<
+    string[]
+  >([])
 
   const { getFromPopulatedNetwork } = useNetworks()
 
@@ -174,7 +187,9 @@ export const useSelectAmount = ({
   // Meld rejects some explicit paymentMethodType filters that the same
   // request with paymentMethodType omitted can still quote. Fire that
   // unfiltered request only while we're actually stuck, to recover instead
-  // of dead-ending the onramp flow. Offramp is unaffected.
+  // of dead-ending the onramp flow. This fallback re-query is onramp-only —
+  // the shouldRetryCryptoQuote retry policy in useCreateCryptoQuote is
+  // separate and applies to both onramp and offramp quotes.
   const isFallbackQuotesEnabled =
     category === ServiceProviderCategories.CRYPTO_ONRAMP &&
     hasNoValidQuotesError &&
@@ -198,6 +213,7 @@ export const useSelectAmount = ({
             paymentMethodIsManual,
             isLoadingFallbackQuotes,
             fallbackQuotes,
+            attemptedPaymentMethods: attemptedFallbackMethods,
             selectedCurrency
           })
         : { action: 'none' as const },
@@ -208,28 +224,47 @@ export const useSelectAmount = ({
       paymentMethodIsManual,
       isLoadingFallbackQuotes,
       fallbackQuotes,
+      attemptedFallbackMethods,
       selectedCurrency
     ]
   )
 
   useEffect(() => {
     if (noValidQuotesFallback.action !== 'adopt') return
-    setPaymentMethod(noValidQuotesFallback.paymentMethodType)
-    if (noValidQuotesFallback.serviceProvider) {
-      setServiceProvider(noValidQuotesFallback.serviceProvider)
-    }
-  }, [noValidQuotesFallback, setPaymentMethod, setServiceProvider])
+    const adopted = noValidQuotesFallback.paymentMethodType
+    // Record both the adopted method and the one that just failed, so neither
+    // is re-adopted if the adopted method also 400s as a filter. serviceProvider
+    // is intentionally left to the default-selection effect, which sets it from
+    // the refreshed (adopted-method) batch — the quote list is empty here in the
+    // errored state, so setting it now would just be overwritten.
+    setAttemptedFallbackMethods(prev => {
+      const withAdopted = prev.includes(adopted) ? prev : [...prev, adopted]
+      return paymentMethod && !withAdopted.includes(paymentMethod)
+        ? [...withAdopted, paymentMethod]
+        : withAdopted
+    })
+    setPaymentMethod(adopted)
+  }, [noValidQuotesFallback, paymentMethod, setPaymentMethod])
 
   useEffect(() => {
     setPaymentMethod(undefined)
     setServiceProvider(undefined)
     setPaymentMethodIsManual(false)
+    setAttemptedFallbackMethods([])
   }, [
     setPaymentMethod,
     setServiceProvider,
     setPaymentMethodIsManual,
     token?.currencyCode
   ])
+
+  // Changing currency or country changes which methods Meld can quote, so a
+  // method blacklisted for the old context must be reconsidered — otherwise
+  // the "try changing your currency" recovery can still dead-end on a method
+  // that would now quote fine.
+  useEffect(() => {
+    setAttemptedFallbackMethods([])
+  }, [selectedCurrency, countryCode])
 
   const walletAddress = useMemo(() => {
     return account && network && getAddressByNetwork(account, network)
@@ -323,6 +358,7 @@ export const useSelectAmount = ({
     setPaymentMethod(undefined)
     setServiceProvider(undefined)
     setPaymentMethodIsManual(false)
+    setAttemptedFallbackMethods([])
     setSourceAmount(0)
   }, [
     setPaymentMethod,

--- a/packages/core-mobile/app/new/features/meld/hooks/useSelectAmount.tsx
+++ b/packages/core-mobile/app/new/features/meld/hooks/useSelectAmount.tsx
@@ -23,6 +23,7 @@ import {
 import {
   useMeldCountryCode,
   useMeldPaymentMethod,
+  useMeldPaymentMethodIsManual,
   useMeldServiceProvider
 } from '../store'
 import {
@@ -31,6 +32,7 @@ import {
   CryptoCurrency,
   SessionTypes
 } from '../types'
+import { isNoValidQuotesError, resolveNoValidQuotesFallback } from '../utils'
 import { useSearchDefaultsByCountry } from './useSearchDefaultsByCountry'
 import { useCreateSessionWidget } from './useCreateSessionWidget'
 import { useServiceProviders } from './useServiceProviders'
@@ -69,6 +71,8 @@ export const useSelectAmount = ({
   const selectedCurrency = useSelector(selectSelectedCurrency)
   const [serviceProvider, setServiceProvider] = useMeldServiceProvider()
   const [paymentMethod, setPaymentMethod] = useMeldPaymentMethod()
+  const [paymentMethodIsManual, setPaymentMethodIsManual] =
+    useMeldPaymentMethodIsManual()
   const {
     sourceAmount,
     setSourceAmount,
@@ -162,10 +166,70 @@ export const useSelectAmount = ({
       enabled
     })
 
+  const hasNoValidQuotesError = useMemo(
+    () => isNoValidQuotesError(cryptoQuotesError),
+    [cryptoQuotesError]
+  )
+
+  // Meld rejects some explicit paymentMethodType filters that the same
+  // request with paymentMethodType omitted can still quote. Fire that
+  // unfiltered request only while we're actually stuck, to recover instead
+  // of dead-ending the onramp flow. Offramp is unaffected.
+  const isFallbackQuotesEnabled =
+    category === ServiceProviderCategories.CRYPTO_ONRAMP &&
+    hasNoValidQuotesError &&
+    paymentMethod !== undefined &&
+    enabled
+
+  const {
+    crytoQuotes: fallbackQuotes,
+    isLoadingCryptoQuotes: isLoadingFallbackQuotes
+  } = useServiceProviders({
+    category,
+    enabled: isFallbackQuotesEnabled
+  })
+
+  const noValidQuotesFallback = useMemo(
+    () =>
+      category === ServiceProviderCategories.CRYPTO_ONRAMP
+        ? resolveNoValidQuotesFallback({
+            isNoValidQuotesError: hasNoValidQuotesError,
+            paymentMethod,
+            paymentMethodIsManual,
+            isLoadingFallbackQuotes,
+            fallbackQuotes,
+            selectedCurrency
+          })
+        : { action: 'none' as const },
+    [
+      category,
+      hasNoValidQuotesError,
+      paymentMethod,
+      paymentMethodIsManual,
+      isLoadingFallbackQuotes,
+      fallbackQuotes,
+      selectedCurrency
+    ]
+  )
+
+  useEffect(() => {
+    if (noValidQuotesFallback.action !== 'adopt') return
+    setPaymentMethod(noValidQuotesFallback.paymentMethodType)
+    if (noValidQuotesFallback.serviceProvider) {
+      setServiceProvider(noValidQuotesFallback.serviceProvider)
+    }
+  }, [noValidQuotesFallback, setPaymentMethod, setServiceProvider])
+
   useEffect(() => {
     setPaymentMethod(undefined)
     setServiceProvider(undefined)
-  }, [setPaymentMethod, setServiceProvider, token?.currencyCode])
+    setPaymentMethodIsManual(false)
+  }, [
+    setPaymentMethod,
+    setServiceProvider,
+    setPaymentMethodIsManual,
+    token?.currencyCode
+  ])
 
   const walletAddress = useMemo(() => {
     return account && network && getAddressByNetwork(account, network)
@@ -258,8 +322,14 @@ export const useSelectAmount = ({
   useLayoutEffect(() => {
     setPaymentMethod(undefined)
     setServiceProvider(undefined)
+    setPaymentMethodIsManual(false)
     setSourceAmount(0)
-  }, [setPaymentMethod, setServiceProvider, setSourceAmount])
+  }, [
+    setPaymentMethod,
+    setServiceProvider,
+    setPaymentMethodIsManual,
+    setSourceAmount
+  ])
 
   useEffect(() => {
     if (paymentMethod === undefined && defaultPaymentMethod) {
@@ -339,6 +409,15 @@ export const useSelectAmount = ({
       return 'Transaction amount is invalid: it must be between the minimum and maximum allowed.'
     }
 
+    // While resolving NO_VALID_QUOTES, only the fallback-derived message
+    // (if any) should show — not the generic message below, which would
+    // otherwise flash while the fallback request is still in flight.
+    if (isFallbackQuotesEnabled) {
+      return noValidQuotesFallback.action === 'error'
+        ? noValidQuotesFallback.message
+        : undefined
+    }
+
     if (cryptoQuotesError?.statusCode) {
       return 'We are unable to fetch the quotes, please check your input. Adjust the country, currency, token, or amount and try again.'
     }
@@ -353,6 +432,8 @@ export const useSelectAmount = ({
     isBelowMaximumLimit,
     maximumLimit,
     minMaxErrorMessage,
+    isFallbackQuotesEnabled,
+    noValidQuotesFallback,
     cryptoQuotesError,
     token?.tokenWithBalance.symbol,
     formatCurrency,

--- a/packages/core-mobile/app/new/features/meld/store.ts
+++ b/packages/core-mobile/app/new/features/meld/store.ts
@@ -19,6 +19,11 @@ export const useMeldPaymentMethod = createZustandStore<string | undefined>(
   undefined
 )
 
+// Distinguishes a user's explicit picker tap (SelectPaymentMethod.tsx) from
+// an auto-defaulted payment method, so the NO_VALID_QUOTES fallback knows
+// whether it's safe to silently switch methods or must ask the user first.
+export const useMeldPaymentMethodIsManual = createZustandStore<boolean>(false)
+
 export const useMeldFiatAmount = createZustandStore<number | undefined>(
   undefined
 )

--- a/packages/core-mobile/app/new/features/meld/utils.test.ts
+++ b/packages/core-mobile/app/new/features/meld/utils.test.ts
@@ -1,5 +1,12 @@
-import { CreateCryptoQuoteErrorCode } from './types'
-import { getErrorMessage } from './utils'
+import { PaymentMethods } from './consts'
+import { CreateCryptoQuoteErrorCode, Quote } from './types'
+import {
+  getErrorMessage,
+  humanizePaymentMethodName,
+  isNoValidQuotesError,
+  resolveNoValidQuotesFallback,
+  shouldRetryCryptoQuote
+} from './utils'
 
 describe('getErrorMessage', () => {
   it('returns message-only API errors with the HTTP status', () => {
@@ -14,6 +21,237 @@ describe('getErrorMessage', () => {
     expect(getErrorMessage(error)).toEqual({
       statusCode: CreateCryptoQuoteErrorCode.BAD_REQUEST,
       message: 'No valid quotes found'
+    })
+  })
+})
+
+describe('isNoValidQuotesError', () => {
+  it('matches the message-only 400 Meld returns for NO_VALID_QUOTES', () => {
+    expect(
+      isNoValidQuotesError({
+        statusCode: CreateCryptoQuoteErrorCode.BAD_REQUEST,
+        message: 'No Valid Quote Combinations Found For Provided Quote Request.'
+      })
+    ).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(
+      isNoValidQuotesError({
+        statusCode: CreateCryptoQuoteErrorCode.BAD_REQUEST,
+        message: 'no valid quote combinations found for provided quote request.'
+      })
+    ).toBe(true)
+  })
+
+  it('rejects a 400 with an unrelated message', () => {
+    expect(
+      isNoValidQuotesError({
+        statusCode: CreateCryptoQuoteErrorCode.BAD_REQUEST,
+        message: 'Some other validation failure'
+      })
+    ).toBe(false)
+  })
+
+  it('rejects a matching message on a non-400 status code', () => {
+    expect(
+      isNoValidQuotesError({
+        statusCode: CreateCryptoQuoteErrorCode.INCOMPATIBLE_REQUEST,
+        message: 'No Valid Quote Combinations Found For Provided Quote Request.'
+      })
+    ).toBe(false)
+  })
+
+  it('rejects undefined', () => {
+    expect(isNoValidQuotesError(undefined)).toBe(false)
+  })
+})
+
+describe('humanizePaymentMethodName', () => {
+  it('uses the known display name when one exists', () => {
+    expect(humanizePaymentMethodName(PaymentMethods.CREDIT_DEBIT_CARD)).toBe(
+      'Debit/credit card'
+    )
+  })
+
+  it('humanizes an unknown payment method', () => {
+    // matches lodash startCase's actual behavior for all-caps input: it
+    // splits on underscores but doesn't re-case letters that are already
+    // capitalized, so an all-caps method name stays all-caps per word.
+    expect(humanizePaymentMethodName('SOME_NEW_METHOD')).toBe('SOME NEW METHOD')
+  })
+
+  it('returns undefined for empty input', () => {
+    expect(humanizePaymentMethodName(undefined)).toBeUndefined()
+    expect(humanizePaymentMethodName(null)).toBeUndefined()
+  })
+})
+
+describe('shouldRetryCryptoQuote', () => {
+  const errorWithStatus = (statusCode: number): Error =>
+    Object.assign(new Error('Request failed'), {
+      response: { status: statusCode, statusText: '', data: undefined }
+    })
+
+  it('retries a 5xx while under the failure-count cap', () => {
+    expect(shouldRetryCryptoQuote(0, errorWithStatus(500))).toBe(true)
+    expect(shouldRetryCryptoQuote(2, errorWithStatus(500))).toBe(true)
+  })
+
+  it('stops retrying a 5xx once the cap is reached', () => {
+    expect(shouldRetryCryptoQuote(3, errorWithStatus(500))).toBe(false)
+  })
+
+  it('never retries a 4xx, since the request params will not change', () => {
+    expect(shouldRetryCryptoQuote(0, errorWithStatus(400))).toBe(false)
+  })
+
+  it('retries a network error (no response, no resolvable status code) while under the cap', () => {
+    expect(shouldRetryCryptoQuote(0, new Error('network down'))).toBe(true)
+    expect(shouldRetryCryptoQuote(2, new Error('network down'))).toBe(true)
+  })
+
+  it('stops retrying a network error once the cap is reached', () => {
+    expect(shouldRetryCryptoQuote(3, new Error('network down'))).toBe(false)
+  })
+})
+
+describe('resolveNoValidQuotesFallback', () => {
+  const quote = (overrides: Partial<Quote> = {}): Quote =>
+    ({
+      paymentMethodType: PaymentMethods.APPLE_PAY,
+      serviceProvider: 'MERCURYO',
+      ...overrides
+    } as Quote)
+
+  const baseArgs = {
+    isNoValidQuotesError: true,
+    paymentMethod: PaymentMethods.BR_BANK_TRANSFER,
+    paymentMethodIsManual: false,
+    isLoadingFallbackQuotes: false,
+    fallbackQuotes: [] as Quote[],
+    selectedCurrency: 'USD'
+  }
+
+  it('does nothing when there is no NO_VALID_QUOTES error', () => {
+    expect(
+      resolveNoValidQuotesFallback({
+        ...baseArgs,
+        isNoValidQuotesError: false,
+        fallbackQuotes: [quote()]
+      })
+    ).toEqual({ action: 'none' })
+  })
+
+  it('does nothing when no payment method is selected', () => {
+    expect(
+      resolveNoValidQuotesFallback({
+        ...baseArgs,
+        paymentMethod: undefined,
+        fallbackQuotes: [quote()]
+      })
+    ).toEqual({ action: 'none' })
+  })
+
+  it('does nothing while the fallback request is still in flight', () => {
+    expect(
+      resolveNoValidQuotesFallback({
+        ...baseArgs,
+        isLoadingFallbackQuotes: true,
+        fallbackQuotes: [quote()]
+      })
+    ).toEqual({ action: 'none' })
+  })
+
+  it('reports no regional support when the fallback also comes back empty', () => {
+    expect(
+      resolveNoValidQuotesFallback({ ...baseArgs, fallbackQuotes: [] })
+    ).toEqual({
+      action: 'error',
+      message:
+        'No payment methods currently support USD purchases in your region. Try changing your currency in settings.'
+    })
+  })
+
+  it('silently adopts the best fallback quote for an auto-defaulted payment method', () => {
+    expect(
+      resolveNoValidQuotesFallback({
+        ...baseArgs,
+        paymentMethodIsManual: false,
+        fallbackQuotes: [
+          quote({
+            paymentMethodType: PaymentMethods.APPLE_PAY,
+            serviceProvider: 'MERCURYO'
+          })
+        ]
+      })
+    ).toEqual({
+      action: 'adopt',
+      paymentMethodType: PaymentMethods.APPLE_PAY,
+      serviceProvider: 'MERCURYO'
+    })
+  })
+
+  it('skips a fallback quote that repeats the already-failing payment method', () => {
+    expect(
+      resolveNoValidQuotesFallback({
+        ...baseArgs,
+        paymentMethod: PaymentMethods.BR_BANK_TRANSFER,
+        paymentMethodIsManual: false,
+        fallbackQuotes: [
+          quote({
+            paymentMethodType: PaymentMethods.BR_BANK_TRANSFER,
+            serviceProvider: 'SAME_METHOD_PROVIDER'
+          }),
+          quote({
+            paymentMethodType: PaymentMethods.APPLE_PAY,
+            serviceProvider: 'MERCURYO'
+          })
+        ]
+      })
+    ).toEqual({
+      action: 'adopt',
+      paymentMethodType: PaymentMethods.APPLE_PAY,
+      serviceProvider: 'MERCURYO'
+    })
+  })
+
+  it('reports no regional support when every fallback quote repeats the failing method', () => {
+    expect(
+      resolveNoValidQuotesFallback({
+        ...baseArgs,
+        paymentMethod: PaymentMethods.BR_BANK_TRANSFER,
+        paymentMethodIsManual: false,
+        fallbackQuotes: [
+          quote({
+            paymentMethodType: PaymentMethods.BR_BANK_TRANSFER,
+            serviceProvider: 'PROVIDER_A'
+          }),
+          quote({
+            paymentMethodType: PaymentMethods.BR_BANK_TRANSFER,
+            serviceProvider: 'PROVIDER_B'
+          })
+        ]
+      })
+    ).toEqual({
+      action: 'error',
+      message:
+        'No payment methods currently support USD purchases in your region. Try changing your currency in settings.'
+    })
+  })
+
+  it('surfaces a switch-method message instead of overriding a manual choice', () => {
+    expect(
+      resolveNoValidQuotesFallback({
+        ...baseArgs,
+        paymentMethod: PaymentMethods.BR_BANK_TRANSFER,
+        paymentMethodIsManual: true,
+        fallbackQuotes: [quote({ paymentMethodType: PaymentMethods.APPLE_PAY })]
+      })
+    ).toEqual({
+      action: 'error',
+      message:
+        "Local Manual Bank Transfer isn't available for this purchase. Try Apple Pay."
     })
   })
 })

--- a/packages/core-mobile/app/new/features/meld/utils.test.ts
+++ b/packages/core-mobile/app/new/features/meld/utils.test.ts
@@ -142,6 +142,7 @@ describe('resolveNoValidQuotesFallback', () => {
     paymentMethodIsManual: false,
     isLoadingFallbackQuotes: false,
     fallbackQuotes: [] as Quote[],
+    attemptedPaymentMethods: [] as string[],
     selectedCurrency: 'USD'
   }
 
@@ -264,6 +265,107 @@ describe('resolveNoValidQuotesFallback', () => {
       action: 'error',
       message:
         "Local Manual Bank Transfer isn't available for this purchase. Try Apple Pay."
+    })
+  })
+
+  it('suggests a different method, not the failing one, for a manual choice', () => {
+    expect(
+      resolveNoValidQuotesFallback({
+        ...baseArgs,
+        paymentMethod: PaymentMethods.BR_BANK_TRANSFER,
+        paymentMethodIsManual: true,
+        // the unfiltered batch lists the user's own failing method first
+        fallbackQuotes: [
+          quote({ paymentMethodType: PaymentMethods.BR_BANK_TRANSFER }),
+          quote({ paymentMethodType: PaymentMethods.CREDIT_DEBIT_CARD })
+        ]
+      })
+    ).toEqual({
+      action: 'error',
+      message:
+        "Local Manual Bank Transfer isn't available for this purchase. Try Debit/credit card."
+    })
+  })
+
+  it('falls back to a generic manual message when no different method exists', () => {
+    expect(
+      resolveNoValidQuotesFallback({
+        ...baseArgs,
+        paymentMethod: PaymentMethods.BR_BANK_TRANSFER,
+        paymentMethodIsManual: true,
+        fallbackQuotes: [
+          quote({ paymentMethodType: PaymentMethods.BR_BANK_TRANSFER })
+        ]
+      })
+    ).toEqual({
+      action: 'error',
+      message:
+        "Local Manual Bank Transfer isn't available for this purchase. Try a different payment method."
+    })
+  })
+
+  it('stops adopting once every quotable method has already been attempted (no infinite loop)', () => {
+    expect(
+      resolveNoValidQuotesFallback({
+        ...baseArgs,
+        paymentMethod: PaymentMethods.APPLE_PAY,
+        paymentMethodIsManual: false,
+        attemptedPaymentMethods: [
+          PaymentMethods.APPLE_PAY,
+          PaymentMethods.CREDIT_DEBIT_CARD
+        ],
+        fallbackQuotes: [
+          quote({ paymentMethodType: PaymentMethods.CREDIT_DEBIT_CARD }),
+          quote({ paymentMethodType: PaymentMethods.APPLE_PAY })
+        ]
+      })
+    ).toEqual({
+      action: 'error',
+      message:
+        'No payment methods currently support USD purchases in your region. Try changing your currency in settings.'
+    })
+  })
+
+  it('adopts the first not-yet-attempted method', () => {
+    expect(
+      resolveNoValidQuotesFallback({
+        ...baseArgs,
+        paymentMethod: PaymentMethods.APPLE_PAY,
+        paymentMethodIsManual: false,
+        attemptedPaymentMethods: [PaymentMethods.APPLE_PAY],
+        fallbackQuotes: [
+          quote({ paymentMethodType: PaymentMethods.APPLE_PAY }),
+          quote({
+            paymentMethodType: PaymentMethods.CREDIT_DEBIT_CARD,
+            serviceProvider: 'MERCURYO'
+          })
+        ]
+      })
+    ).toEqual({
+      action: 'adopt',
+      paymentMethodType: PaymentMethods.CREDIT_DEBIT_CARD,
+      serviceProvider: 'MERCURYO'
+    })
+  })
+
+  it('adopts a later quotable method when the first quote has no paymentMethodType', () => {
+    expect(
+      resolveNoValidQuotesFallback({
+        ...baseArgs,
+        paymentMethod: PaymentMethods.BR_BANK_TRANSFER,
+        paymentMethodIsManual: false,
+        fallbackQuotes: [
+          quote({ paymentMethodType: undefined }),
+          quote({
+            paymentMethodType: PaymentMethods.CREDIT_DEBIT_CARD,
+            serviceProvider: 'MERCURYO'
+          })
+        ]
+      })
+    ).toEqual({
+      action: 'adopt',
+      paymentMethodType: PaymentMethods.CREDIT_DEBIT_CARD,
+      serviceProvider: 'MERCURYO'
     })
   })
 })

--- a/packages/core-mobile/app/new/features/meld/utils.test.ts
+++ b/packages/core-mobile/app/new/features/meld/utils.test.ts
@@ -106,6 +106,18 @@ describe('shouldRetryCryptoQuote', () => {
     expect(shouldRetryCryptoQuote(0, errorWithStatus(400))).toBe(false)
   })
 
+  it('never retries a Meld string error code (deterministic, not a network error)', () => {
+    const errorWithCode = Object.assign(new Error('Request failed'), {
+      response: {
+        data: {
+          code: CreateCryptoQuoteErrorCode.INCOMPATIBLE_REQUEST,
+          message: 'Incompatible request'
+        }
+      }
+    })
+    expect(shouldRetryCryptoQuote(0, errorWithCode)).toBe(false)
+  })
+
   it('retries a network error (no response, no resolvable status code) while under the cap', () => {
     expect(shouldRetryCryptoQuote(0, new Error('network down'))).toBe(true)
     expect(shouldRetryCryptoQuote(2, new Error('network down'))).toBe(true)

--- a/packages/core-mobile/app/new/features/meld/utils.ts
+++ b/packages/core-mobile/app/new/features/meld/utils.ts
@@ -258,6 +258,7 @@ export const resolveNoValidQuotesFallback = ({
   paymentMethodIsManual,
   isLoadingFallbackQuotes,
   fallbackQuotes,
+  attemptedPaymentMethods,
   selectedCurrency
 }: {
   isNoValidQuotesError: boolean
@@ -265,6 +266,7 @@ export const resolveNoValidQuotesFallback = ({
   paymentMethodIsManual: boolean
   isLoadingFallbackQuotes: boolean
   fallbackQuotes: Quote[]
+  attemptedPaymentMethods: string[]
   selectedCurrency: string
 }): NoValidQuotesFallbackResult => {
   if (!hasNoValidQuotesError || paymentMethod === undefined) {
@@ -276,31 +278,35 @@ export const resolveNoValidQuotesFallback = ({
     return { action: 'none' }
   }
 
-  const bestFallback = fallbackQuotes[0]
-
-  if (!bestFallback?.paymentMethodType) {
-    return {
-      action: 'error',
-      message: `No payment methods currently support ${selectedCurrency} purchases in your region. Try changing your currency in settings.`
-    }
+  const noRegionalSupport: NoValidQuotesFallbackResult = {
+    action: 'error',
+    message: `No payment methods currently support ${selectedCurrency} purchases in your region. Try changing your currency in settings.`
   }
 
-  if (!paymentMethodIsManual) {
-    // The failing paymentMethod can still show up in the unfiltered fallback
-    // results (a different, working provider offering the same method type).
-    // Re-adopting that same value is a zustand no-op — the primary query key
-    // never changes, so it would stall on the errored quote with no error
-    // message. Skip ahead to the first quote that's actually different.
-    const adoptable = fallbackQuotes.find(
-      quote =>
-        quote.paymentMethodType && quote.paymentMethodType !== paymentMethod
-    )
+  // paymentMethodType is nullable per the schema, so a leading quote can lack
+  // one while a later quote is still quotable — check the whole batch, not
+  // just the first, before declaring no regional support.
+  if (!fallbackQuotes.some(quote => quote.paymentMethodType)) {
+    return noRegionalSupport
+  }
 
+  // A method Meld returns in the unfiltered fallback batch can itself 400 once
+  // we re-quote with it as an explicit filter (the same over-rejection quirk).
+  // Adopting reactively off the fallback result would then re-adopt another
+  // method, which can fail too and ping-pong back — an infinite render loop.
+  // Only consider methods we haven't already tried this round, so adoption
+  // strictly makes progress and terminates in the error branch once every
+  // quotable method has been exhausted.
+  const adoptable = fallbackQuotes.find(
+    quote =>
+      quote.paymentMethodType &&
+      quote.paymentMethodType !== paymentMethod &&
+      !attemptedPaymentMethods.includes(quote.paymentMethodType)
+  )
+
+  if (!paymentMethodIsManual) {
     if (!adoptable?.paymentMethodType) {
-      return {
-        action: 'error',
-        message: `No payment methods currently support ${selectedCurrency} purchases in your region. Try changing your currency in settings.`
-      }
+      return noRegionalSupport
     }
 
     return {
@@ -311,14 +317,16 @@ export const resolveNoValidQuotesFallback = ({
   }
 
   const currentName = humanizePaymentMethodName(paymentMethod)
-  const fallbackName = humanizePaymentMethodName(bestFallback.paymentMethodType)
+  // Suggest a genuinely different method, not the one the user already picked
+  // (the unfiltered batch can list the failing method first).
+  const suggestionName = humanizePaymentMethodName(adoptable?.paymentMethodType)
 
   return {
     action: 'error',
     message: `${
       currentName ?? 'This payment method'
     } isn't available for this purchase. Try ${
-      fallbackName ?? 'a different payment method'
+      suggestionName ?? 'a different payment method'
     }.`
   }
 }

--- a/packages/core-mobile/app/new/features/meld/utils.ts
+++ b/packages/core-mobile/app/new/features/meld/utils.ts
@@ -204,22 +204,24 @@ export const getErrorMessage = (
 }
 
 /**
- * Only 5xx (Meld/upstream outage) is worth react-query's default retry
- * behavior. 4xx errors like NO_VALID_QUOTES are deterministic for the given
- * request params and won't succeed by retrying unchanged. A network failure
- * (offline, timeout) throws without a `response`, so getErrorMessage can't
- * resolve a statusCode at all — treat that as retryable too, since it's the
- * class of error most likely to be transient and previously got react-query's
- * default retries.
+ * Only transient failures are worth react-query's retry behavior. A network
+ * failure (offline, timeout) throws without a `response`, so getErrorMessage
+ * resolves no statusCode at all — that's the class most likely to be transient
+ * and previously got react-query's default retries. A numeric 5xx is an
+ * upstream outage. Everything else is deterministic for the given request
+ * params and won't succeed by retrying unchanged: a numeric 4xx, and Meld's
+ * string error codes (e.g. INCOMPATIBLE_REQUEST, which getErrorMessage surfaces
+ * via `response.data.code`) — so a non-numeric statusCode is NOT retryable.
  */
 export const shouldRetryCryptoQuote = (
   failureCount: number,
   error: Error
 ): boolean => {
   const statusCode = getErrorMessage(error)?.statusCode
-  return (
-    (typeof statusCode !== 'number' || statusCode >= 500) && failureCount < 3
-  )
+  const isTransient =
+    statusCode === undefined ||
+    (typeof statusCode === 'number' && statusCode >= 500)
+  return isTransient && failureCount < 3
 }
 
 /**

--- a/packages/core-mobile/app/new/features/meld/utils.ts
+++ b/packages/core-mobile/app/new/features/meld/utils.ts
@@ -5,9 +5,11 @@ import { NetworkContractToken, TokenType } from '@avalabs/vm-module-types'
 import { ChainId } from '@avalabs/core-chains-sdk'
 import { router } from 'expo-router'
 import { getLocalTokenId } from 'services/balance/utils/getLocalTokenId'
+import { humanize } from 'utils/string/humanize'
 import { ACTIONS } from '../../../contexts/DeeplinkContext/types'
 import {
   NATIVE_ERC20_TOKEN_CONTRACT_ADDRESS,
+  PaymentMethodNames,
   SOLANA_MELD_CHAIN_ID
 } from './consts'
 import {
@@ -15,7 +17,8 @@ import {
   CreateCryptoQuoteError,
   CryptoCurrency,
   CryptoQuotesError,
-  CreateCryptoQuoteErrorCode
+  CreateCryptoQuoteErrorCode,
+  Quote
 } from './types'
 
 export const asZeroBalanceToken = (
@@ -198,4 +201,122 @@ export const getErrorMessage = (
     }
   }
   return undefined
+}
+
+/**
+ * Only 5xx (Meld/upstream outage) is worth react-query's default retry
+ * behavior. 4xx errors like NO_VALID_QUOTES are deterministic for the given
+ * request params and won't succeed by retrying unchanged. A network failure
+ * (offline, timeout) throws without a `response`, so getErrorMessage can't
+ * resolve a statusCode at all — treat that as retryable too, since it's the
+ * class of error most likely to be transient and previously got react-query's
+ * default retries.
+ */
+export const shouldRetryCryptoQuote = (
+  failureCount: number,
+  error: Error
+): boolean => {
+  const statusCode = getErrorMessage(error)?.statusCode
+  return (
+    (typeof statusCode !== 'number' || statusCode >= 500) && failureCount < 3
+  )
+}
+
+/**
+ * NO_VALID_QUOTES has no dedicated status/code field — Meld returns it as a
+ * plain 400 with only a `message`, which lands in getErrorMessage's
+ * message-only branch above. Detection is by message content.
+ */
+export const isNoValidQuotesError = (error?: CryptoQuotesError): boolean =>
+  error?.statusCode === CreateCryptoQuoteErrorCode.BAD_REQUEST &&
+  (error.message?.toLowerCase().includes('no valid quote') ?? false)
+
+export const humanizePaymentMethodName = (
+  paymentMethodType?: string | null
+): string | undefined => {
+  if (!paymentMethodType) return undefined
+  return PaymentMethodNames[paymentMethodType] ?? humanize(paymentMethodType)
+}
+
+export type NoValidQuotesFallbackResult =
+  | { action: 'none' }
+  | { action: 'adopt'; paymentMethodType: string; serviceProvider?: string }
+  | { action: 'error'; message: string }
+
+/**
+ * Decides what to do once the onramp quote request 400s with NO_VALID_QUOTES
+ * for the currently selected payment method. Meld's crypto-quote endpoint
+ * over-rejects specific paymentMethodType filters that the same request with
+ * paymentMethodType omitted can still quote (verified against the live API).
+ * Callers fire that unfiltered fallback request and pass its result here.
+ */
+export const resolveNoValidQuotesFallback = ({
+  isNoValidQuotesError: hasNoValidQuotesError,
+  paymentMethod,
+  paymentMethodIsManual,
+  isLoadingFallbackQuotes,
+  fallbackQuotes,
+  selectedCurrency
+}: {
+  isNoValidQuotesError: boolean
+  paymentMethod: string | undefined
+  paymentMethodIsManual: boolean
+  isLoadingFallbackQuotes: boolean
+  fallbackQuotes: Quote[]
+  selectedCurrency: string
+}): NoValidQuotesFallbackResult => {
+  if (!hasNoValidQuotesError || paymentMethod === undefined) {
+    return { action: 'none' }
+  }
+
+  // still resolving — avoid flashing an error while the fallback is in flight
+  if (isLoadingFallbackQuotes) {
+    return { action: 'none' }
+  }
+
+  const bestFallback = fallbackQuotes[0]
+
+  if (!bestFallback?.paymentMethodType) {
+    return {
+      action: 'error',
+      message: `No payment methods currently support ${selectedCurrency} purchases in your region. Try changing your currency in settings.`
+    }
+  }
+
+  if (!paymentMethodIsManual) {
+    // The failing paymentMethod can still show up in the unfiltered fallback
+    // results (a different, working provider offering the same method type).
+    // Re-adopting that same value is a zustand no-op — the primary query key
+    // never changes, so it would stall on the errored quote with no error
+    // message. Skip ahead to the first quote that's actually different.
+    const adoptable = fallbackQuotes.find(
+      quote =>
+        quote.paymentMethodType && quote.paymentMethodType !== paymentMethod
+    )
+
+    if (!adoptable?.paymentMethodType) {
+      return {
+        action: 'error',
+        message: `No payment methods currently support ${selectedCurrency} purchases in your region. Try changing your currency in settings.`
+      }
+    }
+
+    return {
+      action: 'adopt',
+      paymentMethodType: adoptable.paymentMethodType,
+      serviceProvider: adoptable.serviceProvider ?? undefined
+    }
+  }
+
+  const currentName = humanizePaymentMethodName(paymentMethod)
+  const fallbackName = humanizePaymentMethodName(bestFallback.paymentMethodType)
+
+  return {
+    action: 'error',
+    message: `${
+      currentName ?? 'This payment method'
+    } isn't available for this purchase. Try ${
+      fallbackName ?? 'a different payment method'
+    }.`
+  }
 }


### PR DESCRIPTION
## Description

**Ticket: [CP-15034]**

A Brazil user with their app currency on USD dead-ended trying to buy USDT: Meld returns HTTP 400 "No Valid Quote Combinations Found" for BR + USD + local bank transfer, and the screen just showed a generic quote error with a disabled Buy button (Sentry CORE-REACT-NATIVE-BAR / 7Y3).

The quote request is assembled from three values that never see each other: country from device locale, fiat from the global currency setting, and payment method from Meld's country-only defaults endpoint (or the picker, whose backing API advertises methods that can't actually quote). Nothing validates the combination before firing.

Changes:

- When the quote fails with NO_VALID_QUOTES, we re-quote once with the payment method omitted (verified live that Meld supports this and returns each provider's best quotable method).
- If the failing method was our auto-default, we silently adopt a different method that actually quotes, so the screen recovers on its own.
- If the user picked the method themselves, we keep their choice and show "X isn't available for this purchase. Try Y." instead of overriding them.
- If nothing quotes at all, the error now points at the currency setting instead of the generic copy.
- The quote query no longer retries deterministic 4xx responses (network errors and 5xx still retry).

New `useMeldPaymentMethodIsManual` store flag tracks manual vs auto selection. Offramp behavior untouched. No new dependencies.

## Screenshots/Videos

Physical Pixel 8 Pro, live production Meld. The failing combination here is BRL + USDT over Local Manual Bank Transfer, which Meld cannot quote — the same class of dead-end the original Sentry user hit.

<table>
<tr><th>Screenshot</th><th width="60%">What it shows</th></tr>
<tr>
<td align="center"><img width="220" src="https://github.com/user-attachments/assets/d2974201-5a57-430e-ad38-92a3fb272a2e" /></td>
<td>Manually selecting <b>Local Manual Bank Transfer</b> (which can't quote USDT in BRL). Instead of a generic "unable to fetch quotes" dead-end, the screen shows the targeted caption <i>"Local Manual Bank Transfer isn't available for this purchase. Try Debit/credit card."</i> — the user's own selection is preserved, and Buy is disabled.</td>
</tr>
<tr>
<td align="center"><img width="220" src="https://github.com/user-attachments/assets/ee496c84-01cc-45e9-b2c9-0522b49f528c" /></td>
<td>After re-selecting a quotable method (PIX / Swapped.com), quotes load and Buy re-enables — the flow recovers instead of trapping the user.</td>
</tr>
</table>

_The auto-default recovery (PIX default → silent switch to a quotable method) and a full screen recording were captured during verification; the recording was lost to a temp-dir cleanup and can be re-recorded on request._

## Testing

**Dev Testing (if applicable)**

- Happy path: Buy, any US/EU locale, enter an amount, quotes load with the country default method, nothing visibly changes
- Repro path: Buy, set Country to Brazil on the locale screen, keep currency USD, pick USDT, enter 50. Expected: Pay with lands on a card method with quotes, not an error
- Manual path: from that state open Pay with and select Local Manual Bank Transfer. Expected: the specific "isn't available, try card" message, Buy disabled, your selection still shown
- Unit tests: `yarn test app/new/features/meld` (39 tests)

**QA Testing (if applicable)**

- Regression: onramp quote flow across a few countries and currencies, offramp (sell) flow end to end since it shares the amount screen hook
- Acceptance: no reachable combination of country, currency, and payment method leaves the screen error-locked when at least one method can quote

## Checklist

Please check all that apply (if applicable)

- [x] I have performed a self-review of my code
- [x] I have verified the code works
- [x] I have included screenshots / videos of android and ios
- [x] I have added testing steps
- [x] I have added/updated necessary unit tests
- [ ] I have updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CP-15034]: https://ava-labs.atlassian.net/browse/CP-15034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
